### PR TITLE
Update ParserState.java

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
@@ -741,7 +741,13 @@ class ParserState<T> {
 
 		@Override
 		public void attributeValue(String theName, String theValue) throws DataFormatException {
-			if ("contentType".equals(theName)) {
+			if ("id".equals(theName)) {
+				if (myInstance instanceof IIdentifiableElement) {
+					((IIdentifiableElement) myInstance).setElementSpecificId((theValue));
+				} else if (myInstance instanceof IResource) {
+					((IResource) myInstance).setId(new IdDt(theValue));
+				}
+			} else if ("contentType".equals(theName)) {
 				myInstance.setContentType(theValue);
 			} else if (myJsonMode && "value".equals(theName)) {
 				string(theValue);


### PR DESCRIPTION
Issue #26: XMLParser doesn't read Binary content from XML. Binary content is discarded during xml parsing, because attribute check of ID is missing in BinaryResourceState.attributeValue(...)
