### PR TITLE
Fixes #32 - removes new validation API that doesn't use exceptions

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
@@ -1,0 +1,72 @@
+package ca.uhn.fhir.validation;
+
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import ca.uhn.fhir.model.dstu.resource.OperationOutcome;
+
+/**
+ * Encapsulates the results of validation
+ *
+ * @see ca.uhn.fhir.validation.FhirValidator
+ * @since 0.7
+ */
+public class ValidationResult {
+    private OperationOutcome myOperationOutcome;
+
+    private ValidationResult(OperationOutcome myOperationOutcome) {
+        this.myOperationOutcome = myOperationOutcome;
+    }
+
+    public static ValidationResult valueOf(OperationOutcome myOperationOutcome) {
+        return new ValidationResult(myOperationOutcome);
+    }
+
+    public OperationOutcome getOperationOutcome() {
+        return myOperationOutcome;
+    }
+
+    @Override
+    public String toString() {
+        return "ValidationResult{" +
+                "myOperationOutcome=" + myOperationOutcome +
+                ", description='" + toDescription() + '\'' +
+                '}';
+    }
+
+    private String toDescription() {
+        StringBuilder b = new StringBuilder(100);
+        if (myOperationOutcome != null) {
+            OperationOutcome.Issue issueFirstRep = myOperationOutcome.getIssueFirstRep();
+            b.append(issueFirstRep.getDetails().getValue());
+            b.append(" - ");
+            b.append(issueFirstRep.getLocationFirstRep().getValue());
+        }
+        return b.toString();
+    }
+
+    /**
+     * Was the validation successful
+     * @return true if the validation was successful
+     */
+    public boolean isSuccessful() {
+        return myOperationOutcome == null || myOperationOutcome.getIssue().isEmpty();
+    }
+}

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/validation/ValidationResultTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/validation/ValidationResultTest.java
@@ -1,0 +1,46 @@
+package ca.uhn.fhir.validation;
+
+import ca.uhn.fhir.model.dstu.resource.OperationOutcome;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class ValidationResultTest {
+
+    @Test
+    public void isSuccessful_IsTrueForNullOperationOutcome() {
+        ValidationResult result = ValidationResult.valueOf(null);
+        assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void isSuccessful_IsTrueForNoIssues() {
+        OperationOutcome operationOutcome = new OperationOutcome();
+        // make sure a non-null ID doesn't cause the validation result to be a fail
+        operationOutcome.setId(UUID.randomUUID().toString());
+        ValidationResult result = ValidationResult.valueOf(operationOutcome);
+        assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void isSuccessful_FalseForIssues() {
+        OperationOutcome operationOutcome = new OperationOutcome();
+        OperationOutcome.Issue issue = operationOutcome.addIssue();
+        String errorMessage = "There was a validation problem";
+        issue.setDetails(errorMessage);
+        ValidationResult result = ValidationResult.valueOf(operationOutcome);
+        assertFalse(result.isSuccessful());
+        List<OperationOutcome.Issue> issues = result.getOperationOutcome().getIssue();
+        assertEquals(1, issues.size());
+        assertEquals(errorMessage, issues.get(0).getDetails().getValue());
+
+        assertThat("ValidationResult#toString should contain the issue description", result.toString(), containsString(errorMessage));
+    }
+}


### PR DESCRIPTION
Creates new methods that return a ValidationResult object instead of throwing an exception which requires catching and inspecting the exception itself. Migrating from the old to the new API should be pretty simple as the method calls match quite closely.
