### PR TITLE
ServerProfileProvider now uses IdDt.getIdPart() rather than getValue() s...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /bin
 /target
+.idea/
+.project/
+.settings/
+*.iml
 *.log
 *.log*
 nohup.out

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/provider/ServerProfileProvider.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/provider/ServerProfileProvider.java
@@ -50,7 +50,7 @@ public class ServerProfileProvider implements IResourceProvider {
 	
 	@Read()
 	public Profile getProfileById(@IdParam IdDt theId) {
-		RuntimeResourceDefinition retVal = myContext.getResourceDefinitionById(theId.getValue());
+		RuntimeResourceDefinition retVal = myContext.getResourceDefinitionById(theId.getIdPart());
 		if (retVal==null) {
 			return null;
 		}

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/context/ModelScannerTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/context/ModelScannerTest.java
@@ -63,5 +63,7 @@ public class ModelScannerTest {
 		assertNotNull(valueDate);
 		
 	}
+
+
 	
 }

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/server/ResfulServerMethodTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/server/ResfulServerMethodTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import ca.uhn.fhir.model.dstu.resource.*;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -44,11 +45,6 @@ import ca.uhn.fhir.model.dstu.composite.CodingDt;
 import ca.uhn.fhir.model.dstu.composite.HumanNameDt;
 import ca.uhn.fhir.model.dstu.composite.IdentifierDt;
 import ca.uhn.fhir.model.dstu.composite.QuantityDt;
-import ca.uhn.fhir.model.dstu.resource.AdverseReaction;
-import ca.uhn.fhir.model.dstu.resource.Conformance;
-import ca.uhn.fhir.model.dstu.resource.DiagnosticReport;
-import ca.uhn.fhir.model.dstu.resource.OperationOutcome;
-import ca.uhn.fhir.model.dstu.resource.Patient;
 import ca.uhn.fhir.model.dstu.valueset.IdentifierUseEnum;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.model.primitive.InstantDt;
@@ -86,6 +82,7 @@ public class ResfulServerMethodTest {
 	private static int ourPort;
 	private static DummyDiagnosticReportResourceProvider ourReportProvider;
 	private static Server ourServer;
+	private static RestfulServer ourRestfulServer;
 
 	@Test
 	public void test404IsPropagatedCorrectly() throws Exception {
@@ -995,6 +992,14 @@ public class ResfulServerMethodTest {
 
 	}
 
+	@Test
+	public void testServerProfileProviderFindsProfiles() {
+		ServerProfileProvider profileProvider = (ServerProfileProvider)ourRestfulServer.getServerProfilesProvider();
+		IdDt id = new IdDt("Profile", "observation");
+		Profile profile = profileProvider.getProfileById(id);
+		assertNotNull(profile);
+	}
+
 	@AfterClass
 	public static void afterClass() throws Exception {
 		ourServer.stop();
@@ -1012,8 +1017,8 @@ public class ResfulServerMethodTest {
 		DummyAdverseReactionResourceProvider adv = new DummyAdverseReactionResourceProvider();
 
 		ServletHandler proxyHandler = new ServletHandler();
-		DummyRestfulServer servlet = new DummyRestfulServer(patientProvider, profProvider, ourReportProvider, adv);
-		ServletHolder servletHolder = new ServletHolder(servlet);
+		ourRestfulServer =new DummyRestfulServer(patientProvider, profProvider, ourReportProvider, adv);
+		ServletHolder servletHolder = new ServletHolder(ourRestfulServer);
 		proxyHandler.addServletWithMapping(servletHolder, "/*");
 		ourServer.setHandler(proxyHandler);
 		ourServer.start();


### PR DESCRIPTION
...o that it can find the profiles in in FhirContext's myIdToResourceDefinition.
This fixes issue #25 (https://github.com/jamesagnew/hapi-fhir/issues/25)
