### PR TITLE
IOException is removed from CustomThymeleafNarrativeGenerator

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative/CustomThymeleafNarrativeGenerator.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative/CustomThymeleafNarrativeGenerator.java
@@ -20,7 +20,6 @@ package ca.uhn.fhir.narrative;
  * #L%
  */
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,10 +38,8 @@ public class CustomThymeleafNarrativeGenerator extends BaseThymeleafNarrativeGen
 	 *            <li>file:/path/to/file/file.properties</li>
 	 *            <li>classpath:/com/package/file.properties</li>
 	 *            </ul>
-	 * @throws IOException
-	 *             If the file can not be found/read
 	 */
-	public CustomThymeleafNarrativeGenerator(String... thePropertyFile) throws IOException {
+	public CustomThymeleafNarrativeGenerator(String... thePropertyFile) {
 		setPropertyFile(thePropertyFile);
 	}
 
@@ -55,8 +52,6 @@ public class CustomThymeleafNarrativeGenerator extends BaseThymeleafNarrativeGen
 	 *            <li>file:/path/to/file/file.properties</li>
 	 *            <li>classpath:/com/package/file.properties</li>
 	 *            </ul>
-	 * @throws IOException
-	 *             If the file can not be found/read
 	 */
 	public void setPropertyFile(String... thePropertyFile) {
 		Validate.notNull(thePropertyFile, "Property file can not be null");

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/narrative/CustomThymeleafNarrativeGeneratorTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/narrative/CustomThymeleafNarrativeGeneratorTest.java
@@ -3,8 +3,6 @@ package ca.uhn.fhir.narrative;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
-
 import org.junit.Test;
 
 import ca.uhn.fhir.model.dstu.composite.NarrativeDt;
@@ -15,7 +13,7 @@ public class CustomThymeleafNarrativeGeneratorTest {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(CustomThymeleafNarrativeGeneratorTest.class);
 
 	@Test
-	public void testGenerator() throws IOException {
+	public void testGenerator() {
 
 		CustomThymeleafNarrativeGenerator gen = new CustomThymeleafNarrativeGenerator("file:src/test/resources/narrative/customnarrative.properties");
 


### PR DESCRIPTION
CustomThymeleafNarrativeGenerator can't throw IOException. It can be thrown later from BaseThymeleafNarrativeGenerator.initialize() while narative resource loading.
