### PR TITLE
issue-1124: renaming valueQuanity to valueQuantity

### DIFF
--- a/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/device.sch
+++ b/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/device.sch
@@ -59,7 +59,7 @@
     <sch:rule context="f:Device/f:version/f:component/f:assigner">
       <sch:assert test="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])">ref-1: SHALL have a contained resource if a local reference is provided</sch:assert>
     </sch:rule>
-    <sch:rule context="f:Device/f:property/f:valueQuanity">
+    <sch:rule context="f:Device/f:property/f:valueQuantity">
       <sch:assert test="not(exists(f:code)) or exists(f:system)">qty-3: If a code for the unit is present, the system SHALL also be present</sch:assert>
     </sch:rule>
     <sch:rule context="f:Device/f:patient">

--- a/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/devicedefinition.sch
+++ b/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/devicedefinition.sch
@@ -83,7 +83,7 @@
     <sch:rule context="f:DeviceDefinition/f:physicalCharacteristics/f:image">
       <sch:assert test="not(exists(f:data)) or exists(f:contentType)">att-1: If the Attachment has data, it SHALL have a contentType</sch:assert>
     </sch:rule>
-    <sch:rule context="f:DeviceDefinition/f:property/f:valueQuanity">
+    <sch:rule context="f:DeviceDefinition/f:property/f:valueQuantity">
       <sch:assert test="not(exists(f:code)) or exists(f:system)">qty-3: If a code for the unit is present, the system SHALL also be present</sch:assert>
     </sch:rule>
     <sch:rule context="f:DeviceDefinition/f:owner">

--- a/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/fhir-invariants.sch
+++ b/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/fhir-invariants.sch
@@ -3314,7 +3314,7 @@
     <sch:rule context="f:Device/f:version/f:component/f:assigner">
       <sch:assert test="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])">ref-1: SHALL have a contained resource if a local reference is provided</sch:assert>
     </sch:rule>
-    <sch:rule context="f:Device/f:property/f:valueQuanity">
+    <sch:rule context="f:Device/f:property/f:valueQuantity">
       <sch:assert test="not(exists(f:code)) or exists(f:system)">qty-3: If a code for the unit is present, the system SHALL also be present</sch:assert>
     </sch:rule>
     <sch:rule context="f:Device/f:patient">
@@ -3427,7 +3427,7 @@
     <sch:rule context="f:DeviceDefinition/f:physicalCharacteristics/f:image">
       <sch:assert test="not(exists(f:data)) or exists(f:contentType)">att-1: If the Attachment has data, it SHALL have a contentType</sch:assert>
     </sch:rule>
-    <sch:rule context="f:DeviceDefinition/f:property/f:valueQuanity">
+    <sch:rule context="f:DeviceDefinition/f:property/f:valueQuantity">
       <sch:assert test="not(exists(f:code)) or exists(f:system)">qty-3: If a code for the unit is present, the system SHALL also be present</sch:assert>
     </sch:rule>
     <sch:rule context="f:DeviceDefinition/f:owner">

--- a/hapi-tinder-plugin/src/main/resources/res/r4/device-spreadsheet.xml
+++ b/hapi-tinder-plugin/src/main/resources/res/r4/device-spreadsheet.xml
@@ -1849,7 +1849,7 @@
     <Cell ss:StyleID="s90"><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="31">
-    <Cell ss:StyleID="s78"><Data ss:Type="String">Device.property.valueQuanity</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s78"><Data ss:Type="String">Device.property.valueQuantity</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s78"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s92"><Data ss:Type="String">0..*</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:Index="5" ss:StyleID="s92"><Data ss:Type="String">Quantity</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>

--- a/hapi-tinder-plugin/src/main/resources/res/r4/devicedefinition-spreadsheet.xml
+++ b/hapi-tinder-plugin/src/main/resources/res/r4/devicedefinition-spreadsheet.xml
@@ -1723,7 +1723,7 @@
     <Cell ss:StyleID="s94"><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="31">
-    <Cell ss:StyleID="s89"><Data ss:Type="String">DeviceDefinition.property.valueQuanity</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><Data ss:Type="String">DeviceDefinition.property.valueQuantity</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s100"><Data ss:Type="String">0..*</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:Index="5" ss:StyleID="s100"><Data ss:Type="String">Quantity</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>


### PR DESCRIPTION
# About
Fix #1124

# Fixes
I located files which had valueQuanity and replaced with valueQuantity. 

# Note
I saw DeviceDefinition.java and Device.java as generated source files. @jamesagnew if this PR does indeed address the issue, is there something I need to do to generate:
* hapi-fhir/hapi-fhir-structures-r4/src/main/java/org/hl7/fhir/r4/model/DeviceDefinition.java
* hapi-fhir/hapi-fhir-structures-r4/src/main/java/org/hl7/fhir/r4/model/Device.java
