### PR TITLE
issue-1107: make v3.3.0 JDK7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>3.3.0</version>
+	<version>3.3.1</version>
 	<name>HAPI-FHIR</name>
 	<url>https://hapifhir.io</url>
 
@@ -443,7 +443,8 @@
 		<commons_lang3_version>3.6</commons_lang3_version>
 		<derby_version>10.14.1.0</derby_version>
 		<error_prone_annotations_version>2.0.18</error_prone_annotations_version>
-		<guava_version>23.0</guava_version>
+		<!-- guava_version: the android flavor is needed for JDK7 (see https://github.com/google/guava/wiki/Compatibility) -->
+		<guava_version>23.0-android</guava_version>
 		<gson_version>2.8.1</gson_version>
 		<jaxb_api_version>2.3.0</jaxb_api_version>
 		<jaxb_core_version>2.3.0</jaxb_core_version>


### PR DESCRIPTION
# Help. I Cannot create PR against tag
I have tried to submit a Pull Request against v3.3.0 tag, [but every time I try](https://github.com/jamesagnew/hapi-fhir/compare/4c0d5b49d9b24e8459d89b6533b4034f60d25082...restevez-chs:issue-1107-v3.3.1-release-candidate), I do not get a "Create Pull Request" form. I see a diff which is correct, but no way to create a Pull Request. That said, the fix here is simple. I did checkout the v3.3.0 tag first, then made the POM file changes. I built locally with `mvn clean install` and it was successful.

I am happy to submit another PR, but I think @jamesagnew there needs to be a branch that you or another HAPI FHIR contributor creates off the v3.3.0 tag. Then I can create a PR to that new branch. Or its a permissions issue?

# About
[Google Guava release 21](https://github.com/google/guava/wiki/Release21) requires JDK8. HAPI FHIR v3.3.0 was previously specifying a newer Guava version which requires JDK8 rather than JDK7, which HAPI FHIR v3.3.0 is [advertised to support](http://hapifhir.io/download.html).

# Changes
Update POM to specify the "android" version which is [recommended](https://github.com/google/guava/wiki/Release22#new-android-version) by Google for JDK7. Using `23.0-android` is the latest Guava available.

# References
* https://github.com/google/guava/wiki/Compatibility
* https://github.com/google/guava/wiki/Release23
* https://github.com/google/guava/wiki/Release22
* https://search.maven.org/artifact/com.google.guava/guava/23.0-android/bundle

#Fix #1107 