### PR TITLE
[hapi-fhir-spring-boot] Fix fullUrls in response bundle

### DIFF
--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
@@ -145,7 +145,7 @@ public class FhirAutoConfiguration {
 			setResourceProviders(this.resourceProviders);
 			setPagingProvider(this.pagingProvider);
 
-			setServerAddressStrategy(new HardcodedServerAddressStrategy(this.properties.getServer().getPath()));
+			setServerAddressStrategy(new HardcodedServerAddressStrategy(this.properties.getServer().getUrl()));
 
 			customize();
 		}


### PR DESCRIPTION
The property `hapi.fhir.server.path` is already used to map the servlet, resulting in fullUrls in response bundles like "/fhir/*/Patient/id" currently.
`hapi.fhir.server.url` seems to be the intended property to be used here.