### PR TITLE
Fixing bug in BaseParser that expects all resources to have an "extension"

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -1198,14 +1198,15 @@ public abstract class BaseParser implements IParser {
 
 		public boolean shouldBeEncoded(boolean theContainedResource) {
 			boolean retVal = true;
+			String elementName = myDef != null ? myDef.getElementName() : "";
 			if (myEncodeElements != null) {
 				retVal = checkIfParentShouldBeEncodedAndBuildPath();
 			}
 			if (retVal && myDontEncodeElements != null) {
 				retVal = !checkIfParentShouldNotBeEncodedAndBuildPath();
 			}
-			if (theContainedResource) {
-				retVal = !notEncodeForContainedResource.contains(myDef.getElementName());
+			if (theContainedResource && myDef != null) {
+				retVal = !notEncodeForContainedResource.contains(elementName);
 			}
 			if (retVal && isSummaryMode() && (getDef() == null || !getDef().isSummary())) {
 				String resourceName = myEncodeContext.getLeafResourceName();
@@ -1215,7 +1216,7 @@ public abstract class BaseParser implements IParser {
 				// https://github.com/smart-on-fhir/Swift-FHIR/issues/26
 				// for example.
 				if (("Conformance".equals(resourceName) || "CapabilityStatement".equals(resourceName)) &&
-					("extension".equals(myDef.getElementName()) || "extension".equals(myEncodeContext.getLeafElementName())
+					("extension".equals(elementName) || "extension".equals(myEncodeContext.getLeafElementName())
 					)) {
 					// skip
 				} else {


### PR DESCRIPTION
I'm trying to import data into my new 4.1 installation and I've hit a NullPointerException error.
the exception is coming from BaseParser.shouldBeEncoded():1208
this.myDef is null
shouldBeEncoded() is being called by JsonParser.isEncodeExtension()
BaseRuntimeChildDefinition childDef = definition.getChildByName("extension");
CompositeChildElement c = new CompositeChildElement(this, theParent, childDef, theEncodeContext);
retVal = c.shouldBeEncoded(theContainedResource);
it is hitting this exception when dealing with a contained Binary resource
the problem, I believe, is that the Binary resource is derived from "Resource", not by "DomainResource". Resource does not have "extension"
So, definition.getChildByName("extension") is returning null
and childDef gets passed as myDef, and there's no null-checking on it in shouldBeEncoded()

This PR is compatible with the v4.1 tag. If possible, please update the 4.1 release with this patch fix so that I can use it in my 4.1 environment.