### PR TITLE
(fix) Change build number properties location configuration

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -169,21 +169,12 @@
 				<inherited>true</inherited>
 				<executions>
 					<execution>
-						<id>standard</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>create</goal>
-						</goals>
-					</execution>
-					<execution>
 						<id>downstream</id>
 						<phase>validate</phase>
 						<goals>
 							<goal>create-metadata</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.directory}/generated-sources/properties</outputDirectory>
-							<outputName>ca/uhn/fhir/hapi-fhir-base-build.properties</outputName>
 							<revisionPropertyName>hapifhir.buildnumber</revisionPropertyName>
 							<timestampPropertyName>hapifhir.timestamp</timestampPropertyName>
 							<timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SXXX</timestampFormat>


### PR DESCRIPTION
I have just removed a duplicate execution `create`, which is obviously done by `create-metadata` as well. I have also removed the properties that provide the location. It takes the default location for the build metadata

> /target/generated/build-metadata

This closes #1356 