### PR TITLE
Adding missing display to ConceptDefinitionComponent in ValidationResult

### DIFF
--- a/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/hapi/ctx/HapiWorkerContext.java
@@ -287,11 +287,15 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
       return null;
     }
 
+    ConceptDefinitionComponent definition = null;
     IssueSeverity severity = null;
-    if (result.getSeverity() != null) {
+    if (result.getSeverity() == null) {
+      definition = new ConceptDefinitionComponent();
+      definition.setCode(result.getCode());
+      definition.setDisplay(result.getDisplay());
+    } else {
       severity = IssueSeverity.fromCode(result.getSeverityCode());
     }
-    ConceptDefinitionComponent definition = new ConceptDefinitionComponent().setCode(result.getCode());
     return new ValidationResult(severity, result.getMessage(), definition);
   }
 

--- a/hapi-fhir-structures-r4/src/main/java/org/hl7/fhir/r4/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-r4/src/main/java/org/hl7/fhir/r4/hapi/ctx/HapiWorkerContext.java
@@ -193,7 +193,9 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
       severity = IssueSeverity.fromCode(result.getSeverityCode());
     }
 
-    ConceptDefinitionComponent definition = new ConceptDefinitionComponent().setCode(result.getCode());
+    ConceptDefinitionComponent definition = new ConceptDefinitionComponent();
+    definition.setCode(result.getCode());
+    definition.setDisplay(result.getDisplay());
     return new ValidationResult(severity, result.getMessage(), definition);
   }
 

--- a/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
@@ -187,7 +187,9 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
 		if (result.getSeverity() != null) {
 			severity = IssueSeverity.fromCode(result.getSeverityCode());
 		}
-		ConceptDefinitionComponent definition = new ConceptDefinitionComponent().setCode(result.getCode());
+		ConceptDefinitionComponent definition = new ConceptDefinitionComponent();
+		definition.setCode(result.getCode());
+		definition.setDisplay(result.getDisplay());
 		return new ValidationResult(severity, result.getMessage(), definition);
 	}
 


### PR DESCRIPTION
- Adding missing display to ConceptDefinitionComponent in ValidationResult

- DSTU3: Correcting so ConceptDefinitionComponent in ValidationResult is only set when the validation has no issues. It is because the implementation of ValidationResult.isOk():
public boolean isOk() { return this.definition != null; }

The implementation of isOk() is different in R4 and R5.