### PR TITLE
Strip protocol from URL from ES props builder if added

### DIFF
--- a/example-projects/hapi-fhir-jpaserver-dynamic/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfigCommon.java
+++ b/example-projects/hapi-fhir-jpaserver-dynamic/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfigCommon.java
@@ -162,6 +162,9 @@ public class FhirServerConfigCommon {
 		extraProperties.put("hibernate.search.indexing_strategy", "manual");
 		extraProperties.put("hibernate.search.default.worker.execution", "async");
 
+
+
+
 		return extraProperties;
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/elastic/ElasticsearchHibernatePropertiesBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/elastic/ElasticsearchHibernatePropertiesBuilder.java
@@ -61,7 +61,7 @@ public class ElasticsearchHibernatePropertiesBuilder {
 	private long myIndexManagementWaitTimeoutMillis = 10000L;
 	private String myDebugSyncStrategy = AutomaticIndexingSynchronizationStrategyNames.ASYNC;
 	private boolean myDebugPrettyPrintJsonLog = false;
-	private String myProtocol;
+	private String myProtocol = "http";
 
 	public ElasticsearchHibernatePropertiesBuilder setUsername(String theUsername) {
 		myUsername = theUsername;
@@ -100,7 +100,6 @@ public class ElasticsearchHibernatePropertiesBuilder {
 		theProperties.put(BackendSettings.backendKey(ElasticsearchBackendSettings.LOG_JSON_PRETTY_PRINTING), Boolean.toString(myDebugPrettyPrintJsonLog));
 
 		injectStartupTemplate(myProtocol, myRestUrl, myUsername, myPassword);
-
 	}
 
 	public ElasticsearchHibernatePropertiesBuilder setRequiredIndexStatus(IndexStatus theRequiredIndexStatus) {
@@ -109,6 +108,12 @@ public class ElasticsearchHibernatePropertiesBuilder {
 	}
 
 	public ElasticsearchHibernatePropertiesBuilder setRestUrl(String theRestUrl) {
+
+		//If the user includes protocol here, strip it and apply it in the correct spot.
+		if (theRestUrl.startsWith("http")) {
+			myProtocol = theRestUrl.substring(0, theRestUrl.indexOf("://"));
+			theRestUrl = theRestUrl.substring(theRestUrl.indexOf("://") + 3);
+		}
 		myRestUrl = theRestUrl;
 		return this;
 	}


### PR DESCRIPTION
The new Elastic client is particular about how the URL is ingested. This forces separation of host and protocol