### PR TITLE
reduce _count to the maximum page size rather than throwing an error.

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -1315,11 +1315,12 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				theParams.setOffset(offset);
 			}
 
-			final Integer count = RestfulServerUtils.extractCountParameter(theRequest);
+			Integer count = RestfulServerUtils.extractCountParameter(theRequest);
 			if (count != null) {
 				Integer maxPageSize = theRequest.getServer().getMaximumPageSize();
-				if (maxPageSize != null) {
-					Validate.inclusiveBetween(1, theRequest.getServer().getMaximumPageSize(), count, "Count must be positive integer and less than " + maxPageSize);
+				if (count > maxPageSize) {
+					ourLog.info("reducing {} from {} to the maximum allowable page size {}", Constants.PARAM_COUNT, count, maxPageSize);
+					count = maxPageSize;
 				}
 				theParams.setCount(count);
 			} else if (theRequest.getServer().getDefaultPageSize() != null) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -1319,7 +1319,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			if (count != null) {
 				Integer maxPageSize = theRequest.getServer().getMaximumPageSize();
 				if (count > maxPageSize) {
-					ourLog.info("reducing {} from {} to the maximum allowable page size {}", Constants.PARAM_COUNT, count, maxPageSize);
+					ourLog.info("Reducing {} from {} to {} which is the maximum allowable page size.", Constants.PARAM_COUNT, count, maxPageSize);
 					count = maxPageSize;
 				}
 				theParams.setCount(count);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -1318,7 +1318,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			Integer count = RestfulServerUtils.extractCountParameter(theRequest);
 			if (count != null) {
 				Integer maxPageSize = theRequest.getServer().getMaximumPageSize();
-				if (count > maxPageSize) {
+				if (maxPageSize != null && count > maxPageSize) {
 					ourLog.info("Reducing {} from {} to {} which is the maximum allowable page size.", Constants.PARAM_COUNT, count, maxPageSize);
 					count = maxPageSize;
 				}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
@@ -1091,7 +1091,7 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc {
 			int minWanted = 0;
 			if (myParams.getCount() != null) {
 				minWanted = myParams.getCount();
-				minWanted = Math.max(minWanted, myPagingProvider.getMaximumPageSize());
+				minWanted = Math.min(minWanted, myPagingProvider.getMaximumPageSize());
 				minWanted += currentlyLoaded;
 			}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
@@ -1091,7 +1091,7 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc {
 			int minWanted = 0;
 			if (myParams.getCount() != null) {
 				minWanted = myParams.getCount();
-				minWanted = Math.min(minWanted, myPagingProvider.getMaximumPageSize());
+				minWanted = Math.max(minWanted, myPagingProvider.getMaximumPageSize());
 				minWanted += currentlyLoaded;
 			}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
@@ -251,7 +251,7 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc {
 				ourLog.trace("Search entity marked as finished with {} results", search.getNumFound());
 				break;
 			}
-			if (search.getNumFound() >= theTo) {
+			if ((search.getNumFound() - search.getNumBlocked()) >= theTo) {
 				ourLog.trace("Search entity has {} results so far", search.getNumFound());
 				break;
 			}
@@ -1091,7 +1091,7 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc {
 			int minWanted = 0;
 			if (myParams.getCount() != null) {
 				minWanted = myParams.getCount();
-				minWanted = Math.max(minWanted, myPagingProvider.getMaximumPageSize());
+				minWanted = Math.min(minWanted, myPagingProvider.getMaximumPageSize());
 				minWanted += currentlyLoaded;
 			}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/ConsentEventsDaoR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/ConsentEventsDaoR4Test.java
@@ -66,8 +66,6 @@ public class ConsentEventsDaoR4Test extends BaseJpaR4SystemTest {
 	public void before() throws ServletException {
 		RestfulServer restfulServer = new RestfulServer();
 		restfulServer.setPagingProvider(myPagingProvider);
-		// TODO KHS get these tests to pass without nulling out the default page size
-		restfulServer.setDefaultPageSize(null);
 
 		when(mySrd.getServer()).thenReturn(restfulServer);
 
@@ -142,7 +140,7 @@ public class ConsentEventsDaoR4Test extends BaseJpaR4SystemTest {
 			}
 		}
 		assertEquals(myObservationIdsEvenOnly.subList(10, 25), returnedIdValues, "Wrong response from " + outcome.getClass());
-		assertEquals(2, hitCount.get());
+		assertEquals(3, hitCount.get());
 	}
 
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/ConsentEventsDaoR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/ConsentEventsDaoR4Test.java
@@ -66,6 +66,8 @@ public class ConsentEventsDaoR4Test extends BaseJpaR4SystemTest {
 	public void before() throws ServletException {
 		RestfulServer restfulServer = new RestfulServer();
 		restfulServer.setPagingProvider(myPagingProvider);
+		// TODO KHS get these tests to pass without nulling out the default page size
+		restfulServer.setDefaultPageSize(null);
 
 		when(mySrd.getServer()).thenReturn(restfulServer);
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4Test.java
@@ -65,6 +65,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -88,7 +89,6 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 	@Autowired
 	@Qualifier(BaseConfig.GRAPHQL_PROVIDER_NAME)
 	private Object myGraphQlProvider;
-	private Integer mySavedDefaultPageSize;
 
 	@Override
 	@AfterEach
@@ -98,7 +98,6 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 		myDaoConfig.setSearchPreFetchThresholds(new DaoConfig().getSearchPreFetchThresholds());
 		ourRestServer.getInterceptorService().unregisterInterceptor(myConsentInterceptor);
 		ourRestServer.unregisterProvider(myGraphQlProvider);
-		ourRestServer.setDefaultPageSize(mySavedDefaultPageSize);
 	}
 
 	@Override
@@ -107,9 +106,6 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 		super.before();
 		myDaoConfig.setSearchPreFetchThresholds(Arrays.asList(20, 50, 190));
 		ourRestServer.registerProvider(myGraphQlProvider);
-		// TODO KHS get these tests to pass without nulling out the default page size
-		mySavedDefaultPageSize = ourRestServer.getDefaultPageSize();
-		ourRestServer.setDefaultPageSize(null);
 	}
 
 	@Test
@@ -131,6 +127,7 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 			.execute();
 		List<IBaseResource> resources = BundleUtil.toListOfResources(myFhirCtx, result);
 		List<String> returnedIdValues = toUnqualifiedVersionlessIdValues(resources);
+		assertThat(returnedIdValues, hasSize(15));
 		assertEquals(myObservationIdsEvenOnly.subList(0, 15), returnedIdValues);
 
 		// Fetch the next page
@@ -140,6 +137,7 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 			.execute();
 		resources = BundleUtil.toListOfResources(myFhirCtx, result);
 		returnedIdValues = toUnqualifiedVersionlessIdValues(resources);
+		assertThat(returnedIdValues, hasSize(10));
 		assertEquals(myObservationIdsEvenOnly.subList(15, 25), returnedIdValues);
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4Test.java
@@ -88,6 +88,7 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 	@Autowired
 	@Qualifier(BaseConfig.GRAPHQL_PROVIDER_NAME)
 	private Object myGraphQlProvider;
+	private Integer mySavedDefaultPageSize;
 
 	@Override
 	@AfterEach
@@ -97,6 +98,7 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 		myDaoConfig.setSearchPreFetchThresholds(new DaoConfig().getSearchPreFetchThresholds());
 		ourRestServer.getInterceptorService().unregisterInterceptor(myConsentInterceptor);
 		ourRestServer.unregisterProvider(myGraphQlProvider);
+		ourRestServer.setDefaultPageSize(mySavedDefaultPageSize);
 	}
 
 	@Override
@@ -105,6 +107,9 @@ public class ConsentInterceptorResourceProviderR4Test extends BaseResourceProvid
 		super.before();
 		myDaoConfig.setSearchPreFetchThresholds(Arrays.asList(20, 50, 190));
 		ourRestServer.registerProvider(myGraphQlProvider);
+		// TODO KHS get these tests to pass without nulling out the default page size
+		mySavedDefaultPageSize = ourRestServer.getDefaultPageSize();
+		ourRestServer.setDefaultPageSize(null);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderInterceptorR4Test.java
@@ -32,7 +32,6 @@ import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -66,26 +65,14 @@ public class ResourceProviderInterceptorR4Test extends BaseResourceProviderR4Tes
 	private IAnonymousInterceptor myHook;
 	@Captor
 	private ArgumentCaptor<HookParams> myParamsCaptor;
-	private Integer mySavedDefaultPageSize;
-
-	@Override
-	@BeforeEach
-	public void before() throws Exception {
-		super.before();
-
-		// TODO KHS get these tests to pass without nulling out the default page size
-		mySavedDefaultPageSize = ourRestServer.getDefaultPageSize();
-		ourRestServer.setDefaultPageSize(null);
-	}
 
 	@Override
 	@AfterEach
 	public void after() throws Exception {
+		super.after();
+
 		myDaoConfig.setSearchPreFetchThresholds(new DaoConfig().getSearchPreFetchThresholds());
 		ourRestServer.getInterceptorService().unregisterAllInterceptors();
-		ourRestServer.setDefaultPageSize(mySavedDefaultPageSize);
-
-		super.after();
 	}
 
 	@Test
@@ -414,6 +401,7 @@ public class ResourceProviderInterceptorR4Test extends BaseResourceProviderR4Tes
 		} finally {
 			ourRestServer.unregisterInterceptor(interceptor);
 		}
+
 
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -675,10 +675,16 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	}
 
 	/**
-	 * Sets the paging provider to use, or <code>null</code> to use no paging (which is the default)
+	 * Sets the paging provider to use, or <code>null</code> to use no paging (which is the default).
+	 * This will set defaultPageSize and maximumPageSize from the paging provider.
 	 */
 	public void setPagingProvider(IPagingProvider thePagingProvider) {
 		myPagingProvider = thePagingProvider;
+		if (myPagingProvider != null) {
+			setDefaultPageSize(myPagingProvider.getDefaultPageSize());
+			setMaximumPageSize(myPagingProvider.getMaximumPageSize());
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
Also when setting the paging provider on a restful server, automatically set the default page size and max page sized of the restful server from the paging provider.