### PR TITLE
Fixed xml.bind conflict between jakakax and javax

### DIFF
--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -79,6 +79,10 @@
 					<groupId>javax.activation</groupId>
 					<artifactId>javax.activation-api</artifactId>
 				</exclusion>
+				<exclusion>
+   					 <groupId>javax.xml.bind</groupId>
+    				 <artifactId>jaxb-api</artifactId>
+                </exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Classpath conflict since `jaxb `is bumped to 3.0.0. The jpaserver-starter can't compile. This is fixed by exclude `jaxb-api` from `hibernate-core`