### PR TITLE
Update to release versions of cql components

### DIFF
--- a/hapi-fhir-jpaserver-cql/pom.xml
+++ b/hapi-fhir-jpaserver-cql/pom.xml
@@ -29,45 +29,6 @@
 			<version>${cql-evaluator.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.opencds.cqf</groupId>
-			<artifactId>tooling</artifactId>
-			<version>${cqf-tooling.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.activation</groupId>
-					<artifactId>javax.activation-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.xml.bind</groupId>
-					<artifactId>jaxb-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>jakarta.xml.bind</groupId>
-					<artifactId>jakarta.xml.bind-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>jakarta.xml.bind</groupId>
-					<artifactId>jaxb-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.istack</groupId>
-					<artifactId>istack-commons-tools</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.istack</groupId>
-					<artifactId>istack-commons-runtime</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>info.bliki.wiki</groupId>
-					<artifactId>bliki-core</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>engine</artifactId>
 			<version>${cql-engine.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -820,10 +820,9 @@
 		<!-- CQL Support -->
 		<!-- FIXME KBD: Change all of these -SNAPSHOT versions to release versions
 		(e.g. 1.3.1-SNAPSHOT -> 1.3.1) before finalizing this work! -->
-		<cqf-tooling.version>1.3.1-SNAPSHOT</cqf-tooling.version>
-		<cql-engine.version>1.5.1-SNAPSHOT</cql-engine.version>
-		<cql-evaluator.version>1.1.0-SNAPSHOT</cql-evaluator.version>
-		<cqframework.version>1.5.2-SNAPSHOT</cqframework.version>
+		<cql-engine.version>1.5.1</cql-engine.version>
+		<cql-evaluator.version>1.1.0</cql-evaluator.version>
+		<cqframework.version>1.5.1</cqframework.version>
 
 		<!-- Site properties -->
 		<fontawesomeVersion>5.4.1</fontawesomeVersion>


### PR DESCRIPTION
* Removed cqf-tooling since it is no longer used
* Update cql-engine to 1.5.1
* Update cql-translator to 1.5.1
* Update cql-evaluator to 1.1.0