### PR TITLE
Fixed bug where AND resource search-params were matched as OR params

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
@@ -225,7 +225,7 @@ public class InMemoryResourceMatcher {
 					if (theSearchParams == null) {
 						return InMemoryMatchResult.successfulMatch();
 					} else {
-						return InMemoryMatchResult.fromBoolean(theAndOrParams.stream().anyMatch(nextAnd -> matchParams(theModelConfig, theResourceName, theParamName, theParamDef, nextAnd, theSearchParams)));
+						return InMemoryMatchResult.fromBoolean(theAndOrParams.stream().allMatch(nextAnd -> matchParams(theModelConfig, theResourceName, theParamName, theParamDef, nextAnd, theSearchParams)));
 					}
 				case COMPOSITE:
 				case HAS:

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
@@ -288,6 +288,27 @@ public class InMemoryResourceMatcherR5Test {
 		assertFalse(result.matched());
 	}
 
+	@Test
+	public void testInPeriod() {
+		Observation insidePeriodObservation = new Observation();
+		insidePeriodObservation.setEffective(new DateTimeType("1985-01-01T00:00:00Z"));
+		ResourceIndexedSearchParams insidePeriodSearchParams = extractDateSearchParam(insidePeriodObservation);
+
+		Observation outsidePeriodObservation = new Observation();
+		outsidePeriodObservation.setEffective(new DateTimeType("2010-01-01T00:00:00Z"));
+		ResourceIndexedSearchParams outsidePeriodSearchParams = extractDateSearchParam(outsidePeriodObservation);
+
+		String search = "date=gt" + EARLY_DATE + "&date=le" + LATE_DATE;
+
+		InMemoryMatchResult resultInsidePeriod = myInMemoryResourceMatcher.match(search, insidePeriodObservation, insidePeriodSearchParams);
+		assertTrue(resultInsidePeriod.supported(), resultInsidePeriod.getUnsupportedReason());
+		assertTrue(resultInsidePeriod.matched());
+
+		InMemoryMatchResult resultOutsidePeriod = myInMemoryResourceMatcher.match(search, outsidePeriodObservation, outsidePeriodSearchParams);
+		assertTrue(resultOutsidePeriod.supported(), resultOutsidePeriod.getUnsupportedReason());
+		assertFalse(resultOutsidePeriod.matched());
+	}
+
 
 	private ResourceIndexedSearchParams extractDateSearchParam(Observation theObservation) {
 		ResourceIndexedSearchParams retval = new ResourceIndexedSearchParams();


### PR DESCRIPTION
The `InMemoryResourceMatcher` contained a bug where AND search parameters were evaluated and matched as OR parameters.

This caused issues where for example `GET /fhir/DocumentReference?indexed=ge2018-01-01&indexed=le2019-01-01` would return DocumentReferences with an indexed data of 2020-01-01.