### PR TITLE
Remove only provider-specific method bindings, not all base on resource name

### DIFF
--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerTest.java
@@ -3,14 +3,19 @@ package ca.uhn.fhir.rest.server;
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Metadata;
+import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.server.IFhirVersionServer;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseConformance;
+import org.hl7.fhir.instance.model.api.IBaseMetaType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,12 +26,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class RestfulServerTest {
@@ -41,6 +44,32 @@ public class RestfulServerTest {
 
 		restfulServer = new RestfulServer(myCtx);
 		restfulServer.init();
+	}
+
+	private void mockResource(Class theClass) {
+		RuntimeResourceDefinition resourceDefinitionMock = mock(RuntimeResourceDefinition.class);
+		String className = theClass.getSimpleName();
+		lenient().when(resourceDefinitionMock.getName()).thenReturn(className);
+		lenient().when(myCtx.getResourceDefinition(className)).thenReturn(resourceDefinitionMock);
+		lenient().when(myCtx.getResourceType(theClass)).thenReturn(className);
+	}
+
+	@Test
+	public void testRegisterProvidersWithMethodBindings() {
+		mockResource(MyResource.class);
+		mockResource(MyResource2.class);
+
+		MyProvider provider = new MyProvider();
+		restfulServer.registerProvider(provider);
+		MyProvider2 provider2 = new MyProvider2();
+		restfulServer.registerProvider(provider2);
+
+		assertFalse(restfulServer.getProviderMethodBindings(provider).isEmpty());
+		assertFalse(restfulServer.getProviderMethodBindings(provider2).isEmpty());
+
+		restfulServer.unregisterProvider(provider);
+		assertTrue(restfulServer.getProviderMethodBindings(provider).isEmpty());
+		assertFalse(restfulServer.getProviderMethodBindings(provider2).isEmpty());
 	}
 
 	@Test
@@ -121,6 +150,91 @@ public class RestfulServerTest {
 		public Class<? extends IBaseResource> getResourceType() {
 			return IBaseResource.class;
 		}
+	}
+
+	private static class MyProvider implements IResourceProvider {
+		@Operation(name = "SHOW_ME_THE_MONEY", typeName = "MyResource")
+		public IBaseBundle match() {
+			return mock(IBaseBundle.class);
+		}
+
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return MyResource.class;
+		}
+	}
+
+	private static class MyProvider2 implements IResourceProvider {
+		@Operation(name = "SHOW_ME_MORE_MONEY", typeName = "MyResource2")
+		public IBaseBundle match() {
+			return mock(IBaseBundle.class);
+		}
+
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return MyResource2.class;
+		}
+	}
+
+	private static class MyResource implements IBaseResource {
+
+		@Override
+		public boolean isEmpty() {
+			return false;
+		}
+
+		@Override
+		public boolean hasFormatComment() {
+			return false;
+		}
+
+		@Override
+		public List<String> getFormatCommentsPre() {
+			return null;
+		}
+
+		@Override
+		public List<String> getFormatCommentsPost() {
+			return null;
+		}
+
+		@Override
+		public Object getUserData(String theName) {
+			return null;
+		}
+
+		@Override
+		public void setUserData(String theName, Object theValue) {
+
+		}
+
+		@Override
+		public IBaseMetaType getMeta() {
+			return null;
+		}
+
+		@Override
+		public IIdType getIdElement() {
+			return null;
+		}
+
+		@Override
+		public IBaseResource setId(String theId) {
+			return null;
+		}
+
+		@Override
+		public IBaseResource setId(IIdType theId) {
+			return null;
+		}
+
+		@Override
+		public FhirVersionEnum getStructureFhirVersionEnum() {
+			return null;
+		}
+	}
+
+	private static class MyResource2 extends MyResource {
 	}
 
 }


### PR DESCRIPTION
When we are deregistering providers, there might be multiple bindings from different providers for the same resource name. Only the provider bindings should be removed.