### PR TITLE
UTF-16 characters might cause errors when calculating hash values

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/StringUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/StringUtil.java
@@ -78,4 +78,37 @@ public class StringUtil {
 		return new String(bytes, StandardCharsets.UTF_8);
 	}
 
+	/**
+	 * Gets the string prefix of the specified length.
+	 *
+	 * @param theString
+	 * 	String to get the prefix from
+	 * @param theCodePointCount
+	 * 	Length of the prefix in code points
+	 * @return
+	 * 	Returns the string prefix of the specified number of codepoints.
+	 */
+	public static String left(String theString, int theCodePointCount) {
+		if (theString == null) {
+			return null;
+		}
+
+		if (theCodePointCount < 0) {
+			return "";
+		}
+
+		if (theString.length() <= theCodePointCount) {
+			return theString;
+		}
+
+		StringBuilder retVal = new StringBuilder();
+		for (int offset = 0; offset < theCodePointCount; ) {
+			int codePoint = theString.codePointAt(offset);
+			offset += Character.charCount(codePoint);
+			retVal.append(Character.toChars(codePoint));
+		}
+
+		return retVal.toString();
+	}
+
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/StringUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/StringUtil.java
@@ -97,6 +97,7 @@ public class StringUtil {
 			return "";
 		}
 
+		// char count can only be bigger than the code point count
 		if (theString.length() <= theCodePointCount) {
 			return theString;
 		}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/StringUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/StringUtil.java
@@ -101,14 +101,7 @@ public class StringUtil {
 			return theString;
 		}
 
-		StringBuilder retVal = new StringBuilder();
-		for (int offset = 0; offset < theCodePointCount; ) {
-			int codePoint = theString.codePointAt(offset);
-			offset += Character.charCount(codePoint);
-			retVal.append(Character.toChars(codePoint));
-		}
-
-		return retVal.toString();
+		return theString.substring(0, theString.offsetByCodePoints(0, theCodePointCount));
 	}
 
 }

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/StringUtilTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/StringUtilTest.java
@@ -10,8 +10,21 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class StringUtilTest {
+
+	@Test
+	public void testLeft() {
+		assertNull(StringUtil.left(null, 1));
+		assertEquals("", StringUtil.left("", 10));
+		assertEquals("STR", StringUtil.left("STR", 10));
+		assertEquals(".", StringUtil.left("...", 1));
+
+		// check supplementary chars
+		assertEquals("\uD800\uDF01", StringUtil.left("\uD800\uDF01\uD800\uDF02", 1));
+	}
+
 	@Test
 	public void testNormalizeString() {
 		assertEquals("TEST TEST", StringUtil.normalizeStringForSearchIndexing("TEST teSt"));

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -48,7 +48,6 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
-import static org.apache.commons.lang3.StringUtils.left;
 
 //@formatter:off
 @Embeddable
@@ -289,6 +288,7 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 			hashPrefixLength = 0;
 		}
 
-		return hash(thePartitionSettings, theRequestPartitionId, theResourceType, theParamName, left(theValueNormalized, hashPrefixLength));
+		return hash(thePartitionSettings, theRequestPartitionId, theResourceType, theParamName, StringUtil.left(theValueNormalized, hashPrefixLength));
 	}
+
 }


### PR DESCRIPTION
Attempting to create a resource with char values outside of the Basic Multilingual Plane might cause an error when calculating hash values.