### PR TITLE
Restful server can handle multiple fhircontext versions

### DIFF
--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -84,6 +84,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Use mockito-inline instead of mockito-core for testing static methods. -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>3.6.28</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/IRestfulServerDefaults.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/IRestfulServerDefaults.java
@@ -1,12 +1,14 @@
 package ca.uhn.fhir.rest.server;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.api.AddProfileTagEnum;
 import ca.uhn.fhir.interceptor.api.IInterceptorService;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
 
 import java.util.List;
+import java.util.Map;
 
 /*
  * #%L
@@ -63,6 +65,18 @@ public interface IRestfulServerDefaults {
 	 * creating their own.
 	 */
 	FhirContext getFhirContext();
+
+	/**
+	 * Gets a {@link FhirContext} associated with the given version and this server
+	 * in case a different version is required than that of {@link #getFhirContext()}.
+	 */
+	default FhirContext getFhirContext(FhirVersionEnum fhirVersion) {
+		if (getFhirContext().getVersion().getVersion().equals(fhirVersion)) {
+			return getFhirContext();
+		} else {
+			return fhirVersion.newContext();
+		}
+	}
 
 	/**
 	 * Returns the list of interceptors registered against this server

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.rest.server;
 
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.context.api.AddProfileTagEnum;
 import ca.uhn.fhir.context.api.BundleInclusionRule;
@@ -146,6 +147,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	private EncodingEnum myDefaultResponseEncoding = EncodingEnum.JSON;
 	private ETagSupportEnum myETagSupport = DEFAULT_ETAG_SUPPORT;
 	private FhirContext myFhirContext;
+	private Map<FhirVersionEnum, FhirContext> myFhirContextMap = new HashMap<>();
 	private boolean myIgnoreServerParsedRequestParameters = true;
 	private String myImplementationDescription;
 	private IPagingProvider myPagingProvider;
@@ -607,6 +609,26 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	public void setFhirContext(FhirContext theFhirContext) {
 		Validate.notNull(theFhirContext, "FhirContext must not be null");
 		myFhirContext = theFhirContext;
+	}
+
+	/**
+	 * Gets a {@link FhirContext} associated with the given version and this server
+	 * in case a different version is required than that of {@link #getFhirContext()}.
+	 */
+	public FhirContext getFhirContext(FhirVersionEnum theFhirVersion) {
+		if (getFhirContext().getVersion().getVersion().equals(theFhirVersion)) {
+			return getFhirContext();
+		} else {
+			return myFhirContextMap.computeIfAbsent(theFhirVersion, FhirVersionEnum::newContext);
+		}
+	}
+
+	public void addFhirContext(FhirVersionEnum theFhirVersion, FhirContext theVersionFhirContext) {
+		myFhirContextMap.put(theFhirVersion, theVersionFhirContext);
+	}
+
+	public Map<FhirVersionEnum, FhirContext> getFhirContextMap() {
+		return myFhirContextMap;
 	}
 
 	public String getImplementationDescription() {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -715,20 +715,23 @@ public class RestfulServerUtils {
 
 	public static IParser getNewParser(FhirContext theContext, FhirVersionEnum theForVersion, RequestDetails theRequestDetails) {
 		FhirContext context = getContextForVersion(theContext, theForVersion);
+		return getNewParser(context, theRequestDetails);
+	}
 
+	public static IParser getNewParser(FhirContext theContext, RequestDetails theRequestDetails) {
 		// Determine response encoding
 		EncodingEnum responseEncoding = RestfulServerUtils.determineResponseEncodingWithDefault(theRequestDetails).getEncoding();
 		IParser parser;
 		switch (responseEncoding) {
 			case JSON:
-				parser = context.newJsonParser();
+				parser = theContext.newJsonParser();
 				break;
 			case RDF:
-				parser = context.newRDFParser();
+				parser = theContext.newRDFParser();
 				break;
 			case XML:
 			default:
-				parser = context.newXmlParser();
+				parser = theContext.newXmlParser();
 				break;
 		}
 
@@ -1009,7 +1012,7 @@ public class RestfulServerUtils {
 			}
 		} else {
 			FhirVersionEnum forVersion = theResource.getStructureFhirVersionEnum();
-			IParser parser = getNewParser(theServer.getFhirContext(), forVersion, theRequestDetails);
+			IParser parser = getNewParser(theServer.getFhirContext(forVersion), theRequestDetails);
 			parser.encodeResourceToWriter(theResource, writer);
 		}
 

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.ServletException;
@@ -70,6 +72,23 @@ public class RestfulServerTest {
 		restfulServer.unregisterProvider(provider);
 		assertTrue(restfulServer.getProviderMethodBindings(provider).isEmpty());
 		assertFalse(restfulServer.getProviderMethodBindings(provider2).isEmpty());
+	}
+
+	@Test
+	public void testFhirContextMap() {
+		FhirContext r4Ctx = Mockito.mock(FhirContext.class, Answers.RETURNS_DEEP_STUBS);
+		when(r4Ctx.getVersion().getVersion()).thenReturn(FhirVersionEnum.R4);
+
+		try (MockedStatic<FhirContext> mfc = Mockito.mockStatic(FhirContext.class)) {
+			// stub the static method that is called by the class under test
+			mfc.when(FhirContext::forR4).thenReturn(r4Ctx);
+
+			assertEquals(myCtx, restfulServer.getFhirContext(FhirVersionEnum.DSTU3));
+			assertNotNull(restfulServer.getFhirContext(FhirVersionEnum.R4));
+
+			restfulServer.addFhirContext(FhirVersionEnum.R4, r4Ctx);
+			assertEquals(r4Ctx, restfulServer.getFhirContext(FhirVersionEnum.R4));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
I am currently trying to work with multiple fhir versions simultaneously by using
one fhir servlet with R4 FhirContext and a resource provider for R4 and an
additional interceptor which converts incoming R3 resources into R4 and the same for outgoing resources.

This is working more or less. 

However, for the outgoing resources there is a problem when the parser needs some non-standard properties:

At the very end of the call stack the RestfulServerUtils class is used for transforming
the Resource into a String. In order to do so, it needs a `FhirContext`. 
However, the context of the server here is of course R4 while R3 is needed. 
The utils class then creates a new default context in the `getNewParser` method using the `getContextForVersion`.

In order to make the new `FhirContext` aware of necessary configurations one
could either trying to copy the configuration from the R4 configuration to the R3 context.
Alternatively one could open the backing `Map<FhirVersionEnum, FhirContext>` by e.g. adding a method
```
    public static void addFhirContext(FhirVersionEnum fhirVersion, FhirContext fhirContext) {
        myFhirContextMap.put(fhirVersion, fhirContext);
    }
```

This alternative has the advantage that the configuration is explicit and does not depend
on some implicit conversion which might even run into incompatibilities between R3 and R4.

A cleaner and more powerful way for doing this, would probably be to add this structure to
the `RestfulServer` and access it via the `IRestfulServerDefaults`

I have explored the latter in this patch which adds a new data structure to the RestfulServer
- a map of `FhirVersionEnums` to `FhirContext` - which is then used by the
`RestfulServerUtils` when serializing a resource.