### PR TITLE
Support MDM expansion in Group Bulk Export

### DIFF
--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -230,6 +230,7 @@
 			</exclusions>
 		</dependency>
 
+
 		<!-- Patch Dependencies -->
 		<dependency>
 			<groupId>io.dogote</groupId>
@@ -258,6 +259,7 @@
 			<groupId>javax.annotation</groupId>
 			<artifactId>javax.annotation-api</artifactId>
 		</dependency>
+
 
 		<!-- Test Database -->
 		<dependency>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/BatchJobsConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/BatchJobsConfig.java
@@ -28,7 +28,9 @@ import org.springframework.context.annotation.Import;
 //When you define a new batch job, add it here.
 @Import({
 	CommonBatchJobConfig.class,
-	BulkExportJobConfig.class,})
+	BulkExportJobConfig.class
+})
 public class BatchJobsConfig {
-	//Empty config, as this is just an aggregator for all the various batch jobs defined around the system.
+	public static final String BULK_EXPORT_JOB_NAME = "bulkExportJob";
+	public static final String GROUP_BULK_EXPORT_JOB_NAME = "groupBulkExportJob";
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BaseBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BaseBulkItemReader.java
@@ -1,0 +1,140 @@
+package ca.uhn.fhir.jpa.bulk.job;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeResourceDefinition;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.batch.log.Logs;
+import ca.uhn.fhir.jpa.dao.ISearchBuilder;
+import ca.uhn.fhir.jpa.dao.SearchBuilderFactory;
+import ca.uhn.fhir.jpa.dao.data.IBulkExportJobDao;
+import ca.uhn.fhir.jpa.entity.BulkExportJobEntity;
+import ca.uhn.fhir.jpa.model.util.JpaConstants;
+import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.util.UrlUtil;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.slf4j.Logger;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class BaseBulkItemReader implements ItemReader<List<ResourcePersistentId>> {
+	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
+
+	@Value("#{stepExecutionContext['resourceType']}")
+	protected String myResourceType;
+	@Value("#{jobExecutionContext['" + BulkExportJobConfig.JOB_UUID_PARAMETER + "']}")
+	protected String myJobUUID;
+	@Value("#{jobParameters['" + BulkExportJobConfig.READ_CHUNK_PARAMETER + "']}")
+	protected Long myReadChunkSize;
+	@Autowired
+	protected DaoRegistry myDaoRegistry;
+	@Autowired
+	protected FhirContext myContext;
+	@Autowired
+	private IBulkExportJobDao myBulkExportJobDao;
+	@Autowired
+	protected SearchBuilderFactory mySearchBuilderFactory;
+	@Autowired
+	private MatchUrlService myMatchUrlService;
+
+	private ISearchBuilder mySearchBuilder;
+	private BulkExportJobEntity myJobEntity;
+	private RuntimeResourceDefinition myResourceDefinition;
+
+	private Iterator<ResourcePersistentId> myPidIterator;
+
+	/**
+	 * Get and cache an ISearchBuilder for the given resource type this partition is responsible for.
+	 */
+	protected ISearchBuilder getSearchBuilderForLocalResourceType() {
+		if (mySearchBuilder == null) {
+			IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(myResourceType);
+			RuntimeResourceDefinition def = myContext.getResourceDefinition(myResourceType);
+			Class<? extends IBaseResource> nextTypeClass = def.getImplementingClass();
+			mySearchBuilder = mySearchBuilderFactory.newSearchBuilder(dao, myResourceType, nextTypeClass);
+		}
+		return mySearchBuilder;
+	}
+
+	/**
+	 * Generate the list of pids of all resources of the given myResourceType, which reference any group member of the given myGroupId.
+	 * Store them in a member iterator.
+	 */
+	protected void loadResourcePids() {
+		//Initialize an array to hold the pids of the target resources to be exported.
+		myPidIterator = getResourcePidIterator();
+	}
+
+	abstract Iterator<ResourcePersistentId> getResourcePidIterator();
+
+	protected SearchParameterMap createSearchParameterMapForJob() {
+		BulkExportJobEntity jobEntity = getJobEntity();
+		RuntimeResourceDefinition theDef = getResourceDefinition();
+		SearchParameterMap map = new SearchParameterMap();
+		Map<String, String[]> requestUrl = UrlUtil.parseQueryStrings(jobEntity.getRequest());
+		String[] typeFilters = requestUrl.get(JpaConstants.PARAM_EXPORT_TYPE_FILTER);
+		if (typeFilters != null) {
+			Optional<String> filter = Arrays.stream(typeFilters).filter(t -> t.startsWith(myResourceType + "?")).findFirst();
+			if (filter.isPresent()) {
+				String matchUrl = filter.get();
+				map = myMatchUrlService.translateMatchUrl(matchUrl, theDef);
+			}
+		}
+		if (jobEntity.getSince() != null) {
+			map.setLastUpdated(new DateRangeParam(jobEntity.getSince(), null));
+		}
+		map.setLoadSynchronous(true);
+		return map;
+	}
+
+	protected RuntimeResourceDefinition getResourceDefinition() {
+		if (myResourceDefinition == null) {
+			myResourceDefinition = myContext.getResourceDefinition(myResourceType);
+		}
+		return myResourceDefinition;
+	}
+
+	protected BulkExportJobEntity getJobEntity() {
+		if (myJobEntity == null) {
+			Optional<BulkExportJobEntity> jobOpt = myBulkExportJobDao.findByJobId(myJobUUID);
+			if (jobOpt.isPresent()) {
+				myJobEntity = jobOpt.get();
+			} else {
+				String errorMessage = String.format("Job with UUID %s does not exist!", myJobUUID);
+				throw new IllegalStateException(errorMessage);
+			}
+		}
+		return myJobEntity;
+	}
+
+	@Override
+	public List<ResourcePersistentId> read() {
+
+		ourLog.info("Bulk export starting generation for batch export job: [{}] with resourceType [{}] and UUID [{}]", getJobEntity(), myResourceType, myJobUUID);
+
+		if (myPidIterator == null) {
+			loadResourcePids();
+		}
+
+		int count = 0;
+		List<ResourcePersistentId> outgoing = new ArrayList<>();
+		while (myPidIterator.hasNext() && count < myReadChunkSize) {
+			outgoing.add(myPidIterator.next());
+			count += 1;
+		}
+
+		return outgoing.size() == 0 ? null : outgoing;
+
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
@@ -48,6 +48,7 @@ import java.util.List;
 public class BulkExportJobConfig {
 	public static final String JOB_UUID_PARAMETER = "jobUUID";
 	public static final String READ_CHUNK_PARAMETER = "readChunkSize";
+	public static final String EXPAND_MDM_PARAMETER = "expandMdm";
 	public static final String GROUP_ID_PARAMETER = "groupId";
 	public static final String RESOURCE_TYPES_PARAMETER = "resourceTypes";
 	public static final int CHUNK_SIZE = 100;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
@@ -20,6 +20,7 @@ package ca.uhn.fhir.jpa.bulk.job;
  * #L%
  */
 
+import ca.uhn.fhir.jpa.batch.BatchJobsConfig;
 import ca.uhn.fhir.jpa.batch.processors.PidToIBaseResourceProcessor;
 import ca.uhn.fhir.jpa.bulk.svc.BulkExportDaoSvc;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
@@ -46,6 +47,7 @@ import java.util.List;
  */
 @Configuration
 public class BulkExportJobConfig {
+
 	public static final String JOB_UUID_PARAMETER = "jobUUID";
 	public static final String READ_CHUNK_PARAMETER = "readChunkSize";
 	public static final String EXPAND_MDM_PARAMETER = "expandMdm";
@@ -70,7 +72,7 @@ public class BulkExportJobConfig {
 	@Bean
 	@Lazy
 	public Job bulkExportJob() {
-		return myJobBuilderFactory.get("bulkExportJob")
+		return myJobBuilderFactory.get(BatchJobsConfig.BULK_EXPORT_JOB_NAME)
 			.validator(bulkJobParameterValidator())
 			.start(createBulkExportEntityStep())
 			.next(partitionStep())
@@ -81,7 +83,7 @@ public class BulkExportJobConfig {
 	@Bean
 	@Lazy
 	public Job groupBulkExportJob() {
-		return myJobBuilderFactory.get("groupBulkExportJob")
+		return myJobBuilderFactory.get(BatchJobsConfig.GROUP_BULK_EXPORT_JOB_NAME)
 			.validator(groupBulkJobParameterValidator())
 			.validator(bulkJobParameterValidator())
 			.start(createBulkExportEntityStep())

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkItemReader.java
@@ -20,15 +20,12 @@ package ca.uhn.fhir.jpa.bulk.job;
  * #L%
  */
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
-import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.batch.log.Logs;
 import ca.uhn.fhir.jpa.dao.IResultIterator;
 import ca.uhn.fhir.jpa.dao.ISearchBuilder;
-import ca.uhn.fhir.jpa.dao.SearchBuilderFactory;
 import ca.uhn.fhir.jpa.dao.data.IBulkExportJobDao;
 import ca.uhn.fhir.jpa.entity.BulkExportJobEntity;
 import ca.uhn.fhir.jpa.model.search.SearchRuntimeDetails;
@@ -38,11 +35,8 @@ import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.util.UrlUtil;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,89 +45,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class BulkItemReader implements ItemReader<List<ResourcePersistentId>> {
+/**
+ * Basic Bulk Export implementation which simply reads all type filters and applies them, along with the _since param
+ * on a given resource type.
+ */
+public class BulkItemReader extends BaseBulkItemReader {
 	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
-	Iterator<ResourcePersistentId> myPidIterator;
 
 
-	@Value("#{jobParameters['" + BulkExportJobConfig.READ_CHUNK_PARAMETER + "']}")
-	private Long myReadChunkSize;
-	@Value("#{jobExecutionContext['"+ BulkExportJobConfig.JOB_UUID_PARAMETER+"']}")
-	private String myJobUUID;
-	@Value("#{stepExecutionContext['resourceType']}")
-	private String myResourceType;
-
-	@Autowired
-	private IBulkExportJobDao myBulkExportJobDao;
-	@Autowired
-	private DaoRegistry myDaoRegistry;
-	@Autowired
-	private FhirContext myContext;
-	@Autowired
-	private SearchBuilderFactory mySearchBuilderFactory;
-
-	@Autowired
-	private MatchUrlService myMatchUrlService;
-
-	private void loadResourcePids() {
-		Optional<BulkExportJobEntity> jobOpt = myBulkExportJobDao.findByJobId(myJobUUID);
-		if (!jobOpt.isPresent()) {
-			ourLog.warn("Job appears to be deleted");
-			return;
-		}
-		BulkExportJobEntity jobEntity = jobOpt.get();
-		ourLog.info("Bulk export starting generation for batch export job: {}", jobEntity);
-
-		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(myResourceType);
-
+	@Override
+	Iterator<ResourcePersistentId> getResourcePidIterator() {
 		ourLog.info("Bulk export assembling export of type {} for job {}", myResourceType, myJobUUID);
 
-		RuntimeResourceDefinition def = myContext.getResourceDefinition(myResourceType);
-		Class<? extends IBaseResource> nextTypeClass = def.getImplementingClass();
-		ISearchBuilder sb = mySearchBuilderFactory.newSearchBuilder(dao, myResourceType, nextTypeClass);
 
-		SearchParameterMap map = createSearchParameterMapFromTypeFilter(jobEntity, def);
-
-		if (jobEntity.getSince() != null) {
-			map.setLastUpdated(new DateRangeParam(jobEntity.getSince(), null));
-		}
-
-		map.setLoadSynchronous(true);
+		SearchParameterMap map = createSearchParameterMapForJob();
+		ISearchBuilder sb = getSearchBuilderForLocalResourceType();
 		IResultIterator myResultIterator = sb.createQuery(map, new SearchRuntimeDetails(null, myJobUUID), null, RequestPartitionId.allPartitions());
+
 		List<ResourcePersistentId> myReadPids = new ArrayList<>();
 		while (myResultIterator.hasNext()) {
 			myReadPids.add(myResultIterator.next());
 		}
-		myPidIterator = myReadPids.iterator();
+		return myReadPids.iterator();
 	}
 
-	private SearchParameterMap createSearchParameterMapFromTypeFilter(BulkExportJobEntity theJobEntity, RuntimeResourceDefinition theDef) {
-		SearchParameterMap map = new SearchParameterMap();
-		Map<String, String[]> requestUrl = UrlUtil.parseQueryStrings(theJobEntity.getRequest());
-		String[] typeFilters = requestUrl.get(JpaConstants.PARAM_EXPORT_TYPE_FILTER);
-		if (typeFilters != null) {
-			Optional<String> filter = Arrays.stream(typeFilters).filter(t -> t.startsWith(myResourceType + "?")).findFirst();
-			if (filter.isPresent()) {
-				String matchUrl = filter.get();
-				map = myMatchUrlService.translateMatchUrl(matchUrl, theDef);
-			}
-		}
-		return map;
-	}
-
-	@Override
-	public List<ResourcePersistentId> read() {
-		if (myPidIterator == null) {
-			loadResourcePids();
-		}
-		int count = 0;
-		List<ResourcePersistentId> outgoing = new ArrayList<>();
-		while (myPidIterator.hasNext() && count < myReadChunkSize) {
-			outgoing.add(myPidIterator.next());
-			count += 1;
-		}
-
-		return outgoing.size() == 0 ? null : outgoing;
-
-	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkExportJobParametersBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkExportJobParametersBuilder.java
@@ -5,4 +5,9 @@ public class GroupBulkExportJobParametersBuilder extends BulkExportJobParameters
 		this.addString(BulkExportJobConfig.GROUP_ID_PARAMETER, theGroupId);
 		return this;
 	}
+
+	public GroupBulkExportJobParametersBuilder setMdm(boolean theMdm) {
+		this.addString(BulkExportJobConfig.EXPAND_MDM_PARAMETER, String.valueOf(theMdm));
+		return this;
+	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
@@ -69,7 +69,7 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 
 	@Value("#{jobParameters['" + BulkExportJobConfig.GROUP_ID_PARAMETER + "']}")
 	private String myGroupId;
-	@Value("#{jobParameters['" + BulkExportJobConfig.EXPAND_MDM_PARAMETER+ "'] ?:false}")
+	@Value("#{jobParameters['" + BulkExportJobConfig.EXPAND_MDM_PARAMETER+ "'] ?: false}")
 	private boolean myMdmEnabled;
 
 	@Autowired

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
@@ -203,7 +203,7 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 	private RuntimeSearchParam validateSearchParameters(SearchParameterMap expandedSpMap) {
 		RuntimeSearchParam runtimeSearchParam = getPatientSearchParam();
 		if (expandedSpMap.get(runtimeSearchParam.getName()) != null) {
-			throw new IllegalArgumentException(String.format("Group Bulk Export manually modifies the Search Parameter called [{}], so you may not include this search parameter in your _typeFilter!", runtimeSearchParam.getName()));
+			throw new IllegalArgumentException(String.format("Group Bulk Export manually modifies the Search Parameter called [%s], so you may not include this search parameter in your _typeFilter!", runtimeSearchParam.getName()));
 		}
 		return runtimeSearchParam;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
@@ -69,7 +69,7 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 
 	@Value("#{jobParameters['" + BulkExportJobConfig.GROUP_ID_PARAMETER + "']}")
 	private String myGroupId;
-	@Value("#{jobParameters['" + BulkExportJobConfig.EXPAND_MDM_PARAMETER+ "']}")
+	@Value("#{jobParameters['" + BulkExportJobConfig.EXPAND_MDM_PARAMETER+ "'] ?:false}")
 	private boolean myMdmEnabled;
 
 	@Autowired

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/provider/BulkDataExportProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/provider/BulkDataExportProvider.java
@@ -189,6 +189,10 @@ public class BulkDataExportProvider {
 		@IdParam IIdType theIdParam,
 		@OperationParam(name = JpaConstants.PARAM_EXPORT_OUTPUT_FORMAT, min = 0, max = 1, typeName = "string") IPrimitiveType<String> theOutputFormat,
 		@OperationParam(name = JpaConstants.PARAM_EXPORT_TYPE, min = 0, max = 1, typeName = "string") IPrimitiveType<String> theType,
+		@OperationParam(name = JpaConstants.PARAM_EXPORT_SINCE, min = 0, max = 1, typeName = "instant") IPrimitiveType<Date> theSince,
+		@OperationParam(name = JpaConstants.PARAM_EXPORT_TYPE_FILTER, min = 0, max = 1, typeName = "string") IPrimitiveType<String> theTypeFilter,
+		@OperationParam(name = JpaConstants.PARAM_EXPORT_MDM, min = 0, max = 1, typeName = "boolean") IPrimitiveType<Boolean> theMdm,
+
 		ServletRequestDetails theRequestDetails
 	) {
 
@@ -207,10 +211,20 @@ public class BulkDataExportProvider {
 
 		//TODO GGG eventually, we will support these things. 
 		Set<String> filters = null;
-		Date since = null;
-		boolean theMdm = false;
 
-		IBulkDataExportSvc.JobInfo outcome = myBulkDataExportSvc.submitJob(new GroupBulkDataExportOptions(outputFormat, resourceTypes, since, filters, theIdParam, theMdm));
+		Date since = null;
+		if (theSince != null) {
+			since = theSince.getValue();
+		}
+
+		boolean mdm = false;
+		if (theMdm != null) {
+			mdm = theMdm.getValue();
+		}
+		if (theTypeFilter != null) {
+			filters = ArrayUtil.commaSeparatedListToCleanSet(theTypeFilter.getValueAsString());
+		}
+		IBulkDataExportSvc.JobInfo outcome = myBulkDataExportSvc.submitJob(new GroupBulkDataExportOptions(outputFormat, resourceTypes, since, filters, theIdParam, mdm));
 
 		String serverBase = getServerBase(theRequestDetails);
 		String pollLocation = serverBase + "/" + JpaConstants.OPERATION_EXPORT_POLL_STATUS + "?" + JpaConstants.PARAM_EXPORT_POLL_STATUS_JOB_ID + "=" + outcome.getJobId();

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
@@ -40,12 +40,6 @@ public interface IMdmLinkDao extends JpaRepository<MdmLink, Long> {
 	@Query("DELETE FROM MdmLink f WHERE (myGoldenResourcePid = :pid OR mySourcePid = :pid) AND myMatchResult <> :matchResult")
 	int deleteWithAnyReferenceToPidAndMatchResultNot(@Param("pid") Long thePid, @Param("matchResult") MdmMatchResultEnum theMatchResult);
 
-	@Query("SELECT f.myGoldenResourcePid, f.mySourcePid FROM MdmLink f WHERE f.myMatchResult=:matchResult AND f.myGoldenResourcePid IN (:pids)")
-	List<Long> expandGoldenResourcePids(@Param("pids")List<Long> theGoldenResourcePids, @Param("matchResult") MdmMatchResultEnum theMdmMatchResultEnum);
-
-	@Query("SELECT f.myGoldenResourcePid FROM MdmLink f WHERE f.mySourcePid IN (:pids)")
-	List<Long> getGoldenResourcePids(@Param("pids") List<Long> theSourcePids);
-
 	@Query("SELECT ml2.myGoldenResourcePid, ml2.mySourcePid FROM MdmLink ml2 " +
 		"WHERE ml2.myMatchResult=:matchResult " +
 		"AND ml2.myGoldenResourcePid IN (" +

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
@@ -52,6 +52,9 @@ public interface IMdmLinkDao extends JpaRepository<MdmLink, Long> {
 			"SELECT ml.myGoldenResourcePid FROM MdmLink ml " +
 			"INNER JOIN ResourceLink hrl " +
 			"ON hrl.myTargetResourcePid=ml.mySourcePid " +
-			"AND hrl.mySourceResourcePid=:groupPid)")
+			"AND hrl.mySourceResourcePid=:groupPid " +
+			"AND hrl.mySourcePath='Group.member.entity' " +
+			"AND hrl.myTargetResourceType='Patient'" +
+		")")
 	List<List<Long>> expandPidsFromGroupPidGivenMatchResult(@Param("groupPid") Long theGroupPid, @Param("matchResult") MdmMatchResultEnum theMdmMatchResultEnum);
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
@@ -40,7 +40,7 @@ public interface IMdmLinkDao extends JpaRepository<MdmLink, Long> {
 	@Query("DELETE FROM MdmLink f WHERE (myGoldenResourcePid = :pid OR mySourcePid = :pid) AND myMatchResult <> :matchResult")
 	int deleteWithAnyReferenceToPidAndMatchResultNot(@Param("pid") Long thePid, @Param("matchResult") MdmMatchResultEnum theMatchResult);
 
-	@Query("SELECT f.mySourcePid FROM MdmLink f WHERE f.myMatchResult=:matchResult AND f.myGoldenResourcePid IN (:pids)")
+	@Query("SELECT f.myGoldenResourcePid, f.mySourcePid FROM MdmLink f WHERE f.myMatchResult=:matchResult AND f.myGoldenResourcePid IN (:pids)")
 	List<Long> expandGoldenResourcePids(@Param("pids")List<Long> theGoldenResourcePids, @Param("matchResult") MdmMatchResultEnum theMdmMatchResultEnum);
 
 	@Query("SELECT f.myGoldenResourcePid FROM MdmLink f WHERE f.mySourcePid IN (:pids)")

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -381,7 +381,6 @@ public class IdHelperService {
 	}
 
 	public Map<Long, Optional<String>> translatePidsToForcedIds(Set<Long> thePids) {
-
 		Map<Long, Optional<String>> retVal = new HashMap<>(myMemoryCacheService.getAllPresent(MemoryCacheService.CacheEnum.FORCED_ID, thePids));
 
 		List<Long> remainingPids = thePids
@@ -432,6 +431,12 @@ public class IdHelperService {
 		List<IIdType> ids = Collections.singletonList(theId);
 		List<ResourcePersistentId> resourcePersistentIds = this.resolveResourcePersistentIdsWithCache(RequestPartitionId.allPartitions(), ids);
 		return resourcePersistentIds.get(0).getIdAsLong();
+	}
+
+	@Nonnull
+	public List<Long> getPidsOrThrowException(List<IIdType> theIds) {
+		List<ResourcePersistentId> resourcePersistentIds = this.resolveResourcePersistentIdsWithCache(RequestPartitionId.allPartitions(), theIds);
+		return resourcePersistentIds.stream().map(ResourcePersistentId::getIdAsLong).collect(Collectors.toList());
 	}
 
 	@Nonnull

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/QueryChunker.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/QueryChunker.java
@@ -35,8 +35,12 @@ import java.util.function.Consumer;
 public class QueryChunker<T> {
 
 	public void chunk(List<T> theInput, Consumer<List<T>> theBatchConsumer) {
-		for (int i = 0; i < theInput.size(); i += SearchBuilder.getMaximumPageSize()) {
-			int to = i + SearchBuilder.getMaximumPageSize();
+		chunk(theInput, SearchBuilder.getMaximumPageSize(), theBatchConsumer);
+	}
+
+	public void chunk(List<T> theInput, int theChunkSize, Consumer<List<T>> theBatchConsumer ) {
+		for (int i = 0; i < theInput.size(); i += theChunkSize) {
+			int to = i + theChunkSize;
 			to = Math.min(to, theInput.size());
 			List<T> batch = theInput.subList(i, to);
 			theBatchConsumer.accept(batch);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
@@ -49,6 +49,8 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -306,11 +308,14 @@ public class BulkDataExportProviderTest {
 
 		InstantType now = InstantType.now();
 
+
 		Parameters input = new Parameters();
+		StringType obsTypeFilter = new StringType("Observation?code=OBSCODE,DiagnosticReport?code=DRCODE");
 		input.addParameter(JpaConstants.PARAM_EXPORT_OUTPUT_FORMAT, new StringType(Constants.CT_FHIR_NDJSON));
 		input.addParameter(JpaConstants.PARAM_EXPORT_TYPE, new StringType("Observation, DiagnosticReport"));
 		input.addParameter(JpaConstants.PARAM_EXPORT_SINCE, now);
-		input.addParameter(JpaConstants.PARAM_EXPORT_TYPE_FILTER, new StringType("Observation?code=OBSCODE,DiagnosticReport?code=DRCODE"));
+		input.addParameter(JpaConstants.PARAM_EXPORT_MDM, true);
+		input.addParameter(JpaConstants.PARAM_EXPORT_TYPE_FILTER, obsTypeFilter);
 
 		ourLog.info(myCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(input));
 
@@ -329,11 +334,9 @@ public class BulkDataExportProviderTest {
 		GroupBulkDataExportOptions options = myGroupBulkDataExportOptionsCaptor.getValue();
 		assertEquals(Constants.CT_FHIR_NDJSON, options.getOutputFormat());
 		assertThat(options.getResourceTypes(), containsInAnyOrder("Observation", "DiagnosticReport"));
-		//TODO GGG eventually, we will support since in group exports
-		assertThat(options.getSince(), nullValue());
-		//TODO GGG eventually, we will support filters in group exports
-		assertThat(options.getFilters(), nullValue());
+		assertThat(options.getSince(), notNullValue());
+		assertThat(options.getFilters(), notNullValue());
 		assertEquals(GROUP_ID, options.getGroupId().getValue());
-		assertFalse(options.isMdm());
+		assertThat(options.isMdm(), is(equalTo(true)));
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -13,13 +13,11 @@ import ca.uhn.fhir.jpa.bulk.model.BulkJobStatusEnum;
 import ca.uhn.fhir.jpa.dao.data.IBulkExportCollectionDao;
 import ca.uhn.fhir.jpa.dao.data.IBulkExportCollectionFileDao;
 import ca.uhn.fhir.jpa.dao.data.IBulkExportJobDao;
-import ca.uhn.fhir.jpa.dao.data.IMdmLinkDao;
 import ca.uhn.fhir.jpa.dao.r4.BaseJpaR4Test;
 import ca.uhn.fhir.jpa.entity.BulkExportCollectionEntity;
 import ca.uhn.fhir.jpa.entity.BulkExportCollectionFileEntity;
 import ca.uhn.fhir.jpa.entity.BulkExportJobEntity;
 import ca.uhn.fhir.jpa.entity.MdmLink;
-import ca.uhn.fhir.mdm.api.IMdmLinkSvc;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.rest.api.Constants;
@@ -298,10 +296,10 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 
 			if ("Patient".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"value\":\"PAT1\"}"));
-				assertEquals(5, nextContents.split("\n").length); // Only female patients
+				assertEquals(7, nextContents.split("\n").length); // Only female patients
 			} else if ("Observation".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"subject\":{\"reference\":\"Patient/PAT0\"}}\n"));
-				assertEquals(10, nextContents.split("\n").length);
+				assertEquals(16, nextContents.split("\n").length);
 			} else {
 				fail(next.getResourceType());
 			}
@@ -351,16 +349,16 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 			ourLog.info("Next contents for type {}:\n{}", next.getResourceType(), nextContents);
 			if ("Patient".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"value\":\"PAT0\""));
-				assertEquals(10, nextContents.split("\n").length);
+				assertEquals(17, nextContents.split("\n").length);
 			} else if ("Observation".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"subject\":{\"reference\":\"Patient/PAT0\"}}\n"));
-				assertEquals(10, nextContents.split("\n").length);
+				assertEquals(16, nextContents.split("\n").length);
 			}else if ("Immunization".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"patient\":{\"reference\":\"Patient/PAT0\"}}\n"));
-				assertEquals(10, nextContents.split("\n").length);
+				assertEquals(16, nextContents.split("\n").length);
 			} else if ("CareTeam".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"id\":\"CT0\""));
-				assertEquals(10, nextContents.split("\n").length);
+				assertEquals(16, nextContents.split("\n").length);
 			} else if ("Group".equals(next.getResourceType())) {
 				assertThat(nextContents, containsString("\"id\":\"G0\""));
 				assertEquals(1, nextContents.split("\n").length);
@@ -761,7 +759,7 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 		}
 		myPatientGroupId =  myGroupDao.update(group).getId();
 
-		//Manually create a golden record
+		//Manually create another golden record
 		Patient goldenPatient2 = new Patient();
 		goldenPatient2.setId("PAT888");
 		DaoMethodOutcome g2Outcome = myPatientDao.update(goldenPatient2);
@@ -777,7 +775,6 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 			createImmunizationWithIndex(i, patId);
 			createCareTeamWithIndex(i, patId);
 		}
-
 	}
 
 	private DaoMethodOutcome createPatientWithIndex(int i) {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/config/TestR4Config.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/config/TestR4Config.java
@@ -73,11 +73,9 @@ public class TestR4Config extends BaseJavaConfigR4 {
 		return new CircularQueueCaptureQueriesListener();
 	}
 
-
 	@Bean
 	public DataSource dataSource() {
 		BasicDataSource retVal = new BasicDataSource() {
-
 
 			@Override
 			public Connection getConnection() {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/BaseJpaR4Test.java
@@ -22,6 +22,7 @@ import ca.uhn.fhir.jpa.config.TestR4Config;
 import ca.uhn.fhir.jpa.dao.BaseJpaTest;
 import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
 import ca.uhn.fhir.jpa.dao.data.IForcedIdDao;
+import ca.uhn.fhir.jpa.dao.data.IMdmLinkDao;
 import ca.uhn.fhir.jpa.dao.data.IPartitionDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTableDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTagDao;
@@ -479,11 +480,13 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 	@Autowired
 	private IBulkDataExportSvc myBulkDataExportSvc;
 	@Autowired
-	private IdHelperService myIdHelperService;
+	protected IdHelperService myIdHelperService;
 	@Autowired
 	protected IBatchJobSubmitter myBatchJobSubmitter;
 	@Autowired
 	protected ValidationSettings myValidationSettings;
+	@Autowired
+	protected IMdmLinkDao myMdmLinkDao;
 
 	@AfterEach()
 	public void afterCleanupDao() {
@@ -549,6 +552,7 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 
 	@AfterEach
 	public void afterPurgeDatabase() {
+		myMdmLinkDao.deleteAll();
 		purgeDatabase(myDaoConfig, mySystemDao, myResourceReindexingSvc, mySearchCoordinatorSvc, mySearchParamRegistry, myBulkDataExportSvc);
 	}
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
@@ -190,10 +190,9 @@ public class JpaConstants {
 	public static final Object PARAM_EXPORT_GROUP_ID = "_groupId";
 
 	/**
-	 * TODO GGG eventually we will support this.
 	 * Whether mdm should be performed on group export items to expand the group items to linked items before performing the export
 	 */
-//	public static final String PARAM_EXPORT_MDM = "_mdm";
+	public static final String PARAM_EXPORT_MDM = "_mdm";
 
 	/**
 	 * Parameter for delete to indicate the deleted resources should also be expunged

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
@@ -187,7 +187,7 @@ public class JpaConstants {
 	/**
 	 * The [id] of the group when $export is called on /Group/[id]/$export
 	 */
-	public static final Object PARAM_EXPORT_GROUP_ID = "_groupId";
+	public static final String PARAM_EXPORT_GROUP_ID = "_groupId";
 
 	/**
 	 * Whether mdm should be performed on group export items to expand the group items to linked items before performing the export

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/config/TestJpaR4Config.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/config/TestJpaR4Config.java
@@ -67,7 +67,8 @@ public class TestJpaR4Config extends BaseJavaConfigR4 {
 		BasicDataSource retVal = new BasicDataSource();
 
 		retVal.setDriver(new org.h2.Driver());
-		retVal.setUrl("jdbc:h2:mem:testdb_r4");
+//		retVal.setUrl("jdbc:h2:mem:testdb_r4");
+		retVal.setUrl("jdbc:h2:file:./testdb_r4;create=true");
 		retVal.setMaxWaitMillis(10000);
 		retVal.setUsername("");
 		retVal.setPassword("");

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/config/TestJpaR4Config.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/config/TestJpaR4Config.java
@@ -67,8 +67,7 @@ public class TestJpaR4Config extends BaseJavaConfigR4 {
 		BasicDataSource retVal = new BasicDataSource();
 
 		retVal.setDriver(new org.h2.Driver());
-//		retVal.setUrl("jdbc:h2:mem:testdb_r4");
-		retVal.setUrl("jdbc:h2:file:./testdb_r4;create=true");
+		retVal.setUrl("jdbc:h2:mem:testdb_r4");
 		retVal.setMaxWaitMillis(10000);
 		retVal.setUsername("");
 		retVal.setPassword("");

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/util/TerserUtil.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/util/TerserUtil.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.mdm.model.CanonicalEID;
 import ca.uhn.fhir.util.FhirTerser;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.slf4j.Logger;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -38,8 +39,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static ca.uhn.fhir.mdm.util.GoldenResourceHelper.FIELD_NAME_IDENTIFIER;
+import static org.slf4j.LoggerFactory.getLogger;
 
 public final class TerserUtil {
+	private static final Logger ourLog = getLogger(TerserUtil.class);
 
 	public static final Collection<String> IDS_AND_META_EXCLUDES =
 		Collections.unmodifiableSet(Stream.of("id", "identifier", "meta").collect(Collectors.toSet()));
@@ -104,6 +107,23 @@ public final class TerserUtil {
 			return false;
 		}
 		return !(resourceIdentifier.getAccessor().getValues(theResource).isEmpty());
+	}
+	/**
+	 * get the Values of a specified field.
+	 *
+	 * @param theFhirContext Context holding resource definition
+	 * @param theResource    Resource to check if the specified field is set
+	 * @param theFieldName   name of the field to check
+	 * @return Returns true if field exists and has any values set, and false otherwise
+	 */
+	public static List<IBase> getValues(FhirContext theFhirContext, IBaseResource theResource, String theFieldName) {
+		RuntimeResourceDefinition resourceDefinition = theFhirContext.getResourceDefinition(theResource);
+		BaseRuntimeChildDefinition resourceIdentifier = resourceDefinition.getChildByName(theFieldName);
+		if (resourceIdentifier == null) {
+			ourLog.info("There is no field named {} in Resource {}", theFieldName, resourceDefinition.getName());
+			return null;
+		}
+		return resourceIdentifier.getAccessor().getValues(theResource);
 	}
 
 	/**


### PR DESCRIPTION
* Add support for `_mdm` boolean flag in Group Bulk Export
* This flag will expand group membership to all matched patients, on top of just group members. 
* Enabled support for `_typeFilter` on Group Bulk Export. The only caveat is that you cannot search on a patient compartment when using Group Bulk Export, as it manually has to set the patient search param. 
* Abstracted out a common Bulk Item Reader

Closes #2433 