### PR TITLE
Fix typos in changelog entry and javadocs.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2446-issues-with-placeholder-reference-targets-need-to-be-resolved-placeholder-extension.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2446-issues-with-placeholder-reference-targets-need-to-be-resolved-placeholder-extension.yaml
@@ -2,4 +2,4 @@
 type: add
 issue: 2446
 title: "Auto-created placeholder reference targets now have an extension with the URL
-   `http://hapifhir.io/fhir/StructureDefinition/resource-meta-placeholder` and a value of `true`."
+   `http://hapifhir.io/fhir/StructureDefinition/resource-placeholder` and a value of `true`."

--- a/hapi-fhir-jpaserver-api/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
+++ b/hapi-fhir-jpaserver-api/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
@@ -1070,7 +1070,7 @@ public class DaoConfig {
 	 * Note however that references containing purely numeric IDs will not be auto-created
 	 * as they are never allowed to be client supplied in HAPI FHIR JPA.
 	 *
-	 * All placeholder resources created in this way have a meta extension
+	 * All placeholder resources created in this way have an extension
 	 * with the URL {@link HapiExtensions#EXT_RESOURCE_PLACEHOLDER} and the value "true".
 	 * </p>
 	 */
@@ -1094,7 +1094,7 @@ public class DaoConfig {
 	 * Note however that references containing purely numeric IDs will not be auto-created
 	 * as they are never allowed to be client supplied in HAPI FHIR JPA.
 	 *
-	 * All placeholder resources created in this way have a meta extension
+	 * All placeholder resources created in this way have an extension
 	 * with the URL {@link HapiExtensions#EXT_RESOURCE_PLACEHOLDER} and the value "true".
 	 * </p>
 	 */


### PR DESCRIPTION
Accidentally left "meta" in a few places.