### PR TITLE
Address CVE-2020-27223

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2454-address-cve-2020-27223.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2454-address-cve-2020-27223.yaml
@@ -1,0 +1,9 @@
+---
+type: security
+issue: 2454
+title: "Addressed the following CVE report by bumping the minor version for Jetty in the root POM:
+   <ul>
+      <li>
+         [CVE-2020-27223](https://nvd.nist.gov/vuln/detail/CVE-2020-27223)
+      </li>
+   </ul>"

--- a/pom.xml
+++ b/pom.xml
@@ -782,7 +782,7 @@
 		<jena_version>3.16.0</jena_version>
 		<jersey_version>3.0.0</jersey_version>
 		<!-- 9.4.17 seems to have issues -->
-		<jetty_version>9.4.35.v20201120</jetty_version>
+		<jetty_version>9.4.38.v20210224</jetty_version>
 		<jsr305_version>3.0.2</jsr305_version>
 		<junit_version>5.7.0</junit_version>
 		<flyway_version>6.5.4</flyway_version>


### PR DESCRIPTION
Closes #2454 

- bumped minor version of Jetty in root POM