### PR TITLE
Have CreatePackageCommand automatically add fhirVersions based on --fhir-version flag

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/CreatePackageCommand.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/CreatePackageCommand.java
@@ -24,6 +24,8 @@ import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import com.google.common.io.Files;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -37,7 +39,6 @@ import org.hl7.fhir.utilities.npm.PackageGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.print.attribute.standard.MediaSize;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -67,7 +68,7 @@ public class CreatePackageCommand extends BaseCommand {
 
 	@Override
 	public String getCommandDescription() {
-		return "Create an NPM package using the FHIR packging format";
+		return "Create an NPM package using the FHIR packaging format";
 	}
 
 	@Override
@@ -129,6 +130,7 @@ public class CreatePackageCommand extends BaseCommand {
 		manifestGenerator.name(myPackageName);
 		manifestGenerator.version(myPackageVersion);
 		manifestGenerator.description(myPackageDescription);
+		injectFhirVersionsArray(manifestGenerator);
 		if (isNotBlank(myPackageDescription)) {
 			manifestGenerator.description(myPackageDescription);
 		}
@@ -175,6 +177,13 @@ public class CreatePackageCommand extends BaseCommand {
 		} catch (IOException e) {
 			throw new ExecutionException("Failed to write file " + targetFile, e);
 		}
+	}
+
+	private void injectFhirVersionsArray(PackageGenerator manifestGenerator) {
+		JsonObject rootJsonObject = manifestGenerator.getRootJsonObject();
+		JsonArray fhirVersionsArray = new JsonArray();
+		fhirVersionsArray.add(myFhirCtx.getVersion().getVersion().getFhirVersionString());
+		rootJsonObject.add("fhirVersions", fhirVersionsArray);
 	}
 
 	public void addFiles(String[] thePackageValues, String theFolder) throws ParseException, ExecutionException {

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/CreatePackageCommandTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/CreatePackageCommandTest.java
@@ -154,7 +154,10 @@ public class CreatePackageCommandTest extends BaseTest {
 
 		String expectedPackageJson = "{\n" +
 			"  \"name\": \"com.example.ig\",\n" +
-			"  \"version\": \"1.0.1\"\n" +
+			"  \"version\": \"1.0.1\",\n" +
+			"  \"fhirVersions\": [\n" +
+			"    \"4.0.1\"\n" +
+			"  ]\n" +
 			"}";
 		assertEquals(expectedPackageJson, packageJsonContents);
 

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/CreatePackageCommandTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/CreatePackageCommandTest.java
@@ -101,6 +101,9 @@ public class CreatePackageCommandTest extends BaseTest {
 		String expectedPackageJson = "{\n" +
 			"  \"name\": \"com.example.ig\",\n" +
 			"  \"version\": \"1.0.1\",\n" +
+			"  \"fhirVersions\": [\n" +
+			"    \"4.0.1\"\n" +
+			"  ],\n" +
 			"  \"dependencies\": {\n" +
 			"    \"hl7.fhir.core\": \"4.0.1\",\n" +
 			"    \"foo.bar\": \"1.2.3\"\n" +
@@ -111,7 +114,6 @@ public class CreatePackageCommandTest extends BaseTest {
 		// Try parsing the module again to make sure we can
 		NpmPackage loadedPackage = NpmPackage.fromPackage(new FileInputStream(igArchive));
 		assertEquals("com.example.ig", loadedPackage.name());
-
 	}
 
 	@Test

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2479-add-fhir-versions-to-created-packages.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2479-add-fhir-versions-to-created-packages.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 2479
+title: "the create-package command of the HAPI FHIR CLI was not correctly adding the `fhirVersions` section to the generated package.json. This has been fixed"


### PR DESCRIPTION
Add fhirVersions to package creator, auto-selected by --fhir-version

[Docs here](https://smilecdr.com/docs/smileutil/create_package.html#options) indicate this functionality already exists, but it doesn't!

Closes #2479 