### PR TITLE
Fix bug with inconsistent error messages

### DIFF
--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
@@ -277,6 +277,8 @@ public class FhirResourceDaoR4SearchCustomSearchParamTest extends BaseJpaR4Test 
 		}
 	}
 
+
+
 	@Test
 	@Disabled
 	public void testCreateInvalidParamInvalidResourceName() {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderCustomSearchParamR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderCustomSearchParamR4Test.java
@@ -14,6 +14,7 @@ import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
+import ca.uhn.fhir.rest.gclient.StringClientParam;
 import ca.uhn.fhir.rest.gclient.TokenClientParam;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.util.BundleUtil;
@@ -31,6 +32,7 @@ import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestResource
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 import org.hl7.fhir.r4.model.Patient;
@@ -54,6 +56,8 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -414,6 +418,59 @@ public class ResourceProviderCustomSearchParamR4Test extends BaseResourceProvide
 		foundResources = toUnqualifiedVersionlessIdValues(result);
 		assertThat(foundResources, contains(patId.getValue()));
 
+	}
+
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithCustomParamInvalidDateFormat() {
+
+		SearchParameter dateParameter = new SearchParameter();
+		dateParameter.setId("explanationofbenefit-service-date");
+		dateParameter.setName("ExplanationOfBenefit_ServiceDate");
+		dateParameter.setCode("service-date");
+		dateParameter.setDescription("test");
+		dateParameter.setUrl("http://integer");
+		dateParameter.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		dateParameter.addBase("ExplanationOfBenefit");
+		dateParameter.setType(Enumerations.SearchParamType.DATE);
+		dateParameter.setExpression("ExplanationOfBenefit.billablePeriod | ExplanationOfBenefit.item.serviced as Date |  ExplanationOfBenefit.item.serviced as Period");
+		dateParameter.setXpath("f:ExplanationOfBenefit/f:billablePeriod | f:ExplanationOfBenefit/f:item/f:serviced/f:servicedDate | f:ExplanationOfBenefit/f:item/f:serviced/f:servicedPeriod");
+		dateParameter.setXpathUsage(SearchParameter.XPathUsageType.NORMAL);
+		mySearchParameterDao.update(dateParameter);
+
+		mySearchParamRegistry.forceRefresh();
+
+		IBundleProvider results;
+		List<String> foundResources;
+		Bundle result;
+
+
+		//Try with builtin SP
+		try {
+			myClient
+				.search()
+				.forResource(ExplanationOfBenefit.class)
+				.where(new StringClientParam("created").matchesExactly().value("01-01-2020"))
+				.returnBundle(Bundle.class)
+				.execute();
+
+		} catch	(Exception e) {
+			assertThat(e.getMessage(), is(equalTo("HTTP 400 Bad Request: Invalid date/time format: \"01-01-2020\"")));
+		}
+
+		//Now with custom SP
+		try {
+			myClient
+				.search()
+				.forResource(ExplanationOfBenefit.class)
+				.where(new StringClientParam("service-date").matchesExactly().value("01-01-2020"))
+				.returnBundle(Bundle.class)
+				.execute();
+
+		} catch	(Exception e) {
+			assertThat(e.getMessage(), is(equalTo("HTTP 400 Bad Request: Invalid date/time format: \"01-01-2020\"")));
+		}
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderCustomSearchParamR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderCustomSearchParamR4Test.java
@@ -451,7 +451,7 @@ public class ResourceProviderCustomSearchParamR4Test extends BaseResourceProvide
 			myClient
 				.search()
 				.forResource(ExplanationOfBenefit.class)
-				.where(new StringClientParam("created").matchesExactly().value("01-01-2020"))
+				.where(new StringClientParam("created").matches().value("01-01-2020"))
 				.returnBundle(Bundle.class)
 				.execute();
 
@@ -464,7 +464,7 @@ public class ResourceProviderCustomSearchParamR4Test extends BaseResourceProvide
 			myClient
 				.search()
 				.forResource(ExplanationOfBenefit.class)
-				.where(new StringClientParam("service-date").matchesExactly().value("01-01-2020"))
+				.where(new StringClientParam("service-date").matches().value("01-01-2020"))
 				.returnBundle(Bundle.class)
 				.execute();
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
@@ -107,7 +107,10 @@ public class ExceptionHandlingInterceptor {
 	@Hook(Pointcut.SERVER_PRE_PROCESS_OUTGOING_EXCEPTION)
 	public BaseServerResponseException preProcessOutgoingException(RequestDetails theRequestDetails, Throwable theException, HttpServletRequest theServletRequest) throws ServletException {
 		BaseServerResponseException retVal;
-		if (theException instanceof DataFormatException) {
+		//TODO GGG this is _not_ the fix.
+		if (theException instanceof InternalErrorException && theException.getCause().getCause() instanceof DataFormatException) {
+			retVal = new InvalidRequestException(theException.getCause().getCause());
+		} else if (theException instanceof DataFormatException) {
 			// Wrapping the DataFormatException as an InvalidRequestException so that it gets sent back to the client as a 400 response.
 			retVal = new InvalidRequestException(theException);
 		} else if (!(theException instanceof BaseServerResponseException)) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
@@ -107,10 +107,7 @@ public class ExceptionHandlingInterceptor {
 	@Hook(Pointcut.SERVER_PRE_PROCESS_OUTGOING_EXCEPTION)
 	public BaseServerResponseException preProcessOutgoingException(RequestDetails theRequestDetails, Throwable theException, HttpServletRequest theServletRequest) throws ServletException {
 		BaseServerResponseException retVal;
-		//TODO GGG this is _not_ the fix.
-		if (theException instanceof InternalErrorException && theException.getCause().getCause() instanceof DataFormatException) {
-			retVal = new InvalidRequestException(theException.getCause().getCause());
-		} else if (theException instanceof DataFormatException) {
+		if (theException instanceof DataFormatException) {
 			// Wrapping the DataFormatException as an InvalidRequestException so that it gets sent back to the client as a 400 response.
 			retVal = new InvalidRequestException(theException);
 		} else if (!(theException instanceof BaseServerResponseException)) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.model.api.IResource;
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.annotation.*;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
@@ -250,6 +251,9 @@ public abstract class BaseMethodBinding<T> {
 		} catch (InvocationTargetException e) {
 			if (e.getCause() instanceof BaseServerResponseException) {
 				throw (BaseServerResponseException) e.getCause();
+			}
+			if (e.getTargetException() instanceof DataFormatException) {
+				throw (DataFormatException)e.getTargetException();
 			}
 			throw new InternalErrorException("Failed to call access method: " + e.getCause(), e);
 		} catch (Exception e) {


### PR DESCRIPTION
* If we catch a DataFormatException during server invocation, rethrow that instead of InternalErrorException.
* This will allow us to cleanly bubble up 400 errors to clients calling custom search parameters with invalid formats. 

Closes #2496 
