### PR TITLE
Correct the path to the select2 library in the testpage overlay

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2505-fix-select2-path.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_4_0/2505-fix-select2-path.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 2505
+title: "An incorrect path caused the select2 library to fail to load in the HAPI FHIR testpage overlay
+   modue. Thanks to Ari Ruotsalainen for reporting!"

--- a/hapi-fhir-testpage-overlay/src/main/webapp/WEB-INF/templates/tmpl-head.html
+++ b/hapi-fhir-testpage-overlay/src/main/webapp/WEB-INF/templates/tmpl-head.html
@@ -31,8 +31,8 @@
    <script th:src="@{/resources/moment/min/moment-with-locales.min.js}"></script>
    <link th:href="@{/resources/Eonasdan-bootstrap-datetimepicker/css/bootstrap-datetimepicker.min.css}" rel="stylesheet" />
    <script th:src="@{/resources/Eonasdan-bootstrap-datetimepicker/js/bootstrap-datetimepicker.js}"></script>
-   <link th:href="@{/resources/select2/dist/css/select2.css}" rel="stylesheet"/>
-   <script th:src="@{/resources/select2/dist/js/select2.min.js}"></script>
+   <link th:href="@{/resources/select2/css/select2.css}" rel="stylesheet"/>
+   <script th:src="@{/resources/select2/js/select2.min.js}"></script>
 
 
    <script src="js/RestfulTester.js" type="text/javascript"></script>


### PR DESCRIPTION
Fix #2504 