### PR TITLE
Issue 2499 identify golden resources in export

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -112,6 +112,11 @@ public class HapiExtensions {
 	public static final String EXT_RESOURCE_PLACEHOLDER = "http://hapifhir.io/fhir/StructureDefinition/resource-placeholder";
 
 	/**
+	 * URL for extension in a Group Bulk Export which identifies the golden patient of a given exported resource.
+	 */
+    public static final String ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL = "https://hapifhir.org/associated-patient-golden-resource/";
+
+    /**
 	 * Non instantiable
 	 */
 	private HapiExtensions() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/CommonBatchJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/CommonBatchJobConfig.java
@@ -20,6 +20,7 @@ package ca.uhn.fhir.jpa.batch;
  * #L%
  */
 
+import ca.uhn.fhir.jpa.batch.processors.GoldenResourceAnnotatingProcessor;
 import ca.uhn.fhir.jpa.batch.processors.PidToIBaseResourceProcessor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +33,12 @@ public class CommonBatchJobConfig {
 	@StepScope
 	public PidToIBaseResourceProcessor pidToResourceProcessor() {
 		return new PidToIBaseResourceProcessor();
+	}
+
+	@Bean
+	@StepScope
+	public GoldenResourceAnnotatingProcessor goldenResourceAnnotatingProcessor() {
+		return new GoldenResourceAnnotatingProcessor();
 	}
 
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -97,7 +97,8 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 		if (patientReference.isPresent()) {
 			addGoldenResourceExtension(iBaseResource, patientReference.get());
 		} else {
-			ourLog.warn("Failed to find the patient reference information for resource {}", iBaseResource);
+			ourLog.error("Failed to find the patient reference information for resource {}. This is a bug, " +
+				"as all resources which can be exported via Group Bulk Export must reference a patient.", iBaseResource);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.jpa.batch.log.Logs;
 import ca.uhn.fhir.jpa.bulk.job.BulkExportJobConfig;
 import ca.uhn.fhir.jpa.dao.mdm.MdmExpansionCacheSvc;
 import ca.uhn.fhir.util.ExtensionUtil;
+import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.SearchParameterUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
@@ -46,7 +47,6 @@ import java.util.Optional;
  */
 public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBaseResource>, List<IBaseResource>> {
 	 private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
-	public static final String ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL = "https://hapifhir.org/associated-patient-golden-resource/";
 
 	@Value("#{stepExecutionContext['resourceType']}")
 	private String myResourceType;
@@ -114,7 +114,7 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 
 	private void addGoldenResourceExtension(IBaseResource iBaseResource, String sourceResourceId) {
 		String goldenResourceId = myMdmExpansionCacheSvc.getGoldenResourceId(sourceResourceId);
-		IBaseExtension<?, ?> extension = ExtensionUtil.getOrCreateExtension(iBaseResource, ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL);
+		IBaseExtension<?, ?> extension = ExtensionUtil.getOrCreateExtension(iBaseResource, HapiExtensions.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL);
 		if (!StringUtils.isBlank(goldenResourceId)) {
 			ExtensionUtil.setExtension(myContext, extension, "reference", prefixPatient(goldenResourceId));
 		} else {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -117,8 +117,6 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 		IBaseExtension<?, ?> extension = ExtensionUtil.getOrCreateExtension(iBaseResource, HapiExtensions.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL);
 		if (!StringUtils.isBlank(goldenResourceId)) {
 			ExtensionUtil.setExtension(myContext, extension, "reference", prefixPatient(goldenResourceId));
-		} else {
-			ExtensionUtil.setExtension(myContext, extension, "string", "This patient has no matched golden resource.");
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -63,9 +63,6 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 	private String myPatientFhirPath;
 	private IFhirPath myFhirPath;
 
-
-
-
 	@Override
 	public List<IBaseResource> process(List<IBaseResource> theIBaseResources) throws Exception {
 		if (myMdmEnabled) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -1,0 +1,98 @@
+package ca.uhn.fhir.jpa.batch.processors;
+
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2021 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.fhirpath.IFhirPath;
+import ca.uhn.fhir.jpa.batch.log.Logs;
+import ca.uhn.fhir.jpa.dao.mdm.MdmExpansionCacheSvc;
+import ca.uhn.fhir.util.ExtensionUtil;
+import ca.uhn.fhir.util.SearchParameterUtil;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.slf4j.Logger;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Reusable Item Processor which converts ResourcePersistentIds to their IBaseResources
+ */
+public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBaseResource>, List<IBaseResource>> {
+	 private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
+	public static final String ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL = "https://hapifhir.org/associated-patient-golden-resource/";
+
+	@Value("#{stepExecutionContext['resourceType']}")
+	private String myResourceType;
+
+	@Autowired
+	private FhirContext myContext;
+
+	@Autowired
+	private MdmExpansionCacheSvc myMdmExpansionCacheSvc;
+
+	private RuntimeSearchParam myRuntimeSearchParam;
+	private IFhirPath myFhirPath;
+
+
+
+
+	@Override
+	public List<IBaseResource> process(List<IBaseResource> theIBaseResources) throws Exception {
+		if (myRuntimeSearchParam == null) {
+			myRuntimeSearchParam = SearchParameterUtil.getPatientSearchParamForResourceType(myContext, myResourceType);
+		}
+		String path = runtimeSearchParamFhirPath();
+		theIBaseResources
+			.forEach(iBaseResource -> annotateResourceWithRelatedGoldenResourcePatient(path, iBaseResource));
+		return theIBaseResources;
+	}
+
+	private void annotateResourceWithRelatedGoldenResourcePatient(String path, IBaseResource iBaseResource) {
+		Optional<IBaseReference> evaluate = getFhirParser().evaluateFirst(iBaseResource, path, IBaseReference.class);
+		if (evaluate.isPresent()) {
+			String sourceResourceId = evaluate.get().getReferenceElement().getIdPart();
+			ExtensionUtil.setExtension(myContext, iBaseResource, ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL, myMdmExpansionCacheSvc.getGoldenResourceId(sourceResourceId));
+		} else {
+			ourLog.warn("Failed to find the patient compartment information for resource {}", iBaseResource);
+		}
+	}
+
+	private IFhirPath getFhirParser() {
+		if (myFhirPath == null) {
+			myFhirPath = myContext.newFhirPath();
+		}
+		return myFhirPath;
+	}
+
+	private String runtimeSearchParamFhirPath() {
+		if (myRuntimeSearchParam == null) {
+			myRuntimeSearchParam = SearchParameterUtil.getPatientSearchParamForResourceType(myContext, myResourceType);
+		}
+		return myRuntimeSearchParam.getPath();
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -101,6 +101,10 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 		if (!StringUtils.isBlank(goldenResourceId)) {
 			IBaseExtension<?, ?> extension = ExtensionUtil.getOrCreateExtension(iBaseResource, ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL);
 			ExtensionUtil.setExtension(myContext, extension, "reference", prefixPatient(goldenResourceId));
+		} else {
+			IBaseExtension<?, ?> extension = ExtensionUtil.getOrCreateExtension(iBaseResource, "failed-to-associated-golden-id");
+			ExtensionUtil.setExtension(myContext, extension, "string", myMdmExpansionCacheSvc.buildLog("not working!", true));
+
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/GoldenResourceAnnotatingProcessor.java
@@ -24,13 +24,14 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.fhirpath.IFhirPath;
 import ca.uhn.fhir.jpa.batch.log.Logs;
+import ca.uhn.fhir.jpa.bulk.job.BulkExportJobConfig;
 import ca.uhn.fhir.jpa.dao.mdm.MdmExpansionCacheSvc;
 import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.SearchParameterUtil;
-import org.hl7.fhir.instance.model.api.IBase;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.IIdType;
 import org.slf4j.Logger;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +56,11 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 	@Autowired
 	private MdmExpansionCacheSvc myMdmExpansionCacheSvc;
 
+	@Value("#{jobParameters['" + BulkExportJobConfig.EXPAND_MDM_PARAMETER+ "'] ?: false}")
+	private boolean myMdmEnabled;
+
 	private RuntimeSearchParam myRuntimeSearchParam;
+	private String myPatientFhirPath;
 	private IFhirPath myFhirPath;
 
 
@@ -63,23 +68,47 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 
 	@Override
 	public List<IBaseResource> process(List<IBaseResource> theIBaseResources) throws Exception {
-		if (myRuntimeSearchParam == null) {
-			myRuntimeSearchParam = SearchParameterUtil.getPatientSearchParamForResourceType(myContext, myResourceType);
+		if (myMdmEnabled) {
+			if (myRuntimeSearchParam == null) {
+				myRuntimeSearchParam = SearchParameterUtil.getPatientSearchParamForResourceType(myContext, myResourceType);
+			}
+			String path = runtimeSearchParamFhirPath();
+			theIBaseResources.forEach(iBaseResource -> annotateClinicalResourceWithRelatedGoldenResourcePatient(path, iBaseResource));
 		}
-		String path = runtimeSearchParamFhirPath();
-		theIBaseResources
-			.forEach(iBaseResource -> annotateResourceWithRelatedGoldenResourcePatient(path, iBaseResource));
+
 		return theIBaseResources;
 	}
 
-	private void annotateResourceWithRelatedGoldenResourcePatient(String path, IBaseResource iBaseResource) {
-		Optional<IBaseReference> evaluate = getFhirParser().evaluateFirst(iBaseResource, path, IBaseReference.class);
-		if (evaluate.isPresent()) {
-			String sourceResourceId = evaluate.get().getReferenceElement().getIdPart();
-			ExtensionUtil.setExtension(myContext, iBaseResource, ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL, myMdmExpansionCacheSvc.getGoldenResourceId(sourceResourceId));
+	private void annotateClinicalResourceWithRelatedGoldenResourcePatient(String path, IBaseResource iBaseResource) {
+		Optional<String> patientReference = getPatientReference(path, iBaseResource);
+		if (patientReference.isPresent()) {
+			addGoldenResourceExtension(iBaseResource, patientReference.get());
 		} else {
-			ourLog.warn("Failed to find the patient compartment information for resource {}", iBaseResource);
+			ourLog.warn("Failed to find the patient reference information for resource {}", iBaseResource);
 		}
+	}
+
+	private Optional<String> getPatientReference(String path, IBaseResource iBaseResource) {
+		//In the case of patient, we will just use the raw ID.
+		if (myResourceType.equalsIgnoreCase("Patient")) {
+			return Optional.of(iBaseResource.getIdElement().getIdPart());
+		//Otherwise, we will perform evaluation of the fhirPath.
+		} else {
+			Optional<IBaseReference> optionalReference = getFhirParser().evaluateFirst(iBaseResource, path, IBaseReference.class);
+			return optionalReference.map(theIBaseReference -> theIBaseReference.getReferenceElement().getIdPart());
+		}
+	}
+
+	private void addGoldenResourceExtension(IBaseResource iBaseResource, String sourceResourceId) {
+		String goldenResourceId = myMdmExpansionCacheSvc.getGoldenResourceId(sourceResourceId);
+		if (!StringUtils.isBlank(goldenResourceId)) {
+			IBaseExtension<?, ?> extension = ExtensionUtil.getOrCreateExtension(iBaseResource, ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL);
+			ExtensionUtil.setExtension(myContext, extension, "reference", prefixPatient(goldenResourceId));
+		}
+	}
+
+	private String prefixPatient(String theResourceId) {
+		return "Patient/" + theResourceId;
 	}
 
 	private IFhirPath getFhirParser() {
@@ -90,9 +119,15 @@ public class GoldenResourceAnnotatingProcessor implements ItemProcessor<List<IBa
 	}
 
 	private String runtimeSearchParamFhirPath() {
-		if (myRuntimeSearchParam == null) {
+		if (myPatientFhirPath == null) {
 			myRuntimeSearchParam = SearchParameterUtil.getPatientSearchParamForResourceType(myContext, myResourceType);
+			myPatientFhirPath = myRuntimeSearchParam.getPath();
+			//Yes this is a stupid hack, but by default this runtime search param will return stuff like
+			// Observation.subject.where(resolve() is Patient) which unfortunately our FHIRpath evaluator doesn't play nicely with.
+			if (myPatientFhirPath.contains(".where")) {
+				myPatientFhirPath = myPatientFhirPath.substring(0, myPatientFhirPath.indexOf(".where"));
+			}
 		}
-		return myRuntimeSearchParam.getPath();
+		return myPatientFhirPath;
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/PidToIBaseResourceProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/processors/PidToIBaseResourceProcessor.java
@@ -50,6 +50,7 @@ public class PidToIBaseResourceProcessor implements ItemProcessor<List<ResourceP
 	@Autowired
 	private DaoRegistry myDaoRegistry;
 
+
 	@Value("#{stepExecutionContext['resourceType']}")
 	private String myResourceType;
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BaseBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BaseBulkItemReader.java
@@ -180,17 +180,14 @@ public abstract class BaseBulkItemReader implements ItemReader<List<ResourcePers
 
 	}
 
-	/**
-	 * Given the resource type, fetch its patient-based search parameter name
-	 * 1. Attempt to find one called 'patient'
-	 * 2. If that fails, find one called 'subject'
-	 * 3. If that fails, find find by Patient Compartment.
-	 *    3.1 If that returns >1 result, throw an error
-	 *    3.2 If that returns 1 result, return it
-	 */
 	protected RuntimeSearchParam getPatientSearchParamForCurrentResourceType() {
 		if (myPatientSearchParam == null) {
-			myPatientSearchParam =  SearchParameterUtil.getPatientSearchParamForResourceType(myContext, myResourceType);
+			Optional<RuntimeSearchParam> onlyPatientSearchParamForResourceType = SearchParameterUtil.getOnlyPatientSearchParamForResourceType(myContext, myResourceType);
+			if (onlyPatientSearchParamForResourceType.isPresent()) {
+				myPatientSearchParam = onlyPatientSearchParamForResourceType.get();
+			} else {
+
+			}
 		}
 		return myPatientSearchParam;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
@@ -161,8 +161,6 @@ public class BulkExportJobConfig {
 		return myStepBuilderFactory.get("groupBulkExportGenerateResourceFilesStep")
 			.<List<ResourcePersistentId>, List<IBaseResource>> chunk(CHUNK_SIZE) //1000 resources per generated file, as the reader returns 10 resources at a time.
 			.reader(groupBulkItemReader())
-//			.processor(myPidToIBaseResourceProcessor)
-//			.processor(myGoldenResourceAnnotatingProcessor)
 			.processor(inflateResourceThenAnnotateWithGoldenResourceProcessor())
 			.writer(resourceToFileWriter())
 			.listener(bulkExportGenerateResourceFilesStepListener())

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobConfig.java
@@ -80,7 +80,7 @@ public class BulkExportJobConfig {
 
 	@Bean
 	@Lazy
-	@StepScope
+	@JobScope
 	public MdmExpansionCacheSvc mdmExpansionCacheSvc() {
 		return new MdmExpansionCacheSvc();
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -123,7 +122,6 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 			IBaseResource group = myDaoRegistry.getResourceDao("Group").read(new IdDt(myGroupId));
 			Long pidOrNull = myIdHelperService.getPidOrNull(group);
 			List<List<Long>> lists = myMdmLinkDao.expandPidsFromGroupPidGivenMatchResult(pidOrNull, MdmMatchResultEnum.MATCH);
-
 			lists.forEach(patientPidsToExport::addAll);
 		}
 		List<ResourcePersistentId> resourcePersistentIds = patientPidsToExport
@@ -161,11 +159,6 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 		if (myMdmEnabled) {
 			List<List<Long>> goldenPidTargetPidTuples = myMdmLinkDao.expandPidsFromGroupPidGivenMatchResult(pidOrNull, MdmMatchResultEnum.MATCH);
 			//Now lets translate these pids into resource IDs
-
-			System.out.println("ZOOPER");
-			goldenPidTargetPidTuples.stream()
-				.map(Object::toString)
-				.forEach(list -> System.out.println(String.join(", ", list)));
 			Set<Long> uniquePids = new HashSet<>();
 			goldenPidTargetPidTuples.forEach(uniquePids::addAll);
 			Map<Long, Optional<String>> pidToForcedIdMap = myIdHelperService.translatePidsToForcedIds(uniquePids);
@@ -180,22 +173,8 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 				}
 				goldenResourceToSourcePidMap.get(goldenPid).add(sourcePid);
 			}
-			Map<String, String> sourceResourceIdToGoldenResourceIdMap = new HashMap<>();
+			populateMdmResourceCacheIfNeeded(goldenResourceToSourcePidMap);
 
-			goldenResourceToSourcePidMap.entrySet()
-				.forEach(entry -> {
-					Long key = entry.getKey();
-					String goldenResourceId = myIdHelperService.translatePidIdToForcedId(new ResourcePersistentId(key)).orElse(key.toString());
-
-					Map<Long, Optional<String>> pidsToForcedIds = myIdHelperService.translatePidsToForcedIds(entry.getValue());
-					Set<String> sourceResourceIds = pidsToForcedIds.entrySet().stream()
-						.map(ent -> ent.getValue().isPresent() ? ent.getValue().get() : ent.getKey().toString())
-						.collect(Collectors.toSet());
-
-					sourceResourceIds
-						.forEach(sourceResourceId -> sourceResourceIdToGoldenResourceIdMap.put(sourceResourceId, goldenResourceId));
-				});
-			myMdmExpansionCacheSvc.setCacheContents(sourceResourceIdToGoldenResourceIdMap);
 
 			//If the result of the translation is an empty optional, it means there is no forced id, and we can use the PID as the resource ID.
 			Set<String> resolvedResourceIds = pidToForcedIdMap.entrySet().stream()
@@ -210,6 +189,28 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 		expandedIds.addAll(getMembers());
 
 		return expandedIds;
+	}
+
+	private void populateMdmResourceCacheIfNeeded(Map<Long, Set<Long>> goldenResourceToSourcePidMap) {
+		if (myMdmExpansionCacheSvc.hasBeenPopulated()) {
+			return;
+		}
+		Map<String, String> sourceResourceIdToGoldenResourceIdMap = new HashMap<>();
+
+		goldenResourceToSourcePidMap.entrySet()
+			.forEach(entry -> {
+				Long key = entry.getKey();
+				String goldenResourceId = myIdHelperService.translatePidIdToForcedId(new ResourcePersistentId(key)).orElse(key.toString());
+
+				Map<Long, Optional<String>> pidsToForcedIds = myIdHelperService.translatePidsToForcedIds(entry.getValue());
+				Set<String> sourceResourceIds = pidsToForcedIds.entrySet().stream()
+					.map(ent -> ent.getValue().isPresent() ? ent.getValue().get() : ent.getKey().toString())
+					.collect(Collectors.toSet());
+
+				sourceResourceIds
+					.forEach(sourceResourceId -> sourceResourceIdToGoldenResourceIdMap.put(sourceResourceId, goldenResourceId));
+			});
+		myMdmExpansionCacheSvc.setCacheContents(sourceResourceIdToGoldenResourceIdMap);
 	}
 
 	private void queryResourceTypeWithReferencesToPatients(Set<ResourcePersistentId> myReadPids, List<String> idChunk) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/GroupBulkItemReader.java
@@ -237,10 +237,6 @@ public class GroupBulkItemReader extends BaseBulkItemReader implements ItemReade
 		return expandedIds;
 	}
 
-	private void populateMdmResourceCacheIfNeeded(Map<Long, Set<Long>> goldenResourceToSourcePidMap) {
-
-	}
-
 	private void queryResourceTypeWithReferencesToPatients(Set<ResourcePersistentId> myReadPids, List<String> idChunk) {
 		//Build SP map
 		//First, inject the _typeFilters and _since from the export job

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkDao.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.jpa.dao.data;
 
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.jpa.entity.MdmLink;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -40,7 +41,7 @@ public interface IMdmLinkDao extends JpaRepository<MdmLink, Long> {
 	@Query("DELETE FROM MdmLink f WHERE (myGoldenResourcePid = :pid OR mySourcePid = :pid) AND myMatchResult <> :matchResult")
 	int deleteWithAnyReferenceToPidAndMatchResultNot(@Param("pid") Long thePid, @Param("matchResult") MdmMatchResultEnum theMatchResult);
 
-	@Query("SELECT ml2.myGoldenResourcePid, ml2.mySourcePid FROM MdmLink ml2 " +
+	@Query("SELECT ml2.myGoldenResourcePid as goldenPid, ml2.mySourcePid as sourcePid FROM MdmLink ml2 " +
 		"WHERE ml2.myMatchResult=:matchResult " +
 		"AND ml2.myGoldenResourcePid IN (" +
 			"SELECT ml.myGoldenResourcePid FROM MdmLink ml " +
@@ -50,5 +51,11 @@ public interface IMdmLinkDao extends JpaRepository<MdmLink, Long> {
 			"AND hrl.mySourcePath='Group.member.entity' " +
 			"AND hrl.myTargetResourceType='Patient'" +
 		")")
-	List<List<Long>> expandPidsFromGroupPidGivenMatchResult(@Param("groupPid") Long theGroupPid, @Param("matchResult") MdmMatchResultEnum theMdmMatchResultEnum);
+	List<MdmPidTuple> expandPidsFromGroupPidGivenMatchResult(@Param("groupPid") Long theGroupPid, @Param("matchResult") MdmMatchResultEnum theMdmMatchResultEnum);
+
+	interface MdmPidTuple {
+		Long getGoldenPid();
+		Long getSourcePid();
+	}
+
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
@@ -2,15 +2,15 @@ package ca.uhn.fhir.jpa.dao.mdm;
 
 import org.slf4j.Logger;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class MdmExpansionCacheSvc {
 	private static final Logger ourLog = getLogger(MdmExpansionCacheSvc.class);
 
-	private Map<String, String> mySourceToGoldenIdCache = new HashMap<>();
+	private ConcurrentHashMap<String, String> mySourceToGoldenIdCache = new ConcurrentHashMap<>();
 
 	public String getGoldenResourceId(String theSourceId) {
 		ourLog.info(buildLog("About to lookup cached resource ID " + theSourceId, true));
@@ -32,6 +32,12 @@ public class MdmExpansionCacheSvc {
 	}
 
 	public void setCacheContents(Map<String, String> theSourceResourceIdToGoldenResourceIdMap) {
-		this.mySourceToGoldenIdCache = theSourceResourceIdToGoldenResourceIdMap;
+		if (mySourceToGoldenIdCache.isEmpty()) {
+			this.mySourceToGoldenIdCache.putAll(theSourceResourceIdToGoldenResourceIdMap);
+		}
+	}
+
+	public boolean hasBeenPopulated() {
+		return !mySourceToGoldenIdCache.isEmpty();
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
@@ -1,0 +1,37 @@
+package ca.uhn.fhir.jpa.dao.mdm;
+
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class MdmExpansionCacheSvc {
+	private static final Logger ourLog = getLogger(MdmExpansionCacheSvc.class);
+
+	private Map<String, String> mySourceToGoldenIdCache = new HashMap<>();
+
+	public String getGoldenResourceId(String theSourceId) {
+		ourLog.info(buildLog("About to lookup cached resource ID " + theSourceId, true));
+		return mySourceToGoldenIdCache.get(theSourceId);
+	}
+
+	public String buildLog(String message, boolean theShowContent) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(message);
+		if (ourLog.isDebugEnabled() || theShowContent) {
+			builder.append("\n")
+				.append("Current cache content is:")
+				.append("\n");
+			mySourceToGoldenIdCache.entrySet().stream().forEach(entry -> builder.append(entry.getKey()).append(" -> ").append(entry.getValue()).append("\n"));
+			return builder.toString();
+		}
+		return builder.toString();
+
+	}
+
+	public void setCacheContents(Map<String, String> theSourceResourceIdToGoldenResourceIdMap) {
+		this.mySourceToGoldenIdCache = theSourceResourceIdToGoldenResourceIdMap;
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
@@ -41,7 +41,7 @@ public class MdmExpansionCacheSvc {
 		return goldenResourceId;
 	}
 
-	public String buildLogMessage(String theMessage) {
+	private String buildLogMessage(String theMessage) {
 		return buildLogMessage(theMessage, false);
 	}
 
@@ -66,12 +66,21 @@ public class MdmExpansionCacheSvc {
 
 	}
 
+	/**
+	 * Populate the cache
+	 *
+	 * @param theSourceResourceIdToGoldenResourceIdMap the source ID -> golden ID map to populate the cache with.
+	 */
 	public void setCacheContents(Map<String, String> theSourceResourceIdToGoldenResourceIdMap) {
 		if (mySourceToGoldenIdCache.isEmpty()) {
 			this.mySourceToGoldenIdCache.putAll(theSourceResourceIdToGoldenResourceIdMap);
 		}
 	}
 
+	/**
+	 * Since this cache is used at @JobScope, we can skip a whole whack of expansions happening by simply checking
+	 * if one of our child steps has populated the cache yet. .
+	 */
 	public boolean hasBeenPopulated() {
 		return !mySourceToGoldenIdCache.isEmpty();
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
@@ -21,6 +21,13 @@ public class MdmExpansionCacheSvc {
 
 	private final ConcurrentHashMap<String, String> mySourceToGoldenIdCache = new ConcurrentHashMap<>();
 
+	/**
+	 * Lookup a given resource's golden resource ID in the cache. Note that if you pass this function the resource ID of a
+	 * golden resource, it will just return itself.
+	 *
+	 * @param theSourceId the resource ID of the source resource ,e.g. PAT123
+	 * @return the resource ID of the associated golden resource.
+	 */
 	public String getGoldenResourceId(String theSourceId) {
 		ourLog.debug(buildLogMessage("About to lookup cached resource ID " + theSourceId));
 		String goldenResourceId = mySourceToGoldenIdCache.get(theSourceId);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmExpansionCacheSvc.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.dao.mdm;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import java.util.Map;
@@ -7,20 +8,47 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+/**
+ * The purpose of this class is to share context between steps of a given GroupBulkExport job.
+ *
+ * This cache allows you to port state between reader/processor/writer. In this case, we are maintaining
+ * a cache of Source Resource ID -> Golden Resource ID, so that we can annotate outgoing resources with their golden owner
+ * if applicable.
+ *
+ */
 public class MdmExpansionCacheSvc {
 	private static final Logger ourLog = getLogger(MdmExpansionCacheSvc.class);
 
-	private ConcurrentHashMap<String, String> mySourceToGoldenIdCache = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, String> mySourceToGoldenIdCache = new ConcurrentHashMap<>();
 
 	public String getGoldenResourceId(String theSourceId) {
-		ourLog.info(buildLog("About to lookup cached resource ID " + theSourceId, true));
-		return mySourceToGoldenIdCache.get(theSourceId);
+		ourLog.debug(buildLogMessage("About to lookup cached resource ID " + theSourceId));
+		String goldenResourceId = mySourceToGoldenIdCache.get(theSourceId);
+
+		//A golden resources' golden resource ID is itself.
+		if (StringUtils.isBlank(goldenResourceId)) {
+			if (mySourceToGoldenIdCache.containsValue(theSourceId)) {
+				goldenResourceId = theSourceId;
+			}
+		}
+		return goldenResourceId;
 	}
 
-	public String buildLog(String message, boolean theShowContent) {
+	public String buildLogMessage(String theMessage) {
+		return buildLogMessage(theMessage, false);
+	}
+
+	/**
+	 * Builds a log message, potentially enriched with the cache content.
+	 *
+	 * @param message The log message
+	 * @param theAddCacheContentContent If true, will annotate the log message with the current cache contents.
+	 * @return a built log message, which may include the cache content.
+	 */
+	public String buildLogMessage(String message, boolean theAddCacheContentContent) {
 		StringBuilder builder = new StringBuilder();
 		builder.append(message);
-		if (ourLog.isDebugEnabled() || theShowContent) {
+		if (ourLog.isDebugEnabled() || theAddCacheContentContent) {
 			builder.append("\n")
 				.append("Current cache content is:")
 				.append("\n");

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -1052,7 +1052,6 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 
 		//Non-cached should all have unique IDs
 		List<String> jobIds = Stream.of(jobInfo5, jobInfo6, jobInfo7, jobInfo8, jobInfo9).map(IBulkDataExportSvc.JobInfo::getJobId).collect(Collectors.toList());
-		ourLog.info("ZOOP {}", String.join(", ", jobIds));
 		Set<String> uniqueJobIds = new HashSet<>(jobIds);
 		assertEquals(uniqueJobIds.size(), jobIds.size());
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -660,7 +660,7 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 		IBulkDataExportSvc.JobInfo jobInfo = myBulkDataExportSvc.getJobInfoOrThrowResourceNotFound(jobDetails.getJobId());
 
 		assertThat(jobInfo.getStatus(), equalTo(BulkJobStatusEnum.COMPLETE));
-		assertThat(jobInfo.getFiles().size(), equalTo(3));
+		assertThat(jobInfo.getFiles().size(), equalTo(2));
 		assertThat(jobInfo.getFiles().get(0).getResourceType(), is(equalTo("Immunization")));
 
 		//Ensure that all immunizations refer to the golden resource via extension
@@ -676,7 +676,7 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 
 		//Ensure all patients are linked to their golden resource.
 		assertThat(jobInfo.getFiles().get(1).getResourceType(), is(equalTo("Patient")));
-		List<Patient> patients = readBulkExportContentsIntoResources(getBinaryContents(jobInfo, 2), Patient.class);
+		List<Patient> patients = readBulkExportContentsIntoResources(getBinaryContents(jobInfo, 1), Patient.class);
 		patients.stream()
 			.filter(patient -> patient.getIdElement().getIdPart().equals("PAT999"))
 			.forEach(patient -> {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -677,7 +677,6 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 		nextContents = getBinaryContents(jobInfo, 2);
 		assertThat(jobInfo.getFiles().get(2).getResourceType(), is(equalTo("Patient")));
 		assertThat(nextContents, is(containsString(GoldenResourceAnnotatingProcessor.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
-
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -6,7 +6,6 @@ import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
 import ca.uhn.fhir.jpa.batch.BatchJobsConfig;
 import ca.uhn.fhir.jpa.batch.api.IBatchJobSubmitter;
-import ca.uhn.fhir.jpa.batch.processors.GoldenResourceAnnotatingProcessor;
 import ca.uhn.fhir.jpa.bulk.api.BulkDataExportOptions;
 import ca.uhn.fhir.jpa.bulk.api.IBulkDataExportSvc;
 import ca.uhn.fhir.jpa.bulk.job.BulkExportJobParametersBuilder;
@@ -20,12 +19,11 @@ import ca.uhn.fhir.jpa.entity.BulkExportCollectionEntity;
 import ca.uhn.fhir.jpa.entity.BulkExportCollectionFileEntity;
 import ca.uhn.fhir.jpa.entity.BulkExportJobEntity;
 import ca.uhn.fhir.jpa.entity.MdmLink;
-import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.rest.api.Constants;
-import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Sets;
@@ -40,7 +38,6 @@ import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.Immunization;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Observation;
-import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.Test;
@@ -56,7 +53,6 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -668,15 +664,15 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 
 		String nextContents = getBinaryContents(jobInfo, 0);
 		assertThat(jobInfo.getFiles().get(0).getResourceType(), is(equalTo("Immunization")));
-		assertThat(nextContents, is(containsString(GoldenResourceAnnotatingProcessor.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
+		assertThat(nextContents, is(containsString(HapiExtensions.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
 
 		nextContents = getBinaryContents(jobInfo, 1);
 		assertThat(jobInfo.getFiles().get(1).getResourceType(), is(equalTo("Observation")));
-		assertThat(nextContents, is(containsString(GoldenResourceAnnotatingProcessor.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
+		assertThat(nextContents, is(containsString(HapiExtensions.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
 
 		nextContents = getBinaryContents(jobInfo, 2);
 		assertThat(jobInfo.getFiles().get(2).getResourceType(), is(equalTo("Patient")));
-		assertThat(nextContents, is(containsString(GoldenResourceAnnotatingProcessor.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
+		assertThat(nextContents, is(containsString(HapiExtensions.ASSOCIATED_GOLDEN_RESOURCE_EXTENSION_URL)));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4ValueSetNoVerCSNoVerTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4ValueSetNoVerCSNoVerTest.java
@@ -541,7 +541,6 @@ public class ResourceProviderR4ValueSetNoVerCSNoVerTest extends BaseResourceProv
 		ValueSet expanded = (ValueSet) respParam.getParameter().get(0).getResource();
 
 		String resp = myFhirCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(expanded);
-		ourLog.info("zoop");
 		ourLog.info(resp);
 
 		assertThat(resp, is(containsStringIgnoringCase("<code value=\"M\"/>")));

--- a/hapi-fhir-jpaserver-batch/src/test/java/ca/uhn/fhir/jpa/batch/config/BatchJobConfig.java
+++ b/hapi-fhir-jpaserver-batch/src/test/java/ca/uhn/fhir/jpa/batch/config/BatchJobConfig.java
@@ -22,6 +22,7 @@ public class BatchJobConfig {
 	private StepBuilderFactory myStepBuilderFactory;
 
 
+
 	@Bean
 	public Job testJob() {
 		return myJobBuilderFactory.get("testJob")


### PR DESCRIPTION
This feature is specifically for Group Bulk Export, when `_mdm=true`, is enabled, forcing MDM expansion of the group. 
## The problem

It is difficult to identify which exported resources belong to which golden resource patient. The exported JSON only shows the actual patient involved, and trying to figure out which golden resource patient it is linked to post-hoc is a very inconvenient thing to have to do. 

## The solution

Add another step to Group Bulk Export Processing which annotates the outgoing resources with their patient's associated Golden Resource patient id. 

## The nuts and bolts

* During MDM expansion, we now need to retain a mapping of source resource id -> golden resource id. new MdmExpansionCacheSvc does this. 
* This bean is job-scoped, so that parallel spring batch executions can all make use of the same cache and every parallel step doesn't have to recompute the group expansion of Golden/1 -> [Patient/2, Patient/3]
* Upon computing the group expansion, create and store  an inverted index for fast-lookup of source resource ID -> golden resource ID. 
* Create a new ItemProcessor `GoldenResourceAnnotatingProcessor` which, before sending an IBaseResource to be written, searches it via fhirpath for its patient reference. If it finds one, it performs the cache lookup, and adds the golden resource ID as an extension to the resource.
 
The following resource:
```json
{
  "resourceType": "Immunization",
  "id": "IMM0",
  "meta": {
    "versionId": "1",
    "lastUpdated": "2021-03-25T12:46:30.970-07:00"
  },
  "vaccineCode": {
    "coding": [
      {
        "system": "vaccines",
        "code": "Flu"
      }
    ]
  },
  "patient": {
    "reference": "Patient/PAT0"
  }
}
```

Will look like this when stored in the NDJSON file.

```json
{
  "resourceType": "Immunization",
  "id": "IMM0",
  "meta": {
    "versionId": "1",
    "lastUpdated": "2021-03-25T12:46:30.970-07:00"
  },
  "extension": [
    {
      "url": "https://hapifhir.org/associated-patient-golden-resource/",
      "valueReference": {
        "reference": "Patient/PAT999"
      }
    }
  ],
  "vaccineCode": {
    "coding": [
      {
        "system": "vaccines",
        "code": "Flu"
      }
    ]
  },
  "patient": {
    "reference": "Patient/PAT0"
  }
}
```