### PR TITLE
Offset query fixes

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FhirResourceDaoEncounterDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FhirResourceDaoEncounterDstu2.java
@@ -44,7 +44,7 @@ public class FhirResourceDaoEncounterDstu2 extends BaseHapiFhirResourceDao<Encou
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 
 //		paramMap.setRevIncludes(Collections.singleton(IResource.INCLUDE_ALL.asRecursive()));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FhirResourceDaoPatientDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FhirResourceDaoPatientDstu2.java
@@ -59,7 +59,7 @@ public class FhirResourceDaoPatientDstu2 extends BaseHapiFhirResourceDao<Patient
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 		if (theContent != null) {
 			paramMap.add(Constants.PARAM_CONTENT, theContent);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoEncounterDstu3.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoEncounterDstu3.java
@@ -45,7 +45,7 @@ public class FhirResourceDaoEncounterDstu3 extends BaseHapiFhirResourceDao<Encou
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 
 //		paramMap.setRevIncludes(Collections.singleton(IResource.INCLUDE_ALL.asRecursive()));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoPatientDstu3.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoPatientDstu3.java
@@ -54,7 +54,7 @@ public class FhirResourceDaoPatientDstu3 extends BaseHapiFhirResourceDao<Patient
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 		if (theContent != null) {
 			paramMap.add(Constants.PARAM_CONTENT, theContent);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoEncounterR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoEncounterR4.java
@@ -45,7 +45,7 @@ public class FhirResourceDaoEncounterR4 extends BaseHapiFhirResourceDao<Encounte
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 
 //		paramMap.setRevIncludes(Collections.singleton(IResource.INCLUDE_ALL.asRecursive()));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoPatientR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoPatientR4.java
@@ -54,7 +54,7 @@ public class FhirResourceDaoPatientR4 extends BaseHapiFhirResourceDao<Patient>im
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 		if (theContent != null) {
 			paramMap.add(Constants.PARAM_CONTENT, theContent);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoEncounterR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoEncounterR5.java
@@ -45,7 +45,7 @@ public class FhirResourceDaoEncounterR5 extends BaseHapiFhirResourceDao<Encounte
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 
 //		paramMap.setRevIncludes(Collections.singleton(IResource.INCLUDE_ALL.asRecursive()));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoPatientR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoPatientR5.java
@@ -54,7 +54,7 @@ public class FhirResourceDaoPatientR5 extends BaseHapiFhirResourceDao<Patient> i
 			paramMap.setCount(theCount.getValue());
 		}
 		if (theOffset != null) {
-			paramMap.setOffset(theOffset.getValue());
+			throw new IllegalArgumentException("Everything operation does not support offset searching");
 		}
 		if (theContent != null) {
 			paramMap.add(Constants.PARAM_CONTENT, theContent);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -1164,7 +1164,7 @@ public class SearchBuilder implements ISearchBuilder {
 					if (myMaxResultsToFetch == null) {
 						if (myParams.getLoadSynchronousUpTo() != null) {
 							myMaxResultsToFetch = myParams.getLoadSynchronousUpTo();
-						} else if (myParams.getCount() != null) {
+						} else if (myParams.getOffset() != null && myParams.getCount() != null) {
 							myMaxResultsToFetch = myParams.getCount();
 						} else {
 							myMaxResultsToFetch = myDaoConfig.getFetchSizeDefaultMaximum();

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -1162,7 +1162,13 @@ public class SearchBuilder implements ISearchBuilder {
 				// If we don't have a query yet, create one
 				if (myResultsIterator == null) {
 					if (myMaxResultsToFetch == null) {
-						myMaxResultsToFetch = myDaoConfig.getFetchSizeDefaultMaximum();
+						if (myParams.getLoadSynchronousUpTo() != null) {
+							myMaxResultsToFetch = myParams.getLoadSynchronousUpTo();
+						} else if (myParams.getCount() != null) {
+							myMaxResultsToFetch = myParams.getCount();
+						} else {
+							myMaxResultsToFetch = myDaoConfig.getFetchSizeDefaultMaximum();
+						}
 					}
 
 					initializeIteratorQuery(myOffset, myMaxResultsToFetch);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/ResourceProviderDstu2Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/ResourceProviderDstu2Test.java
@@ -1660,7 +1660,7 @@ public class ResourceProviderDstu2Test extends BaseResourceProviderDstu2Test {
 	}
 
 	@Test
-	public void testPagingOverEverythingSetWithNoPagingProvider() {
+	public void testEverythingWithNoPagingProvider() {
 		ourRestServer.setPagingProvider(null);
 
 		Patient p = new Patient();
@@ -1689,20 +1689,7 @@ public class ResourceProviderDstu2Test extends BaseResourceProviderDstu2Test {
 
 		assertEquals(10, response.getEntry().size());
 		assertEquals(null, response.getTotalElement().getValue());
-		assertThat(response.getLink("next").getUrl(), not(emptyString()));
-
-		response = ourClient.fetchResourceFromUrl(ca.uhn.fhir.model.dstu2.resource.Bundle.class, response.getLink("next").getUrl());
-
-		assertEquals(10, response.getEntry().size());
-		assertEquals(null, response.getTotalElement().getValue());
-		assertThat(response.getLink("next").getUrl(), not(emptyString()));
-
-		response = ourClient.fetchResourceFromUrl(ca.uhn.fhir.model.dstu2.resource.Bundle.class, response.getLink("next").getUrl());
-
-		assertEquals(1, response.getEntry().size());
-		assertEquals(21, response.getTotalElement().getValue().intValue());
 		assertEquals(null, response.getLink("next"));
-
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
@@ -2375,7 +2375,7 @@ public class ResourceProviderDstu3Test extends BaseResourceProviderDstu3Test {
 	}
 
 	@Test
-	public void testPagingOverEverythingSetWithNoPagingProvider() {
+	public void testEverythingWithNoPagingProvider() {
 		ourRestServer.setPagingProvider(null);
 
 		Patient p = new Patient();
@@ -2404,22 +2404,8 @@ public class ResourceProviderDstu3Test extends BaseResourceProviderDstu3Test {
 
 		assertEquals(10, response.getEntry().size());
 		assertEquals(null, response.getTotalElement().getValue());
-		assertThat(response.getLink("next").getUrl(), not(emptyString()));
-
-		response = ourClient.fetchResourceFromUrl(Bundle.class, response.getLink("next").getUrl());
-
-		assertEquals(10, response.getEntry().size());
-		assertEquals(null, response.getTotalElement().getValue());
-		assertThat(response.getLink("next").getUrl(), not(emptyString()));
-
-		response = ourClient.fetchResourceFromUrl(Bundle.class, response.getLink("next").getUrl());
-
-		assertEquals(1, response.getEntry().size());
-		assertEquals(21, response.getTotalElement().getValue().intValue());
 		assertEquals(null, response.getLink("next"));
-
 	}
-
 
 	@Test
 	public void testPreserveVersionsOnAuditEvent() {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
@@ -3402,6 +3402,37 @@ public class ResourceProviderDstu3Test extends BaseResourceProviderDstu3Test {
 		assertEquals(SearchEntryMode.INCLUDE, found.getEntry().get(1).getSearch().getMode());
 	}
 
+	@Test
+	public void testOffsetSearchWithInclude() {
+		Organization org = new Organization();
+		org.addIdentifier().setSystem("urn:system:rpdstu2").setValue("testSearchWithInclude01");
+		IdType orgId = (IdType) ourClient.create().resource(org).prettyPrint().encodedXml().execute().getId();
+
+		Patient pat = new Patient();
+		pat.addIdentifier().setSystem("urn:system:rpdstu2").setValue("testSearchWithInclude02");
+		pat.getManagingOrganization().setReferenceElement(orgId.toUnqualifiedVersionless());
+		ourClient.create().resource(pat).prettyPrint().encodedXml().execute().getId();
+
+		//@formatter:off
+		Bundle found = ourClient
+			.search()
+			.forResource(Patient.class)
+			.where(Patient.IDENTIFIER.exactly().systemAndIdentifier("urn:system:rpdstu2", "testSearchWithInclude02"))
+			.include(Patient.INCLUDE_ORGANIZATION)
+			.offset(0)
+			.count(1)
+			.prettyPrint()
+			.returnBundle(Bundle.class)
+			.execute();
+		//@formatter:on
+
+		assertEquals(2, found.getEntry().size());
+		assertEquals(Patient.class, found.getEntry().get(0).getResource().getClass());
+		assertEquals(SearchEntryMode.MATCH, found.getEntry().get(0).getSearch().getMode());
+		assertEquals(Organization.class, found.getEntry().get(1).getResource().getClass());
+		assertEquals(SearchEntryMode.INCLUDE, found.getEntry().get(1).getSearch().getMode());
+	}
+
 	@Test()
 	public void testSearchWithInvalidNumberPrefix() {
 		try {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -4849,6 +4849,35 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		assertEquals(SearchEntryMode.INCLUDE, found.getEntry().get(1).getSearch().getMode());
 	}
 
+	@Test
+	public void testOffsetSearchWithInclude() {
+		Organization org = new Organization();
+		org.addIdentifier().setSystem("urn:system:rpr4").setValue("testSearchWithInclude01");
+		IdType orgId = (IdType) myClient.create().resource(org).prettyPrint().encodedXml().execute().getId();
+
+		Patient pat = new Patient();
+		pat.addIdentifier().setSystem("urn:system:rpr4").setValue("testSearchWithInclude02");
+		pat.getManagingOrganization().setReferenceElement(orgId.toUnqualifiedVersionless());
+		myClient.create().resource(pat).prettyPrint().encodedXml().execute();
+
+		Bundle found = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(Patient.IDENTIFIER.exactly().systemAndIdentifier("urn:system:rpr4", "testSearchWithInclude02"))
+			.include(Patient.INCLUDE_ORGANIZATION)
+			.offset(0)
+			.count(1)
+			.prettyPrint()
+			.returnBundle(Bundle.class)
+			.execute();
+
+		assertEquals(2, found.getEntry().size());
+		assertEquals(Patient.class, found.getEntry().get(0).getResource().getClass());
+		assertEquals(SearchEntryMode.MATCH, found.getEntry().get(0).getSearch().getMode());
+		assertEquals(Organization.class, found.getEntry().get(1).getResource().getClass());
+		assertEquals(SearchEntryMode.INCLUDE, found.getEntry().get(1).getSearch().getMode());
+	}
+
 	@Test()
 	public void testSearchWithInvalidNumberPrefix() {
 		try {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -3064,7 +3064,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 
 	@Disabled
 	@Test
-	public void testPagingOverEverythingSetWithNoPagingProvider() {
+	public void testEverythingWithNoPagingProvider() {
 		ourRestServer.setPagingProvider(null);
 
 		Patient p = new Patient();
@@ -3093,22 +3093,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 
 		assertEquals(10, response.getEntry().size());
 		assertEquals(null, response.getTotalElement().getValue());
-		assertThat(response.getLink("next").getUrl(), not(emptyString()));
-
-		response = myClient.fetchResourceFromUrl(Bundle.class, response.getLink("next").getUrl());
-
-		assertEquals(10, response.getEntry().size());
-		assertEquals(null, response.getTotalElement().getValue());
-		assertThat(response.getLink("next").getUrl(), not(emptyString()));
-
-		myCaptureQueriesListener.clear();
-		response = myClient.fetchResourceFromUrl(Bundle.class, response.getLink("next").getUrl());
-		myCaptureQueriesListener.logSelectQueries();
-
-		assertEquals(1, response.getEntry().size());
-		assertEquals(21, response.getTotalElement().getValue().intValue());
 		assertEquals(null, response.getLink("next"));
-
 	}
 
 	@Test

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
@@ -158,7 +158,10 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 					numToReturn = numTotalResults != null ? numTotalResults : Integer.MAX_VALUE;
 				}
 			}
-			if (numToReturn > 0) {
+			if (requestOffset != null) {
+				// When offset query is done theResult already contains correct amount (+ their includes etc.) so return everything
+				resourceList = theResult.getResources(0, Integer.MAX_VALUE);
+			} else if (numToReturn > 0) {
 				resourceList = theResult.getResources(0, numToReturn);
 			} else {
 				resourceList = Collections.emptyList();


### PR DESCRIPTION
Here is couple of fixes for synchronous offset search:

The new search builder did not correctly pass on the count limit to the offset+limit SQL query (which caused the query to default to 10 000 items (or fetch size default maximum). When using offset it should pass on the correct limit). This change is similar to the Legacy search builder.

When offset search was used the includes were dropped from the bundle response. When offset search is used, the BundleProvider will contain correct amount of resources+includes/revIncludes. There was a mistake in the implementation and it caused to "drop" included resources if count was less than resources+their includes. When offset search is used the whole bundle contents should be returned because it already contains correct resources. The DatabaseBackedPagingProvider works differently, as it fetches the includes after some slice is retrieved from the database.