### PR TITLE
Prevent ConsentInterceptor from operating on metadata endpoint

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -352,7 +352,7 @@ public class ConsentInterceptor {
 		}
 	}
 	private boolean isMetaOperation(RequestDetails theRequestDetails) {
-		return theRequestDetails.getOperation() != null && theRequestDetails.getOperation().equals("$meta");
+		return "$meta".equals(theRequestDetails.getOperation());
 	}
 
 	private boolean isMetadataPath(RequestDetails theRequestDetails) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static ca.uhn.fhir.jpa.model.util.JpaConstants.OPERATION_META;
 
 @Interceptor
 public class ConsentInterceptor {
@@ -353,7 +352,7 @@ public class ConsentInterceptor {
 		}
 	}
 	private boolean isMetaOperation(RequestDetails theRequestDetails) {
-		return theRequestDetails.getOperation() != null && theRequestDetails.getOperation().equals(OPERATION_META);
+		return theRequestDetails.getOperation() != null && theRequestDetails.getOperation().equals("$meta");
 	}
 
 	private boolean isMetadataPath(RequestDetails theRequestDetails) {


### PR DESCRIPTION
* add an allowlist for `$meta` operation and `/metadata` which skips running the consent interceptor for most checks. 
* It still calls `completeOperationSuccess` and `completeOperationFailure`, but for all other hooks, it skips. 