### PR TITLE
Ks 20210526 accurate total

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_5_0/2677-fix-accurate-count-zero.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_5_0/2677-fix-accurate-count-zero.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 2674
+title: "When myDaoConfig.setDefaultTotalMode(SearchTotalModeEnum.ACCURATE) and there are zero search results on an _id search,
+An Index Out of Bounds error was thrown.  This has been corrected."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
@@ -1072,7 +1072,7 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc {
 				ourLog.trace("Performing count");
 				ISearchBuilder sb = newSearchBuilder();
 				Iterator<Long> countIterator = sb.createCountQuery(myParams, mySearch.getUuid(), myRequest, myRequestPartitionId);
-				Long count = countIterator.next();
+				Long count = countIterator.hasNext() ? countIterator.next() : 0;
 				ourLog.trace("Got count {}", count);
 
 				TransactionTemplate txTemplate = new TransactionTemplate(myManagedTxManager);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -253,6 +253,9 @@ public class SearchBuilder implements ISearchBuilder {
 		init(theParams, theSearchUuid, theRequestPartitionId);
 
 		ArrayList<SearchQueryExecutor> queries = createQuery(myParams, null, null, null, true, theRequest, null);
+		if (queries.isEmpty()) {
+			return Collections.emptyIterator();
+		}
 		try (SearchQueryExecutor queryExecutor = queries.get(0)) {
 			return Lists.newArrayList(queryExecutor.next()).iterator();
 		}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderSummaryModeR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderSummaryModeR4Test.java
@@ -4,6 +4,9 @@ import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.search.SearchCoordinatorSvcImpl;
 import ca.uhn.fhir.rest.api.SearchTotalModeEnum;
 import ca.uhn.fhir.rest.api.SummaryEnum;
+import ca.uhn.fhir.rest.gclient.ICriterion;
+import ca.uhn.fhir.rest.gclient.StringClientParam;
+import ca.uhn.fhir.rest.param.StringParam;
 import com.google.common.collect.Lists;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Narrative;
@@ -107,6 +110,24 @@ public class ResourceProviderSummaryModeR4Test extends BaseResourceProviderR4Tes
 
 		assertEquals(new Integer(104), outcome.getTotalElement().getValue());
 		assertEquals(10, outcome.getEntry().size());
+	}
+
+	/**
+	 * Test zero counts
+	 */
+	@Test
+	public void testSearchNoHitsWithTotalAccurateSpecifiedAsDefault() {
+		myDaoConfig.setDefaultTotalMode(SearchTotalModeEnum.ACCURATE);
+
+		Bundle outcome = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(new StringClientParam(Patient.SP_RES_ID).matches().value("non-existent-id"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		assertEquals(new Integer(0), outcome.getTotalElement().getValue());
+		assertEquals(0, outcome.getEntry().size());
 	}
 
 	/**


### PR DESCRIPTION
With `myDaoConfig.setDefaultTotalMode(SearchTotalModeEnum.ACCURATE)`
submit a search request searching for a Patient resource by non-numeric ID where ID is for a Patient that is known not to exist in the CDR. For example:

GET http://localhost:8000/Patient/?_id=nonexistentid
