### PR TITLE
Make package ID handling case-insensitive (#2682)

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -195,7 +195,7 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 		ourLog.info("Parsing package .tar.gz ({} bytes) from {}", bytes.length, theSourceDesc);
 
 		NpmPackage npmPackage = NpmPackage.fromPackage(new ByteArrayInputStream(bytes));
-		if (!npmPackage.id().equals(thePackageId)) {
+		if (!npmPackage.id().equalsIgnoreCase(thePackageId)) {
 			throw new InvalidRequestException("Package ID " + npmPackage.id() + " doesn't match expected: " + thePackageId);
 		}
 		if (!PackageVersionComparator.isEquivalent(thePackageVersionId, npmPackage.version())) {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.interceptor.api.IInterceptorService;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageDao;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionDao;
 import ca.uhn.fhir.jpa.dao.r4.BaseJpaR4Test;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor;
 import org.hl7.fhir.utilities.npm.NpmPackage;
@@ -18,6 +19,7 @@ import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class JpaPackageCacheTest extends BaseJpaR4Test {
@@ -123,7 +125,15 @@ public class JpaPackageCacheTest extends BaseJpaR4Test {
 		InputStream stream = IgInstallerDstu3Test.class.getResourceAsStream("/packages/package-davinci-cdex-0.2.0.tgz");
 
 		// The package has the ID in lower-case, so for the test we input the first parameter in upper-case & check that no error is thrown
-		assertDoesNotThrow(() -> myPackageCacheManager.addPackageToCache(packageNameUppercase, "0.2.0", stream, packageNameAllLowercase));
+		assertDoesNotThrow(() -> myPackageCacheManager.addPackageToCache(packageNameUppercase, "0.2.0", stream, "hl7.fhir.us.davinci-cdex"));
+	}
+
+	@Test
+	public void testNonMatchingPackageIdsCauseError() throws IOException {
+		String incorrectPackageName = "hl7.fhir.us.davinci-nonsense";
+		InputStream stream = IgInstallerDstu3Test.class.getResourceAsStream("/packages/package-davinci-cdex-0.2.0.tgz");
+
+		assertThrows(InvalidRequestException.class, () -> myPackageCacheManager.addPackageToCache(incorrectPackageName, "0.2.0", stream, "hl7.fhir.us.davinci-cdex"));
 	}
 
 }

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheTest.java
@@ -14,7 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -112,6 +114,16 @@ public class JpaPackageCacheTest extends BaseJpaR4Test {
 	@Test
 	public void testSavePackageCorrectFhirVersion() {
 
+	}
+
+	@Test
+	public void testPackageIdHandlingIsNotCaseSensitive() throws IOException {
+		String packageNameAllLowercase = "hl7.fhir.us.davinci-cdex";
+		String packageNameUppercase = packageNameAllLowercase.toUpperCase(Locale.ROOT);
+		InputStream stream = IgInstallerDstu3Test.class.getResourceAsStream("/packages/package-davinci-cdex-0.2.0.tgz");
+
+		// The package has the ID in lower-case, so for the test we input the first parameter in upper-case & check that no error is thrown
+		assertDoesNotThrow(() -> myPackageCacheManager.addPackageToCache(packageNameUppercase, "0.2.0", stream, packageNameAllLowercase));
 	}
 
 }


### PR DESCRIPTION
 This PR is a proposal for a resolution of issue #2682. In line with the recent fix for the validator, it makes the package ID comparison case-insensitive.