### PR TITLE
Allow lower case error message to also trigger retry

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/tx/HapiTransactionService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/tx/HapiTransactionService.java
@@ -99,7 +99,7 @@ public class HapiTransactionService {
 		 		 * thrown by one of the client threads, so we auto-retry in order to avoid
 		 		 * annopying spurious failures for the client.
 		 		 */
-				if (e.getMessage().contains("HFJ_TAG_DEF")) {
+				if (e.getMessage().contains("HFJ_TAG_DEF") || e.getMessage().contains("hfj_tag_def")) {
 					maxRetries = 3;
 				}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/tx/HapiTransactionService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/tx/HapiTransactionService.java
@@ -99,7 +99,8 @@ public class HapiTransactionService {
 		 		 * thrown by one of the client threads, so we auto-retry in order to avoid
 		 		 * annopying spurious failures for the client.
 		 		 */
-				if (e.getMessage().contains("HFJ_TAG_DEF") || e.getMessage().contains("hfj_tag_def")) {
+				if (e.getMessage().contains("HFJ_TAG_DEF") || e.getMessage().contains("hfj_tag_def") ||
+					 e.getMessage().contains("HFJ_RES_TAG") || e.getMessage().contains("hfj_res_tag")) {
 					maxRetries = 3;
 				}
 


### PR DESCRIPTION
Example error message:

`2021-05-31 12:29:30.142 [http-nio-8080-exec-4] ERROR o.h.e.j.batch.internal.BatchingBatch [BatchingBatch.java:130] HHH000315: Exception executing batch [java.sql.BatchUpdateException: Batch entry 0 insert into hfj_tag_def (tag_code, tag_display, tag_system, tag_type, tag_id) values ('http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement', NULL, 'https://github.com/hapifhir/hapi-fhir/ns/jpa/profile', 1, 653) was aborted: ERROR: duplicate key value violates unique constraint "idx_tagdef_typesyscode"
  Detail: Key (tag_type, tag_system, tag_code)=(1, https://github.com/hapifhir/hapi-fhir/ns/jpa/profile, http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement) already exists.  Call getNextException to see other errors in the batch.], SQL: insert into hfj_tag_def (tag_code, tag_display, tag_system, tag_type, tag_id) values (?, ?, ?, ?, ?)
`