### PR TITLE
SearchBuilder NPE

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -796,7 +796,7 @@ public class SearchBuilder implements ISearchBuilder {
 				// Account for _include=[resourceType]:*
 				String wantResourceType = null;
 				if (!matchAll) {
-					if (nextInclude.getParamName() != null && nextInclude.getParamName().equals("*")) {
+					if ("*".equals(nextInclude.getParamName())) {
 						wantResourceType = nextInclude.getParamType();
 						matchAll = true;
 					}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -796,7 +796,7 @@ public class SearchBuilder implements ISearchBuilder {
 				// Account for _include=[resourceType]:*
 				String wantResourceType = null;
 				if (!matchAll) {
-					if (nextInclude.getParamName().equals("*")) {
+					if (nextInclude.getParamName() != null && nextInclude.getParamName().equals("*")) {
 						wantResourceType = nextInclude.getParamType();
 						matchAll = true;
 					}


### PR DESCRIPTION
A search with `_include` param that has a "." in the value was causing a NPE.
