### PR TITLE
Add support for generic types in synthetic classes such as weld proxies (#2589)

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/MethodUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/MethodUtil.java
@@ -90,6 +90,15 @@ public class MethodUtil {
 				if (Collection.class.isAssignableFrom(parameterType)) {
 					innerCollectionType = (Class<? extends java.util.Collection<?>>) parameterType;
 					parameterType = ReflectionUtil.getGenericCollectionTypeOfMethodParameter(theMethod, paramIndex);
+					if(parameterType == null && theMethod.getDeclaringClass().isSynthetic()) {
+						try {
+							theMethod = theMethod.getDeclaringClass().getSuperclass().getMethod(theMethod.getName(), parameterTypes);
+							parameterType = ReflectionUtil.getGenericCollectionTypeOfMethodParameter(theMethod, paramIndex);
+						} catch (NoSuchMethodException e) {
+							throw new ConfigurationException("A method with name '" + theMethod.getName() + "' does not exist for super class '"
+								+ theMethod.getDeclaringClass().getSuperclass() + "'");
+						}
+					}
 					declaredParameterType = parameterType;
 				}
 				if (Collection.class.isAssignableFrom(parameterType)) {


### PR DESCRIPTION
I used isSynthetic method to decide whether the declaring class is a proxy one, then I get the superclass of that declaring class and resolve the method from it instead.