### PR TITLE
Paging implementation for MDM query links operation 

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>5.5.0-PRE5-SNAPSHOT</version>
+		 <version>5.5.0-PRE6-SNAPSHOT</version>
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>
 

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
@@ -350,7 +350,6 @@ public class ParametersUtil {
 		} else {
 			partChildElem.getChildByName("value[x]").getMutator().addValue(part, theValue);
 		}
-
 	}
 
 	public static void addPartResource(FhirContext theContext, IBase theParameter, String theName, IBaseResource theValue) {

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -3,14 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ca.uhn.hapi.fhir</groupId>
     <artifactId>hapi-fhir-bom</artifactId>
-    <version>5.5.0-PRE5-SNAPSHOT</version>
+    <version>5.5.0-PRE6-SNAPSHOT</version>
     <packaging>pom</packaging>
 	 <name>HAPI FHIR BOM</name>
 
     <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-		 <version>5.5.0-PRE5-SNAPSHOT</version>
+		 <version>5.5.0-PRE6-SNAPSHOT</version>
       <relativePath>../hapi-deployable-pom/pom.xml</relativePath>
    </parent>
     

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/hapi-fhir-cli-jpaserver/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-jpaserver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../../hapi-deployable-pom</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_5_0/2767-mdm-query-paging.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_5_0/2767-mdm-query-paging.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 2767
+title: "`$mdm-query-links` and `$mdm-duplicate-golden-resources` now enforce paging via parameters `_offset` and `_count`. More
+details can be found in the [MDM Operations documentation](/hapi-fhir/docs/server_jpa_mdm/mdm_operations.html)."
+

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
@@ -695,7 +695,3 @@ This operation can also be done at the Instance level. When this is the case, th
 http://example.com/Patient/123/$mdm-submit
 http://example.com/Practitioner/456/$mdm-submit
 ```
-
-
-
-

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
@@ -26,10 +26,10 @@ With request body:
   "resourceType": "Parameters",
   "parameter": [ {
     "name": "_offset",
-    "valueInteger": 0
+    "valueInteger": 10
   }, {
     "name": "_count",
-    "valueInteger": 2
+    "valueInteger": 10
   } ]
 }
 ```
@@ -41,13 +41,13 @@ The returning response will contain links to the current, next, and previous pag
   "resourceType": "Parameters",
   "parameter": [ {
     "name": "prev",
-    "valueUri": "http://example.com/$mdm-query-links?_offset=8_count=2"
+    "valueUri": "http://example.com/$mdm-query-links?_offset=0&_count=10"
   }, {
     "name": "self",
-    "valueUri": "http://example.com/$mdm-query-links?_offset=10_count=2"
+    "valueUri": "http://example.com/$mdm-query-links?_offset=10&_count=10"
   }, {
     "name": "next",
-    "valueUri": "http://example.com/$mdm-query-links?_offset=12_count=2"
+    "valueUri": "http://example.com/$mdm-query-links?_offset=20&_count=10"
   },...(truncated) 
 ```
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
@@ -4,6 +4,51 @@ MDM links are managed by MDM Operations. These operations are supplied by a [pla
 
 In cases where the operation changes data, if a resource id parameter contains a version (e.g. `Patient/123/_history/1`), then the operation will fail with a 409 CONFLICT if that is not the latest version of that resource.  This feature can be used to prevent update conflicts in an environment where multiple users are working on the same set of mdm links.
 
+## Pagination
+
+In both the `$query-links` operation, and the `$mdm-duplicate-golden-resources` paging is supported via `_count` and `_offset` parameters. By default, if you omit page information from your query, default pagination values will be used.
+The response will return you the next/self/previous links as part of the parameters response. Here are examples of pagination in these MDM queries.
+
+```http request
+GET http://example.com/$mdm-query-links?_offset=0&_count=2
+```
+
+Or if you are making a POST request
+
+```http request
+POST http://example.com/$mdm-query-links
+```
+You could use request body
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [ {
+    "name": "_offset",
+    "valueInt": 0
+  }, {
+    "name": "_count",
+    "valueInt": 2
+  } ]
+}
+```
+
+The returning response will contain links to the current, next, and previous pages. If there is no previous/next link, it means there is no previous/next page of data available.
+
+```text
+{
+  "resourceType": "Parameters",
+  "parameter": [ {
+    "name": "prev",
+    "valueUri": "http://example.com/$mdm-query-links?_offset=8_count=2"
+  }, {
+    "name": "self",
+    "valueUri": "http://example.com/$mdm-query-links?_offset=10_count=2"
+  }, {
+    "name": "next",
+    "valueUri": "http://example.com/$mdm-query-links?_offset=12_count=2"
+  },...(truncated) 
+```
+
 ## Query links
 
 Use the `$mdm-query-links` operation to view MDM links. The results returned are based on the parameters provided. All parameters are optional.  This operation takes the following parameters:
@@ -50,6 +95,22 @@ Use the `$mdm-query-links` operation to view MDM links. The results returned are
                 AUTO, MANUAL.
             </td>
         </tr>
+        <tr>
+            <td>_offset</td>
+            <td>int</td>
+            <td>0..1</td>
+            <td>
+                the offset to begin returning records at.
+            </td>
+        </tr>
+        <tr>
+            <td>_count</td>
+            <td>int</td>
+            <td>0..1</td>
+            <td>
+                The number of links to be returned in a page. 
+            </td>
+        </tr>
     </tbody>
 </table>
 
@@ -58,7 +119,7 @@ Use the `$mdm-query-links` operation to view MDM links. The results returned are
 Use an HTTP GET like `http://example.com/$mdm-query-links?matchResult=POSSIBLE_MATCH` or an HTTP POST to the following URL to invoke this operation:
 
 ```url
-http://example.com/$mdm-query-links
+http://example.com/$mdm-query-links?_offset=10&_count=2
 ```
 
 The following request body could be used to find all POSSIBLE_MATCH links in the system:
@@ -67,6 +128,15 @@ The following request body could be used to find all POSSIBLE_MATCH links in the
 {
   "resourceType": "Parameters",
   "parameter": [ {
+     "name": "prev",
+     "valueUri": "http://example.com/$mdm-query-links?_offset=8_count=2"
+  }, {
+     "name": "self",
+     "valueUri": "http://example.com/$mdm-query-links?_offset=10_count=2"
+  }, {
+     "name": "next",
+     "valueUri": "http://example.com/$mdm-query-links?_offset=12_count=2"
+  }, {
     "name": "matchResult",
     "valueString": "POSSIBLE_MATCH"
   } ]
@@ -79,6 +149,15 @@ This operation returns a `Parameters` resource that looks like the following:
 {
   "resourceType": "Parameters",
   "parameter": [ {
+     "name": "prev",
+     "valueUri": "http://example.com$mdm-query-links?_offset=8_count=2"
+    },  {
+     "name": "self",
+     "valueUri": "http://example.com$mdm-query-links?_offset=10_count=10"
+    }, {
+     "name": "next",
+     "valueUri": "http://example.com$mdm-query-links?_offset=20_count=10"
+    }, {
     "name": "link",
     "part": [ {
       "name": "goldenResourceId",
@@ -118,6 +197,37 @@ Use an HTTP GET to the following URL to invoke this operation:
 ```url
 http://example.com/$mdm-duplicate-golden-resources
 ```
+
+The following is a table of the request parameters supported by this GET operation.
+
+<table class="table table-striped table-condensed">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Cardinality</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>_offset</td>
+            <td>int</td>
+            <td>0..1</td>
+            <td>
+                the offset to begin returning records at.
+            </td>
+        </tr>
+        <tr>
+            <td>_count</td>
+            <td>int</td>
+            <td>0..1</td>
+            <td>
+                The number of links to be returned in a page. 
+            </td>
+        </tr>
+    </tbody>
+</table>
 
 This operation returns `Parameters` similar to `$mdm-query-links`:
 
@@ -583,3 +693,7 @@ This operation can also be done at the Instance level. When this is the case, th
 http://example.com/Patient/123/$mdm-submit
 http://example.com/Practitioner/456/$mdm-submit
 ```
+
+
+
+

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
@@ -18,16 +18,18 @@ Or if you are making a POST request
 ```http request
 POST http://example.com/$mdm-query-links
 ```
-You could use request body
+
+With request body: 
+
 ```json
 {
   "resourceType": "Parameters",
   "parameter": [ {
     "name": "_offset",
-    "valueInt": 0
+    "valueInteger": 0
   }, {
     "name": "_count",
-    "valueInt": 2
+    "valueInteger": 2
   } ]
 }
 ```

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jaxrsserver-example/pom.xml
+++ b/hapi-fhir-jaxrsserver-example/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-api/pom.xml
+++ b/hapi-fhir-jpaserver-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryBuilder.java
@@ -428,7 +428,6 @@ public class SearchQueryBuilder {
 					startOfQueryParameterIndex = bindOffsetParameter(bindVariables, offset, limitHandler, startOfQueryParameterIndex, bindLimitParametersFirst);
 					bindCountParameter(bindVariables, maxResultsToFetch, limitHandler, startOfQueryParameterIndex, bindLimitParametersFirst);
 				}
-
 			}
 		}
 

--- a/hapi-fhir-jpaserver-batch/pom.xml
+++ b/hapi-fhir-jpaserver-batch/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-cql/pom.xml
+++ b/hapi-fhir-jpaserver-cql/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -33,6 +33,9 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -286,8 +289,9 @@ public class MdmLinkDaoSvc {
 	 * @param theExampleLink The MDM link containing the data we would like to search for.
 	 * @return a list of {@link MdmLink} entities which match the example.
 	 */
-	public List<MdmLink> findMdmLinkByExample(Example<MdmLink> theExampleLink) {
-		return myMdmLinkDao.findAll(theExampleLink);
+	public Page<MdmLink> findMdmLinkByExample(Example<MdmLink> theExampleLink, int theOffset, int theCount) {
+		PageRequest of = PageRequest.of(theOffset / theCount, theCount);
+		return myMdmLinkDao.findAll(theExampleLink, of);
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.jpa.entity.MdmLink;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchOutcome;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
+import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.log.Logs;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -34,8 +35,6 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -289,9 +288,8 @@ public class MdmLinkDaoSvc {
 	 * @param theExampleLink The MDM link containing the data we would like to search for.
 	 * @return a list of {@link MdmLink} entities which match the example.
 	 */
-	public Page<MdmLink> findMdmLinkByExample(Example<MdmLink> theExampleLink, int theOffset, int theCount) {
-		PageRequest of = PageRequest.of(theOffset / theCount, theCount);
-		return myMdmLinkDao.findAll(theExampleLink, of);
+	public Page<MdmLink> findMdmLinkByExample(Example<MdmLink> theExampleLink, MdmPageRequest thePageRequest) {
+		return myMdmLinkDao.findAll(theExampleLink, thePageRequest.toPageRequest());
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmControllerSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmControllerSvcImpl.java
@@ -66,18 +66,17 @@ public class MdmControllerSvcImpl implements IMdmControllerSvc {
 	}
 
 	@Override
-	public Stream<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext) {
+	public Stream<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount) {
 		IIdType goldenResourceId = MdmControllerUtil.extractGoldenResourceIdDtOrNull(ProviderConstants.MDM_QUERY_LINKS_GOLDEN_RESOURCE_ID, theGoldenResourceId);
 		IIdType sourceId = MdmControllerUtil.extractSourceIdDtOrNull(ProviderConstants.MDM_QUERY_LINKS_RESOURCE_ID, theSourceResourceId);
 		MdmMatchResultEnum matchResult = MdmControllerUtil.extractMatchResultOrNull(theMatchResult);
 		MdmLinkSourceEnum linkSource = MdmControllerUtil.extractLinkSourceOrNull(theLinkSource);
-
-		return myMdmLinkQuerySvc.queryLinks(goldenResourceId, sourceId, matchResult, linkSource, theMdmTransactionContext);
+		return myMdmLinkQuerySvc.queryLinks(goldenResourceId, sourceId, matchResult, linkSource, theMdmTransactionContext, theOffset, theCount);
 	}
 
 	@Override
-	public Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext) {
-		return myMdmLinkQuerySvc.getDuplicateGoldenResources(theMdmTransactionContext);
+	public Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount) {
+		return myMdmLinkQuerySvc.getDuplicateGoldenResources(theMdmTransactionContext, theOffset, theCount);
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmControllerSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmControllerSvcImpl.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.mdm.api.IMdmLinkUpdaterSvc;
 import ca.uhn.fhir.mdm.api.MdmLinkJson;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
+import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import ca.uhn.fhir.mdm.provider.MdmControllerHelper;
 import ca.uhn.fhir.mdm.provider.MdmControllerUtil;
@@ -34,10 +35,10 @@ import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
-import java.util.stream.Stream;
 
 /**
  * This class acts as a layer between MdmProviders and MDM services to support a REST API that's not a FHIR Operation API.
@@ -66,17 +67,17 @@ public class MdmControllerSvcImpl implements IMdmControllerSvc {
 	}
 
 	@Override
-	public Stream<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount) {
+	public Page<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext, MdmPageRequest thePageRequest) {
 		IIdType goldenResourceId = MdmControllerUtil.extractGoldenResourceIdDtOrNull(ProviderConstants.MDM_QUERY_LINKS_GOLDEN_RESOURCE_ID, theGoldenResourceId);
 		IIdType sourceId = MdmControllerUtil.extractSourceIdDtOrNull(ProviderConstants.MDM_QUERY_LINKS_RESOURCE_ID, theSourceResourceId);
 		MdmMatchResultEnum matchResult = MdmControllerUtil.extractMatchResultOrNull(theMatchResult);
 		MdmLinkSourceEnum linkSource = MdmControllerUtil.extractLinkSourceOrNull(theLinkSource);
-		return myMdmLinkQuerySvc.queryLinks(goldenResourceId, sourceId, matchResult, linkSource, theMdmTransactionContext, theOffset, theCount);
+		return myMdmLinkQuerySvc.queryLinks(goldenResourceId, sourceId, matchResult, linkSource, theMdmTransactionContext, thePageRequest);
 	}
 
 	@Override
-	public Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount) {
-		return myMdmLinkQuerySvc.getDuplicateGoldenResources(theMdmTransactionContext, theOffset, theCount);
+	public Page<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext, MdmPageRequest thePageRequest) {
+		return myMdmLinkQuerySvc.getDuplicateGoldenResources(theMdmTransactionContext, thePageRequest);
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkQuerySvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkQuerySvcImpl.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.mdm.api.MdmLinkJson;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.mdm.api.IMdmLinkQuerySvc;
+import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import ca.uhn.fhir.jpa.dao.index.IdHelperService;
 import ca.uhn.fhir.jpa.mdm.dao.MdmLinkDaoSvc;
@@ -35,8 +36,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 
-import java.util.stream.Stream;
-
 public class MdmLinkQuerySvcImpl implements IMdmLinkQuerySvc {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(MdmLinkQuerySvcImpl.class);
@@ -47,16 +46,19 @@ public class MdmLinkQuerySvcImpl implements IMdmLinkQuerySvc {
 	MdmLinkDaoSvc myMdmLinkDaoSvc;
 
 	@Override
-	public Stream<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext, int theOffset, int theCount) {
+	public Page<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext, MdmPageRequest thePageRequest) {
 		Example<MdmLink> exampleLink = exampleLinkFromParameters(theGoldenResourceId, theSourceResourceId, theMatchResult, theLinkSource);
-		Page<MdmLink> mdmLinkByExample = myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink, theOffset, theCount);
-		return mdmLinkByExample.stream().map(this::toJson);
+		Page<MdmLink> mdmLinkByExample = myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink, thePageRequest);
+		Page<MdmLinkJson> map = mdmLinkByExample.map(this::toJson);
+		return map;
 	}
 
 	@Override
-	public Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext, int theOffset, int theCount) {
+	public Page<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext, MdmPageRequest thePageRequest) {
 		Example<MdmLink> exampleLink = exampleLinkFromParameters(null, null, MdmMatchResultEnum.POSSIBLE_DUPLICATE, null);
-		return myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink, theOffset, theCount).stream().map(this::toJson);
+		Page<MdmLink> mdmLinkPage = myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink, thePageRequest);
+		Page<MdmLinkJson> map = mdmLinkPage.map(this::toJson);
+		return map;
 	}
 
 	private MdmLinkJson toJson(MdmLink theLink) {

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkQuerySvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkQuerySvcImpl.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
 
 import java.util.stream.Stream;
 
@@ -46,17 +47,16 @@ public class MdmLinkQuerySvcImpl implements IMdmLinkQuerySvc {
 	MdmLinkDaoSvc myMdmLinkDaoSvc;
 
 	@Override
-	public Stream<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext) {
+	public Stream<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext, int theOffset, int theCount) {
 		Example<MdmLink> exampleLink = exampleLinkFromParameters(theGoldenResourceId, theSourceResourceId, theMatchResult, theLinkSource);
-		return myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink).stream()
-			.filter(mdmLink -> mdmLink.getMatchResult() != MdmMatchResultEnum.POSSIBLE_DUPLICATE)
-			.map(this::toJson);
+		Page<MdmLink> mdmLinkByExample = myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink, theOffset, theCount);
+		return mdmLinkByExample.stream().map(this::toJson);
 	}
 
 	@Override
-	public Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext) {
+	public Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext, int theOffset, int theCount) {
 		Example<MdmLink> exampleLink = exampleLinkFromParameters(null, null, MdmMatchResultEnum.POSSIBLE_DUPLICATE, null);
-		return myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink).stream().map(this::toJson);
+		return myMdmLinkDaoSvc.findMdmLinkByExample(exampleLink, theOffset, theCount).stream().map(this::toJson);
 	}
 
 	private MdmLinkJson toJson(MdmLink theLink) {

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/BaseMdmR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/BaseMdmR4Test.java
@@ -1,7 +1,9 @@
 package ca.uhn.fhir.jpa.mdm;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.api.AddProfileTagEnum;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
+import ca.uhn.fhir.interceptor.api.IInterceptorService;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
@@ -32,9 +34,19 @@ import ca.uhn.fhir.mdm.rules.svc.MdmResourceMatcherSvc;
 import ca.uhn.fhir.mdm.util.EIDHelper;
 import ca.uhn.fhir.mdm.util.MdmResourceUtil;
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.server.BasePagingProvider;
+import ca.uhn.fhir.rest.server.ETagSupportEnum;
+import ca.uhn.fhir.rest.server.ElementsSupportEnum;
+import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
+import ca.uhn.fhir.rest.server.IPagingProvider;
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matcher;
@@ -49,11 +61,15 @@ import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Reference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -71,6 +87,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {MdmSubmitterConfig.class, MdmConsumerConfig.class, TestMdmConfigR4.class, SubscriptionProcessorConfig.class})
 abstract public class BaseMdmR4Test extends BaseJpaR4Test {
+
+
 	private static final Logger ourLog = getLogger(BaseMdmR4Test.class);
 
 	public static final String NAME_GIVEN_JANE = "Jane";

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/config/BaseTestMdmConfig.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/config/BaseTestMdmConfig.java
@@ -4,6 +4,8 @@ import ca.uhn.fhir.mdm.api.IMdmSettings;
 import ca.uhn.fhir.mdm.rules.config.MdmRuleValidator;
 import ca.uhn.fhir.mdm.rules.config.MdmSettings;
 import ca.uhn.fhir.jpa.mdm.helper.MdmLinkHelper;
+import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
+import ca.uhn.fhir.rest.server.IPagingProvider;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
@@ -31,8 +31,6 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 	private IMdmSubmitSvc myMdmSubmitSvc;
 	@Autowired
 	private MdmSettings myMdmSettings;
-	@Autowired
-	private IPagingProvider myPagingProvider;
 
 	private String defaultScript;
 
@@ -46,7 +44,7 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 
 	@BeforeEach
 	public void before() {
-		myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myPagingProvider);
+		myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc);
 		defaultScript = myMdmSettings.getScriptText();
 	}
 	@AfterEach

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.mdm.api.IMdmMatchFinderSvc;
 import ca.uhn.fhir.mdm.api.IMdmSubmitSvc;
 import ca.uhn.fhir.mdm.provider.MdmProviderDstu3Plus;
 import ca.uhn.fhir.mdm.rules.config.MdmSettings;
+import ca.uhn.fhir.rest.server.IPagingProvider;
 import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
@@ -31,7 +32,7 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 	@Autowired
 	private MdmSettings myMdmSettings;
 	@Autowired
-	private IRestfulServerDefaults myRestfulServerDefaults;
+	private IPagingProvider myPagingProvider;
 
 	private String defaultScript;
 
@@ -45,7 +46,7 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 
 	@BeforeEach
 	public void before() {
-		myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myRestfulServerDefaults);
+		myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myPagingProvider);
 		defaultScript = myMdmSettings.getScriptText();
 	}
 	@AfterEach

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.mdm.api.IMdmMatchFinderSvc;
 import ca.uhn.fhir.mdm.api.IMdmSubmitSvc;
 import ca.uhn.fhir.mdm.provider.MdmProviderDstu3Plus;
 import ca.uhn.fhir.mdm.rules.config.MdmSettings;
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -29,6 +30,8 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 	private IMdmSubmitSvc myMdmSubmitSvc;
 	@Autowired
 	private MdmSettings myMdmSettings;
+	@Autowired
+	private IRestfulServerDefaults myRestfulServerDefaults;
 
 	private String defaultScript;
 
@@ -42,7 +45,7 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 
 	@BeforeEach
 	public void before() {
-		myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc);
+		myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myRestfulServerDefaults);
 		defaultScript = myMdmSettings.getScriptText();
 	}
 	@AfterEach

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderQueryLinkR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderQueryLinkR4Test.java
@@ -90,7 +90,7 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 			ourLog.warn("Search at offset {} took {}ms",offset, sw.getMillisAndRestart());
 			ourLog.warn("Found source resource IDs: {}", sourceResourceIds);
 			offset += count;
-			assertThat(parameter.size(), is(lessThanOrEqualTo(2)));
+			assertThat(parameter.size(), is(lessThanOrEqualTo(3)));
 
 			//We have stopped finding patients.
 			if (StringUtils.isEmpty(sourceResourceIds)) {

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderQueryLinkR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderQueryLinkR4Test.java
@@ -70,7 +70,7 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 	public void testQueryLinkOneMatch() {
 		Parameters result = (Parameters) myMdmProvider.queryLinks(mySourcePatientId, myPatientId, null, null, new UnsignedIntType(0), new UnsignedIntType(10), myRequestDetails);
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(result));
-		List<Parameters.ParametersParameterComponent> list = result.getParameter();
+		List<Parameters.ParametersParameterComponent> list = getParametersByName(result, "link");
 		assertThat(list, hasSize(1));
 		List<Parameters.ParametersParameterComponent> part = list.get(0).getPart();
 		assertMdmLink(7, part, mySourcePatientId.getValue(), myPatientId.getValue(), MdmMatchResultEnum.POSSIBLE_MATCH, "false", "true", null);
@@ -172,7 +172,7 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 	}
 
 	@Test
-	public void testQueryLinkThreeMatches() {
+	public void testQueryLnkThreeMatches() {
 		// Add a third patient
 		Patient patient = createPatientAndUpdateLinks(buildJanePatient());
 		IdType patientId = patient.getIdElement().toVersionless();
@@ -181,9 +181,9 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 
 		Parameters result = (Parameters) myMdmProvider.queryLinks(null, null, null, myLinkSource, new UnsignedIntType(0), new UnsignedIntType(10), myRequestDetails);
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(result));
-		List<Parameters.ParametersParameterComponent> list = result.getParameter();
-		assertThat(list, hasSize(3));
-		List<Parameters.ParametersParameterComponent> part = list.get(2).getPart();
+		List<Parameters.ParametersParameterComponent> list = getParametersByName(result, "link");
+		assertThat(list, hasSize(4));
+		List<Parameters.ParametersParameterComponent> part = list.get(3).getPart();
 		assertMdmLink(7, part, goldenResourceId.getValue(), patientId.getValue(), MdmMatchResultEnum.MATCH, "false", "false", "2");
 	}
 
@@ -191,7 +191,7 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 	public void testQueryPossibleDuplicates() {
 		Parameters result = (Parameters) myMdmProvider.getDuplicateGoldenResources(new UnsignedIntType(0), new UnsignedIntType(10),myRequestDetails);
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(result));
-		List<Parameters.ParametersParameterComponent> list = result.getParameter();
+		List<Parameters.ParametersParameterComponent> list = getParametersByName(result, "link");
 		assertThat(list, hasSize(1));
 		List<Parameters.ParametersParameterComponent> part = list.get(0).getPart();
 		assertMdmLink(2, part, myGoldenResource1Id.getValue(), myGoldenResource2Id.getValue(), MdmMatchResultEnum.POSSIBLE_DUPLICATE, "false", "false", null);
@@ -201,7 +201,8 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 	public void testNotDuplicate() {
 		{
 			Parameters result = (Parameters) myMdmProvider.getDuplicateGoldenResources(new UnsignedIntType(0), new UnsignedIntType(10),myRequestDetails);
-			List<Parameters.ParametersParameterComponent> list = result.getParameter();
+			List<Parameters.ParametersParameterComponent> list = getParametersByName(result, "link");
+
 			assertThat(list, hasSize(1));
 		}
 		{
@@ -212,7 +213,7 @@ public class MdmProviderQueryLinkR4Test extends BaseLinkR4Test {
 		}
 
 		Parameters result = (Parameters) myMdmProvider.getDuplicateGoldenResources(new UnsignedIntType(0), new UnsignedIntType(10),myRequestDetails);
-		List<Parameters.ParametersParameterComponent> list = result.getParameter();
+		List<Parameters.ParametersParameterComponent> list = getParametersByName(result, "link");
 		assertThat(list, hasSize(0));
 	}
 

--- a/hapi-fhir-jpaserver-migrate/pom.xml
+++ b/hapi-fhir-jpaserver-migrate/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -28,6 +28,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>${spring_data_version}</version>
+		</dependency>
+		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
 			<version>${project.version}</version>

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmControllerSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmControllerSvc.java
@@ -28,9 +28,9 @@ import java.util.stream.Stream;
 
 public interface IMdmControllerSvc {
 
-	Stream<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext);
+	Stream<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount);
 
-	Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext);
+	Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount);
 
 	void notDuplicateGoldenResource(String theGoldenResourceId, String theTargetGoldenResourceId, MdmTransactionContext theMdmTransactionContext);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmControllerSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmControllerSvc.java
@@ -20,17 +20,18 @@ package ca.uhn.fhir.mdm.api;
  * #L%
  */
 
+import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import org.hl7.fhir.instance.model.api.IAnyResource;
+import org.springframework.data.domain.Page;
 
 import javax.annotation.Nullable;
-import java.util.stream.Stream;
 
 public interface IMdmControllerSvc {
 
-	Stream<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount);
+	Page<MdmLinkJson> queryLinks(@Nullable String theGoldenResourceId, @Nullable String theSourceResourceId, @Nullable String theMatchResult, @Nullable String theLinkSource, MdmTransactionContext theMdmTransactionContext, MdmPageRequest thePageRequest);
 
-	Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext, int theOffset, int theCount);
+	Page<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmTransactionContext, MdmPageRequest thePageRequest);
 
 	void notDuplicateGoldenResource(String theGoldenResourceId, String theTargetGoldenResourceId, MdmTransactionContext theMdmTransactionContext);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmLinkQuerySvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmLinkQuerySvc.java
@@ -20,15 +20,15 @@ package ca.uhn.fhir.mdm.api;
  * #L%
  */
 
+import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import org.hl7.fhir.instance.model.api.IIdType;
-
-import java.util.stream.Stream;
+import org.springframework.data.domain.Page;
 
 /**
  * This service supports the MDM operation providers for those services that return multiple MDM links.
  */
 public interface IMdmLinkQuerySvc {
-	Stream<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext, int theOffset, int theCount);
-	Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext, int theOffset, int theCount);
+	Page<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext, MdmPageRequest thePageRequest);
+	Page<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext, MdmPageRequest thePageRequest);
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmLinkQuerySvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmLinkQuerySvc.java
@@ -29,6 +29,6 @@ import java.util.stream.Stream;
  * This service supports the MDM operation providers for those services that return multiple MDM links.
  */
 public interface IMdmLinkQuerySvc {
-	Stream<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext);
-	Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext);
+	Stream<MdmLinkJson> queryLinks(IIdType theGoldenResourceId, IIdType theSourceResourceId, MdmMatchResultEnum theMatchResult, MdmLinkSourceEnum theLinkSource, MdmTransactionContext theMdmContext, int theOffset, int theCount);
+	Stream<MdmLinkJson> getDuplicateGoldenResources(MdmTransactionContext theMdmContext, int theOffset, int theCount);
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
@@ -25,22 +25,27 @@ public final class MdmPageLinkBuilder {
 	 * @return the {@link MdmPageLinkTuple}
 	 */
 	public static MdmPageLinkTuple buildMdmPageLinks(ServletRequestDetails theServletRequestDetails, Page<MdmLinkJson> theCurrentPage, MdmPageRequest thePageRequest) {
-		MdmPageLinkTuple tuple = new MdmPageLinkTuple();
 		String urlWithoutPaging = RestfulServerUtils.createLinkSelfWithoutGivenParameters(theServletRequestDetails.getFhirServerBase(), theServletRequestDetails, Arrays.asList(PARAM_OFFSET, PARAM_COUNT));
-		tuple.setSelfLink(buildLinkWithOffsetAndCount(urlWithoutPaging, thePageRequest.getCount(), thePageRequest.getOffset()));
-		if (theCurrentPage.hasNext()) {
-			tuple.setNextLink(buildLinkWithOffsetAndCount(urlWithoutPaging,thePageRequest.getCount(), thePageRequest.getNextOffset()));
-		}
-		if (theCurrentPage.hasPrevious()) {
-			tuple.setPreviousLink(buildLinkWithOffsetAndCount(urlWithoutPaging,thePageRequest.getCount(), thePageRequest.getPreviousOffset()));
-		}
-		return tuple;
+		return buildMdmPageLinks(urlWithoutPaging, theCurrentPage, thePageRequest);
 	}
 
-	private static String buildLinkWithOffsetAndCount(String theStartingUrl, int theCount, int theOffset) {
+	public static MdmPageLinkTuple buildMdmPageLinks(String theUrlWithoutPaging, Page<MdmLinkJson> theCurrentPage, MdmPageRequest thePageRequest) {
+		MdmPageLinkTuple tuple = new MdmPageLinkTuple();
+		tuple.setSelfLink(buildLinkWithOffsetAndCount(theUrlWithoutPaging, thePageRequest.getCount(), thePageRequest.getOffset()));
+		if (theCurrentPage.hasNext()) {
+			tuple.setNextLink(buildLinkWithOffsetAndCount(theUrlWithoutPaging,thePageRequest.getCount(), thePageRequest.getNextOffset()));
+		}
+		if (theCurrentPage.hasPrevious()) {
+			tuple.setPreviousLink(buildLinkWithOffsetAndCount(theUrlWithoutPaging,thePageRequest.getCount(), thePageRequest.getPreviousOffset()));
+		}
+		return tuple;
+
+	}
+
+	public static String buildLinkWithOffsetAndCount(String theBaseUrl, int theCount, int theOffset) {
 		StringBuilder builder = new StringBuilder();
-		builder.append(theStartingUrl);
-		if (!theStartingUrl.contains("?")) {
+		builder.append(theBaseUrl);
+		if (!theBaseUrl.contains("?")) {
 			builder.append("?");
 		}
 		builder.append(PARAM_OFFSET).append("=").append(theOffset);

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
@@ -1,0 +1,38 @@
+package ca.uhn.fhir.mdm.api.paging;
+
+import ca.uhn.fhir.mdm.api.MdmLinkJson;
+import ca.uhn.fhir.rest.server.RestfulServerUtils;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import ca.uhn.fhir.util.ParametersUtil;
+import org.springframework.data.domain.Page;
+
+import java.util.Arrays;
+
+import static ca.uhn.fhir.rest.api.Constants.PARAM_COUNT;
+import static ca.uhn.fhir.rest.api.Constants.PARAM_OFFSET;
+
+public final class MdmPageLinkBuilder {
+	public static MdmPageLinkTuple buildMdmPageLinks(ServletRequestDetails theServletRequestDetails, Page<MdmLinkJson> theCurrentPage, MdmPageRequest thePageRequest) {
+		MdmPageLinkTuple tuple = new MdmPageLinkTuple();
+		String urlWithoutPaging = RestfulServerUtils.createLinkSelfWithoutGivenParameters(theServletRequestDetails.getFhirServerBase(), theServletRequestDetails, Arrays.asList(PARAM_OFFSET, PARAM_COUNT));
+		tuple.setSelfLink(buildLinkWithOffsetAndCount(urlWithoutPaging, thePageRequest.getCount(), thePageRequest.getOffset()));
+		if (theCurrentPage.hasNext()) {
+			tuple.setNextLink(buildLinkWithOffsetAndCount(urlWithoutPaging,thePageRequest.getCount(), thePageRequest.getNextOffset()));
+		}
+		if (theCurrentPage.hasPrevious()) {
+			tuple.setPreviousLink(buildLinkWithOffsetAndCount(urlWithoutPaging,thePageRequest.getCount(), thePageRequest.getPreviousOffset()));
+		}
+		return tuple;
+
+	}
+	protected static String buildLinkWithOffsetAndCount(String theStartingUrl, int theCount, int theOffset) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(theStartingUrl);
+		if (!theStartingUrl.contains("?")) {
+			builder.append("?");
+		}
+		builder.append(PARAM_OFFSET).append("=").append(theOffset);
+		builder.append(PARAM_COUNT).append("=").append(theCount);
+		return builder.toString();
+	}
+}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
@@ -47,6 +47,8 @@ public final class MdmPageLinkBuilder {
 		builder.append(theBaseUrl);
 		if (!theBaseUrl.contains("?")) {
 			builder.append("?");
+		} else {
+			builder.append("&");
 		}
 		builder.append(PARAM_OFFSET).append("=").append(theOffset);
 		builder.append("&");

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
@@ -3,7 +3,6 @@ package ca.uhn.fhir.mdm.api.paging;
 import ca.uhn.fhir.mdm.api.MdmLinkJson;
 import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
-import ca.uhn.fhir.util.ParametersUtil;
 import org.springframework.data.domain.Page;
 
 import java.util.Arrays;
@@ -11,7 +10,20 @@ import java.util.Arrays;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_COUNT;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_OFFSET;
 
+/**
+ * Builder to generate {@link MdmPageLinkTuple} objects, based on a given page of data and the incoming page request.
+ */
 public final class MdmPageLinkBuilder {
+
+	/**
+	 * Generates an {@link MdmPageLinkTuple} which contains previous/self/next links for pagination purposes.
+	 *
+	 * @param theServletRequestDetails the incoming request details. Used to determine server base.
+	 * @param theCurrentPage the page of MDM link data. Used for determining if there are next/previous pages available.
+	 * @param thePageRequest the incoming Page request, containing requested offset and count. Used for building offset for outgoing URLs.
+	 *
+	 * @return the {@link MdmPageLinkTuple}
+	 */
 	public static MdmPageLinkTuple buildMdmPageLinks(ServletRequestDetails theServletRequestDetails, Page<MdmLinkJson> theCurrentPage, MdmPageRequest thePageRequest) {
 		MdmPageLinkTuple tuple = new MdmPageLinkTuple();
 		String urlWithoutPaging = RestfulServerUtils.createLinkSelfWithoutGivenParameters(theServletRequestDetails.getFhirServerBase(), theServletRequestDetails, Arrays.asList(PARAM_OFFSET, PARAM_COUNT));
@@ -23,9 +35,9 @@ public final class MdmPageLinkBuilder {
 			tuple.setPreviousLink(buildLinkWithOffsetAndCount(urlWithoutPaging,thePageRequest.getCount(), thePageRequest.getPreviousOffset()));
 		}
 		return tuple;
-
 	}
-	protected static String buildLinkWithOffsetAndCount(String theStartingUrl, int theCount, int theOffset) {
+
+	private static String buildLinkWithOffsetAndCount(String theStartingUrl, int theCount, int theOffset) {
 		StringBuilder builder = new StringBuilder();
 		builder.append(theStartingUrl);
 		if (!theStartingUrl.contains("?")) {

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
@@ -49,6 +49,7 @@ public final class MdmPageLinkBuilder {
 			builder.append("?");
 		}
 		builder.append(PARAM_OFFSET).append("=").append(theOffset);
+		builder.append("&");
 		builder.append(PARAM_COUNT).append("=").append(theCount);
 		return builder.toString();
 	}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilder.java
@@ -1,5 +1,25 @@
 package ca.uhn.fhir.mdm.api.paging;
 
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2021 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import ca.uhn.fhir.mdm.api.MdmLinkJson;
 import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkTuple.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkTuple.java
@@ -1,5 +1,25 @@
 package ca.uhn.fhir.mdm.api.paging;
 
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2021 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Optional;
 
 /**

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkTuple.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkTuple.java
@@ -2,13 +2,15 @@ package ca.uhn.fhir.mdm.api.paging;
 
 import java.util.Optional;
 
+/**
+ * Data clump class to keep the relevant paging URLs together for MDM.
+ */
 public class MdmPageLinkTuple {
 	private String myPreviousLink = null;
 	private String mySelfLink = null;
 	private String myNextLink = null;
 
-	MdmPageLinkTuple() {
-	}
+	MdmPageLinkTuple() {}
 
 	public Optional<String> getPreviousLink() {
 		return Optional.ofNullable(myPreviousLink);

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkTuple.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkTuple.java
@@ -1,0 +1,36 @@
+package ca.uhn.fhir.mdm.api.paging;
+
+import java.util.Optional;
+
+public class MdmPageLinkTuple {
+	private String myPreviousLink = null;
+	private String mySelfLink = null;
+	private String myNextLink = null;
+
+	MdmPageLinkTuple() {
+	}
+
+	public Optional<String> getPreviousLink() {
+		return Optional.ofNullable(myPreviousLink);
+	}
+
+	public void setPreviousLink(String thePreviousLink) {
+		this.myPreviousLink = thePreviousLink;
+	}
+
+	public String getSelfLink() {
+		return mySelfLink;
+	}
+
+	public void setSelfLink(String theSelfLink) {
+		this.mySelfLink = theSelfLink;
+	}
+
+	public Optional<String> getNextLink() {
+		return Optional.ofNullable(myNextLink);
+	}
+
+	public void setNextLink(String theNextLink) {
+		this.myNextLink = theNextLink;
+	}
+}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
@@ -1,5 +1,25 @@
 package ca.uhn.fhir.mdm.api.paging;
 
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2021 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import ca.uhn.fhir.rest.server.IPagingProvider;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.apache.commons.lang3.StringUtils;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
@@ -1,7 +1,6 @@
 package ca.uhn.fhir.mdm.api.paging;
 
 import ca.uhn.fhir.rest.server.IPagingProvider;
-import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.UnsignedIntType;
@@ -12,6 +11,11 @@ import static ca.uhn.fhir.rest.api.Constants.PARAM_COUNT;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_OFFSET;
 import static org.slf4j.LoggerFactory.getLogger;
 
+/**
+ * This class is essentially just a data clump of offset + count, as well as the ability to convert itself into a standard
+ * {@link PageRequest} for spring data to use. The reason we don't use PageRequest natively is because it is concerned with `pages` and `counts`,
+ * but we are using `offset` and `count` which requires some minor translation.
+ */
 public class MdmPageRequest {
 	private static final Logger ourLog = getLogger(MdmPageRequest.class);
 
@@ -32,10 +36,6 @@ public class MdmPageRequest {
 		validatePagingParameters(myOffset, myCount);
 
 		this.myPage = myOffset / myCount;
-	}
-
-	public PageRequest toPageRequest() {
-		return PageRequest.of(this.myPage, this.myCount);
 	}
 
 	private void validatePagingParameters(int theOffset, int theCount) {
@@ -67,7 +67,12 @@ public class MdmPageRequest {
 	public int getNextOffset() {
 		return myOffset + myCount;
 	}
+
 	public int getPreviousOffset() {
 		return myOffset - myCount;
+	}
+
+	public PageRequest toPageRequest() {
+		return PageRequest.of(this.myPage, this.myCount);
 	}
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
@@ -1,0 +1,69 @@
+package ca.uhn.fhir.mdm.api.paging;
+
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.dstu3.model.UnsignedIntType;
+import org.slf4j.Logger;
+import org.springframework.data.domain.PageRequest;
+
+import static ca.uhn.fhir.rest.api.Constants.PARAM_COUNT;
+import static ca.uhn.fhir.rest.api.Constants.PARAM_OFFSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class MdmPageRequest {
+	private static final Logger ourLog = getLogger(MdmPageRequest.class);
+
+	private int myPage;
+	private int myOffset;
+	private int myCount;
+	private IRestfulServerDefaults myRestfulServerDefaults;
+
+	public MdmPageRequest(UnsignedIntType theOffset, UnsignedIntType theCount, IRestfulServerDefaults theDefaults) {
+		myOffset = theOffset == null ? 0 : theOffset.getValue();
+		myCount = theCount == null ? theDefaults.getDefaultPageSize() : theCount.getValue();
+		validatePagingParameters(myOffset, myCount);
+
+		this.myPage = myOffset / myCount;
+	}
+
+	public PageRequest toPageRequest() {
+		return PageRequest.of(this.myPage, this.myCount);
+	}
+
+	private void validatePagingParameters(int theOffset, int theCount) {
+		String errorMessage = "";
+
+		if (theOffset < 0) {
+			errorMessage += PARAM_OFFSET + " must be greater than or equal to 0. ";
+		}
+		if (theCount <= 0 ) {
+			errorMessage += PARAM_COUNT + " must be greater than 0.";
+		}
+		if (myRestfulServerDefaults.getMaximumPageSize() != null && theCount > myRestfulServerDefaults.getMaximumPageSize() ) {
+			ourLog.debug("Shrinking page size down to {}, as this is the maximum allowed.", myRestfulServerDefaults.getMaximumPageSize());
+		}
+		if (StringUtils.isNotEmpty(errorMessage)) {
+			throw new InvalidRequestException(errorMessage);
+		}
+	}
+
+	public int getOffset() {
+		return myOffset;
+	}
+
+	public int getPage() {
+		return myPage;
+	}
+
+	public int getCount() {
+		return myCount;
+	}
+
+	public int getNextOffset() {
+		return myOffset + myCount;
+	}
+	public int getPreviousOffset() {
+		return myOffset - myCount;
+	}
+}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
@@ -24,12 +24,17 @@ public class MdmPageRequest {
 	private final int myOffset;
 	private final int myCount;
 
-	public MdmPageRequest(@Nullable UnsignedIntType theOffset, @Nullable UnsignedIntType theCount, IPagingProvider thePagingProvider) {
+	public MdmPageRequest(@Nullable UnsignedIntType theOffset, @Nullable UnsignedIntType theCount, int theDefaultPageSize, int theMaximumPageSize) {
 		myOffset = theOffset == null ? 0 : theOffset.getValue();
-		myCount = theCount == null
-			? thePagingProvider.getDefaultPageSize() : theCount.getValue() > thePagingProvider.getMaximumPageSize()
-			? thePagingProvider.getMaximumPageSize() : theCount.getValue();
+		myCount = theCount == null ? theDefaultPageSize : Math.min(theCount.getValue(), theMaximumPageSize);
+		validatePagingParameters(myOffset, myCount);
 
+		this.myPage = myOffset / myCount;
+	}
+
+	public MdmPageRequest(@Nullable Integer theOffset, @Nullable Integer theCount, int theDefaultPageSize, int theMaximumPageSize) {
+		myOffset = theOffset == null ? 0 : theOffset;
+		myCount = theCount == null ? theDefaultPageSize : Math.min(theCount, theMaximumPageSize);
 		validatePagingParameters(myOffset, myCount);
 
 		this.myPage = myOffset / myCount;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/paging/MdmPageRequest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.server.IPagingProvider;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.UnsignedIntType;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.slf4j.Logger;
 import org.springframework.data.domain.PageRequest;
 
@@ -24,7 +25,7 @@ public class MdmPageRequest {
 	private final int myOffset;
 	private final int myCount;
 
-	public MdmPageRequest(@Nullable UnsignedIntType theOffset, @Nullable UnsignedIntType theCount, int theDefaultPageSize, int theMaximumPageSize) {
+	public MdmPageRequest(@Nullable IPrimitiveType<Integer> theOffset, @Nullable IPrimitiveType<Integer> theCount, int theDefaultPageSize, int theMaximumPageSize) {
 		myOffset = theOffset == null ? 0 : theOffset.getValue();
 		myCount = theCount == null ? theDefaultPageSize : Math.min(theCount.getValue(), theMaximumPageSize);
 		validatePagingParameters(myOffset, myCount);

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
@@ -23,17 +23,26 @@ package ca.uhn.fhir.mdm.provider;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.mdm.api.MdmLinkJson;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
+import ca.uhn.fhir.mdm.api.paging.MdmPageLinkBuilder;
+import ca.uhn.fhir.mdm.api.paging.MdmPageLinkTuple;
+import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.TransactionLogMessages;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.util.ParametersUtil;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.springframework.data.domain.Page;
 
-import java.util.stream.Stream;
+import java.util.Arrays;
+
+import static ca.uhn.fhir.rest.api.Constants.PARAM_COUNT;
+import static ca.uhn.fhir.rest.api.Constants.PARAM_OFFSET;
 
 public abstract class BaseMdmProvider {
 
@@ -92,9 +101,9 @@ public abstract class BaseMdmProvider {
 		return theString.getValue();
 	}
 
-	protected IBaseParameters parametersFromMdmLinks(Stream<MdmLinkJson> theMdmLinkStream, boolean includeResultAndSource) {
+	protected IBaseParameters parametersFromMdmLinks(Page<MdmLinkJson> theMdmLinkStream, boolean includeResultAndSource, ServletRequestDetails theServletRequestDetails, MdmPageRequest thePageRequest) {
 		IBaseParameters retval = ParametersUtil.newInstance(myFhirContext);
-
+		addPagingParameters(retval, theMdmLinkStream, theServletRequestDetails, thePageRequest);
 		theMdmLinkStream.forEach(mdmLink -> {
 			IBase resultPart = ParametersUtil.addParameterToParameters(myFhirContext, retval, "link");
 			ParametersUtil.addPartString(myFhirContext, resultPart, "goldenResourceId", mdmLink.getGoldenResourceId());
@@ -111,4 +120,15 @@ public abstract class BaseMdmProvider {
 		return retval;
 	}
 
+	protected void addPagingParameters(IBaseParameters theParameters, Page<MdmLinkJson> theCurrentPage, ServletRequestDetails theServletRequestDetails, MdmPageRequest thePageRequest) {
+		MdmPageLinkTuple mdmPageLinkTuple = MdmPageLinkBuilder.buildMdmPageLinks(theServletRequestDetails, theCurrentPage, thePageRequest);
+		ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "self", mdmPageLinkTuple.getSelfLink());
+
+		if (mdmPageLinkTuple.getNextLink().isPresent()) {
+			ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "next", mdmPageLinkTuple.getNextLink().get());
+		}
+		if (mdmPageLinkTuple.getPreviousLink().isPresent()) {
+			ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "prev", mdmPageLinkTuple.getPreviousLink().get());
+		}
+	}
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
@@ -122,13 +122,15 @@ public abstract class BaseMdmProvider {
 
 	protected void addPagingParameters(IBaseParameters theParameters, Page<MdmLinkJson> theCurrentPage, ServletRequestDetails theServletRequestDetails, MdmPageRequest thePageRequest) {
 		MdmPageLinkTuple mdmPageLinkTuple = MdmPageLinkBuilder.buildMdmPageLinks(theServletRequestDetails, theCurrentPage, thePageRequest);
+
+		if (mdmPageLinkTuple.getPreviousLink().isPresent()) {
+			ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "prev", mdmPageLinkTuple.getPreviousLink().get());
+		}
+
 		ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "self", mdmPageLinkTuple.getSelfLink());
 
 		if (mdmPageLinkTuple.getNextLink().isPresent()) {
 			ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "next", mdmPageLinkTuple.getNextLink().get());
-		}
-		if (mdmPageLinkTuple.getPreviousLink().isPresent()) {
-			ParametersUtil.addParameterToParametersUri(myFhirContext, theParameters, "prev", mdmPageLinkTuple.getPreviousLink().get());
 		}
 	}
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
@@ -28,7 +28,6 @@ import ca.uhn.fhir.mdm.api.paging.MdmPageLinkTuple;
 import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.TransactionLogMessages;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
@@ -39,10 +38,6 @@ import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.springframework.data.domain.Page;
 
-import java.util.Arrays;
-
-import static ca.uhn.fhir.rest.api.Constants.PARAM_COUNT;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_OFFSET;
 
 public abstract class BaseMdmProvider {
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
@@ -36,6 +36,7 @@ import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.IPagingProvider;
 import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
@@ -75,7 +76,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 	private final IMdmMatchFinderSvc myMdmMatchFinderSvc;
 	private final IMdmExpungeSvc myMdmExpungeSvc;
 	private final IMdmSubmitSvc myMdmSubmitSvc;
-	private final IRestfulServerDefaults myRestfulServerDefaults;
+	private final IPagingProvider myPagingProvider;
 
 	/**
 	 * Constructor
@@ -83,13 +84,13 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 	 * Note that this is not a spring bean. Any necessary injections should
 	 * happen in the constructor
 	 */
-	public MdmProviderDstu3Plus(FhirContext theFhirContext, IMdmControllerSvc theMdmControllerSvc, IMdmMatchFinderSvc theMdmMatchFinderSvc, IMdmExpungeSvc theMdmExpungeSvc, IMdmSubmitSvc theMdmSubmitSvc, IRestfulServerDefaults theRestfulServerDefaults) {
+	public MdmProviderDstu3Plus(FhirContext theFhirContext, IMdmControllerSvc theMdmControllerSvc, IMdmMatchFinderSvc theMdmMatchFinderSvc, IMdmExpungeSvc theMdmExpungeSvc, IMdmSubmitSvc theMdmSubmitSvc, IPagingProvider thePagingProvider) {
 		super(theFhirContext);
 		myMdmControllerSvc = theMdmControllerSvc;
 		myMdmMatchFinderSvc = theMdmMatchFinderSvc;
 		myMdmExpungeSvc = theMdmExpungeSvc;
 		myMdmSubmitSvc = theMdmSubmitSvc;
-		myRestfulServerDefaults = theRestfulServerDefaults;
+		myPagingProvider = thePagingProvider;
 	}
 
 	@Operation(name = ProviderConstants.EMPI_MATCH, typeName = "Patient")
@@ -213,7 +214,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 														 UnsignedIntType theCount,
 
 												 ServletRequestDetails theRequestDetails) {
-		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myRestfulServerDefaults);
+		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider);
 		Page<MdmLinkJson> mdmLinkJson = myMdmControllerSvc.queryLinks(extractStringOrNull(theGoldenResourceId),
 			extractStringOrNull(theResourceId), extractStringOrNull(theMatchResult), extractStringOrNull(theLinkSource),
 			createMdmContext(theRequestDetails, MdmTransactionContext.OperationType.QUERY_LINKS,
@@ -233,7 +234,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 			UnsignedIntType theCount,
 		ServletRequestDetails theRequestDetails) {
 
-		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myRestfulServerDefaults);
+		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider);
 
 		Page<MdmLinkJson> possibleDuplicates = myMdmControllerSvc.getDuplicateGoldenResources(createMdmContext(theRequestDetails, MdmTransactionContext.OperationType.DUPLICATE_GOLDEN_RESOURCES, (String) null), mdmPageRequest);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
@@ -198,7 +198,6 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 		return retval;
 	}
 
-
 	@Operation(name = ProviderConstants.MDM_QUERY_LINKS, idempotent = true)
 	public IBaseParameters queryLinks(@OperationParam(name = ProviderConstants.MDM_QUERY_LINKS_GOLDEN_RESOURCE_ID, min = 0, max = 1, typeName = "string") IPrimitiveType<String> theGoldenResourceId,
 												 @OperationParam(name = ProviderConstants.MDM_QUERY_LINKS_RESOURCE_ID, min = 0, max = 1, typeName = "string") IPrimitiveType<String> theResourceId,

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
@@ -31,20 +31,18 @@ import ca.uhn.fhir.mdm.api.MdmLinkJson;
 import ca.uhn.fhir.mdm.api.paging.MdmPageRequest;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import ca.uhn.fhir.model.api.annotation.Description;
+import ca.uhn.fhir.model.primitive.IntegerDt;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.server.IPagingProvider;
-import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.util.BundleBuilder;
 import ca.uhn.fhir.util.ParametersUtil;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.dstu3.model.UnsignedIntType;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
@@ -207,11 +205,11 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 														 IPrimitiveType<String> theLinkSource,
 
 												 @Description(formalDefinition="Results from this method are returned across multiple pages. This parameter controls the offset when fetching a page.")
-												 @OperationParam(name = PARAM_OFFSET, min = 0, max = 1)
-														 UnsignedIntType theOffset,
+												 @OperationParam(name = PARAM_OFFSET, min = 0, max = 1, typeName = "integer")
+														 IPrimitiveType<Integer> theOffset,
 												 @Description(formalDefinition = "Results from this method are returned across multiple pages. This parameter controls the size of those pages.")
-												 @OperationParam(name = Constants.PARAM_COUNT, min = 0, max = 1)
-														 UnsignedIntType theCount,
+												 @OperationParam(name = Constants.PARAM_COUNT, min = 0, max = 1, typeName = "integer")
+														 IPrimitiveType<Integer> theCount,
 
 												 ServletRequestDetails theRequestDetails) {
 		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
@@ -223,15 +221,14 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 		return parametersFromMdmLinks(mdmLinkJson, true, theRequestDetails, mdmPageRequest);
 	}
 
-
 	@Operation(name = ProviderConstants.MDM_DUPLICATE_GOLDEN_RESOURCES, idempotent = true)
 	public IBaseParameters getDuplicateGoldenResources(
 		@Description(formalDefinition="Results from this method are returned across multiple pages. This parameter controls the offset when fetching a page.")
-		@OperationParam(name = PARAM_OFFSET, min = 0, max = 1)
-			UnsignedIntType theOffset,
+		@OperationParam(name = PARAM_OFFSET, min = 0, max = 1, typeName = "integer")
+			IPrimitiveType<Integer> theOffset,
 		@Description(formalDefinition = "Results from this method are returned across multiple pages. This parameter controls the size of those pages.")
-		@OperationParam(name = Constants.PARAM_COUNT, min = 0, max = 1)
-			UnsignedIntType theCount,
+		@OperationParam(name = Constants.PARAM_COUNT, min = 0, max = 1, typeName = "integer")
+			IPrimitiveType<Integer> theCount,
 		ServletRequestDetails theRequestDetails) {
 
 		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
@@ -76,7 +76,9 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 	private final IMdmMatchFinderSvc myMdmMatchFinderSvc;
 	private final IMdmExpungeSvc myMdmExpungeSvc;
 	private final IMdmSubmitSvc myMdmSubmitSvc;
-	private final IPagingProvider myPagingProvider;
+
+	public static final int DEFAULT_PAGE_SIZE = 20;
+	public static final int MAX_PAGE_SIZE = 100;
 
 	/**
 	 * Constructor
@@ -84,13 +86,12 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 	 * Note that this is not a spring bean. Any necessary injections should
 	 * happen in the constructor
 	 */
-	public MdmProviderDstu3Plus(FhirContext theFhirContext, IMdmControllerSvc theMdmControllerSvc, IMdmMatchFinderSvc theMdmMatchFinderSvc, IMdmExpungeSvc theMdmExpungeSvc, IMdmSubmitSvc theMdmSubmitSvc, IPagingProvider thePagingProvider) {
+	public MdmProviderDstu3Plus(FhirContext theFhirContext, IMdmControllerSvc theMdmControllerSvc, IMdmMatchFinderSvc theMdmMatchFinderSvc, IMdmExpungeSvc theMdmExpungeSvc, IMdmSubmitSvc theMdmSubmitSvc) {
 		super(theFhirContext);
 		myMdmControllerSvc = theMdmControllerSvc;
 		myMdmMatchFinderSvc = theMdmMatchFinderSvc;
 		myMdmExpungeSvc = theMdmExpungeSvc;
 		myMdmSubmitSvc = theMdmSubmitSvc;
-		myPagingProvider = thePagingProvider;
 	}
 
 	@Operation(name = ProviderConstants.EMPI_MATCH, typeName = "Patient")
@@ -213,7 +214,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 														 UnsignedIntType theCount,
 
 												 ServletRequestDetails theRequestDetails) {
-		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider.getDefaultPageSize(), myPagingProvider.getMaximumPageSize());
+		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
 		Page<MdmLinkJson> mdmLinkJson = myMdmControllerSvc.queryLinks(extractStringOrNull(theGoldenResourceId),
 			extractStringOrNull(theResourceId), extractStringOrNull(theMatchResult), extractStringOrNull(theLinkSource),
 			createMdmContext(theRequestDetails, MdmTransactionContext.OperationType.QUERY_LINKS,
@@ -233,7 +234,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 			UnsignedIntType theCount,
 		ServletRequestDetails theRequestDetails) {
 
-		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider.getDefaultPageSize(), myPagingProvider.getMaximumPageSize());
+		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
 
 		Page<MdmLinkJson> possibleDuplicates = myMdmControllerSvc.getDuplicateGoldenResources(createMdmContext(theRequestDetails, MdmTransactionContext.OperationType.DUPLICATE_GOLDEN_RESOURCES, (String) null), mdmPageRequest);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
@@ -213,7 +213,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 														 UnsignedIntType theCount,
 
 												 ServletRequestDetails theRequestDetails) {
-		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider);
+		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider.getDefaultPageSize(), myPagingProvider.getMaximumPageSize());
 		Page<MdmLinkJson> mdmLinkJson = myMdmControllerSvc.queryLinks(extractStringOrNull(theGoldenResourceId),
 			extractStringOrNull(theResourceId), extractStringOrNull(theMatchResult), extractStringOrNull(theLinkSource),
 			createMdmContext(theRequestDetails, MdmTransactionContext.OperationType.QUERY_LINKS,
@@ -233,7 +233,7 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 			UnsignedIntType theCount,
 		ServletRequestDetails theRequestDetails) {
 
-		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider);
+		MdmPageRequest mdmPageRequest = new MdmPageRequest(theOffset, theCount, myPagingProvider.getDefaultPageSize(), myPagingProvider.getMaximumPageSize());
 
 		Page<MdmLinkJson> possibleDuplicates = myMdmControllerSvc.getDuplicateGoldenResources(createMdmContext(theRequestDetails, MdmTransactionContext.OperationType.DUPLICATE_GOLDEN_RESOURCES, (String) null), mdmPageRequest);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderLoader.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderLoader.java
@@ -26,7 +26,9 @@ import ca.uhn.fhir.mdm.api.IMdmControllerSvc;
 import ca.uhn.fhir.mdm.api.IMdmExpungeSvc;
 import ca.uhn.fhir.mdm.api.IMdmMatchFinderSvc;
 import ca.uhn.fhir.mdm.api.IMdmSubmitSvc;
+import ca.uhn.fhir.rest.server.IPagingProvider;
 import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
+import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.provider.ResourceProviderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -48,7 +50,7 @@ public class MdmProviderLoader {
 	@Autowired
 	private IMdmSubmitSvc myMdmSubmitSvc;
 	@Autowired
-	private IRestfulServerDefaults myRestfulServerDefaults;
+	private IPagingProvider myPagingProvider;
 
 	private BaseMdmProvider myMdmProvider;
 
@@ -57,7 +59,7 @@ public class MdmProviderLoader {
 			case DSTU3:
 			case R4:
 				myResourceProviderFactory.addSupplier(() -> {
-					myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myRestfulServerDefaults);
+					myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myPagingProvider);
 					return myMdmProvider;
 				});
 				break;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderLoader.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderLoader.java
@@ -49,8 +49,6 @@ public class MdmProviderLoader {
 	private IMdmExpungeSvc myMdmExpungeSvc;
 	@Autowired
 	private IMdmSubmitSvc myMdmSubmitSvc;
-	@Autowired
-	private IPagingProvider myPagingProvider;
 
 	private BaseMdmProvider myMdmProvider;
 
@@ -59,7 +57,7 @@ public class MdmProviderLoader {
 			case DSTU3:
 			case R4:
 				myResourceProviderFactory.addSupplier(() -> {
-					myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myPagingProvider);
+					myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc);
 					return myMdmProvider;
 				});
 				break;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderLoader.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderLoader.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.mdm.api.IMdmControllerSvc;
 import ca.uhn.fhir.mdm.api.IMdmExpungeSvc;
 import ca.uhn.fhir.mdm.api.IMdmMatchFinderSvc;
 import ca.uhn.fhir.mdm.api.IMdmSubmitSvc;
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
 import ca.uhn.fhir.rest.server.provider.ResourceProviderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,8 @@ public class MdmProviderLoader {
 	private IMdmExpungeSvc myMdmExpungeSvc;
 	@Autowired
 	private IMdmSubmitSvc myMdmSubmitSvc;
+	@Autowired
+	private IRestfulServerDefaults myRestfulServerDefaults;
 
 	private BaseMdmProvider myMdmProvider;
 
@@ -54,7 +57,7 @@ public class MdmProviderLoader {
 			case DSTU3:
 			case R4:
 				myResourceProviderFactory.addSupplier(() -> {
-					myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc);
+					myMdmProvider = new MdmProviderDstu3Plus(myFhirContext, myMdmControllerSvc, myMdmMatchFinderSvc, myMdmExpungeSvc, myMdmSubmitSvc, myRestfulServerDefaults);
 					return myMdmProvider;
 				});
 				break;

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilderTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/api/paging/MdmPageLinkBuilderTest.java
@@ -1,0 +1,37 @@
+package ca.uhn.fhir.mdm.api.paging;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MdmPageLinkBuilderTest {
+
+	@Test
+	void buildLinkWithExistingParameters() {
+		//Given
+		String expected = "http://localhost:8000/$mdm-query-links?sourceResourceId=Patient/123&_offset=1&_count=1";
+		String baseUrl = "http://localhost:8000/$mdm-query-links?sourceResourceId=Patient/123";
+
+		//When
+		String builtUrl = MdmPageLinkBuilder.buildLinkWithOffsetAndCount(baseUrl, 1, 1);
+
+		//Then
+		assertThat(builtUrl, is(equalTo(expected)));
+	}
+
+	@Test
+	void buildLinkWithoutExistingParameters() {
+		//Given
+		String expected = "http://localhost:8000/$mdm-query-links?_offset=1&_count=1";
+		String baseUrl = "http://localhost:8000/$mdm-query-links";
+
+		//When
+		String builtUrl = MdmPageLinkBuilder.buildLinkWithOffsetAndCount(baseUrl, 1, 1);
+
+		//Then
+		assertThat(builtUrl, is(equalTo(expected)));
+	}
+}

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -272,7 +272,7 @@ public class RestfulServerUtils {
 			boolean first = true;
 			Map<String, String[]> parameters = theRequest.getParameters();
 			for (String nextParamName : new TreeSet<>(parameters.keySet())) {
-				if (excludedParameterNames != null && !excludedParameterNames.contains(nextParamName)) {
+				if (excludedParameterNames == null || !excludedParameterNames.contains(nextParamName)) {
 					for (String nextParamValue : parameters.get(nextParamName)) {
 						if (first) {
 							b.append('?');

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -252,6 +252,9 @@ public class RestfulServerUtils {
 		return createLinkSelfWithoutGivenParameters(theServerBase, theRequest, null);
 	}
 
+	/**
+	 * This function will create a self link but omit any parameters passed in via the excludedParameterNames list.
+	 */
 	public static String createLinkSelfWithoutGivenParameters(String theServerBase, RequestDetails theRequest, List<String> excludedParameterNames) {
 		StringBuilder b = new StringBuilder();
 		b.append(theServerBase);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -249,6 +249,10 @@ public class RestfulServerUtils {
 
 
 	public static String createLinkSelf(String theServerBase, RequestDetails theRequest) {
+		return createLinkSelfWithoutGivenParameters(theServerBase, theRequest, null);
+	}
+
+	public static String createLinkSelfWithoutGivenParameters(String theServerBase, RequestDetails theRequest, List<String> excludedParameterNames) {
 		StringBuilder b = new StringBuilder();
 		b.append(theServerBase);
 
@@ -265,21 +269,24 @@ public class RestfulServerUtils {
 			boolean first = true;
 			Map<String, String[]> parameters = theRequest.getParameters();
 			for (String nextParamName : new TreeSet<>(parameters.keySet())) {
-				for (String nextParamValue : parameters.get(nextParamName)) {
-					if (first) {
-						b.append('?');
-						first = false;
-					} else {
-						b.append('&');
+				if (excludedParameterNames != null && !excludedParameterNames.contains(nextParamName)) {
+					for (String nextParamValue : parameters.get(nextParamName)) {
+						if (first) {
+							b.append('?');
+							first = false;
+						} else {
+							b.append('&');
+						}
+						b.append(UrlUtil.escapeUrlParam(nextParamName));
+						b.append('=');
+						b.append(UrlUtil.escapeUrlParam(nextParamValue));
 					}
-					b.append(UrlUtil.escapeUrlParam(nextParamName));
-					b.append('=');
-					b.append(UrlUtil.escapeUrlParam(nextParamValue));
 				}
 			}
 		}
 
 		return b.toString();
+
 	}
 
 	public static String createOffsetPagingLink(BundleLinks theBundleLinks, String requestPath, String tenantId, Integer theOffset, Integer theCount, Map<String, String[]> theRequestParameters) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleTarget.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleTarget.java
@@ -1,5 +1,25 @@
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
+/*-
+ * #%L
+ * HAPI FHIR - Server Framework
+ * %%
+ * Copyright (C) 2014 - 2021 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.hl7.fhir.instance.model.api.IBaseResource;

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerUtilsTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerUtilsTest.java
@@ -3,8 +3,19 @@ package ca.uhn.fhir.rest.server;
 import ca.uhn.fhir.rest.api.PreferHandlingEnum;
 import ca.uhn.fhir.rest.api.PreferHeader;
 import ca.uhn.fhir.rest.api.PreferReturnEnum;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static ca.uhn.fhir.rest.api.RequestTypeEnum.GET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RestfulServerUtilsTest{
@@ -52,5 +63,38 @@ public class RestfulServerUtilsTest{
 		assertEquals(PreferReturnEnum.REPRESENTATION, header.getReturn());
 		assertFalse(header.getRespondAsync());
 		assertEquals(PreferHandlingEnum.LENIENT, header.getHanding());
+	}
+
+	@Test
+	public void testCreateSelfLinks() {
+		//Given
+		String baseUrl = "http://localhost:8000";
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("_format", new String[]{"json"});
+		parameters.put("_count", new String[]{"10"});
+		parameters.put("_offset", new String[]{"100"});
+		List<String> paramsToRemove = Arrays.asList("_count", "_offset");
+
+		ServletRequestDetails servletRequestDetails = new ServletRequestDetails();
+		servletRequestDetails.setFhirServerBase("http://localhost:8000");
+		servletRequestDetails.setRequestPath("$my-operation");
+		servletRequestDetails.setRequestType(GET);
+		servletRequestDetails.setParameters(parameters);
+
+		//When
+		String linkSelf = RestfulServerUtils.createLinkSelf(baseUrl, servletRequestDetails);
+		//Then
+		assertThat(linkSelf, is(containsString("http://localhost:8000/$my-operation?")));
+		assertThat(linkSelf, is(containsString("_format=json")));
+		assertThat(linkSelf, is(containsString("_count=10")));
+		assertThat(linkSelf, is(containsString("_offset=100")));
+
+
+		//When
+		String linkSelfWithoutGivenParameters = RestfulServerUtils.createLinkSelfWithoutGivenParameters(baseUrl, servletRequestDetails, paramsToRemove);
+		//Then
+		assertThat(linkSelfWithoutGivenParameters, is(containsString("http://localhost:8000/$my-operation?")));
+		assertThat(linkSelfWithoutGivenParameters, is(containsString("_format=json")));
+
 	}
 }

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-okhttp</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-server-jersey</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-samples</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>5.5.0-PRE5-SNAPSHOT</version>
+      <version>5.5.0-PRE6-SNAPSHOT</version>
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>
 

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -58,37 +58,37 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r5</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-dstu2</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-dstu3</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-r4</artifactId>
-			<version>5.5.0-PRE5-SNAPSHOT</version>
+			<version>5.5.0-PRE6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.velocity</groupId>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>5.5.0-PRE5-SNAPSHOT</version>
+	<version>5.5.0-PRE6-SNAPSHOT</version>
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>
 	<url>https://hapifhir.io</url>

--- a/restful-server-example/pom.xml
+++ b/restful-server-example/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>5.5.0-PRE5-SNAPSHOT</version>
+		<version>5.5.0-PRE6-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Closes #2765
Add the following query parameters to both `$mdm-query-links` and `$mdm-duplicate-golden-resources`:
* `_offset`
* `_count`

This allows for rudimentary pagination on those two operations. The response generates `next` `self` and `prev` links in the resulting Parameters response, which point to the next page of results. While the client could keep track of its last offset, we elect to also provide it back as part of the response. 
