### PR TITLE
Bump commons-compress version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,7 +767,7 @@
 		<aries_spifly_version>1.2</aries_spifly_version>
 		<caffeine_version>2.9.1</caffeine_version>
 		<commons_codec_version>1.15</commons_codec_version>
-		<commons_compress_version>1.20</commons_compress_version>
+		<commons_compress_version>1.21</commons_compress_version>
 		<commons_text_version>1.9</commons_text_version>
 		<commons_io_version>2.8.0</commons_io_version>
 		<commons_lang3_version>3.12.0</commons_lang3_version>


### PR DESCRIPTION
Closes #2833 

* Updates commons-compress version, which currently has 4 open CVEs against it. 