### PR TITLE
bump Jetty for CVEs

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_5_0/2835-jetty-cve.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_5_0/2835-jetty-cve.yaml
@@ -1,0 +1,9 @@
+---
+type: security
+issue: 2835
+title: "Addressed the following CVE report by bumping the minor version for Jetty in the root POM:
+   <ul>
+      <li>
+         [CVE-2021-34429](https://github.com/advisories/GHSA-vjv5-gp2w-65vm)
+      </li>
+   </ul>"

--- a/pom.xml
+++ b/pom.xml
@@ -786,8 +786,7 @@
 		<jaxb_runtime_version>3.0.0</jaxb_runtime_version>
 		<jena_version>3.17.0</jena_version>
 		<jersey_version>3.0.0</jersey_version>
-		<!-- 9.4.17 seems to have issues -->
-		<jetty_version>9.4.42.v20210604</jetty_version>
+		<jetty_version>9.4.43.v20210629</jetty_version>
 		<jsr305_version>3.0.2</jsr305_version>
 		<junit_version>5.7.1</junit_version>
 		<flexmark_version>0.50.40</flexmark_version>


### PR DESCRIPTION
Closes #2835 

Minor version bump to avoid new CVEs. 