### PR TITLE
Fix loinc designation issue with FormalName

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/loinc/LoincLinguisticVariantHandler.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/loinc/LoincLinguisticVariantHandler.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.term.loinc;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.trim;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 import java.util.Map;
 
@@ -54,18 +55,31 @@ public class LoincLinguisticVariantHandler implements IZipContentsHandlerCsv {
 			return;
 		}
 	
-		addDesignation(theRecord, concept, "COMPONENT");
-		addDesignation(theRecord, concept, "PROPERTY");
-		addDesignation(theRecord, concept, "TIME_ASPCT");
-		addDesignation(theRecord, concept, "SYSTEM");
-		addDesignation(theRecord, concept, "SCALE_TYP");
+		// The following should be created as designations for each term:
+        // COMPONENT:PROPERTY:TIME_ASPCT:SYSTEM:SCALE_TYP:METHOD_TYP (as colon-separated concatenation - FormalName)
+        // SHORTNAME
+        // LONG_COMMON_NAME
+        // LinguisticVariantDisplayName
+			
+		//-- add formalName designation
+		StringBuilder formalName = new StringBuilder();
+		formalName.append(trimToEmpty(theRecord.get("COMPONENT") + ":"));
+		formalName.append(trimToEmpty(theRecord.get("PROPERTY") + ":"));
+		formalName.append(trimToEmpty(theRecord.get("TIME_ASPCT") + ":"));
+		formalName.append(trimToEmpty(theRecord.get("SYSTEM") + ":"));
+		formalName.append(trimToEmpty(theRecord.get("SCALE_TYP") + ":"));
+		formalName.append(trimToEmpty(theRecord.get("METHOD_TYP")));
 		
-		addDesignation(theRecord, concept, "METHOD_TYP");
-		addDesignation(theRecord, concept, "CLASS");
+		concept.addDesignation()
+		  .setLanguage(myLanguageCode)
+		  .setUseSystem(ITermLoaderSvc.LOINC_URI)
+		  .setUseCode("FormalName")
+	      .setUseDisplay("FormalName")
+	      .setValue(formalName.toString());
+		
+		//-- other designations
 		addDesignation(theRecord, concept, "SHORTNAME");
-		addDesignation(theRecord, concept, "LONG_COMMON_NAME");
-		addDesignation(theRecord, concept, "RELATEDNAMES2");
-		
+		addDesignation(theRecord, concept, "LONG_COMMON_NAME");		
 		addDesignation(theRecord, concept, "LinguisticVariantDisplayName");
 		
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/loinc/LoincLinguisticVariantHandler.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/loinc/LoincLinguisticVariantHandler.java
@@ -73,8 +73,8 @@ public class LoincLinguisticVariantHandler implements IZipContentsHandlerCsv {
 		concept.addDesignation()
 		  .setLanguage(myLanguageCode)
 		  .setUseSystem(ITermLoaderSvc.LOINC_URI)
-		  .setUseCode("FormalName")
-	      .setUseDisplay("FormalName")
+		  .setUseCode("FullySpecifiedName")
+	      .setUseDisplay("FullySpecifiedName")
 	      .setValue(formalName.toString());
 		
 		//-- other designations

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincTest.java
@@ -966,7 +966,7 @@ public class TerminologyLoaderSvcLoincTest extends BaseLoaderTest {
 		for (TermConceptDesignation designation : designationList) {
 			if (theLanguage.equals(designation.getLanguage())) {
 				
-				if ("FormalName".equals(designation.getUseDisplay())) 
+				if ("FullySpecifiedName".equals(designation.getUseDisplay())) 
 					formalNameDes = designation;
 				
 				if ("SHORTNAME".equals(designation.getUseDisplay())) 
@@ -978,7 +978,7 @@ public class TerminologyLoaderSvcLoincTest extends BaseLoaderTest {
 			}
 		}
 		
-		verifyDesignation(formalNameDes, ITermLoaderSvc.LOINC_URI, "FormalName", theComponent+":"+theProperty+":"+theTimeAspct+":"+theSystem+":"+theScaleTyp+":"+methodType);
+		verifyDesignation(formalNameDes, ITermLoaderSvc.LOINC_URI, "FullySpecifiedName", theComponent+":"+theProperty+":"+theTimeAspct+":"+theSystem+":"+theScaleTyp+":"+methodType);
 		verifyDesignation(shortNameDes, ITermLoaderSvc.LOINC_URI, "SHORTNAME", theShortName);
 		verifyDesignation(longCommonNameDes, ITermLoaderSvc.LOINC_URI, "LONG_COMMON_NAME", theLongCommonName);		
 		verifyDesignation(linguisticVariantDisplayNameDes, ITermLoaderSvc.LOINC_URI, "LinguisticVariantDisplayName", theLinguisticVariantDisplayName);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincTest.java
@@ -478,13 +478,13 @@ public class TerminologyLoaderSvcLoincTest extends BaseLoaderTest {
 		// Consumer Name
 		if (theIncludeConsumerNameAndLinguisticVariants) {
 		    code = concepts.get("61438-8");
-		    assertEquals(28, code.getDesignations().size());
+		    assertEquals(8, code.getDesignations().size());
 		    verifyConsumerName(code.getDesignations(), "Consumer Name 61438-8");
 		    verifyLinguisticVariant(code.getDesignations(), "de-AT", "Entlassungsbrief Ärztlich","Ergebnis","Zeitpunkt","{Setting}","Dokument","Dermatologie","DOC.ONTOLOGY","de shortname","de long common name","de related names 2","de linguistic variant display name");
 		    verifyLinguisticVariant(code.getDesignations(), "fr-CA", "Cellules de Purkinje cytoplasmique type 2 , IgG","Titre","Temps ponctuel","Sérum","Quantitatif","Immunofluorescence","Sérologie","","","","");
 		    verifyLinguisticVariant(code.getDesignations(), "zh-CN", "血流速度.收缩期.最大值","速度","时间点","大脑中动脉","定量型","超声.多普勒","产科学检查与测量指标.超声","","", "Cereb 动态 可用数量表示的;定量性;数值型;数量型;连续数值型标尺 大脑（Cerebral） 时刻;随机;随意;瞬间 术语\"cerebral\"指的是主要由中枢半球（大脑皮质和基底神经节）组成的那部分脑结构 流 流量;流速;流体 血;全血 血流量;血液流量 速度(距离/时间);速率;速率(距离/时间)","");
 		    code = concepts.get("17787-3");
-		    assertEquals(19, code.getDesignations().size());
+		    assertEquals(6, code.getDesignations().size());
 		    verifyConsumerName(code.getDesignations(), "Consumer Name 17787-3");
 		    verifyLinguisticVariant(code.getDesignations(), "de-AT", "","","","","","","","","","CoV OC43 RNA ql/SM P","Coronavirus OC43 RNA ql. /Sondermaterial PCR");
 		    verifyLinguisticVariant(code.getDesignations(), "fr-CA", "Virus respiratoire syncytial bovin","Présence-Seuil","Temps ponctuel","XXX","Ordinal","Culture spécifique à un microorganisme","Microbiologie","","","","");
@@ -958,61 +958,29 @@ public class TerminologyLoaderSvcLoincTest extends BaseLoaderTest {
 			String methodType, String theClass, String theShortName, String theLongCommonName, String theRelatedName2,
 			String theLinguisticVariantDisplayName) {
 
-		TermConceptDesignation componentDes = null;
-		TermConceptDesignation propertyDes = null;
-		TermConceptDesignation timeAspctDes = null;
-		TermConceptDesignation systemDes = null;
-		TermConceptDesignation scaleTypDes = null;
-
-		TermConceptDesignation methodTypDes = null;
-		TermConceptDesignation classDes = null;
+		TermConceptDesignation formalNameDes = null;
 		TermConceptDesignation shortNameDes = null;
-		TermConceptDesignation longCommonNameDes = null;
-		TermConceptDesignation relatedNames2Des = null;
-		
+		TermConceptDesignation longCommonNameDes = null;	
 		TermConceptDesignation linguisticVariantDisplayNameDes = null;
 		
 		for (TermConceptDesignation designation : designationList) {
 			if (theLanguage.equals(designation.getLanguage())) {
 				
-				if ("COMPONENT".equals(designation.getUseDisplay())) 
-					componentDes = designation;
-				if ("PROPERTY".equals(designation.getUseDisplay())) 
-					propertyDes = designation;
-				if ("TIME_ASPCT".equals(designation.getUseDisplay())) 
-					timeAspctDes = designation;
-				if ("SYSTEM".equals(designation.getUseDisplay())) 
-					systemDes = designation;
-				if ("SCALE_TYP".equals(designation.getUseDisplay())) 
-					scaleTypDes = designation;
+				if ("FormalName".equals(designation.getUseDisplay())) 
+					formalNameDes = designation;
 				
-				if ("METHOD_TYP".equals(designation.getUseDisplay())) 
-					methodTypDes = designation;
-				if ("CLASS".equals(designation.getUseDisplay())) 
-					classDes = designation;
 				if ("SHORTNAME".equals(designation.getUseDisplay())) 
 					shortNameDes = designation;
 				if ("LONG_COMMON_NAME".equals(designation.getUseDisplay())) 
 					longCommonNameDes = designation;
-				if ("RELATEDNAMES2".equals(designation.getUseDisplay())) 
-					relatedNames2Des = designation;
-				
 				if ("LinguisticVariantDisplayName".equals(designation.getUseDisplay())) 
 					linguisticVariantDisplayNameDes = designation;
 			}
 		}
-		verifyDesignation(componentDes, ITermLoaderSvc.LOINC_URI, "COMPONENT", theComponent);
-		verifyDesignation(propertyDes, ITermLoaderSvc.LOINC_URI, "PROPERTY", theProperty);
-		verifyDesignation(timeAspctDes, ITermLoaderSvc.LOINC_URI, "TIME_ASPCT", theTimeAspct);
-		verifyDesignation(systemDes, ITermLoaderSvc.LOINC_URI, "SYSTEM", theSystem);
-		verifyDesignation(scaleTypDes, ITermLoaderSvc.LOINC_URI, "SCALE_TYP", theScaleTyp);
 		
-		verifyDesignation(methodTypDes, ITermLoaderSvc.LOINC_URI, "METHOD_TYP", methodType);
-		verifyDesignation(classDes, ITermLoaderSvc.LOINC_URI, "CLASS", theClass);
+		verifyDesignation(formalNameDes, ITermLoaderSvc.LOINC_URI, "FormalName", theComponent+":"+theProperty+":"+theTimeAspct+":"+theSystem+":"+theScaleTyp+":"+methodType);
 		verifyDesignation(shortNameDes, ITermLoaderSvc.LOINC_URI, "SHORTNAME", theShortName);
-		verifyDesignation(longCommonNameDes, ITermLoaderSvc.LOINC_URI, "LONG_COMMON_NAME", theLongCommonName);
-		verifyDesignation(relatedNames2Des, ITermLoaderSvc.LOINC_URI, "RELATEDNAMES2", theRelatedName2);
-		
+		verifyDesignation(longCommonNameDes, ITermLoaderSvc.LOINC_URI, "LONG_COMMON_NAME", theLongCommonName);		
 		verifyDesignation(linguisticVariantDisplayNameDes, ITermLoaderSvc.LOINC_URI, "LinguisticVariantDisplayName", theLinguisticVariantDisplayName);
 	}
 	


### PR DESCRIPTION
The following should be created as designations for each term:
COMPONENT:PROPERTY:TIME_ASPCT:SYSTEM:SCALE_TYP:METHOD_TYP (as colon-separated concatenation - FormalName)
 SHORTNAME
LONG_COMMON_NAME
LinguisticVariantDisplayName