### PR TITLE
Issue 2883 unable to load open api docs

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2883-unable-to-load-OpenAPI-docs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2883-unable-to-load-OpenAPI-docs.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 2883
+jira: SMILE-1107
+title: "Open API docs failed to load if a custom context path is set. This has been corrected."

--- a/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
+++ b/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
@@ -283,7 +283,7 @@ public class OpenApiInterceptor {
 		context.setVariable("SERVER_VERSION", cs.getSoftware().getVersion());
 		context.setVariable("BASE_URL", cs.getImplementation().getUrl());
 		context.setVariable("BANNER_IMAGE_URL", getBannerImage());
-		context.setVariable("OPENAPI_DOCS", cs.getImplementation().getUrl() + "/api-docs");
+		context.setVariable("OPENAPI_DOCS", cs.getImplementation().getUrl() + "api-docs");
 		context.setVariable("FHIR_VERSION", cs.getFhirVersion().toCode());
 		context.setVariable("FHIR_VERSION_CODENAME", FhirVersionEnum.forVersionString(cs.getFhirVersion().toCode()).name());
 

--- a/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
+++ b/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
@@ -267,10 +267,17 @@ public class OpenApiInterceptor {
 		return false;
 	}
 
+	public String removeTrailingSlash(String theUrl) {
+		while(theUrl.endsWith("/")) {
+			theUrl = theUrl.substring(0, theUrl.length() - 1);
+		}
+		return theUrl;
+	}
+
 	@SuppressWarnings("unchecked")
 	private void serveSwaggerUiHtml(ServletRequestDetails theRequestDetails, HttpServletResponse theResponse) throws IOException {
 		CapabilityStatement cs = getCapabilityStatement(theRequestDetails);
-
+		String baseUrl = removeTrailingSlash(cs.getImplementation().getUrl());
 		theResponse.setStatus(200);
 		theResponse.setContentType(Constants.CT_HTML);
 
@@ -281,9 +288,9 @@ public class OpenApiInterceptor {
 		context.setVariable("DESCRIPTION", cs.getImplementation().getDescription());
 		context.setVariable("SERVER_NAME", cs.getSoftware().getName());
 		context.setVariable("SERVER_VERSION", cs.getSoftware().getVersion());
-		context.setVariable("BASE_URL", cs.getImplementation().getUrl());
+		context.setVariable("BASE_URL", baseUrl);
 		context.setVariable("BANNER_IMAGE_URL", getBannerImage());
-		context.setVariable("OPENAPI_DOCS", cs.getImplementation().getUrl() + "api-docs");
+		context.setVariable("OPENAPI_DOCS", baseUrl + "/api-docs");
 		context.setVariable("FHIR_VERSION", cs.getFhirVersion().toCode());
 		context.setVariable("FHIR_VERSION_CODENAME", FhirVersionEnum.forVersionString(cs.getFhirVersion().toCode()).name());
 

--- a/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
+++ b/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
@@ -268,7 +268,7 @@ public class OpenApiInterceptor {
 	}
 
 	public String removeTrailingSlash(String theUrl) {
-		while(theUrl.endsWith("/")) {
+		while(theUrl != null && theUrl.endsWith("/")) {
 			theUrl = theUrl.substring(0, theUrl.length() - 1);
 		}
 		return theUrl;
@@ -288,7 +288,7 @@ public class OpenApiInterceptor {
 		context.setVariable("DESCRIPTION", cs.getImplementation().getDescription());
 		context.setVariable("SERVER_NAME", cs.getSoftware().getName());
 		context.setVariable("SERVER_VERSION", cs.getSoftware().getVersion());
-		context.setVariable("BASE_URL", baseUrl);
+		context.setVariable("BASE_URL", cs.getImplementation().getUrl());
 		context.setVariable("BANNER_IMAGE_URL", getBannerImage());
 		context.setVariable("OPENAPI_DOCS", baseUrl + "/api-docs");
 		context.setVariable("FHIR_VERSION", cs.getFhirVersion().toCode());

--- a/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.html
+++ b/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.html
@@ -45,7 +45,7 @@
     window.onload = function() {
         // Begin Swagger UI call region
         const ui = SwaggerUIBundle({
-            url: "[[@{/api-docs(page=${PAGE})}]]",
+            url: "[[${OPENAPI_DOCS} + '?page=' + ${PAGE}]]",
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [

--- a/hapi-fhir-server-openapi/src/test/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptorTest.java
+++ b/hapi-fhir-server-openapi/src/test/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptorTest.java
@@ -207,7 +207,12 @@ public class OpenApiInterceptorTest {
 		assertEquals(expect, url3);
 	}
 
-
+	@Test
+	public void testRemoveTrailingSlashWithNullUrl() {
+		OpenApiInterceptor interceptor = new OpenApiInterceptor();
+		String url = interceptor.removeTrailingSlash(null);
+		assertEquals(null, url);
+	}
 
 	private String fetchSwaggerUi(String url) throws IOException {
 		String resp;

--- a/hapi-fhir-server-openapi/src/test/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptorTest.java
+++ b/hapi-fhir-server-openapi/src/test/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptorTest.java
@@ -195,6 +195,20 @@ public class OpenApiInterceptorTest {
 		assertThat(buttonTexts.toString(), buttonTexts, Matchers.contains("All", "System Level Operations", "OperationDefinition 1", "Observation", "Patient"));
 	}
 
+	@Test
+	public void testRemoveTrailingSlash() {
+		OpenApiInterceptor interceptor = new OpenApiInterceptor();
+		String url1 = interceptor.removeTrailingSlash("http://localhost:8000");
+		String url2 = interceptor.removeTrailingSlash("http://localhost:8000/");
+		String url3 = interceptor.removeTrailingSlash("http://localhost:8000//");
+		String expect = "http://localhost:8000";
+		assertEquals(expect, url1);
+		assertEquals(expect, url2);
+		assertEquals(expect, url3);
+	}
+
+
+
 	private String fetchSwaggerUi(String url) throws IOException {
 		String resp;
 		HttpGet get = new HttpGet(url);


### PR DESCRIPTION
Closes #2883 

Implementation URLs that end with trailing slashes cause problems with openAPI page loading as we end up adding a double slash. This ends up causing subsequent failed calls. 