### PR TITLE
set version map to check all partitions

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/cache/ResourceVersionSvcDaoImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/cache/ResourceVersionSvcDaoImpl.java
@@ -20,6 +20,7 @@ package ca.uhn.fhir.jpa.cache;
  * #L%
  */
 
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
@@ -28,6 +29,7 @@ import ca.uhn.fhir.jpa.partition.SystemRequestDetails;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.util.QueryChunker;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,12 +38,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 /**
  * This service builds a map of resource ids to versions based on a SearchParameterMap.
  * It is used by the in-memory resource-version cache to detect when resource versions have been changed by remote processes.
  */
 @Service
 public class ResourceVersionSvcDaoImpl implements IResourceVersionSvc {
+	private static final Logger ourLog = getLogger(ResourceVersionSvcDaoImpl.class);
 
 	@Autowired
 	DaoRegistry myDaoRegistry;
@@ -53,7 +58,11 @@ public class ResourceVersionSvcDaoImpl implements IResourceVersionSvc {
 	public ResourceVersionMap getVersionMap(String theResourceName, SearchParameterMap theSearchParamMap) {
 		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(theResourceName);
 
-		List<Long> matchingIds = dao.searchForIds(theSearchParamMap, new SystemRequestDetails()).stream()
+		if (ourLog.isDebugEnabled()) {
+			ourLog.debug("About to retrieve version map for resource type: {}", theResourceName);
+		}
+
+		List<Long> matchingIds = dao.searchForIds(theSearchParamMap, new SystemRequestDetails().setRequestPartitionId(RequestPartitionId.allPartitions())).stream()
 			.map(ResourcePersistentId::getIdAsLong)
 			.collect(Collectors.toList());
 


### PR DESCRIPTION
If partitioning is enabled, and `refreshCacheAndNotifyListener` from `ResourceChangeListenerCacheRefreshImpl` is called, and REQUEST_TENANT_URL mode is selected for read partition selection, this results in the following stack trace, indicating `No tenant ID has been selected`

```
ca.uhn.fhir.rest.server.exceptions.InternalErrorException: No tenant ID has been specified
    at ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor.extractPartitionIdFromRequest(RequestTenantPartitionInterceptor.java:66)
    at ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor.PartitionIdentifyRead(RequestTenantPartitionInterceptor.java:57)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at ca.uhn.fhir.interceptor.executor.BaseInterceptorService$HookInvoker.invoke(BaseInterceptorService.java:563) [1 skipped]
    at ca.uhn.fhir.interceptor.executor.BaseInterceptorService.doCallHooks(BaseInterceptorService.java:300)
    at ca.uhn.fhir.interceptor.executor.BaseInterceptorService.callHooksAndReturnObject(BaseInterceptorService.java:269)
    at ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster$1.callHooksAndReturnObject(CompositeInterceptorBroadcaster.java:81)
    at ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster$1.callHooksAndReturnObject(CompositeInterceptorBroadcaster.java:63)
    at ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster.doCallHooksAndReturnObject(CompositeInterceptorBroadcaster.java:52)
    at ca.uhn.fhir.jpa.partition.RequestPartitionHelperSvc.determineReadPartitionForRequest(RequestPartitionHelperSvc.java:124)
    at ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc.determineReadPartitionForRequestForSearchType(IRequestPartitionHelperSvc.java:49)
    at ca.uhn.fhir.jpa.dao.BaseHapiFhirResourceDao.lambda$searchForIds$14(BaseHapiFhirResourceDao.java:1510)
    at ca.uhn.fhir.jpa.dao.tx.HapiTransactionService.doExecuteCallback(HapiTransactionService.java:147) [1 skipped]
    at ca.uhn.fhir.jpa.dao.tx.HapiTransactionService.execute(HapiTransactionService.java:80)
    at ca.uhn.fhir.jpa.dao.tx.HapiTransactionService.execute(HapiTransactionService.java:72)
    at ca.uhn.fhir.jpa.dao.BaseHapiFhirResourceDao.searchForIds(BaseHapiFhirResourceDao.java:1497)
    at ca.uhn.fhir.jpa.api.dao.IFhirResourceDao.searchForIds(IFhirResourceDao.java:216)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at ca.cdr.pers.aspect.InvocationCountingAspect.doBasicProfiling(InvocationCountingAspect.java:36) [7 skipped]
    at jdk.internal.reflect.GeneratedMethodAccessor191.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at jdk.proxy2/jdk.proxy2.$Proxy355.searchForIds(Unknown Source) [8 skipped]
    at ca.uhn.fhir.jpa.cache.ResourceVersionSvcDaoImpl.getVersionMap(ResourceVersionSvcDaoImpl.java:56)
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCacheRefresherImpl.refreshCacheAndNotifyListener(ResourceChangeListenerCacheRefresherImpl.java:133)
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCache.lambda$refreshCacheAndNotifyListenersWithRetry$0(ResourceChangeListenerCache.java:145)
    at ca.uhn.fhir.jpa.searchparam.retry.Retrier.lambda$runWithRetry$0(Retrier.java:87)
    at ca.uhn.fhir.jpa.searchparam.retry.Retrier.runWithRetry(Retrier.java:87) [2 skipped]
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCache.refreshCacheAndNotifyListenersWithRetry(ResourceChangeListenerCache.java:148)
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCache.refreshCacheWithRetry(ResourceChangeListenerCache.java:130)
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCache.refreshCacheIfNecessary(ResourceChangeListenerCache.java:111)
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCacheRefresherImpl.refreshExpiredCachesAndNotifyListeners(ResourceChangeListenerCacheRefresherImpl.java:90)
    at ca.uhn.fhir.jpa.cache.ResourceChangeListenerCacheRefresherImpl$Job.execute(ResourceChangeListenerCacheRefresherImpl.java:80)
    ```