### PR TITLE
Add prefix toggle for channel settings

### DIFF
--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/BaseChannelSettings.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/BaseChannelSettings.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.jpa.subscription.channel.api;
 
 public abstract class BaseChannelSettings implements IChannelSettings {
 	private boolean myQualifyChannelName = true;
+	private boolean myPrefixChannelName = true;
 
 	/**
 	 * Default true.  Used by IChannelNamer to decide how to qualify the channel name.
@@ -29,6 +30,18 @@ public abstract class BaseChannelSettings implements IChannelSettings {
 	@Override
 	public boolean isQualifyChannelName() {
 		return myQualifyChannelName;
+	}
+
+	@Override
+	public boolean isPrefixChannelName() {
+		return myPrefixChannelName;
+	}
+
+	/**
+	 * Default true.  Used by IChannelNamer to decide whether to add a prefix to the channel.
+	 */
+	public void setPrefixChannelName(boolean thePrefixChannelName) {
+		myPrefixChannelName = thePrefixChannelName;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/IChannelSettings.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/IChannelSettings.java
@@ -22,4 +22,5 @@ package ca.uhn.fhir.jpa.subscription.channel.api;
 
 public interface IChannelSettings {
 	boolean isQualifyChannelName();
+	boolean isPrefixChannelName();
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -88,6 +88,7 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 
 		ChannelProducerSettings channelSettings = new ChannelProducerSettings();
 		channelSettings.setQualifyChannelName(false);
+		channelSettings.setPrefixChannelName(false);
 
 		IChannelProducer channelProducer = myChannelFactory.getOrCreateProducer(queueName, ResourceModifiedJsonMessage.class, channelSettings);
 


### PR DESCRIPTION
* Add isPrefixChannelName method to IChannelSettings interfaec. 
* This will allow downstream consumers to select whether the channel should use some global prefix. 
