### PR TITLE
Remove essentially duplicate bean definition

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/CommonBatchJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/CommonBatchJobConfig.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.jpa.batch;
 
 import ca.uhn.fhir.jpa.batch.processor.GoldenResourceAnnotatingProcessor;
 import ca.uhn.fhir.jpa.batch.processor.PidToIBaseResourceProcessor;
+import ca.uhn.fhir.jpa.reindex.job.ReindexWriter;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,12 @@ public class CommonBatchJobConfig {
 	@StepScope
 	public GoldenResourceAnnotatingProcessor goldenResourceAnnotatingProcessor() {
 		return new GoldenResourceAnnotatingProcessor();
+	}
+
+	@Bean
+	@StepScope
+	public ReindexWriter reindexWriter() {
+		return new ReindexWriter();
 	}
 
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/job/ReindexEverythingJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/job/ReindexEverythingJobConfig.java
@@ -49,6 +49,8 @@ public class ReindexEverythingJobConfig {
 	private StepBuilderFactory myStepBuilderFactory;
 	@Autowired
 	private JobBuilderFactory myJobBuilderFactory;
+	@Autowired
+	private ReindexWriter myReindexWriter;
 
 	@Bean(name = REINDEX_EVERYTHING_JOB_NAME)
 	@Lazy
@@ -63,7 +65,7 @@ public class ReindexEverythingJobConfig {
 		return myStepBuilderFactory.get(REINDEX_EVERYTHING_STEP_NAME)
 			.<List<Long>, List<Long>>chunk(1)
 			.reader(cronologicalBatchAllResourcePidReader())
-			.writer(reindexWriter())
+			.writer(myReindexWriter)
 			.listener(reindexEverythingPidCountRecorderListener())
 			.listener(reindexEverythingPromotionListener())
 			.build();
@@ -73,12 +75,6 @@ public class ReindexEverythingJobConfig {
 	@StepScope
 	public CronologicalBatchAllResourcePidReader cronologicalBatchAllResourcePidReader() {
 		return new CronologicalBatchAllResourcePidReader();
-	}
-
-	@Bean
-	@StepScope
-	public ReindexWriter reindexWriter() {
-		return new ReindexWriter();
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/job/ReindexJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/job/ReindexJobConfig.java
@@ -51,6 +51,8 @@ public class ReindexJobConfig extends MultiUrlProcessorJobConfig {
 	private StepBuilderFactory myStepBuilderFactory;
 	@Autowired
 	private JobBuilderFactory myJobBuilderFactory;
+	@Autowired
+	private ReindexWriter myReindexWriter;
 
 	@Bean(name = REINDEX_JOB_NAME)
 	@Lazy
@@ -66,16 +68,10 @@ public class ReindexJobConfig extends MultiUrlProcessorJobConfig {
 		return myStepBuilderFactory.get(REINDEX_URL_LIST_STEP_NAME)
 			.<List<Long>, List<Long>>chunk(1)
 			.reader(reverseCronologicalBatchResourcePidReader())
-			.writer(reindexWriter())
+			.writer(myReindexWriter)
 			.listener(pidCountRecorderListener())
 			.listener(reindexPromotionListener())
 			.build();
-	}
-
-	@Bean
-	@StepScope
-	public ReindexWriter reindexWriter() {
-		return new ReindexWriter();
 	}
 
 	@Bean


### PR DESCRIPTION
Closes #2925 

* Move ReindexWriter Bean definition into the common class, and autowire its usages. 

This is causing a bit of havoc without downstream implementations (see https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/264)