### PR TITLE
Clear the memory cache whenever ExpungeEverythingService is used.

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
@@ -126,37 +126,37 @@ public class ExpungeEverythingService {
 			counter.addAndGet(doExpungeEverythingQuery("UPDATE " + TermCodeSystem.class.getSimpleName() + " d SET d.myCurrentVersion = null"));
 			return null;
 		});
-		counter.addAndGet(expungeEverythingByType(NpmPackageVersionResourceEntity.class, false));
-		counter.addAndGet(expungeEverythingByType(NpmPackageVersionEntity.class, false));
-		counter.addAndGet(expungeEverythingByType(NpmPackageEntity.class, false));
-		counter.addAndGet(expungeEverythingByType(SearchParamPresent.class, false));
-		counter.addAndGet(expungeEverythingByType(BulkImportJobFileEntity.class, false));
-		counter.addAndGet(expungeEverythingByType(BulkImportJobEntity.class, false));
-		counter.addAndGet(expungeEverythingByType(ForcedId.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamDate.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamNumber.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamQuantity.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamQuantityNormalized.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamString.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamToken.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamUri.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamCoords.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedComboStringUnique.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedComboTokenNonUnique.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceLink.class, false));
-		counter.addAndGet(expungeEverythingByType(SearchResult.class, false));
-		counter.addAndGet(expungeEverythingByType(SearchInclude.class, false));
-		counter.addAndGet(expungeEverythingByType(TermValueSetConceptDesignation.class, false));
-		counter.addAndGet(expungeEverythingByType(TermValueSetConcept.class, false));
-		counter.addAndGet(expungeEverythingByType(TermValueSet.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptParentChildLink.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptMapGroupElementTarget.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptMapGroupElement.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptMapGroup.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptMap.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptProperty.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConceptDesignation.class, false));
-		counter.addAndGet(expungeEverythingByType(TermConcept.class, false));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(NpmPackageVersionResourceEntity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(NpmPackageVersionEntity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(NpmPackageEntity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(SearchParamPresent.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(BulkImportJobFileEntity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(BulkImportJobEntity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ForcedId.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamDate.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamNumber.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamQuantity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamQuantityNormalized.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamString.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamToken.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamUri.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedSearchParamCoords.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedComboStringUnique.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceIndexedComboTokenNonUnique.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceLink.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(SearchResult.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(SearchInclude.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermValueSetConceptDesignation.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermValueSetConcept.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermValueSet.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptParentChildLink.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptMapGroupElementTarget.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptMapGroupElement.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptMapGroup.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptMap.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptProperty.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConceptDesignation.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermConcept.class));
 		myTxTemplate.execute(t -> {
 			for (TermCodeSystem next : myEntityManager.createQuery("SELECT c FROM " + TermCodeSystem.class.getName() + " c", TermCodeSystem.class).getResultList()) {
 				next.setCurrentVersion(null);
@@ -164,70 +164,66 @@ public class ExpungeEverythingService {
 			}
 			return null;
 		});
-		counter.addAndGet(expungeEverythingByType(TermCodeSystemVersion.class, false));
-		counter.addAndGet(expungeEverythingByType(TermCodeSystem.class, false));
-		counter.addAndGet(expungeEverythingByType(SubscriptionTable.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceHistoryTag.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceTag.class, false));
-		counter.addAndGet(expungeEverythingByType(TagDefinition.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceHistoryProvenanceEntity.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceHistoryTable.class, false));
-		counter.addAndGet(expungeEverythingByType(ResourceTable.class, false));
-		counter.addAndGet(expungeEverythingByType(PartitionEntity.class, false));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermCodeSystemVersion.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TermCodeSystem.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(SubscriptionTable.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceHistoryTag.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceTag.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(TagDefinition.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceHistoryProvenanceEntity.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceHistoryTable.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(ResourceTable.class));
+		counter.addAndGet(expungeEverythingByTypeWithoutPurging(PartitionEntity.class));
 		myTxTemplate.execute(t -> {
 			counter.addAndGet(doExpungeEverythingQuery("DELETE from " + Search.class.getSimpleName() + " d"));
 			return null;
 		});
 
-                myTxTemplate.execute(t -> {
-                        myMemoryCacheService.invalidateAllCaches();
-                        return null;
-                        });
+                purgeAllCaches();
 
 		ourLog.info("COMPLETED GLOBAL $expunge - Deleted {} rows", counter.get());
 	}
 
-        public int expungeEverythingByType(Class<?> theEntityType, boolean purgeMemoryCache) {
-                int outcome = expungeEverythingByType(theEntityType);
+        private void purgeAllCaches() {
+                myTxTemplate.execute(t -> {
+                        myMemoryCacheService.invalidateAllCaches();
+                        return null;
+                });
+        }
 
-                if (purgeMemoryCache) {
-                        myTxTemplate.execute(t -> {
-                                myMemoryCacheService.invalidateAllCaches();
-                                return null;
+        private int expungeEverythingByTypeWithoutPurging(Class<?> theEntityType) {
+                int outcome = 0;
+                while (true) {
+                        StopWatch sw = new StopWatch();
+
+                        @SuppressWarnings("ConstantConditions")
+                        int count = myTxTemplate.execute(t -> {
+                                CriteriaBuilder cb = myEntityManager.getCriteriaBuilder();
+                                CriteriaQuery<?> cq = cb.createQuery(theEntityType);
+                                cq.from(theEntityType);
+                                TypedQuery<?> query = myEntityManager.createQuery(cq);
+                                query.setMaxResults(1000);
+                                List<?> results = query.getResultList();
+                                for (Object result : results) {
+                                        myEntityManager.remove(result);
+                                }
+                                return results.size();
                         });
-                }
 
+                        outcome += count;
+                        if (count == 0) {
+                                break;
+                        }
+
+                        ourLog.info("Have deleted {} entities of type {} in {}", outcome, theEntityType.getSimpleName(), sw.toString());
+                }
                 return outcome;
         }
 
 	public int expungeEverythingByType(Class<?> theEntityType) {
-
-		int outcome = 0;
-		while (true) {
-			StopWatch sw = new StopWatch();
-
-			@SuppressWarnings("ConstantConditions")
-			int count = myTxTemplate.execute(t -> {
-				CriteriaBuilder cb = myEntityManager.getCriteriaBuilder();
-				CriteriaQuery<?> cq = cb.createQuery(theEntityType);
-				cq.from(theEntityType);
-				TypedQuery<?> query = myEntityManager.createQuery(cq);
-				query.setMaxResults(1000);
-				List<?> results = query.getResultList();
-				for (Object result : results) {
-					myEntityManager.remove(result);
-				}
-				return results.size();
-			});
-
-			outcome += count;
-			if (count == 0) {
-				break;
-			}
-
-			ourLog.info("Have deleted {} entities of type {} in {}", outcome, theEntityType.getSimpleName(), sw.toString());
-		}
-		return outcome;
+                int result = expungeEverythingByTypeWithoutPurging(theEntityType);
+                purgeAllCaches();
+                return result;
 	}
 
 	private int doExpungeEverythingQuery(String theQuery) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
@@ -65,6 +65,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.entity.ResourceTag;
 import ca.uhn.fhir.jpa.model.entity.SearchParamPresent;
 import ca.uhn.fhir.jpa.model.entity.TagDefinition;
+import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
@@ -100,6 +101,9 @@ public class ExpungeEverythingService {
 
 	private TransactionTemplate myTxTemplate;
 
+	@Autowired
+	private MemoryCacheService myMemoryCacheService;
+
 	@PostConstruct
 	public void initTxTemplate() {
 		myTxTemplate = new TransactionTemplate(myPlatformTransactionManager);
@@ -122,37 +126,37 @@ public class ExpungeEverythingService {
 			counter.addAndGet(doExpungeEverythingQuery("UPDATE " + TermCodeSystem.class.getSimpleName() + " d SET d.myCurrentVersion = null"));
 			return null;
 		});
-		counter.addAndGet(expungeEverythingByType(NpmPackageVersionResourceEntity.class));
-		counter.addAndGet(expungeEverythingByType(NpmPackageVersionEntity.class));
-		counter.addAndGet(expungeEverythingByType(NpmPackageEntity.class));
-		counter.addAndGet(expungeEverythingByType(SearchParamPresent.class));
-		counter.addAndGet(expungeEverythingByType(BulkImportJobFileEntity.class));
-		counter.addAndGet(expungeEverythingByType(BulkImportJobEntity.class));
-		counter.addAndGet(expungeEverythingByType(ForcedId.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamDate.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamNumber.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamQuantity.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamQuantityNormalized.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamString.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamToken.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamUri.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamCoords.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedComboStringUnique.class));
-		counter.addAndGet(expungeEverythingByType(ResourceIndexedComboTokenNonUnique.class));
-		counter.addAndGet(expungeEverythingByType(ResourceLink.class));
-		counter.addAndGet(expungeEverythingByType(SearchResult.class));
-		counter.addAndGet(expungeEverythingByType(SearchInclude.class));
-		counter.addAndGet(expungeEverythingByType(TermValueSetConceptDesignation.class));
-		counter.addAndGet(expungeEverythingByType(TermValueSetConcept.class));
-		counter.addAndGet(expungeEverythingByType(TermValueSet.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptParentChildLink.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptMapGroupElementTarget.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptMapGroupElement.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptMapGroup.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptMap.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptProperty.class));
-		counter.addAndGet(expungeEverythingByType(TermConceptDesignation.class));
-		counter.addAndGet(expungeEverythingByType(TermConcept.class));
+		counter.addAndGet(expungeEverythingByType(NpmPackageVersionResourceEntity.class, false));
+		counter.addAndGet(expungeEverythingByType(NpmPackageVersionEntity.class, false));
+		counter.addAndGet(expungeEverythingByType(NpmPackageEntity.class, false));
+		counter.addAndGet(expungeEverythingByType(SearchParamPresent.class, false));
+		counter.addAndGet(expungeEverythingByType(BulkImportJobFileEntity.class, false));
+		counter.addAndGet(expungeEverythingByType(BulkImportJobEntity.class, false));
+		counter.addAndGet(expungeEverythingByType(ForcedId.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamDate.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamNumber.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamQuantity.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamQuantityNormalized.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamString.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamToken.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamUri.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedSearchParamCoords.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedComboStringUnique.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceIndexedComboTokenNonUnique.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceLink.class, false));
+		counter.addAndGet(expungeEverythingByType(SearchResult.class, false));
+		counter.addAndGet(expungeEverythingByType(SearchInclude.class, false));
+		counter.addAndGet(expungeEverythingByType(TermValueSetConceptDesignation.class, false));
+		counter.addAndGet(expungeEverythingByType(TermValueSetConcept.class, false));
+		counter.addAndGet(expungeEverythingByType(TermValueSet.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptParentChildLink.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptMapGroupElementTarget.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptMapGroupElement.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptMapGroup.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptMap.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptProperty.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConceptDesignation.class, false));
+		counter.addAndGet(expungeEverythingByType(TermConcept.class, false));
 		myTxTemplate.execute(t -> {
 			for (TermCodeSystem next : myEntityManager.createQuery("SELECT c FROM " + TermCodeSystem.class.getName() + " c", TermCodeSystem.class).getResultList()) {
 				next.setCurrentVersion(null);
@@ -160,23 +164,41 @@ public class ExpungeEverythingService {
 			}
 			return null;
 		});
-		counter.addAndGet(expungeEverythingByType(TermCodeSystemVersion.class));
-		counter.addAndGet(expungeEverythingByType(TermCodeSystem.class));
-		counter.addAndGet(expungeEverythingByType(SubscriptionTable.class));
-		counter.addAndGet(expungeEverythingByType(ResourceHistoryTag.class));
-		counter.addAndGet(expungeEverythingByType(ResourceTag.class));
-		counter.addAndGet(expungeEverythingByType(TagDefinition.class));
-		counter.addAndGet(expungeEverythingByType(ResourceHistoryProvenanceEntity.class));
-		counter.addAndGet(expungeEverythingByType(ResourceHistoryTable.class));
-		counter.addAndGet(expungeEverythingByType(ResourceTable.class));
-		counter.addAndGet(expungeEverythingByType(PartitionEntity.class));
+		counter.addAndGet(expungeEverythingByType(TermCodeSystemVersion.class, false));
+		counter.addAndGet(expungeEverythingByType(TermCodeSystem.class, false));
+		counter.addAndGet(expungeEverythingByType(SubscriptionTable.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceHistoryTag.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceTag.class, false));
+		counter.addAndGet(expungeEverythingByType(TagDefinition.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceHistoryProvenanceEntity.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceHistoryTable.class, false));
+		counter.addAndGet(expungeEverythingByType(ResourceTable.class, false));
+		counter.addAndGet(expungeEverythingByType(PartitionEntity.class, false));
 		myTxTemplate.execute(t -> {
 			counter.addAndGet(doExpungeEverythingQuery("DELETE from " + Search.class.getSimpleName() + " d"));
 			return null;
 		});
 
+                myTxTemplate.execute(t -> {
+                        myMemoryCacheService.invalidateAllCaches();
+                        return null;
+                        });
+
 		ourLog.info("COMPLETED GLOBAL $expunge - Deleted {} rows", counter.get());
 	}
+
+        public int expungeEverythingByType(Class<?> theEntityType, boolean purgeMemoryCache) {
+                int outcome = expungeEverythingByType(theEntityType);
+
+                if (purgeMemoryCache) {
+                        myTxTemplate.execute(t -> {
+                                myMemoryCacheService.invalidateAllCaches();
+                                return null;
+                        });
+                }
+
+                return outcome;
+        }
 
 	public int expungeEverythingByType(Class<?> theEntityType) {
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeHookTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeHookTest.java
@@ -76,7 +76,6 @@ public class ExpungeHookTest extends BaseJpaDstu3Test {
                 Meta theMeta = new Meta();
                 theMeta.addProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient");
                 thePatient.setMeta(theMeta);
-                myPatientDao.update(thePatient, mySrd);
 
                 IIdType id = myPatientDao.update(thePatient, mySrd).getId();
                 assertNotNull(myPatientDao.read(id));

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeHookTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeHookTest.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.jpa.dao.dstu3.BaseJpaDstu3Test;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.test.concurrency.PointcutLatch;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,8 @@ public class ExpungeHookTest extends BaseJpaDstu3Test {
 	@BeforeEach
 	public void before() {
 		myDaoConfig.setExpungeEnabled(true);
+                myDaoConfig.setResourceClientIdStrategy(DaoConfig.ClientIdStrategyEnum.ALPHANUMERIC);
+                myDaoConfig.setAutoCreatePlaceholderReferenceTargets(true);
 		myInterceptorService.registerAnonymousInterceptor(Pointcut.STORAGE_PRESTORAGE_EXPUNGE_EVERYTHING, myEverythingLatch);
 		myInterceptorService.registerAnonymousInterceptor(Pointcut.STORAGE_PRESTORAGE_EXPUNGE_RESOURCE, myExpungeResourceLatch);
 	}
@@ -64,6 +67,43 @@ public class ExpungeHookTest extends BaseJpaDstu3Test {
 
 		assertPatientGone(id);
 	}
+
+        @Test
+        public void expungeEverythingAndRecreate() throws InterruptedException {
+                // Create a patient.
+                Patient thePatient = new Patient();
+                thePatient.setId("ABC123");
+                Meta theMeta = new Meta();
+                theMeta.addProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient");
+                thePatient.setMeta(theMeta);
+                myPatientDao.update(thePatient, mySrd);
+
+                IIdType id = myPatientDao.update(thePatient, mySrd).getId();
+                assertNotNull(myPatientDao.read(id));
+
+                // Expunge it directly.
+                myPatientDao.delete(id);
+                ExpungeOptions options = new ExpungeOptions();
+                options.setExpungeEverything(true);
+                options.setExpungeDeletedResources(true);
+                options.setExpungeOldVersions(true);
+                myPatientDao.expunge(id.toUnqualifiedVersionless(), options, mySrd);
+                assertPatientGone(id);
+               
+                // Create it a second time.
+                myPatientDao.update(thePatient, mySrd);
+                assertNotNull(myPatientDao.read(id));
+
+                // Expunge everything with the service.
+                myEverythingLatch.setExpectedCount(1);
+                myExpungeService.expunge(null, null, null, options, mySrd);
+                myEverythingLatch.awaitExpected();
+                assertPatientGone(id);
+
+                // Create it a third time.
+                myPatientDao.update(thePatient, mySrd);
+                assertNotNull(myPatientDao.read(id));
+        }
 
 	private void assertPatientGone(IIdType theId) {
 		try {


### PR DESCRIPTION
The [ResourceExpungeService](https://github.com/hapifhir/hapi-fhir/blob/7a83c76e65befe14c83376ce8dbd2032d6f31808/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ResourceExpungeService.java#L162) already clears out the memory cache whenever it is used to expunge specific resource.  However, the [ExpungeEverythingService](https://github.com/hapifhir/hapi-fhir/blob/6d37749be88461ce0afb7d8e7e677ce5ddb35e31/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java#L178) currently does not.  This can lead to errors such as described in #2793 whenever a resource is expunged then re-created.

We solve this issue by clearing the memory cache whenever the ExpungeEverythingService is called.


 