### PR TITLE
Double conditional create issue

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2933-fix-double-conditional-create.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2933-fix-double-conditional-create.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 2933
+jira: SMILE-3056
+title: "Fixed a regression which causes transactions with multiple identical ifNoneExist clauses to create duplicate data."
+

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -261,7 +261,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 						// No matches
 						.filter(match -> !match.myResolved)
 						.forEach(match -> {
-							ourLog.warn("Was unable to match url {} from database", match.myRequestUrl);
+							ourLog.debug("Was unable to match url {} from database", match.myRequestUrl);
 							theTransactionDetails.addResolvedMatchUrl(match.myRequestUrl, TransactionDetails.NOT_FOUND);
 						});
 				}
@@ -337,7 +337,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 	}
 
 	private void setSearchToResolvedAndPrefetchFoundResourcePid(TransactionDetails theTransactionDetails, List<Long> idsToPreFetch, ResourceIndexedSearchParamToken nextResult, MatchUrlToResolve nextSearchParameterMap) {
-		ourLog.warn("Matched url {} from database", nextSearchParameterMap.myRequestUrl);
+		ourLog.debug("Matched url {} from database", nextSearchParameterMap.myRequestUrl);
 		idsToPreFetch.add(nextResult.getResourcePid());
 		myMatchResourceUrlService.matchUrlResolved(theTransactionDetails, nextSearchParameterMap.myResourceDefinition.getName(), nextSearchParameterMap.myRequestUrl, new ResourcePersistentId(nextResult.getResourcePid()));
 		theTransactionDetails.addResolvedMatchUrl(nextSearchParameterMap.myRequestUrl, new ResourcePersistentId(nextResult.getResourcePid()));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -244,17 +244,21 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 				if (orPredicates.size() > 1) {
 					cq.where(cb.or(orPredicates.toArray(EMPTY_PREDICATE_ARRAY)));
 
-					Map<Long, MatchUrlToResolve> hashToSearchMap = buildHashToSearchMap(searchParameterMapsToResolve);
+					Map<Long, List<MatchUrlToResolve>> hashToSearchMap = buildHashToSearchMap(searchParameterMapsToResolve);
 
 					TypedQuery<ResourceIndexedSearchParamToken> query = myEntityManager.createQuery(cq);
 					List<ResourceIndexedSearchParamToken> results = query.getResultList();
 
 					for (ResourceIndexedSearchParamToken nextResult : results) {
-						Optional<MatchUrlToResolve> matchedSearch = Optional.ofNullable(hashToSearchMap.get(nextResult.getHashSystemAndValue()));
+						Optional<List<MatchUrlToResolve>> matchedSearch = Optional.ofNullable(hashToSearchMap.get(nextResult.getHashSystemAndValue()));
 						if (!matchedSearch.isPresent()) {
 							matchedSearch =  Optional.ofNullable(hashToSearchMap.get(nextResult.getHashValue()));
 						}
-						matchedSearch.ifPresent(matchUrlToResolve -> setSearchToResolvedAndPrefetchFoundResourcePid(theTransactionDetails, idsToPreFetch, nextResult, matchUrlToResolve));
+						matchedSearch.ifPresent(matchUrlsToResolve -> {
+							matchUrlsToResolve.forEach(matchUrl -> {
+								setSearchToResolvedAndPrefetchFoundResourcePid(theTransactionDetails, idsToPreFetch, nextResult, matchUrl);
+							});
+						});
 					}
 					//For each SP Map which did not return a result, tag it as not found.
 					searchParameterMapsToResolve.stream()
@@ -322,15 +326,19 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 		return hashPredicate;
 	}
 
-	private Map<Long, MatchUrlToResolve> buildHashToSearchMap(List<MatchUrlToResolve> searchParameterMapsToResolve) {
-		Map<Long, MatchUrlToResolve> hashToSearch = new HashMap<>();
+	private Map<Long, List<MatchUrlToResolve>> buildHashToSearchMap(List<MatchUrlToResolve> searchParameterMapsToResolve) {
+		Map<Long, List<MatchUrlToResolve>> hashToSearch = new HashMap<>();
 		//Build a lookup map so we don't have to iterate over the searches repeatedly.
 		for (MatchUrlToResolve nextSearchParameterMap : searchParameterMapsToResolve) {
 			if (nextSearchParameterMap.myHashSystemAndValue != null) {
-				hashToSearch.put(nextSearchParameterMap.myHashSystemAndValue,  nextSearchParameterMap);
+				List<MatchUrlToResolve> matchUrlsToResolve = hashToSearch.getOrDefault(nextSearchParameterMap.myHashSystemAndValue, new ArrayList<>());
+				matchUrlsToResolve.add(nextSearchParameterMap);
+				hashToSearch.put(nextSearchParameterMap.myHashSystemAndValue,  matchUrlsToResolve);
 			}
 			if (nextSearchParameterMap.myHashValue!= null) {
-				hashToSearch.put(nextSearchParameterMap.myHashValue,  nextSearchParameterMap);
+				List<MatchUrlToResolve> matchUrlsToResolve = hashToSearch.getOrDefault(nextSearchParameterMap.myHashValue, new ArrayList<>());
+				matchUrlsToResolve.add(nextSearchParameterMap);
+				hashToSearch.put(nextSearchParameterMap.myHashValue,  matchUrlsToResolve);
 			}
 		}
 		return hashToSearch;

--- a/hapi-fhir-jpaserver-base/src/test/resources/duplicate-conditional-create.json
+++ b/hapi-fhir-jpaserver-base/src/test/resources/duplicate-conditional-create.json
@@ -1,0 +1,66 @@
+{
+	"resourceType": "Bundle",
+	"type": "transaction",
+	"entry": [
+		{
+			"fullUrl": "urn:uuid:4cd35592-5d4d-462b-8483-e404c023d316",
+			"resource": {
+				"resourceType": "Organization",
+				"identifier": [
+					{
+						"system": "https://fhir.tester.ca/NamingSystem/ca-on-health-care-facility-id",
+						"value": "3972"
+					}
+				]
+			},
+			"request": {
+				"method": "POST",
+				"url": "/Organization",
+				"ifNoneExist": "Organization?identifier=https://fhir.tester.ca/NamingSystem/ca-on-health-care-facility-id|3972"
+			}
+		},
+		{
+			"fullUrl": "urn:uuid:02643c1d-94d1-4991-a063-036fa0f57ec2",
+			"resource": {
+				"resourceType": "Organization",
+				"identifier": [
+					{
+						"system": "https://fhir.tester.ca/NamingSystem/ca-on-health-care-facility-id",
+						"value": "3972"
+					}
+				]
+			},
+			"request": {
+				"method": "POST",
+				"url": "/Organization",
+				"ifNoneExist": "Organization?identifier=https://fhir.tester.ca/NamingSystem/ca-on-health-care-facility-id|3972"
+			}
+		},
+		{
+			"fullUrl": "urn:uuid:8271e94f-e08b-498e-ad6d-751928c3ff99",
+			"resource": {
+				"resourceType": "ServiceRequest",
+				"identifier": [
+					{
+						"system": "https://fhir-tester.ca/NamingSystem/service-request-id",
+						"value": "1"
+					}
+				],
+				"performer": [
+					{
+						"reference": "urn:uuid:4cd35592-5d4d-462b-8483-e404c023d316",
+						"type": "Organization"
+					},
+					{
+						"reference": "urn:uuid:02643c1d-94d1-4991-a063-036fa0f57ec2",
+						"type": "Organization"
+					}
+				]
+			},
+			"request": {
+				"method": "PUT",
+				"url": "/ServiceRequest?identifier=https://fhir-tester.ca/NamingSystem/service-request-id|1"
+			}
+		}
+	]
+}

--- a/hapi-fhir-jpaserver-base/src/test/resources/logback-test.xml
+++ b/hapi-fhir-jpaserver-base/src/test/resources/logback-test.xml
@@ -42,7 +42,7 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="ca.uhn.fhir.jpa.dao" additivity="false" level="info">
+	<logger name="ca.uhn.fhir.jpa.dao" additivity="false" level="debug">
 		<appender-ref ref="STDOUT" />
 	</logger>
 

--- a/hapi-fhir-jpaserver-base/src/test/resources/logback-test.xml
+++ b/hapi-fhir-jpaserver-base/src/test/resources/logback-test.xml
@@ -42,7 +42,7 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="ca.uhn.fhir.jpa.dao" additivity="false" level="debug">
+	<logger name="ca.uhn.fhir.jpa.dao" additivity="false" level="info">
 		<appender-ref ref="STDOUT" />
 	</logger>
 


### PR DESCRIPTION
Closes #2933 

* A previous improvement to transaction processing speed(by yours truly) caused a bug in which bundles containing multiple identical conditional create `ifNoneExist` clauses would not got correctly collapsed. 
* This lead to duplicate resources during conditional create
* Fix to the optimization to allow it to support multiple identical SearchParameterMaps.
* Add test. 
* Add Changelog
 