### PR TITLE
[2935] Escape "%" in like expression

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2935-Search-with-trailing-percent-sign.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2935-Search-with-trailing-percent-sign.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 2935
+jira: SMILE-3022
+title: "No resource returned when search with percent sign. Problem is now fixed"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/StringPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/StringPredicateBuilder.java
@@ -225,15 +225,15 @@ public class StringPredicateBuilder extends BaseSearchParamPredicateBuilder {
 	}
 
 	public static String createLeftAndRightMatchLikeExpression(String likeExpression) {
-		return "%" + likeExpression.replace("%", "[%]") + "%";
+		return "%" + likeExpression.replace("%", "\\%") + "%";
 	}
 
 	public static String createLeftMatchLikeExpression(String likeExpression) {
-		return likeExpression.replace("%", "[%]") + "%";
+		return likeExpression.replace("%", "\\%") + "%";
 	}
 
 	public static String createRightMatchLikeExpression(String likeExpression) {
-		return "%" + likeExpression.replace("%", "[%]");
+		return "%" + likeExpression.replace("%", "\\%");
 	}
 
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -295,7 +295,6 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		myCaptureQueriesListener.logSelectQueries();
 	}
 
-
 	@Test
 	public void testSearchWithContainsLowerCase() {
 		myDaoConfig.setAllowContainsSearches(true);
@@ -331,6 +330,37 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		ids = output.getEntry().stream().map(t -> t.getResource().getIdElement().toUnqualifiedVersionless().getValue()).collect(Collectors.toList());
 		assertThat(ids, containsInAnyOrder(pt1id));
 
+	}
+
+	@Test
+	public void testSearchWithPercentSign() {
+		myDaoConfig.setAllowContainsSearches(true);
+
+		Patient pt1 = new Patient();
+		pt1.addName().setFamily("Smith%");
+		String pt1id = myPatientDao.create(pt1).getId().toUnqualifiedVersionless().getValue();
+
+		Bundle output = myClient
+			.search()
+			.forResource("Patient")
+			.where(Patient.NAME.contains().value("Smith%"))
+			.returnBundle(Bundle.class)
+			.execute();
+		List<String> ids = output.getEntry().stream().map(t -> t.getResource().getIdElement().toUnqualifiedVersionless().getValue()).collect(Collectors.toList());
+		assertThat(ids, containsInAnyOrder(pt1id));
+
+		Patient pt2 = new Patient();
+		pt2.addName().setFamily("Sm%ith");
+		String pt2id = myPatientDao.create(pt2).getId().toUnqualifiedVersionless().getValue();
+
+		output = myClient
+			.search()
+			.forResource("Patient")
+			.where(Patient.NAME.contains().value("Sm%ith"))
+			.returnBundle(Bundle.class)
+			.execute();
+		ids = output.getEntry().stream().map(t -> t.getResource().getIdElement().toUnqualifiedVersionless().getValue()).collect(Collectors.toList());
+		assertThat(ids, containsInAnyOrder(pt2id));
 	}
 
 	@Test


### PR DESCRIPTION
Close #2935 
* Fix the way to escape `%` wildcard character when generate `like` clause in `StringPredicateBuilder`
* Add test
* Add Changelog