### PR TITLE
Fix bundle batch pool bug when identical tags are present. 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2978-bundle-batch-tag-bug.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/2978-bundle-batch-tag-bug.yaml
@@ -1,0 +1,3 @@
+---
+type: fix
+title: "Fixed a bug where two identical tags in parallel entries being created in a batch would fail."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -1691,7 +1691,7 @@ public abstract class BaseTransactionProcessor {
 		private final Map<Integer, Object> myResponseMap;
 		private final int myResponseOrder;
 		private final boolean myNestedMode;
-		private Throwable myLastSeenException;
+		private BaseServerResponseException myLastSeenException;
 
 		protected RetriableBundleTask(CountDownLatch theCompletedLatch, RequestDetails theRequestDetails, Map<Integer, Object> theResponseMap, int theResponseOrder, IBase theNextReqEntry, boolean theNestedMode) {
 			this.myCompletedLatch = theCompletedLatch;
@@ -1731,7 +1731,7 @@ public abstract class BaseTransactionProcessor {
 					myLastSeenException = e;
 					return false;
 				} catch (Throwable t) {
-					myLastSeenException = t;
+					myLastSeenException = new InternalErrorException(t);
 					//If we have caught a non-tag-storage failure we are unfamiliar with, or we have exceeded max attempts, exit.
 					if (!DaoFailureUtil.isTagStorageFailure(t) || attempt >= maxAttempts) {
 						ourLog.error("Failure during BATCH sub transaction processing", t);
@@ -1755,7 +1755,7 @@ public abstract class BaseTransactionProcessor {
 
 		private void populateResponseMapWithLastSeenException() {
 			BaseServerResponseExceptionHolder caughtEx = new BaseServerResponseExceptionHolder();
-			caughtEx.setException(new InternalErrorException(myLastSeenException));
+			caughtEx.setException(myLastSeenException);
 			myResponseMap.put(myResponseOrder, caughtEx);
 		}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/DaoFailureUtil.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/DaoFailureUtil.java
@@ -1,0 +1,18 @@
+package ca.uhn.fhir.jpa.dao;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility class to help identify classes of failure.
+ */
+public class DaoFailureUtil {
+
+	public static boolean isTagStorageFailure(Throwable t) {
+		if (StringUtils.isBlank(t.getMessage())) {
+			return false;
+		} else {
+			String msg = t.getMessage().toLowerCase();
+			return msg.contains("hfj_tag_def") || msg.contains("hfj_res_tag");
+		}
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/tx/HapiTransactionService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/tx/HapiTransactionService.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.api.model.ResourceVersionConflictResolutionStrategy;
 import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
+import ca.uhn.fhir.jpa.dao.DaoFailureUtil;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
@@ -93,10 +94,9 @@ public class HapiTransactionService {
 		 		 * known to the system already, they'll both try to create a row in HFJ_TAG_DEF,
 		 		 * which is the tag definition table. In that case, a constraint error will be
 		 		 * thrown by one of the client threads, so we auto-retry in order to avoid
-		 		 * annopying spurious failures for the client.
+		 		 * annoying spurious failures for the client.
 		 		 */
-				if (e.getMessage().contains("HFJ_TAG_DEF") || e.getMessage().contains("hfj_tag_def") ||
-					 e.getMessage().contains("HFJ_RES_TAG") || e.getMessage().contains("hfj_res_tag")) {
+				if (DaoFailureUtil.isTagStorageFailure(e)) {
 					maxRetries = 3;
 				}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamString;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.entity.ResourceTag;
 import ca.uhn.fhir.jpa.model.entity.TagTypeEnum;
+import ca.uhn.fhir.jpa.partition.SystemRequestDetails;
 import ca.uhn.fhir.jpa.provider.SystemProviderDstu2Test;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4BundleTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4BundleTest.java
@@ -249,6 +249,45 @@ public class ResourceProviderR4BundleTest extends BaseResourceProviderR4Test {
 		assertEquals(ids.get(4), bundleEntries.get(6).getResource().getIdElement().toUnqualifiedVersionless().getValueAsString());
 
 	}
+
+	@Test
+	public void testTagCacheWorksWithBatchMode() {
+		Bundle input = new Bundle();
+		input.setType(BundleType.BATCH);
+
+		Patient p = new Patient();
+		p.setId("100");
+		p.setGender(AdministrativeGender.MALE);
+		p.addIdentifier().setSystem("urn:foo").setValue("A");
+		p.addName().setFamily("Smith");
+		p.getMeta().addTag().setSystem("mysystem").setCode("mycode");
+		input.addEntry().setResource(p).getRequest().setMethod(HTTPVerb.POST);
+
+		Patient p2 = new Patient();
+		p2.setId("200");
+		p2.setGender(AdministrativeGender.MALE);
+		p2.addIdentifier().setSystem("urn:foo").setValue("A");
+		p2.addName().setFamily("Smith");
+		p2.getMeta().addTag().setSystem("mysystem").setCode("mycode");
+		input.addEntry().setResource(p).getRequest().setMethod(HTTPVerb.POST);
+
+		Patient p3 = new Patient();
+		p3.setId("pat-300");
+		p3.setGender(AdministrativeGender.MALE);
+		p3.addIdentifier().setSystem("urn:foo").setValue("A");
+		p3.addName().setFamily("Smith");
+		p3.getMeta().addTag().setSystem("mysystem").setCode("mycode");
+		input.addEntry().setResource(p).getRequest().setMethod(HTTPVerb.PUT).setUrl("Patient/pat-300");
+
+		Bundle output = myClient.transaction().withBundle(input).execute();
+		output.getEntry().stream()
+			.map(BundleEntryComponent::getResponse)
+			.map(Bundle.BundleEntryResponseComponent::getStatus)
+			.forEach(statusCode -> {
+				assertEquals(statusCode, "201 Created");
+			});
+	}
+
 	
 	private List<String> createPatients(int count) {
 		List<String> ids = new ArrayList<String>();


### PR DESCRIPTION
* Recent implementation of thread pool for Batch operations ran into the same Tag storage bug as transactions before it. 
* add a simple retry mechanism if we detect a tag storage failure (same thing as transactions currently do) 
* Add test 
* Add changelog 