### PR TITLE
add support for OIDC authentication to Swagger API

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/3005-oidc-support-in-swagger.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/3005-oidc-support-in-swagger.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 3005
+jira: SMILE-723
+title: "Open up the visibility of some methods in the generation of the Open API definition files to allow extenders to add support for OIDC authorization."

--- a/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
+++ b/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
@@ -262,6 +262,13 @@ public class OpenApiInterceptor {
 				return true;
 			}
 
+			if (resourcePath.endsWith(".html")) {
+				theResponse.setContentType(Constants.CT_HTML);
+				theResponse.setStatus(200);
+				IOUtils.copy(resource, theResponse.getOutputStream());
+				theResponse.getOutputStream().close();
+				return true;
+			}
 		}
 		return false;
 	}
@@ -336,10 +343,16 @@ public class OpenApiInterceptor {
 		String page = extractPageName(theRequestDetails, PAGE_SYSTEM);
 		context.setVariable("PAGE", page);
 
+		populateOIDCVariables(context);
+
 		String outcome = myTemplateEngine.process("index.html", context);
 
 		theResponse.getWriter().write(outcome);
 		theResponse.getWriter().close();
+	}
+
+	protected void populateOIDCVariables(WebContext context) {
+		context.setVariable("OAUTH2_REDIRECT_URL_PROPERTY", "");
 	}
 
 	private String extractPageName(ServletRequestDetails theRequestDetails, String theDefault) {
@@ -354,7 +367,7 @@ public class OpenApiInterceptor {
 		return page;
 	}
 
-	private OpenAPI generateOpenApi(ServletRequestDetails theRequestDetails) {
+	protected OpenAPI generateOpenApi(ServletRequestDetails theRequestDetails) {
 		String page = extractPageName(theRequestDetails, null);
 
 		CapabilityStatement cs = getCapabilityStatement(theRequestDetails);

--- a/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
+++ b/hapi-fhir-server-openapi/src/main/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptor.java
@@ -343,7 +343,7 @@ public class OpenApiInterceptor {
 		String page = extractPageName(theRequestDetails, PAGE_SYSTEM);
 		context.setVariable("PAGE", page);
 
-		populateOIDCVariables(context);
+		populateOIDCVariables(theRequestDetails, context);
 
 		String outcome = myTemplateEngine.process("index.html", context);
 
@@ -351,8 +351,8 @@ public class OpenApiInterceptor {
 		theResponse.getWriter().close();
 	}
 
-	protected void populateOIDCVariables(WebContext context) {
-		context.setVariable("OAUTH2_REDIRECT_URL_PROPERTY", "");
+	protected void populateOIDCVariables(ServletRequestDetails theRequestDetails, WebContext theContext) {
+		theContext.setVariable("OAUTH2_REDIRECT_URL_PROPERTY", "");
 	}
 
 	private String extractPageName(ServletRequestDetails theRequestDetails, String theDefault) {

--- a/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.css
+++ b/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.css
@@ -18,7 +18,7 @@ body
     background: #fafafa;
 }
 
-.scheme-container, .information-container
+.information-container
 {
     display: none
 }

--- a/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.html
+++ b/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
@@ -55,7 +56,8 @@
             plugins: [
                 // SwaggerUIBundle.plugins.DownloadUrl
             ],
-            // layout: "StandaloneLayout"
+            // layout: "StandaloneLayout",
+            oauth2RedirectUrl: "[[${OAUTH2_REDIRECT_URL_PROPERTY}]]"
         });
         // End Swagger UI call region
 

--- a/hapi-fhir-server-openapi/src/test/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptorTest.java
+++ b/hapi-fhir-server-openapi/src/test/java/ca/uhn/fhir/rest/openapi/OpenApiInterceptorTest.java
@@ -213,6 +213,17 @@ public class OpenApiInterceptorTest {
 		assertEquals(null, url);
 	}
 
+	@Test
+	public void testStandardRedirectScriptIsAccessible() throws IOException {
+		myServer.getRestfulServer().registerInterceptor(new AddResourceCountsInterceptor());
+		myServer.getRestfulServer().registerInterceptor(new OpenApiInterceptor());
+
+		HttpGet get = new HttpGet("http://localhost:" + myServer.getPort() + "/fhir/swagger-ui/oauth2-redirect.html");
+		try (CloseableHttpResponse response = myClient.execute(get)) {
+			assertEquals(200, response.getStatusLine().getStatusCode());
+		}
+	}
+
 	private String fetchSwaggerUi(String url) throws IOException {
 		String resp;
 		HttpGet get = new HttpGet(url);


### PR DESCRIPTION
This merge request opens up some extension points in the hapi-fhir implementation of the Swagger API which are needed for customization in Smile CDR.