### PR TITLE
3110 zh disallow unknown extensions

### DIFF
--- a/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/RepositoryValidatingInterceptorExamples.java
+++ b/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/RepositoryValidatingInterceptorExamples.java
@@ -121,8 +121,10 @@ public class RepositoryValidatingInterceptorExamples {
 			.forResourcesOfType("Patient")
 			.requireValidationToDeclaredProfiles()
 
-			// Configure the validator to never reject extensions
-			.allowAnyExtensions()
+			// Configure the validator to reject unknown extensions
+			// by default, all extensions are accepted and to undo this rejection
+			// call allowAnyExtensions()
+			.allowKnownExtensionsOnly()
 
 			// Configure the validator to not perform terminology validation
 			.disableTerminologyChecks()

--- a/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/RepositoryValidatingInterceptorExamples.java
+++ b/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/RepositoryValidatingInterceptorExamples.java
@@ -28,7 +28,6 @@ import ca.uhn.fhir.jpa.interceptor.validation.RepositoryValidatingRuleBuilder;
 import ca.uhn.fhir.validation.ResultSeverityEnum;
 import org.springframework.context.ApplicationContext;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 @SuppressWarnings("unused")
@@ -124,7 +123,7 @@ public class RepositoryValidatingInterceptorExamples {
 			// Configure the validator to reject unknown extensions
 			// by default, all extensions are accepted and to undo this rejection
 			// call allowAnyExtensions()
-			.allowKnownExtensionsOnly()
+			.rejectUnknownExtensions()
 
 			// Configure the validator to not perform terminology validation
 			.disableTerminologyChecks()

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/3110-add-toggle-to-deny-unknown-extensions.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_6_0/3110-add-toggle-to-deny-unknown-extensions.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 3110
+title: "Added a functionality to deny unknown extensions."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingRuleBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingRuleBuilder.java
@@ -306,6 +306,15 @@ public final class RepositoryValidatingRuleBuilder implements IRuleRoot {
 			}
 
 			/**
+			 * Configure the validator to reject unknown extensions
+			 */
+			@Nonnull
+			public FinalizedRequireValidationRule allowKnownExtensionsOnly() {
+				myRule.getValidator().setAnyExtensionsAllowed(false);
+				return this;
+			}
+
+			/**
 			 * Configure the validator to not perform terminology validation
 			 */
 			@Nonnull

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingRuleBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingRuleBuilder.java
@@ -309,7 +309,7 @@ public final class RepositoryValidatingRuleBuilder implements IRuleRoot {
 			 * Configure the validator to reject unknown extensions
 			 */
 			@Nonnull
-			public FinalizedRequireValidationRule allowKnownExtensionsOnly() {
+			public FinalizedRequireValidationRule rejectUnknownExtensions() {
 				myRule.getValidator().setAnyExtensionsAllowed(false);
 				return this;
 			}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptorR4Test.java
@@ -292,12 +292,12 @@ public class RepositoryValidatingInterceptorR4Test extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void testRequireValidation_AdditionalOptions_Allow_Known_Extensions_Only() {
+	public void testRequireValidation_AdditionalOptions_Reject_UnKnown_Extensions() {
 		List<IRepositoryValidatingRule> rules = newRuleBuilder()
 			.forResourcesOfType("Observation")
 			.requireValidationToDeclaredProfiles()
 			.withBestPracticeWarningLevel("IGNORE")
-			.allowKnownExtensionsOnly()
+			.rejectUnknownExtensions()
 			.disableTerminologyChecks()
 			.errorOnUnknownProfiles()
 			.suppressNoBindingMessage()

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptorR4Test.java
@@ -292,6 +292,33 @@ public class RepositoryValidatingInterceptorR4Test extends BaseJpaR4Test {
 	}
 
 	@Test
+	public void testRequireValidation_AdditionalOptions_Allow_Known_Extensions_Only() {
+		List<IRepositoryValidatingRule> rules = newRuleBuilder()
+			.forResourcesOfType("Observation")
+			.requireValidationToDeclaredProfiles()
+			.withBestPracticeWarningLevel("IGNORE")
+			.allowKnownExtensionsOnly()
+			.disableTerminologyChecks()
+			.errorOnUnknownProfiles()
+			.suppressNoBindingMessage()
+			.suppressWarningForExtensibleValueSetValidation()
+			.build();
+
+		myValInterceptor.setRules(rules);
+
+		Observation obs = new Observation();
+		obs.getCode().addCoding().setSystem("http://foo").setCode("123").setDisplay("help im a bug");
+		obs.setStatus(Observation.ObservationStatus.AMENDED);
+		try {
+			IIdType id = myObservationDao.create(obs).getId();
+			assertEquals("1", id.getVersionIdPart());
+		} catch (PreconditionFailedException e) {
+			// should not happen
+			fail(myFhirCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(e.getOperationOutcome()));
+		}
+	}
+
+	@Test
 	public void testRequireValidation_FailNoRejectAndTag() {
 		List<IRepositoryValidatingRule> rules = newRuleBuilder()
 			.forResourcesOfType("Observation")


### PR DESCRIPTION
-Added allowKnownExtensionsOnly() method which serves to exclude all unknown extensions when called. 
-Added building test for allowKnownExtensionsOnly() to make sure the program can build 
-Added allowKnownExtensionsOnly() documentation.