### PR TITLE
Build issue caused by hapi-fhir-validation module.

### DIFF
--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -310,12 +310,12 @@
 			<artifactId>jena-arq</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-jpaserver-model</artifactId>
-            <version>5.4.0-PRE8-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
+	  <dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-jpaserver-model</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+	  </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
The hapi-fhir-validation module depends on an older snapshot version of hapi-fhir-jpaserver-model module. This results in build failures if you have a clean m2 repository.

These changes ensure that the hapi-fhir-jpaserver-model uses the same version as he current maven version of the project. 

