### PR TITLE
3170 language portion of language code is case insensitive

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3170-allow-language-code-validation-to-be-case-insensitive.yml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3170-allow-language-code-validation-to-be-case-insensitive.yml
@@ -1,4 +1,4 @@
 ---
 type: fix
 issue: 3170
-title: "Fixed language code validation so that language portion of language-region code (eg, en-US) is case insensitive"
+title: "Fixed language code validation so that it is case insensitive (eg, en-US, en-us, EN-US, EN-us should all work)"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3170-allow-language-code-validation-to-be-case-insensitive.yml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3170-allow-language-code-validation-to-be-case-insensitive.yml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 3170
+title: "Fixed language code validation so that language portion of language-region code (eg, en-US) is case insensitive"

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.java
@@ -212,7 +212,6 @@ public class CommonCodeSystemsTerminologyService implements IValidationSupport {
 
 	@Override
 	public LookupCodeResult lookupCode(ValidationSupportContext theValidationSupportContext, String theSystem, String theCode, String theDisplayLanguage) {
-
 		Map<String, String> map;
 		switch (theSystem) {
 			case LANGUAGES_CODESYSTEM_URL:
@@ -254,9 +253,7 @@ public class CommonCodeSystemsTerminologyService implements IValidationSupport {
 	}
 
 	private LookupCodeResult lookupLanguageCode(String theCode) {
-		Map<String, String> languagesMap = myLanguagesLanugageMap;
-		Map<String, String> regionsMap = myLanguagesRegionMap;
-		if (languagesMap == null || regionsMap == null) {
+		if (myLanguagesLanugageMap == null || myLanguagesRegionMap == null) {
 			initializeBcp47LanguageMap();
 		}
 
@@ -266,7 +263,9 @@ public class CommonCodeSystemsTerminologyService implements IValidationSupport {
 		String region;
 
 		if (hasRegionAndCodeSegments) {
-			language = myLanguagesLanugageMap.get(theCode.substring(0, langRegionSeparatorIndex));
+			// we look for languages in lowercase only
+			// this will allow case insensitivity for language portion of code
+			language = myLanguagesLanugageMap.get(theCode.substring(0, langRegionSeparatorIndex).toLowerCase());
 			region = myLanguagesRegionMap.get(theCode.substring(langRegionSeparatorIndex + 1));
 
 			if (language == null || region == null) {
@@ -278,7 +277,8 @@ public class CommonCodeSystemsTerminologyService implements IValidationSupport {
 			}
 		} else {
 			//In case user has only provided a language, we build the lookup from only that.
-			language = myLanguagesLanugageMap.get(theCode);
+			//NB: we only use the lowercase version of the language
+			language = myLanguagesLanugageMap.get(theCode.toLowerCase());
 			if (language == null) {
 				ourLog.warn("Couldn't find a valid bcp47 language from code: {}", theCode);
 				return buildNotFoundLookupCodeResult(theCode);

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.java
@@ -266,7 +266,7 @@ public class CommonCodeSystemsTerminologyService implements IValidationSupport {
 			// we look for languages in lowercase only
 			// this will allow case insensitivity for language portion of code
 			language = myLanguagesLanugageMap.get(theCode.substring(0, langRegionSeparatorIndex).toLowerCase());
-			region = myLanguagesRegionMap.get(theCode.substring(langRegionSeparatorIndex + 1));
+			region = myLanguagesRegionMap.get(theCode.substring(langRegionSeparatorIndex + 1).toUpperCase());
 
 			if (language == null || region == null) {
 				//In case the user provides both a language and a region, they must both be valid for the lookup to succeed.

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -52,6 +53,26 @@ public class CommonCodeSystemsTerminologyServiceTest {
 	public void testUcum_LookupCode_UnknownSystem() {
 		IValidationSupport.LookupCodeResult outcome = mySvc.lookupCode(newSupport(), "http://foo", "AAAAA", null);
 		assertNull(outcome);
+	}
+
+	@Test
+	public void lookupCode_languageOnlyLookup_isCaseInsensitive() {
+		IValidationSupport.LookupCodeResult outcomeUpper = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "SGN", "Sign Languages");
+		IValidationSupport.LookupCodeResult outcomeLower = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "sgn", "Sign Languages");
+		assertNotNull(outcomeUpper);
+		assertNotNull(outcomeLower);
+		assertTrue(outcomeLower.isFound());
+		assertTrue(outcomeUpper.isFound());
+	}
+
+	@Test
+	public void lookupCode_languageAndRegionLookup_languageIsCaseInsensitive() {
+		IValidationSupport.LookupCodeResult outcomeUpper = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "EN-US", "English");
+		IValidationSupport.LookupCodeResult outcomeLower = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "en-US", "English");
+		assertNotNull(outcomeUpper);
+		assertNotNull(outcomeLower);
+		assertTrue(outcomeLower.isFound());
+		assertTrue(outcomeUpper.isFound());
 	}
 
 	@Test

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
@@ -66,9 +66,9 @@ public class CommonCodeSystemsTerminologyServiceTest {
 	}
 
 	@Test
-	public void lookupCode_languageAndRegionLookup_languageIsCaseInsensitive() {
+	public void lookupCode_languageAndRegionLookup_isCaseInsensitive() {
 		IValidationSupport.LookupCodeResult outcomeUpper = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "EN-US", "English");
-		IValidationSupport.LookupCodeResult outcomeLower = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "en-US", "English");
+		IValidationSupport.LookupCodeResult outcomeLower = mySvc.lookupCode(newSupport(), "urn:ietf:bcp:47", "en-us", "English");
 		assertNotNull(outcomeUpper);
 		assertNotNull(outcomeLower);
 		assertTrue(outcomeLower.isFound());


### PR DESCRIPTION
closes #3170 

- Updated CommonCodeSystemsTerminologyService to allow language portion of language-region code to be case insensitive
- updated changelog