### PR TITLE
Add executeRawSql() method to Migrator

### DIFF
--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -97,6 +97,14 @@ public class Builder {
 		return this;
 	}
 
+	/**
+	 * Builder method to define a raw SQL execution migration that needs to take place against multiple database types,
+	 * and the SQL they need to use is not equal. Provide a map of driver types to SQL statements.
+	 *
+	 * @param theVersion The version of the migration.
+	 * @param theDriverToSql Map of driver types to SQL statements.
+	 * @return
+	 */
 	public Builder executeRawSql(String theVersion, Map<DriverTypeEnum, String> theDriverToSql) {
 		ExecuteRawSqlTask executeRawSqlTask = new ExecuteRawSqlTask(myRelease, theVersion);
 		theDriverToSql.entrySet().stream()

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -47,6 +47,7 @@ import org.intellij.lang.annotations.Language;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -93,6 +94,16 @@ public class Builder {
 
 	public Builder executeRawSql(String theVersion, DriverTypeEnum theDriver, @Language("SQL") String theSql) {
 		mySink.addTask(new ExecuteRawSqlTask(myRelease, theVersion).addSql(theDriver, theSql));
+		return this;
+	}
+
+	public Builder executeRawSql(String theVersion, Map<DriverTypeEnum, String> theDriverToSql) {
+		ExecuteRawSqlTask executeRawSqlTask = new ExecuteRawSqlTask(myRelease, theVersion);
+		theDriverToSql.entrySet().stream()
+				.forEach(entry -> {
+					executeRawSqlTask.addSql(entry.getKey(), entry.getValue());
+				});
+		mySink.addTask(executeRawSqlTask);
 		return this;
 	}
 

--- a/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTaskTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTaskTest.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.util.VersionEnum;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -76,6 +77,41 @@ public class ExecuteRawSqlTaskTest extends BaseTest {
 		if (theTestDatabaseDetails.get().getDriverType() == DriverTypeEnum.H2_EMBEDDED) {
 			assertEquals(1, output.size());
 			assertEquals(123L, output.get(0).get("PID"));
+		} else {
+			assertEquals(0, output.size());
+		}
+	}
+
+	@ParameterizedTest(name = "{index}: {0}")
+	@MethodSource("data")
+	public void testDriverTypeBasedRawSqlExecution(Supplier<TestDatabaseDetails> theTestDatabaseDetails) {
+		//Given
+		before(theTestDatabaseDetails);
+		executeSql("create table SOMETABLE (PID bigint not null, TEXTCOL varchar(255))");
+
+		BaseMigrationTasks<VersionEnum> tasks = new BaseMigrationTasks<>();
+		Map<DriverTypeEnum, String> driverToSql = new HashMap<>();
+
+		//When
+		driverToSql.put(DriverTypeEnum.H2_EMBEDDED, "INSERT INTO SOMETABLE (PID, TEXTCOL) VALUES (123, 'abc')");
+		driverToSql.put(DriverTypeEnum.DERBY_EMBEDDED, "INSERT INTO SOMETABLE (PID, TEXTCOL) VALUES (456, 'def')");
+		tasks
+			.forVersion(VersionEnum.V4_0_0)
+			.executeRawSql("2001.01", driverToSql);
+
+		getMigrator().addTasks(tasks.getTasks(VersionEnum.V0_1, VersionEnum.V4_0_0));
+		getMigrator().migrate();
+
+		List<Map<String, Object>> output = executeQuery("SELECT PID,TEXTCOL FROM SOMETABLE");
+		//Then
+		if (theTestDatabaseDetails.get().getDriverType() == DriverTypeEnum.H2_EMBEDDED) {
+			assertEquals(1, output.size());
+			assertEquals(123L, output.get(0).get("PID"));
+			assertEquals("abc", output.get(0).get("TEXTCOL"));
+		} else if (theTestDatabaseDetails.get().getDriverType() == DriverTypeEnum.DERBY_EMBEDDED) {
+			assertEquals(1, output.size());
+			assertEquals(456L, output.get(0).get("PID"));
+			assertEquals("def", output.get(0).get("TEXTCOL"));
 		} else {
 			assertEquals(0, output.size());
 		}


### PR DESCRIPTION
Currently executing driver-based raw sql is limited to Tasks in which you are adding a table. This pull request:

 *   Adds the ability to create a single migration which accepts a map of Driver -> SQL String for its SQL argument.
  *  Adds a test

Changelog is omitted here as there is nothing public facing that I'm aware of.