### PR TITLE
Add executeRawSqlStub() to Migrator

### DIFF
--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -76,9 +76,19 @@ public class Builder {
 	}
 
 	public BuilderCompleteTask executeRawSql(String theVersion, @Language("SQL") String theSql) {
-		ExecuteRawSqlTask task = new ExecuteRawSqlTask(myRelease, theVersion).addSql(theSql);
-		mySink.addTask(task);
+		ExecuteRawSqlTask task = executeRawSqlOptional(false, theVersion, theSql);
 		return new BuilderCompleteTask(task);
+	}
+
+	public void executeRawSqlStub(String theVersion, @Language("SQL") String theSql) {
+		executeRawSqlOptional(true, theVersion, theSql);
+	}
+
+	private ExecuteRawSqlTask executeRawSqlOptional(boolean theDoNothing, String theVersion, @Language("SQL") String theSql) {
+		ExecuteRawSqlTask task = new ExecuteRawSqlTask(myRelease, theVersion).addSql(theSql);
+		task.setDoNothing(theDoNothing);
+		mySink.addTask(task);
+		return task;
 	}
 
 	public Builder initializeSchema(String theVersion, ISchemaInitializationProvider theSchemaInitializationProvider) {

--- a/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTaskTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTaskTest.java
@@ -117,5 +117,22 @@ public class ExecuteRawSqlTaskTest extends BaseTest {
 		}
 	}
 
+	@ParameterizedTest(name = "{index}: {0}")
+	@MethodSource("data")
+	public void testExecuteRawSqlStub(Supplier<TestDatabaseDetails> theTestDatabaseDetails) {
+		//Given
+		before(theTestDatabaseDetails);
+		executeSql("create table SOMETABLE (PID bigint not null, TEXTCOL varchar(255))");
 
+		BaseMigrationTasks<VersionEnum> tasks = new BaseMigrationTasks<>();
+		tasks.forVersion(VersionEnum.V4_0_0)
+			.executeRawSqlStub("2001.01", "INSERT INTO SOMETABLE (PID, TEXTCOL) VALUES (123, 'abc')");
+
+		getMigrator().addTasks(tasks.getTasks(VersionEnum.V0_1, VersionEnum.V4_0_0));
+		getMigrator().migrate();
+
+		List<Map<String, Object>> output = executeQuery("SELECT PID,TEXTCOL FROM SOMETABLE");
+
+		assertEquals(0, output.size());
+	}
 }


### PR DESCRIPTION
For skipping failing migrations