### PR TITLE
bumped log4j version to newest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,7 +832,7 @@
         <servicemix_saxon_version>9.8.0-15</servicemix_saxon_version>
         <servicemix_xmlresolver_version>1.2_5</servicemix_xmlresolver_version>
         <slf4j_version>1.7.30</slf4j_version>
-        <log4j_to_slf4j_version>2.11.1</log4j_to_slf4j_version>
+        <log4j_to_slf4j_version>2.15.0</log4j_to_slf4j_version>
         <spring_version>5.3.13</spring_version>
         <spring_data_version>2.5.0</spring_data_version>
         <spring_batch_version>4.3.3</spring_batch_version>


### PR DESCRIPTION
despite hapi not being affected by CVE-2021-44228 this PR pushes log4j to the newest version just to be safe and get rid of OWASP warnings in build stacks.

fixes #3238