### PR TITLE
populate ValueSet.url in $expand Operation

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
@@ -419,7 +419,6 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 			accumulator.addParameter().setName("count").setValue(new IntegerType(count));
 		}
 
-
 		expandValueSetIntoAccumulator(theValueSetToExpand, theExpansionOptions, accumulator, theFilter, true);
 
 		if (accumulator.getTotalConcepts() != null) {
@@ -427,6 +426,7 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 		}
 
 		ValueSet valueSet = new ValueSet();
+		valueSet.setUrl(theValueSetToExpand.getUrl());
 		valueSet.setId(theValueSetToExpand.getId());
 		valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		valueSet.setCompose(theValueSetToExpand.getCompose());


### PR DESCRIPTION
Currently §expand creates VS without a set url. This PR populates VS.url with the url of the valueSet which is to be expanded.

fixes #2502