### PR TITLE
3283 delete will not return a 404 if resource is not found

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/HeaderPassthroughOptionTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/HeaderPassthroughOptionTest.java
@@ -54,6 +54,8 @@ public class HeaderPassthroughOptionTest {
 	private final UploadTerminologyCommand testedCommand =
 		new RequestCapturingUploadTerminologyCommand(myCapturingInterceptor);
 
+	private Object locker = new Object();
+
 	@Mock
 	protected ITermLoaderSvc myTermLoaderSvc;
 
@@ -69,13 +71,14 @@ public class HeaderPassthroughOptionTest {
 		myServer.setHandler(proxyHandler);
 		JettyUtil.startServer(myServer);
 		myPort = JettyUtil.getPortForStartedServer(myServer);
-		writeConceptAndHierarchyFiles();
+//		writeConceptAndHierarchyFiles();
 		when(myTermLoaderSvc.loadCustom(eq("http://foo"), anyList(), any()))
 			.thenReturn(new UploadStatistics(100, new IdType("CodeSystem/101")));
 	}
 
 	@Test
 	public void oneHeader() throws Exception {
+		writeConceptAndHierarchyFiles();
 		String[] args = new String[] {
 			"-v", FHIR_VERSION,
 			"-m", "SNAPSHOT",
@@ -101,6 +104,7 @@ public class HeaderPassthroughOptionTest {
 
 	@Test
 	public void twoHeadersSameKey() throws Exception {
+		writeConceptAndHierarchyFiles();
 		final String headerValue2 = "test header value-2";
 
 		String[] args = new String[] {
@@ -131,6 +135,7 @@ public class HeaderPassthroughOptionTest {
 
 	@Test
 	public void twoHeadersDifferentKeys() throws Exception {
+		writeConceptAndHierarchyFiles();
 		final String headerKey2 = "test-header-key-2";
 		final String headerValue2 = "test header value-2";
 

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/HeaderPassthroughOptionTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/HeaderPassthroughOptionTest.java
@@ -54,8 +54,6 @@ public class HeaderPassthroughOptionTest {
 	private final UploadTerminologyCommand testedCommand =
 		new RequestCapturingUploadTerminologyCommand(myCapturingInterceptor);
 
-	private Object locker = new Object();
-
 	@Mock
 	protected ITermLoaderSvc myTermLoaderSvc;
 
@@ -71,7 +69,7 @@ public class HeaderPassthroughOptionTest {
 		myServer.setHandler(proxyHandler);
 		JettyUtil.startServer(myServer);
 		myPort = JettyUtil.getPortForStartedServer(myServer);
-//		writeConceptAndHierarchyFiles();
+		writeConceptAndHierarchyFiles();
 		when(myTermLoaderSvc.loadCustom(eq("http://foo"), anyList(), any()))
 			.thenReturn(new UploadStatistics(100, new IdType("CodeSystem/101")));
 	}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3283-delete-does-not-throw-404.yml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3283-delete-does-not-throw-404.yml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 3283
+title: "Calling delete on a non-existent resource should not return a 404 (not found)."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -502,7 +502,6 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			// Because no object actually existed, we'll
 			// just set the id and nothing else
 			DaoMethodOutcome outcome = createMethodOutcomeForDelete(theId.getValue());
-			outcome.setNop(true);
 			return outcome;
 		}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
@@ -1,20 +1,78 @@
 package ca.uhn.fhir.jpa.dao;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
+import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
+import ca.uhn.fhir.jpa.api.model.DeleteConflictList;
+import ca.uhn.fhir.jpa.dao.index.IdHelperService;
+import ca.uhn.fhir.jpa.model.entity.ForcedId;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.partition.SystemRequestDetails;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
+import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.persistence.EntityManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(MockitoExtension.class)
 class BaseHapiFhirResourceDaoTest {
 
-	TestResourceDao mySvc = new TestResourceDao();
+	@Mock
+	private IRequestPartitionHelperSvc myRequestPartitionHelperSvc;
+
+	@Mock
+	private IdHelperService myIdHelperService;
+
+	@Mock
+	private EntityManager myEntityManager;
+
+	@Mock
+	private DaoConfig myConfig;
+
+	// we won't inject this
+	private FhirContext myFhirContext = FhirContext.forR4Cached();
+
+	@InjectMocks
+	private TestResourceDao mySvc;
+
+	@BeforeEach
+	public void init() {
+		// set our context
+		// NB: if other tests need to
+		// have access to resourcetype/name
+		// the individual tests will have to start
+		// by calling setup themselves
+		mySvc.setContext(myFhirContext);
+	}
+
+	/**
+	 * To be called for tests that require additional
+	 * setup
+	 * @param clazz
+	 */
+	private void setup(Class clazz) {
+		mySvc.setResourceType(clazz);
+		mySvc.postConstruct();
+	}
 
 	@Test
 	public void validateResourceIdCreation_asSystem() {
@@ -60,6 +118,51 @@ class BaseHapiFhirResourceDaoTest {
 		mySvc.getConfig().setResourceClientIdStrategy(DaoConfig.ClientIdStrategyEnum.ALPHANUMERIC);
 		mySvc.validateResourceIdCreation(patient, sysRequest);
 		// no exception is thrown
+	}
+
+	@Test
+	public void delete_nonExistentEntity_doesNotThrow404() {
+		// initialize our class
+		setup(Patient.class);
+
+		// setup
+		IIdType id = new IdType("Patient/123"); // id part is only numbers
+		DeleteConflictList deleteConflicts = new DeleteConflictList();
+		RequestDetails requestDetails = new SystemRequestDetails();
+		TransactionDetails transactionDetails = new TransactionDetails();
+
+		RequestPartitionId partitionId = Mockito.mock(RequestPartitionId.class);
+		ResourcePersistentId resourcePersistentId = new ResourcePersistentId("Patient", 1l);
+		ResourceTable entity = new ResourceTable();
+		entity.setForcedId(new ForcedId());
+
+		// mock
+		Mockito.when(myRequestPartitionHelperSvc.determineReadPartitionForRequestForRead(
+			Mockito.any(RequestDetails.class),
+			Mockito.anyString(),
+			Mockito.any(IIdType.class)
+		)).thenReturn(partitionId);
+		Mockito.when(myIdHelperService.resolveResourcePersistentIds(
+			Mockito.any(RequestPartitionId.class),
+			Mockito.anyString(),
+			Mockito.anyString()
+		)).thenReturn(resourcePersistentId);
+		Mockito.when(myEntityManager.find(
+			Mockito.any(Class.class),
+			Mockito.anyString()
+		)).thenReturn(entity);
+		// we don't stub myConfig.getResourceClientIdStrategy()
+		// because even a null return isn't ANY...
+		// if this changes, though, we will have to stub it.
+		// but for now, Mockito will complain, so we'll leave it out
+
+		// test
+		DaoMethodOutcome outcome = mySvc.delete(id, deleteConflicts, requestDetails, transactionDetails);
+
+		// verify
+		Assertions.assertNotNull(outcome);
+		Assertions.assertEquals(id.getValue(), outcome.getId().getValue());
+		Assertions.assertTrue(outcome.isNop());
 	}
 
 	static class TestResourceDao extends BaseHapiFhirResourceDao<Patient> {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
@@ -162,7 +162,6 @@ class BaseHapiFhirResourceDaoTest {
 		// verify
 		Assertions.assertNotNull(outcome);
 		Assertions.assertEquals(id.getValue(), outcome.getId().getValue());
-		Assertions.assertTrue(outcome.isNop());
 	}
 
 	static class TestResourceDao extends BaseHapiFhirResourceDao<Patient> {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -6115,6 +6115,31 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 	}
 
 	@Test
+	public void testDeleteSameResourceTwice() throws IOException {
+		String id = "A";
+
+		Patient p = new Patient();
+		p.setId(id);
+		String encoded = myFhirCtx.newJsonParser().encodeResourceToString(p);
+
+		HttpPut put = new HttpPut(ourServerBase + "/Patient/" + id);
+		put.setEntity(new StringEntity(encoded, ContentType.create("application/fhir+json", "UTF-8")));
+		try (CloseableHttpResponse response = ourHttpClient.execute(put)) {
+			assertEquals(201, response.getStatusLine().getStatusCode());
+		}
+
+		HttpDelete delete = new HttpDelete(ourServerBase + "/Patient/" + id);
+
+		for (int i = 0; i < 2; i++) {
+			// multiple deletes of the same resource
+			// should always succeed
+			try (CloseableHttpResponse response = ourHttpClient.execute(delete)) {
+				Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+			}
+		}
+	}
+
+	@Test
 	public void testUpdateWithClientSuppliedIdWhichDoesntExist() {
 		Patient p1 = new Patient();
 		p1.addIdentifier().setSystem("urn:system").setValue("testUpdateWithClientSuppliedIdWhichDoesntExistrpr4");

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -6107,7 +6107,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	public void testDeleteNonExistentResourceReturns200() throws IOException {
-		HttpDelete delete = new HttpDelete(ourServerBase + "/Patient/A");
+		HttpDelete delete = new HttpDelete(ourServerBase + "/Patient/someIdHereThatIsUnique");
 
 		try (CloseableHttpResponse response = ourHttpClient.execute(delete)) {
 			Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
@@ -6116,7 +6116,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	public void testDeleteSameResourceTwice() throws IOException {
-		String id = "A";
+		String id = "mySecondUniqueId";
 
 		Patient p = new Patient();
 		p.setId(id);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -219,9 +219,9 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		mySearchCoordinatorSvcRaw.setSyncSizeForUnitTests(SearchCoordinatorSvcImpl.DEFAULT_SYNC_SIZE);
 		mySearchCoordinatorSvcRaw.setNeverUseLocalSearchForUnitTests(false);
 		mySearchCoordinatorSvcRaw.cancelAllActiveSearches();
-        myDaoConfig.getModelConfig().setNormalizedQuantitySearchLevel(NormalizedQuantitySearchLevel.NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED);
+		myDaoConfig.getModelConfig().setNormalizedQuantitySearchLevel(NormalizedQuantitySearchLevel.NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED);
 
-        myClient.unregisterInterceptor(myCapturingInterceptor);
+		myClient.unregisterInterceptor(myCapturingInterceptor);
 	}
 
 	@BeforeEach

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -135,6 +135,7 @@ import org.hl7.fhir.r4.model.UnsignedIntType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -6102,6 +6103,15 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 			response.close();
 		}
 
+	}
+
+	@Test
+	public void testDeleteNonExistentResourceReturns200() throws IOException {
+		HttpDelete delete = new HttpDelete(ourServerBase + "/Patient/A");
+
+		try (CloseableHttpResponse response = ourHttpClient.execute(delete)) {
+			Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
closes #3283 

Fixed code to not throw a 404 if resource is not found on delete.
Added changelog