### PR TITLE
Fixes #3289 Javadoc inverted the boolean value

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IBundleProvider.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IBundleProvider.java
@@ -195,7 +195,7 @@ public interface IBundleProvider {
 	Integer size();
 
 	/**
-	 * This method returns <code>true</code> if the bundle provider knows that at least
+	 * This method returns <code>false</code> if the bundle provider knows that at least
 	 * one result exists.
 	 */
 	default boolean isEmpty() {


### PR DESCRIPTION
The method returned the opposite of what the Javadoc declares it will do. I assume that the default implementation is right and the Javadoc contained an error. I think it's somewhat confusing to have Javadoc say A and the method do B. Aligning them to each other will help implementors to understand clearly what is expected.