### PR TITLE
2718 cross partition support for subscription

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -136,6 +136,11 @@ public class HapiExtensions {
 	public static final String EX_SEND_DELETE_MESSAGES = "http://hapifhir.io/fhir/StructureDefinition/subscription-send-delete-messages";
 
 	/**
+	 * This entension allows subscriptions to be marked as cross partition and with correct settings, listen to incoming resources from all partitions.
+	 */
+	public static final String EXTENSION_SUBSCRIPTION_CROSS_PARTITION = "https://smilecdr.com/fhir/ns/StructureDefinition/subscription-cross-partition";
+
+	/**
 	 * Non instantiable
 	 */
 	private HapiExtensions() {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
@@ -61,4 +61,7 @@ public class SubscriptionUtil {
 		populatePrimitiveValue(theContext, theSubscription, "status", theStatus);
 	}
 
+	public static boolean isCrossPartition(IBaseResource theSubscription) {
+		return ExtensionUtil.hasExtension(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION) && ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).getValue().toString().equals("BooleanType[true]");
+	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
@@ -5,11 +5,14 @@ import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseBooleanDatatype;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.thymeleaf.util.Validate;
 
 import java.util.List;
+import java.util.Objects;
 
 /*
  * #%L
@@ -62,6 +65,19 @@ public class SubscriptionUtil {
 	}
 
 	public static boolean isCrossPartition(IBaseResource theSubscription) {
-		return ExtensionUtil.hasExtension(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION) && ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).getValue().toString().equals("BooleanType[true]");
+		IBaseExtension extension = ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION);
+		if (Objects.nonNull(extension)) {
+			try {
+				IBaseBooleanDatatype booleanDatatype = (IBaseBooleanDatatype) (extension.getValue());
+				return booleanDatatype.getValue();
+			}
+			catch (ClassCastException theClassCastException){
+				return false;
+			}
+
+		}
+		else{
+			return false;
+		}
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBooleanDatatype;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.thymeleaf.util.Validate;
@@ -65,19 +66,17 @@ public class SubscriptionUtil {
 	}
 
 	public static boolean isCrossPartition(IBaseResource theSubscription) {
-		IBaseExtension extension = ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION);
-		if (Objects.nonNull(extension)) {
-			try {
-				IBaseBooleanDatatype booleanDatatype = (IBaseBooleanDatatype) (extension.getValue());
-				return booleanDatatype.getValue();
+		if (theSubscription instanceof IBaseHasExtensions) {
+			IBaseExtension extension = ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION);
+			if (Objects.nonNull(extension)) {
+				try {
+					IBaseBooleanDatatype booleanDatatype = (IBaseBooleanDatatype) (extension.getValue());
+					return booleanDatatype.getValue();
+				} catch (ClassCastException theClassCastException) {
+					return false;
+				}
 			}
-			catch (ClassCastException theClassCastException){
-				return false;
-			}
-
 		}
-		else{
-			return false;
-		}
+		return false;
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/2718-add-cross-partition-subscription.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/2718-add-cross-partition-subscription.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 2718
+title: "Added support for cross-partition subscriptions. Subscription in the default partition can now listen to resource changes from all partitions"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3251-terminology-reindexing-job-is-never-triggered.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3251-terminology-reindexing-job-is-never-triggered.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+title: "Terminology reindexing job was launching the wrong process, so terminology reindexing was never
+   launched. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_partitioning/partitioning.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_partitioning/partitioning.md
@@ -173,4 +173,4 @@ None of the limitations listed here are considered permanent. Over time the HAPI
 
 * **Advanced Elasticsearch indexing is not partition optimized**: The results are correctly partitioned, but the extended indexing is not optimized to account for partitions. 
 
-* **Subscriptions are partition aware**: Subscriptions can be placed on any partition and will deliver matching resources from the same partition.
+* **Subscriptions are partition aware**: Subscriptions can be placed on any partition and will deliver matching resources from the same partition. A subscription on the default can deliver resource from all partition if it is placed in the default partition with the cross-partition extension and the server allows cross-partition subscriptions.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReindexingSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReindexingSvcImpl.java
@@ -161,11 +161,11 @@ public class TermReindexingSvcImpl implements ITermReindexingSvc {
 
 	public static class Job implements HapiJob {
 		@Autowired
-		private ITermDeferredStorageSvc myTerminologySvc;
+		private ITermReindexingSvc myTermReindexingSvc;
 
 		@Override
 		public void execute(JobExecutionContext theContext) {
-			myTerminologySvc.saveDeferred();
+			myTermReindexingSvc.processReindexing();
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
@@ -210,7 +210,6 @@ public class SubscriptionValidatingInterceptorTest {
 
 		// No asserts here because the function should throw an UnprocessableEntityException exception if the subscription
 		// is invalid
-		;
 		assertDoesNotThrow(() -> mySvc.validateSubmittedSubscription(subscription, requestDetails));
 		Mockito.verify(myDaoConfig, times(1)).isCrossPartitionSubscription();
 		Mockito.verify(myDaoRegistry, times(1)).isResourceTypeSupported(eq("Patient"));

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -209,7 +210,8 @@ public class SubscriptionValidatingInterceptorTest {
 
 		// No asserts here because the function should throw an UnprocessableEntityException exception if the subscription
 		// is invalid
-		mySvc.validateSubmittedSubscription(subscription, requestDetails);
+		;
+		assertDoesNotThrow(() -> mySvc.validateSubmittedSubscription(subscription, requestDetails));
 		Mockito.verify(myDaoConfig, times(1)).isCrossPartitionSubscription();
 		Mockito.verify(myDaoRegistry, times(1)).isResourceTypeSupported(eq("Patient"));
 		Mockito.verify(myRequestPartitionHelperSvc, times(1)).determineCreatePartitionForRequest(isA(RequestDetails.class), isA(Subscription.class), eq("Subscription"));

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
@@ -185,7 +185,7 @@ public class SubscriptionValidatingInterceptorTest {
 	}
 
 	@Test
-	public void testValidate_Cross_Partition_Subscription(){
+	public void testValidate_Cross_Partition_Subscription() {
 		when(myDaoRegistry.isResourceTypeSupported(eq("Patient"))).thenReturn(true);
 		when(myDaoConfig.isCrossPartitionSubscription()).thenReturn(true);
 		when(myRequestPartitionHelperSvc.determineCreatePartitionForRequest(any(), any(), any())).thenReturn(RequestPartitionId.defaultPartition());
@@ -196,7 +196,7 @@ public class SubscriptionValidatingInterceptorTest {
 		subscription.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
 		subscription.getChannel().setEndpoint("http://foo");
 
-		subscription.addExtension().setUrl(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).setValue(new BooleanType().setValue(true));
+		subscription.addExtension().setUrl(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).setValue(new BooleanType(true));
 
 		RequestDetails requestDetails = new SystemRequestDetails();
 		requestDetails.setRestOperationType(RestOperationTypeEnum.CREATE);
@@ -207,7 +207,7 @@ public class SubscriptionValidatingInterceptorTest {
 	}
 
 	@Test
-	public void testValidate_Cross_Partition_Subscription_On_Wrong_Partition(){
+	public void testValidate_Cross_Partition_Subscription_On_Wrong_Partition() {
 		when(myDaoConfig.isCrossPartitionSubscription()).thenReturn(true);
 		when(myRequestPartitionHelperSvc.determineCreatePartitionForRequest(any(), any(), any())).thenReturn(RequestPartitionId.fromPartitionId(1));
 
@@ -217,7 +217,7 @@ public class SubscriptionValidatingInterceptorTest {
 		subscription.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
 		subscription.getChannel().setEndpoint("http://foo");
 
-		subscription.addExtension().setUrl(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).setValue(new BooleanType().setValue(true));
+		subscription.addExtension().setUrl(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).setValue(new BooleanType(true));
 
 		RequestDetails requestDetails = new SystemRequestDetails();
 		requestDetails.setRestOperationType(RestOperationTypeEnum.CREATE);
@@ -225,14 +225,13 @@ public class SubscriptionValidatingInterceptorTest {
 		try {
 			mySvc.validateSubmittedSubscription(subscription, requestDetails);
 			fail();
-		}
-		catch (UnprocessableEntityException theUnprocessableEntityException){
-			assertEquals(theUnprocessableEntityException.getMessage(), "Cross partition subscription must be created on the default partition");
+		} catch (UnprocessableEntityException theUnprocessableEntityException) {
+			assertEquals("Cross partition subscription must be created on the default partition", theUnprocessableEntityException.getMessage());
 		}
 	}
 
 	@Test
-	public void testValidate_Cross_Partition_Subscription_Without_Setting(){
+	public void testValidate_Cross_Partition_Subscription_Without_Setting() {
 		when(myDaoConfig.isCrossPartitionSubscription()).thenReturn(false);
 
 		Subscription subscription = new Subscription();
@@ -241,7 +240,7 @@ public class SubscriptionValidatingInterceptorTest {
 		subscription.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
 		subscription.getChannel().setEndpoint("http://foo");
 
-		subscription.addExtension().setUrl(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).setValue(new BooleanType().setValue(true));
+		subscription.addExtension().setUrl(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).setValue(new BooleanType(true));
 
 		RequestDetails requestDetails = new SystemRequestDetails();
 		requestDetails.setRestOperationType(RestOperationTypeEnum.CREATE);
@@ -249,9 +248,8 @@ public class SubscriptionValidatingInterceptorTest {
 		try {
 			mySvc.validateSubmittedSubscription(subscription, requestDetails);
 			fail();
-		}
-		catch (UnprocessableEntityException theUnprocessableEntityException){
-			assertEquals(theUnprocessableEntityException.getMessage(), "Cross partition subscription is not enabled on this server");
+		} catch (UnprocessableEntityException theUnprocessableEntityException) {
+			assertEquals("Cross partition subscription is not enabled on this server", theUnprocessableEntityException.getMessage());
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/term/TermReindexingSvcImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/term/TermReindexingSvcImplTest.java
@@ -1,0 +1,39 @@
+package ca.uhn.fhir.jpa.term;
+
+import ca.uhn.fhir.jpa.term.api.ITermReindexingSvc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TermReindexingSvcImplTest {
+
+	@Mock JobExecutionContext myJobExecutionContext;
+	@Mock ITermReindexingSvc jobReindexingSvc;
+
+
+	@Test
+	void validateReindexingJobExecutesReindexing() {
+		TermReindexingSvcImpl.Job innerJob = new TermReindexingSvcImpl.Job();
+
+		// validates that inner Job has an myTermReindexingSvc field of class ITermReindexingSvc
+		try {
+			ReflectionTestUtils.setField(innerJob, "myTermReindexingSvc", jobReindexingSvc);
+		} catch (Exception theE) {
+			fail("ITermReindexingSvc implementation inner Job doesn't have a 'myTermReindexingSvc' property");
+		}
+
+		innerJob.execute(myJobExecutionContext);
+
+		// validates that inner Job calls myTermReindexingSvc.processReindexing when executed
+		verify(jobReindexingSvc, atLeastOnce()).processReindexing();
+	}
+
+}

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ModelConfig.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ModelConfig.java
@@ -82,6 +82,7 @@ public class ModelConfig {
 	private Set<String> myTreatReferencesAsLogical = new HashSet<>(DEFAULT_LOGICAL_BASE_URLS);
 	private boolean myDefaultSearchParamsCanBeOverridden = true;
 	private Set<Subscription.SubscriptionChannelType> mySupportedSubscriptionTypes = new HashSet<>();
+	private boolean crossPartitionSubscription = false;
 	private String myEmailFromAddress = "noreply@unknown.com";
 	private String myWebsocketContextPath = DEFAULT_WEBSOCKET_CONTEXT_PATH;
 	/**
@@ -848,6 +849,36 @@ public class ModelConfig {
 			}
 		}
 
+	}
+
+	/**
+	 * If enabled, the server will support cross-partition subscription.
+	 * This subscription will be the responsible for all the requests from all the partitions on this server.
+	 * For example, if the server has 3 partitions, P1, P2, P3
+	 * The subscription will live in the DEFAULT partition. Resource posted to DEFAULT, P1, P2, and P3 will trigger this subscription.
+	 * <p>
+	 * Default is <code>false</code>
+	 * </p>
+	 *
+	 * @since 7.5.0
+	 */
+	public boolean isCrossPartitionSubscription() {
+		return crossPartitionSubscription;
+	}
+
+	/**
+	 * If enabled, the server will support cross-partition subscription.
+	 * This subscription will be the responsible for all the requests from all the partitions on this server.
+	 * For example, if the server has 3 partitions, P1, P2, P3
+	 * The subscription will live in the DEFAULT partition. Resource posted to DEFAULT, P1, P2, and P3 will trigger this subscription.
+	 * <p>
+	 * Default is <code>false</code>
+	 * </p>
+	 *
+	 * @since 7.5.0
+	 */
+	public void setCrossPartitionSubscription(boolean theAllowCrossPartitionSubscription) {
+		crossPartitionSubscription = theAllowCrossPartitionSubscription;
 	}
 
 }

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ModelConfig.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ModelConfig.java
@@ -82,7 +82,7 @@ public class ModelConfig {
 	private Set<String> myTreatReferencesAsLogical = new HashSet<>(DEFAULT_LOGICAL_BASE_URLS);
 	private boolean myDefaultSearchParamsCanBeOverridden = true;
 	private Set<Subscription.SubscriptionChannelType> mySupportedSubscriptionTypes = new HashSet<>();
-	private boolean crossPartitionSubscription = false;
+	private boolean myCrossPartitionSubscription = false;
 	private String myEmailFromAddress = "noreply@unknown.com";
 	private String myWebsocketContextPath = DEFAULT_WEBSOCKET_CONTEXT_PATH;
 	/**
@@ -863,7 +863,7 @@ public class ModelConfig {
 	 * @since 7.5.0
 	 */
 	public boolean isCrossPartitionSubscription() {
-		return crossPartitionSubscription;
+		return myCrossPartitionSubscription;
 	}
 
 	/**
@@ -878,7 +878,7 @@ public class ModelConfig {
 	 * @since 7.5.0
 	 */
 	public void setCrossPartitionSubscription(boolean theAllowCrossPartitionSubscription) {
-		crossPartitionSubscription = theAllowCrossPartitionSubscription;
+		myCrossPartitionSubscription = theAllowCrossPartitionSubscription;
 	}
 
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -127,7 +127,7 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 			// skip if the partitions don't match
 			CanonicalSubscription subscription = nextActiveSubscription.getSubscription();
 			if (subscription != null && subscription.getRequestPartitionId() != null && theMsg.getPartitionId() != null
-				&& !subscription.isMyCrossPartitionEnabled() && !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {
+				&& !subscription.getCrossPartitionEnabled() && !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {
 				continue;
 			}
 			String nextSubscriptionId = getId(nextActiveSubscription);

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -127,7 +127,7 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 			// skip if the partitions don't match
 			CanonicalSubscription subscription = nextActiveSubscription.getSubscription();
 			if (subscription != null && subscription.getRequestPartitionId() != null && theMsg.getPartitionId() != null
-				&& !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {
+				&& !subscription.isMyCrossPartitionEnabled() && !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {
 				continue;
 			}
 			String nextSubscriptionId = getId(nextActiveSubscription);

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -39,8 +39,8 @@ import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
-import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.HapiExtensions;
+import ca.uhn.fhir.util.SubscriptionUtil;
 import com.google.common.annotations.VisibleForTesting;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -110,8 +110,8 @@ public class SubscriptionValidatingInterceptor {
 		}
 
 		// If the subscription has the cross partition tag &&
-		if (isCrossPartition(theSubscription)) {
-			if (!myDaoConfig.isCrossPartitionSubscription()) {
+		if (SubscriptionUtil.isCrossPartition(theSubscription)) {
+			if (!myDaoConfig.isCrossPartitionSubscription()){
 				throw new UnprocessableEntityException("Cross partition subscription is not enabled on this server");
 			}
 
@@ -119,7 +119,7 @@ public class SubscriptionValidatingInterceptor {
 				throw new UnprocessableEntityException("Cross partition subscription must be created on the default partition");
 			}
 
-			subscription.setMyCrossPartitionEnabled(true);
+			subscription.setCrossPartitionEnabled(true);
 		}
 
 		mySubscriptionCanonicalizer.setMatchingStrategyTag(theSubscription, null);
@@ -160,10 +160,6 @@ public class SubscriptionValidatingInterceptor {
 			default:
 				return null;
 		}
-	}
-
-	private boolean isCrossPartition(IBaseResource theSubscription) {
-		return ExtensionUtil.hasExtension(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION) && ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).getValue().toString().equals("BooleanType[true]");
 	}
 
 	public void validateQuery(String theQuery, String theFieldName) {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
+import ca.uhn.fhir.jpa.partition.SystemRequestDetails;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.SubscriptionMatchingStrategy;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.SubscriptionStrategyEvaluator;
 import ca.uhn.fhir.jpa.subscription.match.matcher.subscriber.SubscriptionCriteriaParser;
@@ -115,11 +116,9 @@ public class SubscriptionValidatingInterceptor {
 				throw new UnprocessableEntityException("Cross partition subscription is not enabled on this server");
 			}
 
-			if (!Objects.equals(determinePartition(theRequestDetails, theSubscription), RequestPartitionId.defaultPartition())) {
+			if (!(theRequestDetails instanceof SystemRequestDetails) && !determinePartition(theRequestDetails, theSubscription).isDefaultPartition()) {
 				throw new UnprocessableEntityException("Cross partition subscription must be created on the default partition");
 			}
-
-			subscription.setCrossPartitionEnabled(true);
 		}
 
 		mySubscriptionCanonicalizer.setMatchingStrategyTag(theSubscription, null);

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -111,12 +111,12 @@ public class SubscriptionValidatingInterceptor {
 		}
 
 		// If the subscription has the cross partition tag &&
-		if (SubscriptionUtil.isCrossPartition(theSubscription)) {
+		if (SubscriptionUtil.isCrossPartition(theSubscription) && !(theRequestDetails instanceof SystemRequestDetails)) {
 			if (!myDaoConfig.isCrossPartitionSubscription()){
 				throw new UnprocessableEntityException("Cross partition subscription is not enabled on this server");
 			}
 
-			if (!(theRequestDetails instanceof SystemRequestDetails) && !determinePartition(theRequestDetails, theSubscription).isDefaultPartition()) {
+			if (!determinePartition(theRequestDetails, theSubscription).isDefaultPartition()) {
 				throw new UnprocessableEntityException("Cross partition subscription must be created on the default partition");
 			}
 		}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -24,7 +24,10 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.SubscriptionMatchingStrategy;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.SubscriptionStrategyEvaluator;
 import ca.uhn.fhir.jpa.subscription.match.matcher.subscriber.SubscriptionCriteriaParser;
@@ -33,8 +36,10 @@ import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscriptionChannelType;
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.google.common.annotations.VisibleForTesting;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -42,6 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -53,18 +59,22 @@ public class SubscriptionValidatingInterceptor {
 	@Autowired
 	private DaoRegistry myDaoRegistry;
 	@Autowired
+	private DaoConfig myDaoConfig;
+	@Autowired
 	private SubscriptionStrategyEvaluator mySubscriptionStrategyEvaluator;
 	@Autowired
 	private FhirContext myFhirContext;
+	@Autowired
+	private IRequestPartitionHelperSvc myRequestPartitionHelperSvc;
 
 	@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
-	public void resourcePreCreate(IBaseResource theResource) {
-		validateSubmittedSubscription(theResource);
+	public void resourcePreCreate(IBaseResource theResource, RequestDetails theRequestDetails) {
+		validateSubmittedSubscription(theResource, theRequestDetails);
 	}
 
 	@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
-	public void resourcePreCreate(IBaseResource theOldResource, IBaseResource theResource) {
-		validateSubmittedSubscription(theResource);
+	public void resourcePreCreate(IBaseResource theOldResource, IBaseResource theResource, RequestDetails theRequestDetails) {
+		validateSubmittedSubscription(theResource, theRequestDetails);
 	}
 
 	@VisibleForTesting
@@ -72,7 +82,12 @@ public class SubscriptionValidatingInterceptor {
 		myFhirContext = theFhirContext;
 	}
 
+	@Deprecated
 	public void validateSubmittedSubscription(IBaseResource theSubscription) {
+		validateSubmittedSubscription(theSubscription, null);
+	}
+
+	public void validateSubmittedSubscription(IBaseResource theSubscription, RequestDetails theRequestDetails) {
 		if (!"Subscription".equals(myFhirContext.getResourceType(theSubscription))) {
 			return;
 		}
@@ -92,6 +107,17 @@ public class SubscriptionValidatingInterceptor {
 			case NULL:
 				finished = true;
 				break;
+		}
+
+		// If the subscription has the cross partition tag &&
+		if (isCrossPartition(theSubscription)) {
+			if (!myDaoConfig.isCrossPartitionSubscription()){
+				throw new UnprocessableEntityException("Cross partition subscription is not enabled on this server");
+			}
+
+			if (!Objects.equals(determinePartition(theRequestDetails, theSubscription), RequestPartitionId.defaultPartition())){
+				throw new UnprocessableEntityException("Cross partition subscription must be created on the default partition");
+			}
 		}
 
 		mySubscriptionCanonicalizer.setMatchingStrategyTag(theSubscription, null);
@@ -121,6 +147,21 @@ public class SubscriptionValidatingInterceptor {
 
 
 		}
+	}
+
+	private RequestPartitionId determinePartition(RequestDetails theRequestDetails, IBaseResource theResource){
+		switch (theRequestDetails.getRestOperationType()){
+			case CREATE:
+				return myRequestPartitionHelperSvc.determineCreatePartitionForRequest(theRequestDetails, theResource, "Subscription");
+			case UPDATE:
+				return myRequestPartitionHelperSvc.determineReadPartitionForRequestForRead(theRequestDetails, "Subscription", theResource.getIdElement());
+			default:
+				return null;
+		}
+	}
+
+	private boolean isCrossPartition(IBaseResource theSubscription) {
+		return ExtensionUtil.hasExtension(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION) && ExtensionUtil.getExtensionByUrl(theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION).getValue().toString().equals("BooleanType[true]");
 	}
 
 	public void validateQuery(String theQuery, String theFieldName) {
@@ -213,6 +254,16 @@ public class SubscriptionValidatingInterceptor {
 	@VisibleForTesting
 	public void setDaoRegistryForUnitTest(DaoRegistry theDaoRegistry) {
 		myDaoRegistry = theDaoRegistry;
+	}
+
+	@VisibleForTesting
+	public void setDaoConfigForUnitTest(DaoConfig theDaoConfig){
+		myDaoConfig = theDaoConfig;
+	}
+
+	@VisibleForTesting
+	public void setRequestPartitionHelperSvcForUnitTest(IRequestPartitionHelperSvc theRequestPartitionHelperSvc){
+		myRequestPartitionHelperSvc = theRequestPartitionHelperSvc;
 	}
 
 

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -111,13 +111,15 @@ public class SubscriptionValidatingInterceptor {
 
 		// If the subscription has the cross partition tag &&
 		if (isCrossPartition(theSubscription)) {
-			if (!myDaoConfig.isCrossPartitionSubscription()){
+			if (!myDaoConfig.isCrossPartitionSubscription()) {
 				throw new UnprocessableEntityException("Cross partition subscription is not enabled on this server");
 			}
 
-			if (!Objects.equals(determinePartition(theRequestDetails, theSubscription), RequestPartitionId.defaultPartition())){
+			if (!Objects.equals(determinePartition(theRequestDetails, theSubscription), RequestPartitionId.defaultPartition())) {
 				throw new UnprocessableEntityException("Cross partition subscription must be created on the default partition");
 			}
+
+			subscription.setMyCrossPartitionEnabled(true);
 		}
 
 		mySubscriptionCanonicalizer.setMatchingStrategyTag(theSubscription, null);
@@ -149,8 +151,8 @@ public class SubscriptionValidatingInterceptor {
 		}
 	}
 
-	private RequestPartitionId determinePartition(RequestDetails theRequestDetails, IBaseResource theResource){
-		switch (theRequestDetails.getRestOperationType()){
+	private RequestPartitionId determinePartition(RequestDetails theRequestDetails, IBaseResource theResource) {
+		switch (theRequestDetails.getRestOperationType()) {
 			case CREATE:
 				return myRequestPartitionHelperSvc.determineCreatePartitionForRequest(theRequestDetails, theResource, "Subscription");
 			case UPDATE:
@@ -257,12 +259,12 @@ public class SubscriptionValidatingInterceptor {
 	}
 
 	@VisibleForTesting
-	public void setDaoConfigForUnitTest(DaoConfig theDaoConfig){
+	public void setDaoConfigForUnitTest(DaoConfig theDaoConfig) {
 		myDaoConfig = theDaoConfig;
 	}
 
 	@VisibleForTesting
-	public void setRequestPartitionHelperSvcForUnitTest(IRequestPartitionHelperSvc theRequestPartitionHelperSvc){
+	public void setRequestPartitionHelperSvcForUnitTest(IRequestPartitionHelperSvc theRequestPartitionHelperSvc) {
 		myRequestPartitionHelperSvc = theRequestPartitionHelperSvc;
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
 import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -87,6 +88,18 @@ public class CanonicalSubscriptionTest {
 		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
 
 		assertEquals(canonicalSubscription.getCrossPartitionEnabled(), true);
+	}
+
+	@Test
+	public void testSerializeIncorrectMultiPartitionSubscription(){
+		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4());
+		Subscription subscription = makeEmailSubscription();
+		subscription.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new StringType().setValue("false"));
+		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
+
+		System.out.print(canonicalSubscription);
+
+		assertEquals(canonicalSubscription.getCrossPartitionEnabled(), false);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -98,6 +98,7 @@ public class CanonicalSubscriptionTest {
 	}
 
 	@Test
+	//FIXME LM finish this test
 	public void testLegacyCanonicalSubscription(){
 		String legacyCanonical = "{}";
 	}

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -5,9 +5,11 @@ import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionCanonicalizer;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
+import ca.uhn.fhir.util.HapiExtensions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
+import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +73,33 @@ public class CanonicalSubscriptionTest {
 		CanonicalSubscription sub1 = canonicalizer.canonicalize(makeEmailSubscription());
 		CanonicalSubscription sub2 = canonicalizer.canonicalize(makeEmailSubscription());
 		assertTrue(sub1.equals(sub2));
+	}
+
+	@Test
+	public void testSerializeMultiPartitionSubscription(){
+		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4());
+		Subscription subscription = makeEmailSubscription();
+		subscription.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new BooleanType().setValue(true));
+		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
+
+		assertEquals(canonicalSubscription.getCrossPartitionEnabled(), true);
+	}
+
+	@Test
+	public void testSerializeNonMultiPartitionSubscription(){
+		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4());
+		Subscription subscription = makeEmailSubscription();
+		subscription.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new BooleanType().setValue(false));
+		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
+
+		System.out.print(canonicalSubscription);
+
+		assertEquals(canonicalSubscription.getCrossPartitionEnabled(), false);
+	}
+
+	@Test
+	public void testLegacyCanonicalSubscription(){
+		String legacyCanonical = "{}";
 	}
 
 	private Subscription makeEmailSubscription() {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -6,12 +6,15 @@ import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionCanonicalizer;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
 import ca.uhn.fhir.util.HapiExtensions;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -22,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CanonicalSubscriptionTest {
+	private static final Logger ourLog = LoggerFactory.getLogger(CanonicalSubscriptionTest.class);
 
 	private static final String TAG_SYSTEM = "https://hapifhir.org/NamingSystem/managing-mdm-system";
 	private static final String TAG_VALUE = "HAPI-MDM";
@@ -98,9 +102,14 @@ public class CanonicalSubscriptionTest {
 	}
 
 	@Test
-	//FIXME LM finish this test
-	public void testLegacyCanonicalSubscription(){
-		String legacyCanonical = "{}";
+	public void testLegacyCanonicalSubscription() throws JsonProcessingException {
+		String legacyCanonical = "{\"headers\":{\"retryCount\":0,\"customHeaders\":{}},\"payload\":{\"canonicalSubscription\":{\"extensions\":{\"key1\":[\"VALUE1\"],\"key2\":[\"VALUE2a\",\"VALUE2b\"]},\"sendDeleteMessages\":false},\"partitionId\":{\"allPartitions\":false,\"partitionIds\":[null]}}}";
+		ObjectMapper mapper = new ObjectMapper();
+		ResourceDeliveryJsonMessage resourceDeliveryMessage = mapper.readValue(legacyCanonical, ResourceDeliveryJsonMessage.class);
+
+		CanonicalSubscription payload = resourceDeliveryMessage.getPayload().getSubscription();
+
+		assertEquals(payload.getCrossPartitionEnabled(), false);
 	}
 
 	private Subscription makeEmailSubscription() {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/standalone/BaseBlockingQueueSubscribableChannelDstu3Test.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/standalone/BaseBlockingQueueSubscribableChannelDstu3Test.java
@@ -7,7 +7,6 @@ import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
-import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.subscription.channel.api.ChannelConsumerSettings;
 import ca.uhn.fhir.jpa.subscription.channel.subscription.ISubscriptionDeliveryChannelNamer;
@@ -45,7 +44,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,6 +90,8 @@ public abstract class BaseBlockingQueueSubscribableChannelDstu3Test extends Base
 	private ISubscriptionDeliveryChannelNamer mySubscriptionDeliveryChannelNamer;
 	@Autowired
 	protected PartitionSettings myPartitionSettings;
+	@Autowired
+	protected DaoConfig myDaoConfig;
 
 	protected String myCode = "1000000050";
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -1,7 +1,9 @@
 package ca.uhn.fhir.jpa.subscription.submit.interceptor;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.SubscriptionStrategyEvaluator;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionCanonicalizer;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
@@ -29,6 +31,10 @@ public class SubscriptionValidatingInterceptorTest {
 	private DaoRegistry myDaoRegistry;
 	@MockBean
 	private SubscriptionStrategyEvaluator mySubscriptionStrategyEvaluator;
+	@MockBean
+	private DaoConfig myDaoConfig;
+	@MockBean
+	private IRequestPartitionHelperSvc myRequestPartitionHelperSvc;
 
 	@BeforeEach
 	public void before() {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
@@ -292,8 +292,8 @@ public class DaoConfig {
 	 */
 	private boolean myStoreResourceInLuceneIndex;
 
-  /** 
-   * @see FhirValidator#isConcurrentBundleValidation()
+	/**
+	 * @see FhirValidator#isConcurrentBundleValidation()
 	 * @since 5.7.0
 	 */
 	private boolean myConcurrentBundleValidation;
@@ -2760,10 +2760,10 @@ public class DaoConfig {
 	 */
 	public void setStoreResourceInLuceneIndex(boolean theStoreResourceInLuceneIndex) {
 		myStoreResourceInLuceneIndex = theStoreResourceInLuceneIndex;
-  }
-  
-	/** 
-   * @see FhirValidator#isConcurrentBundleValidation()
+	}
+
+	/**
+	 * @see FhirValidator#isConcurrentBundleValidation()
 	 * @since 5.7.0
 	 */
 	public boolean isConcurrentBundleValidation() {
@@ -2777,6 +2777,26 @@ public class DaoConfig {
 	public DaoConfig setConcurrentBundleValidation(boolean theConcurrentBundleValidation) {
 		myConcurrentBundleValidation = theConcurrentBundleValidation;
 		return this;
+	}
+
+	/**
+	 * This setting indicates if a cross-partition subscription can be made.
+	 *
+	 * @see ModelConfig#setCrossPartitionSubscription(boolean)
+	 * @since 7.5.0
+	 */
+	public boolean isCrossPartitionSubscription() {
+		return this.myModelConfig.isCrossPartitionSubscription();
+	}
+
+	/**
+	 * This setting indicates if a cross-partition subscription can be made.
+	 *
+	 * @see ModelConfig#setCrossPartitionSubscription(boolean)
+	 * @since 7.5.0
+	 */
+	public void setCrossPartitionSubscription(boolean theAllowCrossPartitionSubscription) {
+		this.myModelConfig.setCrossPartitionSubscription(theAllowCrossPartitionSubscription);
 	}
 
 	public enum StoreMetaSourceInformationEnum {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
@@ -31,6 +31,7 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.util.HapiExtensions;
+import ca.uhn.fhir.util.SubscriptionUtil;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
@@ -95,6 +96,7 @@ public class SubscriptionCanonicalizer {
 			retVal.setIdElement(subscription.getIdElement());
 			retVal.setPayloadString(subscription.getChannel().getPayload());
 			retVal.setTags(extractTags(subscription));
+			retVal.setCrossPartitionEnabled(SubscriptionUtil.isCrossPartition(theSubscription));
 		} catch (FHIRException theE) {
 			throw new InternalErrorException(theE);
 		}
@@ -135,6 +137,7 @@ public class SubscriptionCanonicalizer {
 			retVal.setPayloadString(subscription.getChannel().getPayload());
 			retVal.setPayloadSearchCriteria(getExtensionString(subscription, HapiExtensions.EXT_SUBSCRIPTION_PAYLOAD_SEARCH_CRITERIA));
 			retVal.setTags(extractTags(subscription));
+			retVal.setCrossPartitionEnabled(SubscriptionUtil.isCrossPartition(theSubscription));
 
 			if (retVal.getChannelType() == CanonicalSubscriptionChannelType.EMAIL) {
 				String from;
@@ -235,6 +238,7 @@ public class SubscriptionCanonicalizer {
 		retVal.setPayloadSearchCriteria(getExtensionString(subscription, HapiExtensions.EXT_SUBSCRIPTION_PAYLOAD_SEARCH_CRITERIA));
 		retVal.setTags(extractTags(subscription));
 		setPartitionIdOnReturnValue(theSubscription, retVal);
+		retVal.setCrossPartitionEnabled(SubscriptionUtil.isCrossPartition(theSubscription));
 
 		if (retVal.getChannelType() == CanonicalSubscriptionChannelType.EMAIL) {
 			String from;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/CanonicalSubscription.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/CanonicalSubscription.java
@@ -241,11 +241,11 @@ public class CanonicalSubscription implements Serializable, Cloneable, IModelJso
 		myPartitionId = thePartitionId;
 	}
 
-	public boolean isMyCrossPartitionEnabled() {
+	public boolean getCrossPartitionEnabled() {
 		return myCrossPartitionEnabled;
 	}
 
-	public void setMyCrossPartitionEnabled(boolean myCrossPartitionEnabled) {
+	public void setCrossPartitionEnabled(boolean myCrossPartitionEnabled) {
 		this.myCrossPartitionEnabled = myCrossPartitionEnabled;
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/CanonicalSubscription.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/CanonicalSubscription.java
@@ -74,6 +74,8 @@ public class CanonicalSubscription implements Serializable, Cloneable, IModelJso
 	private String myPayloadSearchCriteria;
 	@JsonProperty("partitionId")
 	private Integer myPartitionId;
+	@JsonProperty("crossPartitionEnabled")
+	private boolean myCrossPartitionEnabled;
 	@JsonProperty("sendDeleteMessages")
 	private boolean mySendDeleteMessages;
 
@@ -239,6 +241,14 @@ public class CanonicalSubscription implements Serializable, Cloneable, IModelJso
 		myPartitionId = thePartitionId;
 	}
 
+	public boolean isMyCrossPartitionEnabled() {
+		return myCrossPartitionEnabled;
+	}
+
+	public void setMyCrossPartitionEnabled(boolean myCrossPartitionEnabled) {
+		this.myCrossPartitionEnabled = myCrossPartitionEnabled;
+	}
+
 	/**
 	 * For now we're using the R4 triggerdefinition, but this
 	 * may change in the future when things stabilize
@@ -247,7 +257,9 @@ public class CanonicalSubscription implements Serializable, Cloneable, IModelJso
 		return myTrigger;
 	}
 
-	public boolean getSendDeleteMessages() { return mySendDeleteMessages; }
+	public boolean getSendDeleteMessages() {
+		return mySendDeleteMessages;
+	}
 
 	public void setSendDeleteMessages(boolean theSendDeleteMessages) {
 		mySendDeleteMessages = theSendDeleteMessages;


### PR DESCRIPTION
added the option for subscriptions to be matched against resources from all partitions rather than just the the partition the subscription is saved on