### PR TITLE
Issue 2377 missing entry full url in document

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/IVersionSpecificBundleFactory.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/IVersionSpecificBundleFactory.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -37,7 +38,7 @@ import java.util.Set;
  */
 public interface IVersionSpecificBundleFactory {
 
-	void addResourcesToBundle(List<IBaseResource> theResult, BundleTypeEnum theBundleType, String theServerBase, BundleInclusionRule theBundleInclusionRule, Set<Include> theIncludes);
+	void addResourcesToBundle(List<IBaseResource> theResult, BundleTypeEnum theBundleType, String theServerBase, @Nullable BundleInclusionRule theBundleInclusionRule, @Nullable Set<Include> theIncludes);
 
 	void addRootPropertiesToBundle(String theId, @Nonnull BundleLinks theBundleLinks, Integer theTotalResults, IPrimitiveType<Date> theLastUpdated);
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/2377-document-full-url.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/2377-document-full-url.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 2377
+jira: SMILE-807
+title: "Calling the `$document` operation previously omitted the fullUrl of the bundle entries. This has been corrected."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaResourceProviderCompositionDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaResourceProviderCompositionDstu2.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.model.dstu2.resource.Composition;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 
 /*
@@ -33,16 +34,15 @@ public class BaseJpaResourceProviderCompositionDstu2 extends JpaResourceProvider
 	 * Composition/123/$document
 	 */
 	//@formatter:off
-	@Operation(name = JpaConstants.OPERATION_DOCUMENT, idempotent = true, bundleType=BundleTypeEnum.SEARCHSET)
-	public IBaseBundle getDocumentForComposition(
+	@Operation(name = JpaConstants.OPERATION_DOCUMENT, idempotent = true, bundleType=BundleTypeEnum.DOCUMENT)
+	public IBundleProvider getDocumentForComposition(
 
 			javax.servlet.http.HttpServletRequest theServletRequest) {
 		//@formatter:on
 
 		startRequest(theServletRequest);
 		try {
-			((IFhirResourceDaoComposition<Composition>)getDao()).getDocumentForComposition(theServletRequest, null, null, null, null, null, null);
-			return null;
+			return ((IFhirResourceDaoComposition<Composition>)getDao()).getDocumentForComposition(theServletRequest, null, null, null, null, null, null);
 		} finally {
 			endRequest(theServletRequest);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/dstu3/BaseJpaResourceProviderCompositionDstu3.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/dstu3/BaseJpaResourceProviderCompositionDstu3.java
@@ -52,7 +52,7 @@ public class BaseJpaResourceProviderCompositionDstu3 extends JpaResourceProvider
 	 */
 	//@formatter:off
 	@Operation(name = JpaConstants.OPERATION_DOCUMENT, idempotent = true, bundleType=BundleTypeEnum.DOCUMENT)
-	public IBaseBundle getDocumentForComposition(
+	public IBundleProvider getDocumentForComposition(
 
 			javax.servlet.http.HttpServletRequest theServletRequest,
 
@@ -81,14 +81,7 @@ public class BaseJpaResourceProviderCompositionDstu3 extends JpaResourceProvider
 		startRequest(theServletRequest);
 		try {
 			IBundleProvider bundleProvider = ((IFhirResourceDaoComposition<Composition>) getDao()).getDocumentForComposition(theServletRequest, theId, theCount, theOffset, theLastUpdated, theSortSpec, theRequestDetails);
-			List<IBaseResource> resourceList = bundleProvider.getAllResources();
-
-			boolean foundCompositionResource = false;
-			Bundle bundle = new Bundle().setType(Bundle.BundleType.DOCUMENT);
-			for (IBaseResource resource : resourceList) {
-				bundle.addEntry(new Bundle.BundleEntryComponent().setResource((Resource) resource));
-			}
-			return bundle;
+			return bundleProvider;
 		} finally {
 			endRequest(theServletRequest);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderCompositionR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderCompositionR4.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.provider.r4;
 
+import ca.uhn.fhir.context.api.BundleInclusionRule;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDaoComposition;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.model.api.annotation.Description;
@@ -8,19 +9,24 @@ import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.annotation.Sort;
+import ca.uhn.fhir.rest.api.BundleLinks;
 import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.IVersionSpecificBundleFactory;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.hapi.rest.server.R4BundleFactory;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.UnsignedIntType;
 
+import java.util.Date;
 import java.util.List;
 
 
@@ -50,7 +56,8 @@ public class BaseJpaResourceProviderCompositionR4 extends JpaResourceProviderR4<
 	 * Composition/123/$document
 	 */
 	@Operation(name = JpaConstants.OPERATION_DOCUMENT, idempotent = true, bundleType=BundleTypeEnum.DOCUMENT)
-	public IBaseBundle getDocumentForComposition(
+//	public IBaseBundle getDocumentForComposition(
+	public IBundleProvider getDocumentForComposition(
 
 			javax.servlet.http.HttpServletRequest theServletRequest,
 
@@ -78,14 +85,7 @@ public class BaseJpaResourceProviderCompositionR4 extends JpaResourceProviderR4<
 		startRequest(theServletRequest);
 		try {
 			IBundleProvider bundleProvider = ((IFhirResourceDaoComposition<Composition>) getDao()).getDocumentForComposition(theServletRequest, theId, theCount, theOffset, theLastUpdated, theSortSpec, theRequestDetails);
-			List<IBaseResource> resourceList = bundleProvider.getAllResources();
-
-			boolean foundCompositionResource = false;
-			Bundle bundle = new Bundle().setType(Bundle.BundleType.DOCUMENT);
-			for (IBaseResource resource : resourceList) {
-				bundle.addEntry(new Bundle.BundleEntryComponent().setResource((Resource) resource));
-			}
-			return bundle;
+			return bundleProvider;
 		} finally {
 			endRequest(theServletRequest);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderCompositionR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderCompositionR4.java
@@ -82,9 +82,7 @@ public class BaseJpaResourceProviderCompositionR4 extends JpaResourceProviderR4<
 
 			boolean foundCompositionResource = false;
 			Bundle bundle = new Bundle().setType(Bundle.BundleType.DOCUMENT);
-			for (IBaseResource resource : resourceList) {
-				bundle.addEntry(new Bundle.BundleEntryComponent().setResource((Resource) resource));
-			}
+			bundle.
 			return bundle;
 		} finally {
 			endRequest(theServletRequest);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderCompositionR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderCompositionR4.java
@@ -82,7 +82,9 @@ public class BaseJpaResourceProviderCompositionR4 extends JpaResourceProviderR4<
 
 			boolean foundCompositionResource = false;
 			Bundle bundle = new Bundle().setType(Bundle.BundleType.DOCUMENT);
-			bundle.
+			for (IBaseResource resource : resourceList) {
+				bundle.addEntry(new Bundle.BundleEntryComponent().setResource((Resource) resource));
+			}
 			return bundle;
 		} finally {
 			endRequest(theServletRequest);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r5/BaseJpaResourceProviderCompositionR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r5/BaseJpaResourceProviderCompositionR5.java
@@ -50,7 +50,7 @@ public class BaseJpaResourceProviderCompositionR5 extends JpaResourceProviderR5<
 	 * Composition/123/$document
 	 */
 	@Operation(name = JpaConstants.OPERATION_DOCUMENT, idempotent = true, bundleType=BundleTypeEnum.DOCUMENT)
-	public IBaseBundle getDocumentForComposition(
+	public IBundleProvider getDocumentForComposition(
 
 			javax.servlet.http.HttpServletRequest theServletRequest,
 
@@ -78,14 +78,7 @@ public class BaseJpaResourceProviderCompositionR5 extends JpaResourceProviderR5<
 		startRequest(theServletRequest);
 		try {
 			IBundleProvider bundleProvider = ((IFhirResourceDaoComposition<Composition>) getDao()).getDocumentForComposition(theServletRequest, theId, theCount, theOffset, theLastUpdated, theSortSpec, theRequestDetails);
-			List<IBaseResource> resourceList = bundleProvider.getAllResources();
-
-			boolean foundCompositionResource = false;
-			Bundle bundle = new Bundle().setType(Bundle.BundleType.DOCUMENT);
-			for (IBaseResource resource : resourceList) {
-				bundle.addEntry(new Bundle.BundleEntryComponent().setResource((Resource) resource));
-			}
-			return bundle;
+			return bundleProvider;
 		} finally {
 			endRequest(theServletRequest);
 		}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/CompositionDocumentDstu3Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/CompositionDocumentDstu3Test.java
@@ -32,8 +32,10 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CompositionDocumentDstu3Test extends BaseResourceProviderDstu3Test {
@@ -117,6 +119,12 @@ public class CompositionDocumentDstu3Test extends BaseResourceProviderDstu3Test 
 		String theUrl = ourServerBase + "/" + compId + "/$document?_format=json";
 		Bundle bundle = fetchBundle(theUrl, EncodingEnum.JSON);
 
+		bundle.getEntry().stream()
+			.forEach(entry -> {
+				assertThat(entry.getFullUrl(), is(equalTo(entry.getResource().getIdElement().toVersionless().toString())));
+			});
+
+		assertThat(bundle.getType(), is(equalTo(Bundle.BundleType.DOCUMENT)));
 		assertNull(bundle.getLink("next"));
 
 		Set<String> actual = new HashSet<>();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/CompositionDocumentR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/CompositionDocumentR4Test.java
@@ -117,11 +117,13 @@ public class CompositionDocumentR4Test extends BaseResourceProviderR4Test {
 
 		String theUrl = ourServerBase + "/" + compId + "/$document?_format=json";
 		Bundle bundle = fetchBundle(theUrl, EncodingEnum.JSON);
+		//Ensure each entry has a URL.
+
+		assertThat(bundle.getType(), is(equalTo(Bundle.BundleType.DOCUMENT)));
 		bundle.getEntry().stream()
 				.forEach(entry -> {
-					assertThat(entry.getFullUrl(), is(equalTo("http://localhost:8000/" + entry.getResource().getId())));
+					assertThat(entry.getFullUrl(), is(equalTo(entry.getResource().getIdElement().toVersionless().toString())));
 				});
-
 		assertNull(bundle.getLink("next"));
 
 		Set<String> actual = new HashSet<>();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/CompositionDocumentR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/CompositionDocumentR4Test.java
@@ -25,8 +25,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -115,6 +117,10 @@ public class CompositionDocumentR4Test extends BaseResourceProviderR4Test {
 
 		String theUrl = ourServerBase + "/" + compId + "/$document?_format=json";
 		Bundle bundle = fetchBundle(theUrl, EncodingEnum.JSON);
+		bundle.getEntry().stream()
+				.forEach(entry -> {
+					assertThat(entry.getFullUrl(), is(equalTo("http://localhost:8000/" + entry.getResource().getId())));
+				});
 
 		assertNull(bundle.getLink("next"));
 


### PR DESCRIPTION
Closes #2377 

* For a reason that is unclear to me, the operation providers were not using the standard method of returning IBundleProviders, and were instead hand-rolling bundle entries. This has been corrected in all STU versions. 
* Modified Tests 
* Added changelog
