### PR TITLE
Resolve "Rest hook subscription with payload search criteria is not getting triggered"

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3274-transactions-with-full-request-url-will-be-rejected.yml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/3274-transactions-with-full-request-url-will-be-rejected.yml
@@ -1,4 +1,5 @@
 ---
 issue: 3274
+type: fix
 title: "Transactions with entries that have request.url values that are fully
       qualified urls will now be rejected."


### PR DESCRIPTION
Fixed issue where the rest hook subscription with payload search criteria is not getting triggered