### PR TITLE
Add okhttp dep to r5 and indicate which deps need to be included

### DIFF
--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -287,6 +287,17 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<configuration>
 					<show>public</show>
+					<includeDependencySources>true</includeDependencySources>
+					<dependencySourceIncludes>
+						<include>ca.uhn.hapi.fhir:org.hl7.fhir.r5</include>
+					</dependencySourceIncludes>
+					<additionalDependencies>
+						<dependency>
+							<groupId>com.squareup.okhttp3</groupId>
+							<artifactId>okhttp</artifactId>
+							<version>${okhttp_version}</version>
+						</dependency>
+					</additionalDependencies>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
* Currently building javadocs in R5 is failing, causing a failed deploy to sonatype: 
```
[ERROR] /__w/1/s/hapi-fhir-structures-r5/target/distro-javadoc-sources/org.hl7.fhir.r5-5.6.27-sources/org/hl7/fhir/r5/utils/client/network/FhirLoggingInterceptor.java:4: error: package okio does not exist
[ERROR] import okio.Buffer;
[ERROR]            ^
```
* Failure can be replicated by cleaning your ~/.m2 and running `mvn clean install -P DIST` in the hapi-fhir-structures-r5 directory
* This MR makes the R5 pom.xml match the structure of R4 and DSTU3, which import the lib as an addditional dep during javadoc generation. 
