### PR TITLE
2714 allow alternative character encoding length in searchparams

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderEnum.java
@@ -44,10 +44,23 @@ public enum PhoneticEncoderEnum {
 
 	private final IPhoneticEncoder myPhoneticEncoder;
 
+	/**
+	 * Do not construct this enum via constructor.
+	 *
+	 * Use PhoneticEncoderWrapper instead.
+	 */
+	@Deprecated
 	PhoneticEncoderEnum(IPhoneticEncoder thePhoneticEncoder) {
 		myPhoneticEncoder = thePhoneticEncoder;
 	}
 
+	/**
+	 * Use PhoneticEncoderWrapper.getEncoderWrapper(PhoneticEncoderEnum.name())
+	 *
+	 * This is a deprecated method of getting the encoder (as they
+	 * are static across the server and non-configurable).
+	 */
+	@Deprecated
 	public IPhoneticEncoder getPhoneticEncoder() {
 		return myPhoneticEncoder;
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderWrapper.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderWrapper.java
@@ -1,0 +1,133 @@
+package ca.uhn.fhir.context.phonetic;
+
+import org.apache.commons.codec.language.Caverphone1;
+import org.apache.commons.codec.language.Caverphone2;
+import org.apache.commons.codec.language.ColognePhonetic;
+import org.apache.commons.codec.language.DoubleMetaphone;
+import org.apache.commons.codec.language.MatchRatingApproachEncoder;
+import org.apache.commons.codec.language.Metaphone;
+import org.apache.commons.codec.language.Nysiis;
+import org.apache.commons.codec.language.RefinedSoundex;
+import org.apache.commons.codec.language.Soundex;
+import org.apache.commons.lang3.EnumUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PhoneticEncoderWrapper {
+	private static final Logger ourLog = LoggerFactory.getLogger(PhoneticEncoderWrapper.class);
+
+	private final IPhoneticEncoder myEncoder;
+
+	public PhoneticEncoderWrapper(IPhoneticEncoder thePhoneticEncoder) {
+		myEncoder = thePhoneticEncoder;
+	}
+
+	public IPhoneticEncoder getPhoneticEncoder() {
+		return myEncoder;
+	}
+
+	/**
+	 * Creates the phonetic encoder wrapper from
+	 * an input string.
+	 *
+	 * String must be in the format of...
+	 *
+	 * PhoneticEncoderEnum(MAX_LENGTH)
+	 */
+	public static PhoneticEncoderWrapper getEncoderWrapper(String theString) {
+		String encoderType = null;
+		int encoderMaxString = -1;
+
+		int braceIndex = theString.indexOf("(");
+		if (braceIndex != -1) {
+			int len = theString.length();
+			if (theString.charAt(len - 1) == ')') {
+				encoderType = theString.substring(0, braceIndex);
+				String num = theString.substring(braceIndex + 1, len - 1);
+
+				try {
+					encoderMaxString = Integer.parseInt(num);
+				} catch (NumberFormatException ex) {
+					encoderType = null;
+					ourLog.error("Invalid encoder max character length: " + num);
+				}
+			}
+			// else - parse error
+		}
+		else {
+			encoderType = theString;
+		}
+
+		IPhoneticEncoder encoder = getEncoderFromString(encoderType, encoderMaxString);
+		if (encoder != null) {
+			return new PhoneticEncoderWrapper(encoder);
+		}
+		else {
+			ourLog.warn("Invalid phonetic param string " + theString);
+			return null;
+		}
+	}
+
+	private static IPhoneticEncoder getEncoderFromString(String theName, int theMax) {
+		IPhoneticEncoder encoder = null;
+		PhoneticEncoderEnum enumVal = EnumUtils.getEnum(PhoneticEncoderEnum.class, theName);
+
+		if (enumVal != null) {
+			switch (enumVal) {
+				case CAVERPHONE1:
+					Caverphone1 caverphone1 = new Caverphone1();
+					encoder = new ApacheEncoder(theName, caverphone1);
+					break;
+				case CAVERPHONE2:
+					Caverphone2 caverphone2 = new Caverphone2();
+					encoder = new ApacheEncoder(theName, caverphone2);
+					break;
+				case COLOGNE:
+					ColognePhonetic colognePhonetic = new ColognePhonetic();
+					encoder = new ApacheEncoder(theName, colognePhonetic);
+					break;
+				case DOUBLE_METAPHONE:
+					DoubleMetaphone doubleMetaphone = new DoubleMetaphone();
+					if (theMax >= 0) {
+						doubleMetaphone.setMaxCodeLen(theMax);
+					}
+					encoder = new ApacheEncoder(theName, doubleMetaphone);
+					break;
+				case MATCH_RATING_APPROACH:
+					MatchRatingApproachEncoder matchRatingApproachEncoder = new MatchRatingApproachEncoder();
+					encoder = new ApacheEncoder(theName, matchRatingApproachEncoder);
+					break;
+				case METAPHONE:
+					Metaphone metaphone = new Metaphone();
+					if (theMax >= 0) {
+						metaphone.setMaxCodeLen(theMax);
+					}
+					encoder = new ApacheEncoder(theName, metaphone);
+					break;
+				case NYSIIS:
+					Nysiis nysiis = new Nysiis();
+					encoder = new ApacheEncoder(theName, nysiis);
+					break;
+				case REFINED_SOUNDEX:
+					RefinedSoundex refinedSoundex = new RefinedSoundex();
+					encoder = new ApacheEncoder(theName, refinedSoundex);
+					break;
+				case SOUNDEX:
+					Soundex soundex = new Soundex();
+					// soundex has deprecated setting the max size
+					encoder = new ApacheEncoder(theName, soundex);
+					break;
+				case NUMERIC:
+					encoder = new NumericEncoder();
+					break;
+				default:
+					// we don't ever expect to be here
+					// this log message is purely for devs who update this
+					// enum, but not this method
+					ourLog.info("Unhandled PhoneticParamEnum value " + enumVal.name());
+					break;
+			}
+		}
+		return encoder;
+	}
+}

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderTest.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.context.phonetic;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
@@ -10,7 +11,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class PhoneticEncoderTest {
+public class PhoneticEncoderTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(PhoneticEncoderTest.class);
 
 	private static final String NUMBER = "123";
@@ -21,7 +22,9 @@ class PhoneticEncoderTest {
 	@ParameterizedTest
 	@EnumSource(PhoneticEncoderEnum.class)
 	public void testEncodeAddress(PhoneticEncoderEnum thePhoneticEncoderEnum) {
-		String encoded = thePhoneticEncoderEnum.getPhoneticEncoder().encode(ADDRESS_LINE);
+		PhoneticEncoderWrapper wrapper = PhoneticEncoderWrapper.getEncoderWrapper(thePhoneticEncoderEnum.name());
+		Assertions.assertNotNull(wrapper);
+		String encoded = wrapper.getPhoneticEncoder().encode(ADDRESS_LINE);
 		ourLog.info("{}: {}", thePhoneticEncoderEnum.name(), encoded);
 		if (thePhoneticEncoderEnum == PhoneticEncoderEnum.NUMERIC) {
 			assertEquals(NUMBER + SUITE, encoded);

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderWrapperTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/context/phonetic/PhoneticEncoderWrapperTest.java
@@ -1,0 +1,89 @@
+package ca.uhn.fhir.context.phonetic;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+public class PhoneticEncoderWrapperTest {
+
+	private final Logger myLogger  = (Logger) LoggerFactory.getLogger(PhoneticEncoderWrapper.class);
+
+	private ListAppender<ILoggingEvent> myListAppender;
+
+	@BeforeEach
+	public void init() {
+		myListAppender = Mockito.mock(ListAppender.class);
+		myLogger.addAppender(myListAppender);
+	}
+
+	@Test
+	public void getEncoderWrapper_withNumberProvided_parsesOutCorrectValue() {
+		int num = 5;
+		PhoneticEncoderEnum enumVal = PhoneticEncoderEnum.DOUBLE_METAPHONE;
+		String enumString = enumVal.name() + "(" + num + ")";
+
+		// test
+		PhoneticEncoderWrapper wrapper = PhoneticEncoderWrapper.getEncoderWrapper(enumString);
+
+		Assertions.assertNotNull(wrapper);
+		Assertions.assertEquals(enumVal.name(), wrapper.getPhoneticEncoder().name());
+	}
+
+	@Test
+	public void getEncoderWrapper_withNoNumber_parsesOutCorrectValue() {
+		// test
+		for (PhoneticEncoderEnum enumVal : PhoneticEncoderEnum.values()) {
+			PhoneticEncoderWrapper wrapper = PhoneticEncoderWrapper.getEncoderWrapper(enumVal.name());
+
+			Assertions.assertNotNull(wrapper);
+			Assertions.assertEquals(enumVal.name(), wrapper.getPhoneticEncoder().name());
+		}
+	}
+
+	@Test
+	public void getEncoderWrapper_withInvalidNumber_returnsNullAndLogs() {
+		// setup
+		myLogger.setLevel(Level.ERROR);
+		String num = "A";
+
+		// test
+		PhoneticEncoderWrapper wrapper = PhoneticEncoderWrapper.getEncoderWrapper(
+			PhoneticEncoderEnum.METAPHONE.name() + "(" + num + ")"
+		);
+
+		// verify
+		Assertions.assertNull(wrapper);
+		ArgumentCaptor<ILoggingEvent> loggingCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+		Mockito.verify(myListAppender).doAppend(loggingCaptor.capture());
+		Assertions.assertEquals(1, loggingCaptor.getAllValues().size());
+		ILoggingEvent event = loggingCaptor.getValue();
+		Assertions.assertEquals("Invalid encoder max character length: " + num,
+			event.getMessage());
+	}
+
+	@Test
+	public void parseFromString_unknownValue_returnsNull() {
+		// setup
+		myLogger.setLevel(Level.WARN);
+		String theString = "Not a valid encoder value";
+
+		PhoneticEncoderWrapper retEnum = PhoneticEncoderWrapper.getEncoderWrapper(theString);
+
+		// verify
+		Assertions.assertNull(retEnum);
+		ArgumentCaptor<ILoggingEvent> captor = ArgumentCaptor.forClass(ILoggingEvent.class);
+		Mockito.verify(myListAppender)
+			.doAppend(captor.capture());
+		Assertions.assertEquals(1, captor.getAllValues().size());
+		ILoggingEvent event = captor.getValue();
+		Assertions.assertEquals("Invalid phonetic param string " + theString,
+			event.getMessage());
+	}
+}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/2714-added-configuration-to-specify-max-code-lengths.yml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/5_7_0/2714-added-configuration-to-specify-max-code-lengths.yml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 2714
+title: "Added ability to specify max code lengths for supported
+      Phonetic Encoders (Metaphone, Double_Metaphone)."

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
@@ -1,6 +1,7 @@
 package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.context.phonetic.PhoneticEncoderEnum;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IAnonymousInterceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
@@ -10,6 +11,7 @@ import ca.uhn.fhir.jpa.model.entity.NormalizedQuantitySearchLevel;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.model.search.StorageProcessingMessage;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateParam;
@@ -20,6 +22,7 @@ import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import ca.uhn.fhir.util.HapiExtensions;
 import org.hamcrest.Matchers;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Appointment;
@@ -53,6 +56,7 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.Specimen;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -195,6 +199,60 @@ public class FhirResourceDaoR4SearchCustomSearchParamTest extends BaseJpaR4Test 
 
 		search = myPatientDao.search(SearchParameterMap.newSynchronous("future-appointment-count", new NumberParam("lt0")));
 		assertEquals(0, search.size());
+	}
+
+	@Test
+	public void testCreatePhoneticSearchParameterWithOptionalCharacterLength() {
+		String testString = "Richard Smith";
+		int modifiedLength = 7;
+
+		// create 2 different search parameters
+		// same encoder, but different lengths
+		SearchParameter searchParam = constructSearchParameter();
+		searchParam.setCode("fuzzydefault");
+		searchParam.addExtension()
+			.setUrl(HapiExtensions.EXT_SEARCHPARAM_PHONETIC_ENCODER)
+			.setValue(new StringType(PhoneticEncoderEnum.METAPHONE.name()));
+
+		mySearchParameterDao.create(searchParam, mySrd);
+		mySearchParamRegistry.forceRefresh();
+
+		SearchParameter searchParamModified = constructSearchParameter();
+		searchParamModified.setCode("fuzzymodified");
+		searchParamModified.addExtension()
+			.setUrl(HapiExtensions.EXT_SEARCHPARAM_PHONETIC_ENCODER)
+			.setValue(new StringType(PhoneticEncoderEnum.METAPHONE.name() + "(" + modifiedLength + ")"));
+
+		mySearchParameterDao.create(searchParamModified, mySrd);
+		mySearchParamRegistry.forceRefresh();
+
+		// check the 2 parameters are different
+		// when fetched from the system
+		RuntimeSearchParam paramdefault = mySearchParamRegistry.getActiveSearchParam("Patient",
+			"fuzzydefault");
+		RuntimeSearchParam parammodified = mySearchParamRegistry.getActiveSearchParam("Patient",
+			"fuzzymodified");
+
+		// verify the encoders are different!
+		Assertions.assertNotEquals(paramdefault, parammodified);
+		String encodedDefault = paramdefault.encode(testString);
+		String encodedMod = parammodified.encode(testString);
+		Assertions.assertEquals(modifiedLength, encodedMod.length());
+		Assertions.assertNotEquals(encodedDefault.length(), encodedMod.length());
+	}
+
+	/**
+	 * Constructs a search parameter for patients on name.
+	 * No code or extentions are set
+	 * (so the calling test should set these).
+	 */
+	private SearchParameter constructSearchParameter() {
+		SearchParameter sp = new SearchParameter();
+		sp.addBase("Patient");
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.setType(Enumerations.SearchParamType.STRING);
+		sp.setExpression("Patient.name.given.first() + ' ' + Patient.name.family");
+		return sp;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -23,14 +23,13 @@ package ca.uhn.fhir.jpa.searchparam.registry;
 import ca.uhn.fhir.context.ComboSearchParamType;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeSearchParam;
-import ca.uhn.fhir.context.phonetic.PhoneticEncoderEnum;
+import ca.uhn.fhir.context.phonetic.PhoneticEncoderWrapper;
 import ca.uhn.fhir.model.api.ExtensionDt;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.DatatypeUtil;
 import ca.uhn.fhir.util.FhirTerser;
 import ca.uhn.fhir.util.HapiExtensions;
-import org.apache.commons.lang3.EnumUtils;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.SearchParameter;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -374,11 +373,15 @@ public class SearchParameterCanonicalizer {
 	private void setEncoder(RuntimeSearchParam theRuntimeSearchParam, IBaseDatatype theValue) {
 		if (theValue instanceof IPrimitiveType) {
 			String stringValue = ((IPrimitiveType<?>) theValue).getValueAsString();
-			// FIXME LS parse out to support DOUBLE_METAPHONE(7) format when we instantiate it, ensure the number gets to where it needs to go
-			PhoneticEncoderEnum encoderEnum = EnumUtils.getEnum(PhoneticEncoderEnum.class, stringValue);
-			if (encoderEnum != null) {
-				theRuntimeSearchParam.setPhoneticEncoder(encoderEnum.getPhoneticEncoder());
-			} else {
+
+			// every string creates a completely new encoder wrapper.
+			// this is fine, because the runtime search parameters are constructed at startup
+			// for every saved value
+			PhoneticEncoderWrapper wrapper = PhoneticEncoderWrapper.getEncoderWrapper(stringValue);
+			if (wrapper != null) {
+				theRuntimeSearchParam.setPhoneticEncoder(wrapper.getPhoneticEncoder());
+			}
+			else {
 				ourLog.error("Invalid PhoneticEncoderEnum value '" + stringValue + "'");
 			}
 		}

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -374,6 +374,7 @@ public class SearchParameterCanonicalizer {
 	private void setEncoder(RuntimeSearchParam theRuntimeSearchParam, IBaseDatatype theValue) {
 		if (theValue instanceof IPrimitiveType) {
 			String stringValue = ((IPrimitiveType<?>) theValue).getValueAsString();
+			// FIXME LS parse out to support DOUBLE_METAPHONE(7) format when we instantiate it, ensure the number gets to where it needs to go
 			PhoneticEncoderEnum encoderEnum = EnumUtils.getEnum(PhoneticEncoderEnum.class, stringValue);
 			if (encoderEnum != null) {
 				theRuntimeSearchParam.setPhoneticEncoder(encoderEnum.getPhoneticEncoder());

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/matcher/PhoneticEncoderMatcher.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/matcher/PhoneticEncoderMatcher.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.mdm.rules.matcher;
 
 import ca.uhn.fhir.context.phonetic.IPhoneticEncoder;
 import ca.uhn.fhir.context.phonetic.PhoneticEncoderEnum;
+import ca.uhn.fhir.context.phonetic.PhoneticEncoderWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,8 @@ public class PhoneticEncoderMatcher implements IMdmStringMatcher {
 	private final IPhoneticEncoder myStringEncoder;
 
 	public PhoneticEncoderMatcher(PhoneticEncoderEnum thePhoneticEnum) {
-		myStringEncoder = thePhoneticEnum.getPhoneticEncoder();
+		PhoneticEncoderWrapper wrapper = PhoneticEncoderWrapper.getEncoderWrapper(thePhoneticEnum.name());
+		myStringEncoder = wrapper.getPhoneticEncoder();
 	}
 
 	@Override


### PR DESCRIPTION
closes #2714

Updated PhoneticEncoder to allow specifying max code length.

This will only work for supported encoders (Metaphone ones right now are all).

Added Changelog
Deprecated PhoneticEncoderEnum
Created https://gitlab.com/simpatico.ai/cdr/-/issues/2780 to handle changes in smile