### PR TITLE
add needed dependendencies for mysql and mssql

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -239,6 +239,14 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-sqlserver</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-mysql</artifactId>
+		</dependency>
 
 		<!-- Test Deps -->
 		<dependency>

--- a/hapi-fhir-jpaserver-cql/pom.xml
+++ b/hapi-fhir-jpaserver-cql/pom.xml
@@ -27,6 +27,13 @@
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>evaluator.engine</artifactId>
 			<version>${cql-evaluator.version}</version>
+			<exclusions>
+				<!-- we exclude this because we don't want javax.mail and will use jakarta.mail instead -->
+				<exclusion>
+					<groupId>com.sun.mail</groupId>
+					<artifactId>javax.mail</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.cql</groupId>
@@ -88,6 +95,12 @@
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 			<version>${jaxb_api_version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.activation</groupId>
+					<artifactId>javax.activation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.jamesmurty.utils</groupId>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -73,6 +73,15 @@
 			<artifactId>flyway-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-sqlserver</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-mysql</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-commons</artifactId>
 		</dependency>

--- a/hapi-fhir-sql-migrate/src/test/java/FlywayDbCompatibilityTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/FlywayDbCompatibilityTest.java
@@ -16,7 +16,13 @@ public class FlywayDbCompatibilityTest {
 		assertThat(sqlServerType.getName(), is(equalTo("Azure Synapse")));
 
 		DatabaseType oracleType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:oracle:thin:@//host:port/service");
-		assertThat(oracleType.getName(), is(equalTo("Azure Synapse")));
+		assertThat(oracleType.getName(), is(equalTo("Oracle")));
+
+		DatabaseType mySqlType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:mysql://localhost:3306/cdr?serverTimezone=Canada/Eastern");
+		assertThat(mySqlType.getName(), is(equalTo("mySQL")));
+
+		DatabaseType postgresType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:postgres://localhost:5432/cdr");
+		assertThat(mySqlType.getName(), is(equalTo("mySQL")));
 
 	}
 

--- a/hapi-fhir-sql-migrate/src/test/java/FlywayDbCompatibilityTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/FlywayDbCompatibilityTest.java
@@ -19,11 +19,13 @@ public class FlywayDbCompatibilityTest {
 		assertThat(oracleType.getName(), is(equalTo("Oracle")));
 
 		DatabaseType mySqlType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:mysql://localhost:3306/cdr?serverTimezone=Canada/Eastern");
-		assertThat(mySqlType.getName(), is(equalTo("mySQL")));
+		assertThat(mySqlType.getName(), is(equalTo("MySQL")));
 
-		DatabaseType postgresType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:postgres://localhost:5432/cdr");
-		assertThat(mySqlType.getName(), is(equalTo("mySQL")));
+		DatabaseType postgresType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:postgresql://localhost:5432/cdr");
+		assertThat(postgresType.getName(), is(equalTo("CockroachDB")));
 
+		DatabaseType mariaDbType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:mariadb://localhost:3306/cdr");
+		assertThat(mariaDbType.getName(), is(equalTo("MariaDB")));
 	}
 
 }

--- a/hapi-fhir-sql-migrate/src/test/java/FlywayDbCompatibilityTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/FlywayDbCompatibilityTest.java
@@ -1,0 +1,23 @@
+import org.flywaydb.core.internal.database.DatabaseType;
+import org.flywaydb.core.internal.database.DatabaseTypeRegister;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class FlywayDbCompatibilityTest {
+	@Test
+	public void testFlywayDbCompatibility() {
+		DatabaseType h2Type = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:h2:mem:test");
+		assertThat(h2Type.getName(), is(equalTo("H2")));
+
+		DatabaseType sqlServerType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:sqlserver://localhost:1433;database=test");
+		assertThat(sqlServerType.getName(), is(equalTo("Azure Synapse")));
+
+		DatabaseType oracleType = DatabaseTypeRegister.getDatabaseTypeForUrl("jdbc:oracle:thin:@//host:port/service");
+		assertThat(oracleType.getName(), is(equalTo("Azure Synapse")));
+
+	}
+
+}

--- a/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/FlywayMigrationTaskTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/FlywayMigrationTaskTest.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.jpa.migrate.tasks.api.ISchemaInitializationProvider;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.flywaydb.core.api.migration.Context;
+import org.flywaydb.core.internal.database.DatabaseTypeRegister;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/pom.xml
+++ b/pom.xml
@@ -1943,6 +1943,16 @@
 				<version>${flyway_version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.flywaydb</groupId>
+				<artifactId>flyway-sqlserver</artifactId>
+				<version>${flyway_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.flywaydb</groupId>
+				<artifactId>flyway-mysql</artifactId>
+				<version>${flyway_version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.batch</groupId>
 				<artifactId>spring-batch-test</artifactId>
 				<version>${spring_batch_version}</version>


### PR DESCRIPTION
A recent upgrade in flyway versions caused a regression which meant that we can no longer connect to mysql or mssql databases, as the dependencies from flyway were pulled out into additional dependencies. This MR adds those dependencies, and writes a small test to catch if other dependencies are pulled out. 

