### PR TITLE
Initial implementation of HEAD request support in HAPI client.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IReadExecutable.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IReadExecutable.java
@@ -34,4 +34,13 @@ public interface IReadExecutable<T extends IBaseResource> extends IClientExecuta
 	 */
 	IReadIfNoneMatch<T> ifVersionMatches(String theVersion);
 
+	/**
+	 * Send a HEAD request instead of a GET.
+	 * This returns the same status code and headers as a GET request, but without the response body.
+	 * It is useful for detecting if a resource exists.
+	 * 
+	 * When using this option, the Resource returned from calling {@link IClientExecutable#execute()} will only have 
+	 * the ID set, since the resource body is not fetched from the server.
+	 */
+	IReadExecutable<T> useHead(boolean useHead);
 }

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpClient.java
@@ -72,6 +72,8 @@ public class ApacheHttpClient extends BaseHttpClient implements IHttpClient {
 			HttpPut httpPut = new HttpPut(url);
 			httpPut.setEntity(theEntity);
 			return httpPut;
+		case HEAD:
+			return new HttpHead(url);
 		case GET:
 		default:
 			return new HttpGet(url);

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -162,7 +162,7 @@ public abstract class BaseClient implements IRestfulClient {
 
 	@Override
 	public <T extends IBaseResource> T fetchResourceFromUrl(Class<T> theResourceType, String theUrl) {
-		BaseHttpClientInvocation clientInvocation = new HttpGetClientInvocation(getFhirContext(), theUrl);
+		BaseHttpClientInvocation clientInvocation = new HttpGetClientInvocation(getFhirContext(), theUrl, false);
 		ResourceResponseHandler<T> binding = new ResourceResponseHandler<>(theResourceType);
 		return invokeClient(getFhirContext(), binding, clientInvocation, null, false, false, null, null, null, null, null);
 	}

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HistoryMethodBinding.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HistoryMethodBinding.java
@@ -145,7 +145,7 @@ public class HistoryMethodBinding extends BaseResourceReturningMethodBinding {
 			}
 		}
 
-		HttpGetClientInvocation retVal = new HttpGetClientInvocation(theContext, b.toString());
+		HttpGetClientInvocation retVal = new HttpGetClientInvocation(theContext, b.toString(), false);
 		return retVal;
 	}
 

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HttpGetClientInvocation.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HttpGetClientInvocation.java
@@ -43,20 +43,23 @@ public class HttpGetClientInvocation extends BaseHttpClientInvocation {
 	private final Map<String, List<String>> myParameters;
 	private final String myUrlPath;
 	private final UrlSourceEnum myUrlSource;
+	private final boolean doHeadRequest;
 
-	public HttpGetClientInvocation(FhirContext theContext, Map<String, List<String>> theParameters, String... theUrlFragments) {
-		this(theContext, theParameters, UrlSourceEnum.GENERATED, theUrlFragments);
+	public HttpGetClientInvocation(FhirContext theContext, Map<String, List<String>> theParameters, boolean useHead, String... theUrlFragments) {
+		this(theContext, theParameters, UrlSourceEnum.GENERATED, useHead, theUrlFragments);
 	}
 
-	public HttpGetClientInvocation(FhirContext theContext, Map<String, List<String>> theParameters, UrlSourceEnum theUrlSource, String... theUrlFragments) {
+	public HttpGetClientInvocation(FhirContext theContext, Map<String, List<String>> theParameters, UrlSourceEnum theUrlSource, boolean useHead, String... theUrlFragments) {
 		super(theContext);
 		myParameters = theParameters;
+		doHeadRequest = useHead;
 		myUrlPath = StringUtils.join(theUrlFragments, '/');
 		myUrlSource = theUrlSource;
 	}
 
-	public HttpGetClientInvocation(FhirContext theContext, String theUrlPath) {
+	public HttpGetClientInvocation(FhirContext theContext, String theUrlPath, boolean useHead) {
 		super(theContext);
+		doHeadRequest = useHead;
 		myParameters = new HashMap<>();
 		myUrlPath = theUrlPath;
 		myUrlSource = UrlSourceEnum.GENERATED;
@@ -103,7 +106,8 @@ public class HttpGetClientInvocation extends BaseHttpClientInvocation {
 
 		appendExtraParamsWithQuestionMark(theExtraParams, b, first);
 
-		IHttpRequest retVal = super.createHttpRequest(b.toString(), theEncoding, RequestTypeEnum.GET);
+		IHttpRequest retVal = super.createHttpRequest(b.toString(), theEncoding, 
+			doHeadRequest ? RequestTypeEnum.HEAD : RequestTypeEnum.GET);
 		retVal.setUrlSource(myUrlSource);
 
 		return retVal;

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/MethodUtil.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/MethodUtil.java
@@ -102,7 +102,7 @@ public class MethodUtil {
 	}
 
 	public static HttpGetClientInvocation createConformanceInvocation(FhirContext theContext) {
-		return new HttpGetClientInvocation(theContext, "metadata");
+		return new HttpGetClientInvocation(theContext, "metadata", false);
 	}
 
 	public static HttpPostClientInvocation createCreateInvocation(IBaseResource theResource, FhirContext theContext) {

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/OperationMethodBinding.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/OperationMethodBinding.java
@@ -211,7 +211,7 @@ public class OperationMethodBinding extends BaseResourceReturningMethodBinding {
 			IPrimitiveType<?> primitive = (IPrimitiveType<?>) value;
 			params.get(nextName).add(primitive.getValueAsString());
 		}
-		return new HttpGetClientInvocation(theContext, params, b.toString());
+		return new HttpGetClientInvocation(theContext, params, false, b.toString());
 	}
 
 	public static BaseHttpClientInvocation createProcessMsgInvocation(FhirContext theContext, String theOperationName, IBaseBundle theInput, Map<String, List<String>> urlParams) {

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/ReadMethodBinding.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/ReadMethodBinding.java
@@ -93,9 +93,9 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding implem
 		IIdType id = ((IIdType) theArgs[myIdIndex]);
 		String resourceName = getResourceName();
 		if (id.hasVersionIdPart()) {
-			retVal = createVReadInvocation(getContext(), new IdDt(resourceName, id.getIdPart(), id.getVersionIdPart()), resourceName);
+			retVal = createVReadInvocation(getContext(), new IdDt(resourceName, id.getIdPart(), id.getVersionIdPart()), resourceName, false);
 		} else {
-			retVal = createReadInvocation(getContext(), id, resourceName);
+			retVal = createReadInvocation(getContext(), id, resourceName, false);
 		}
 
 		for (int idx = 0; idx < theArgs.length; idx++) {
@@ -137,20 +137,20 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding implem
 		return mySupportsVersion;
 	}
 
-	public static HttpGetClientInvocation createAbsoluteReadInvocation(FhirContext theContext, IIdType theId) {
-		return new HttpGetClientInvocation(theContext, theId.toVersionless().getValue());
+	public static HttpGetClientInvocation createAbsoluteReadInvocation(FhirContext theContext, IIdType theId, boolean useHead) {
+		return new HttpGetClientInvocation(theContext, theId.toVersionless().getValue(), useHead);
 	}
 
-	public static HttpGetClientInvocation createAbsoluteVReadInvocation(FhirContext theContext, IIdType theId) {
-		return new HttpGetClientInvocation(theContext, theId.getValue());
+	public static HttpGetClientInvocation createAbsoluteVReadInvocation(FhirContext theContext, IIdType theId, boolean useHead) {
+		return new HttpGetClientInvocation(theContext, theId.getValue(), useHead);
 	}
 
-	public static HttpGetClientInvocation createReadInvocation(FhirContext theContext, IIdType theId, String theResourceName) {
-		return new HttpGetClientInvocation(theContext, new IdDt(theResourceName, theId.getIdPart()).getValue());
+	public static HttpGetClientInvocation createReadInvocation(FhirContext theContext, IIdType theId, String theResourceName, boolean useHead) {
+		return new HttpGetClientInvocation(theContext, new IdDt(theResourceName, theId.getIdPart()).getValue(), useHead);
 	}
 
-	public static HttpGetClientInvocation createVReadInvocation(FhirContext theContext, IIdType theId, String theResourceName) {
-		return new HttpGetClientInvocation(theContext, new IdDt(theResourceName, theId.getIdPart(), theId.getVersionIdPart()).getValue());
+	public static HttpGetClientInvocation createVReadInvocation(FhirContext theContext, IIdType theId, String theResourceName, boolean useHead) {
+		return new HttpGetClientInvocation(theContext, new IdDt(theResourceName, theId.getIdPart(), theId.getVersionIdPart()).getValue(), useHead);
 	}
 
 	@Override

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/SearchMethodBinding.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/SearchMethodBinding.java
@@ -23,7 +23,6 @@ package ca.uhn.fhir.rest.client.method;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.model.api.annotation.Description;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.api.Constants;
@@ -47,7 +46,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class SearchMethodBinding extends BaseResourceReturningMethodBinding {
 	private String myCompartmentName;
@@ -158,7 +156,7 @@ public class SearchMethodBinding extends BaseResourceReturningMethodBinding {
 	}
 
 	public static BaseHttpClientInvocation createSearchInvocation(FhirContext theContext, String theSearchUrl, UrlSourceEnum theUrlSource, Map<String, List<String>> theParams) {
-		return new HttpGetClientInvocation(theContext, theParams, theUrlSource, theSearchUrl);
+		return new HttpGetClientInvocation(theContext, theParams, theUrlSource, false, theSearchUrl);
 	}
 
 
@@ -199,16 +197,16 @@ public class SearchMethodBinding extends BaseResourceReturningMethodBinding {
 		case GET:
 		default:
 			if (compartmentSearch) {
-				invocation = new HttpGetClientInvocation(theContext, theParameters, theResourceName, theId.getIdPart(), theCompartmentName);
+				invocation = new HttpGetClientInvocation(theContext, theParameters, false, theResourceName, theId.getIdPart(), theCompartmentName);
 			} else {
-				invocation = new HttpGetClientInvocation(theContext, theParameters, theResourceName);
+				invocation = new HttpGetClientInvocation(theContext, theParameters, false, theResourceName);
 			}
 			break;
 		case GET_WITH_SEARCH:
 			if (compartmentSearch) {
-				invocation = new HttpGetClientInvocation(theContext, theParameters, theResourceName, theId.getIdPart(), theCompartmentName, Constants.PARAM_SEARCH);
+				invocation = new HttpGetClientInvocation(theContext, theParameters, false, theResourceName, theId.getIdPart(), theCompartmentName, Constants.PARAM_SEARCH);
 			} else {
-				invocation = new HttpGetClientInvocation(theContext, theParameters, theResourceName, Constants.PARAM_SEARCH);
+				invocation = new HttpGetClientInvocation(theContext, theParameters, false, theResourceName, Constants.PARAM_SEARCH);
 			}
 			break;
 		case POST:


### PR DESCRIPTION
Fixes https://github.com/hapifhir/hapi-fhir/issues/3366, see ticket for motivation.

Things I am uncertain about require guidance before proceeding:
- Name `useHead`. This is revealing a low-level detail of the transport (type of HTTP request) at a higher level where 'fhir' operations are exposed. However, there's no specific FHIR operation indicating that a HEAD request should be used.
- Extension of `HttpGetClientInvocation` to also send HEAD requests. This might be misleading.
- HTTP client implementations other than apache. I've only tested this with apache.
- Supporting HEAD requests in operations other than `read`

PR is marked draft as no additional tests are added yet.

Sample code showing use of this new API
```java
import ca.uhn.fhir.context.FhirContext;
import ca.uhn.fhir.rest.api.MethodOutcome;
import ca.uhn.fhir.rest.client.api.IGenericClient;
import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
import org.hl7.fhir.instance.model.api.IBaseResource;
import org.hl7.fhir.r4.model.IdType;
import org.hl7.fhir.r4.model.Patient;

public class Main {
	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Main.class);
	public static void main(String[] args) {
		FhirContext ctx = FhirContext.forR4();
		IGenericClient client = ctx.newRestfulGenericClient("http://hapi.fhir.org/baseR4");
		LoggingInterceptor loggingInterceptor = new LoggingInterceptor();
		loggingInterceptor.setLogRequestSummary(true);
		client.registerInterceptor(loggingInterceptor);
		Patient patient = new Patient();
		patient.addName()
			.setFamily("Jameson")
			.addGiven("J")
			.addGiven("Jonah");
		IdType patientID = IdType.newRandomUuid();
		patient.setId(patientID);
		log.info("Patient exists: {}", patientExists(client, patientID.getValue()));
		MethodOutcome methodOutcome = client.create().resource(patient).execute();
		patient = (Patient) methodOutcome.getResource();
		log.info("Patient exists: {}", patientExists(client, patient.getId()));
	}

	private static boolean patientExists(IGenericClient client, String id) {
		try {
			IBaseResource ignored = client.read().resource(Patient.class).withId(id).useHead(true).execute();
			return true;
		} catch (ResourceNotFoundException ignored) {
			return false;
		}
	}
}
```