### PR TITLE
return implementations instead of interfaces in spring batch job configs. 

### DIFF
--- a/hapi-fhir-batch/src/test/java/ca/uhn/fhir/jpa/batch/config/BatchJobConfig.java
+++ b/hapi-fhir-batch/src/test/java/ca/uhn/fhir/jpa/batch/config/BatchJobConfig.java
@@ -44,7 +44,7 @@ public class BatchJobConfig {
 
 	@Bean
 	@StepScope
-	public ItemReader<String> reader() {
+	public SampleItemReader reader() {
 		return new SampleItemReader();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/mdm/job/MdmClearJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch/mdm/job/MdmClearJobConfig.java
@@ -94,7 +94,7 @@ public class MdmClearJobConfig {
 
 	@Bean
 	@StepScope
-	public ItemProcessor<List<Long>, List<String>> deleteThenExpungeCompositeProcessor() {
+	public CompositeItemProcessor<List<Long>, List<String>> deleteThenExpungeCompositeProcessor() {
 		CompositeItemProcessor<List<Long>, List<String>> compositeProcessor = new CompositeItemProcessor<>();
 		List itemProcessors = new ArrayList<>();
 		itemProcessors.add(mdmLinkDeleter());

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/imprt/job/BulkImportJobConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/imprt/job/BulkImportJobConfig.java
@@ -177,7 +177,7 @@ public class BulkImportJobConfig {
 
 	@Bean
 	@StepScope
-	public ItemWriter<ParsedBulkImportRecord> bulkImportFileWriter() {
+	public BulkImportFileWriter bulkImportFileWriter() {
 		return new BulkImportFileWriter();
 	}
 


### PR DESCRIPTION
* This prevents the following warnings from appearing in our logs: 
```
16:24:47.357 [main] WARN  M: R: o.s.b.c.l.AbstractListenerFactoryBean - org.springframework.batch.item.ItemWriter is an interface. The implementing class will not be queried for annotation based listener configurations. If using @StepScope on a @Bean method, be sure to return the implementing class so listener annotations can be used.
```