### PR TITLE
Run online index operations non-transactionally on Postgres

### DIFF
--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddIndexTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddIndexTask.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -135,6 +134,8 @@ public class AddIndexTask extends BaseTableTask {
 			switch (getDriverType()) {
 				case POSTGRES_9_4:
 					postgresOnline = "CONCURRENTLY ";
+					// This runs without a lock, and can't be done transactionally.
+					setTransactional(false);
 					break;
 				case ORACLE_12C:
 					oracleOnlineDeferred = " ONLINE DEFERRED INVALIDATION";

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
@@ -54,6 +54,16 @@ public abstract class BaseTask {
 	private String myDescription;
 	private int myChangesCount;
 	private boolean myDryRun;
+
+	/**
+	 * Some migrations can not be run in a transaction.
+	 * When this is true, {@link BaseTask#executeSql} will run without a transaction
+	 */
+	public void setTransactional(boolean theTransactional) {
+		myTransactional = theTransactional;
+	}
+
+	private boolean myTransactional = true;
 	private boolean myDoNothing;
 	private List<ExecutedStatement> myExecutedStatements = new ArrayList<>();
 	private Set<DriverTypeEnum> myOnlyAppliesToPlatforms = new HashSet<>();
@@ -134,32 +144,41 @@ public abstract class BaseTask {
 	 * @param theArguments The SQL statement arguments
 	 */
 	public void executeSql(String theTableName, @Language("SQL") String theSql, Object... theArguments) {
-		if (isDryRun() == false) {
-			Integer changes = getConnectionProperties().getTxTemplate().execute(t -> {
-				JdbcTemplate jdbcTemplate = getConnectionProperties().newJdbcTemplate();
-				try {
-					int changesCount = jdbcTemplate.update(theSql, theArguments);
-					if (!"true".equals(System.getProperty("unit_test_mode"))) {
-						logInfo(ourLog, "SQL \"{}\" returned {}", theSql, changesCount);
-					}
-					return changesCount;
-				} catch (DataAccessException e) {
-					if (myFailureAllowed) {
-						ourLog.info("Task {} did not exit successfully, but task is allowed to fail", getFlywayVersion());
-						ourLog.debug("Error was: {}", e.getMessage(), e);
-						return 0;
-					} else {
-						throw new DataAccessException(Msg.code(61) + "Failed during task " + getFlywayVersion() + ": " + e, e) {
-							private static final long serialVersionUID = 8211678931579252166L;
-						};
-					}
-				}
-			});
+		if (!isDryRun()) {
+			Integer changes;
+			if (myTransactional) {
+				changes = getConnectionProperties().getTxTemplate().execute(t -> {
+					return doExecuteSql(theSql, theArguments);
+				});
+			} else {
+				changes =  doExecuteSql(theSql, theArguments);
+			}
 
 			myChangesCount += changes;
 		}
 
 		captureExecutedStatement(theTableName, theSql, theArguments);
+	}
+
+	private int doExecuteSql(@Language("SQL") String theSql, Object[] theArguments) {
+		JdbcTemplate jdbcTemplate = getConnectionProperties().newJdbcTemplate();
+		try {
+			int changesCount = jdbcTemplate.update(theSql, theArguments);
+			if (!"true".equals(System.getProperty("unit_test_mode"))) {
+				logInfo(ourLog, "SQL \"{}\" returned {}", theSql, changesCount);
+			}
+			return changesCount;
+		} catch (DataAccessException e) {
+			if (myFailureAllowed) {
+				ourLog.info("Task {} did not exit successfully, but task is allowed to fail", getFlywayVersion());
+				ourLog.debug("Error was: {}", e.getMessage(), e);
+				return 0;
+			} else {
+				throw new DataAccessException(Msg.code(61) + "Failed during task " + getFlywayVersion() + ": " + e, e) {
+					private static final long serialVersionUID = 8211678931579252166L;
+				};
+			}
+		}
 	}
 
 	protected void captureExecutedStatement(String theTableName, @Language("SQL") String theSql, Object[] theArguments) {

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropIndexTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropIndexTask.java
@@ -92,6 +92,7 @@ public class DropIndexTask extends BaseTableTask {
 				case POSTGRES_9_4:
 					sql.add("alter table " + getTableName() + " drop constraint if exists " + myIndexName + " cascade");
 					sql.add("drop index " + (myOnline?"CONCURRENTLY ":"") + "if exists " + myIndexName + " cascade");
+					setTransactional(false);
 					break;
 			}
 		} else {
@@ -103,6 +104,7 @@ public class DropIndexTask extends BaseTableTask {
 					break;
 				case POSTGRES_9_4:
 					sql.add("drop index " + (myOnline?"CONCURRENTLY ":"") + myIndexName);
+					setTransactional(false);
 					break;
 				case DERBY_EMBEDDED:
 				case H2_EMBEDDED:

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropIndexTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropIndexTask.java
@@ -92,7 +92,7 @@ public class DropIndexTask extends BaseTableTask {
 				case POSTGRES_9_4:
 					sql.add("alter table " + getTableName() + " drop constraint if exists " + myIndexName + " cascade");
 					sql.add("drop index " + (myOnline?"CONCURRENTLY ":"") + "if exists " + myIndexName + " cascade");
-					setTransactional(false);
+					setTransactional(!myOnline);
 					break;
 			}
 		} else {
@@ -104,7 +104,7 @@ public class DropIndexTask extends BaseTableTask {
 					break;
 				case POSTGRES_9_4:
 					sql.add("drop index " + (myOnline?"CONCURRENTLY ":"") + myIndexName);
-					setTransactional(false);
+					setTransactional(!myOnline);
 					break;
 				case DERBY_EMBEDDED:
 				case H2_EMBEDDED:


### PR DESCRIPTION
Oracle just ignores the transaction, but Postgres actually fails.  So we add a `transactional` boolean property to tasks, and set it for add/drop index when online.