### PR TITLE
Skip database query when hibernate search fully satisfies search

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3478-fast-hibernate-search.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3478-fast-hibernate-search.yaml
@@ -1,0 +1,6 @@
+---
+type: perf
+issue: 3478
+title: "When using JPA persistence with Hibernate Search (Lucene or Elasticsearch), simple FHIR queries that can be 
+ satisfied completely by Hibernate Search no longer query the database.  Before, every search involved the database,
+ even when not needed.  This is faster when there are many results."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -1750,6 +1750,9 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			if (myDaoConfig.isAdvancedLuceneIndexing()) {
 				ExtendedLuceneIndexData luceneIndexData = myFulltextSearchSvc.extractLuceneIndexData(theResource, theNewParams);
 				theEntity.setLuceneIndexData(luceneIndexData);
+				if(myDaoConfig.isStoreResourceInLuceneIndex()) {
+					theEntity.setRawResourceData(theContext.newJsonParser().encodeResourceToString(theResource));
+				}
 			}
 		}
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -813,9 +813,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 
 	private <MT extends IBaseMetaType> void doMetaDelete(MT theMetaDel, BaseHasResource theEntity, RequestDetails theRequestDetails, TransactionDetails theTransactionDetails) {
 
-		// fixme mb update hibernate search.
 		IBaseResource oldVersion = toResource(theEntity, false);
-
 
 		List<TagDefinition> tags = toTagList(theMetaDel);
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -813,6 +813,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 
 	private <MT extends IBaseMetaType> void doMetaDelete(MT theMetaDel, BaseHasResource theEntity, RequestDetails theRequestDetails, TransactionDetails theTransactionDetails) {
 
+		// fixme mb update hibernate search.
 		IBaseResource oldVersion = toResource(theEntity, false);
 
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
@@ -281,7 +281,6 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 					f.field("myId", Long.class),
 					f.field("myForcedId", String.class),
 					f.field("myRawResource", String.class))
-				//f -> f.field("myRawResource", String.class)
 			)
 			.where(
 				f -> f.id().matchingAny(thePids) // matches '_id' from resource index

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneClauseBuilder;
 import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneIndexExtractor;
 import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneSearchBuilder;
 import ca.uhn.fhir.jpa.dao.search.LastNOperation;
+import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneResourceProjection;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.search.ExtendedLuceneIndexData;
 import ca.uhn.fhir.jpa.search.autocomplete.ValueSetAutocompleteOptions;
@@ -35,7 +36,6 @@ import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
 import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
 import ca.uhn.fhir.model.api.IQueryParameterType;
-import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -271,40 +271,13 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 		return convertLongsToResourcePersistentIds(pidList);
 	}
 
-	public static class ResourceProjection {
-		final long myPid;
-		final String myForcedId;
-		final String myResourceString;
-
-		public ResourceProjection(long thePid, String theForcedId, String theResourceString) {
-			myPid = thePid;
-			myForcedId = theForcedId;
-			myResourceString = theResourceString;
-		}
-
-		public IBaseResource toResource(IParser theParser) {
-			// fixme test
-			IBaseResource result = theParser.parseResource(myResourceString);
-
-			IdDt id;
-			if (myForcedId != null) {
-				id = new IdDt(myForcedId);
-			} else {
-				id = new IdDt(myPid);
-			}
-			result.setId(id);
-
-			return result;
-		}
-	}
-
 	@Override
 	public List<IBaseResource> getResources(Collection<Long> thePids) {
 		SearchSession session = getSearchSession();
-		List<ResourceProjection> rawResourceDataList = session.search(ResourceTable.class)
+		List<ExtendedLuceneResourceProjection> rawResourceDataList = session.search(ResourceTable.class)
 			.select(
 				f -> f.composite(
-					(pid, forcedId, resource)-> new ResourceProjection(pid, forcedId, resource),
+					(pid, forcedId, resource)-> new ExtendedLuceneResourceProjection(pid, forcedId, resource),
 					f.field("myId", Long.class),
 					f.field("myForcedId", String.class),
 					f.field("myRawResource", String.class))

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
@@ -23,11 +23,12 @@ package ca.uhn.fhir.jpa.dao;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
+import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneClauseBuilder;
 import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneIndexExtractor;
+import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneResourceProjection;
 import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneSearchBuilder;
 import ca.uhn.fhir.jpa.dao.search.LastNOperation;
-import ca.uhn.fhir.jpa.dao.search.ExtendedLuceneResourceProjection;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.search.ExtendedLuceneIndexData;
 import ca.uhn.fhir.jpa.search.autocomplete.ValueSetAutocompleteOptions;
@@ -38,10 +39,7 @@ import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.Constants;
-import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
-import ca.uhn.fhir.rest.param.StringParam;
-import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.rest.server.util.ResourceSearchParams;
 import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
@@ -49,7 +47,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.util.common.SearchException;
-import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -80,6 +77,9 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 	private DaoConfig myDaoConfig;
 	@Autowired
 	ISearchParamExtractor mySearchParamExtractor;
+	@Autowired
+	IIdHelperService myIdHelperService;
+
 	final private ExtendedLuceneSearchBuilder myAdvancedIndexQueryBuilder = new ExtendedLuceneSearchBuilder();
 
 	private Boolean ourDisabled;
@@ -140,7 +140,7 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 					/*
 					 * Handle _text parameter (resource narrative content)
 					 *
-					 * Positerity:
+					 * Posterity:
 					 * We do not want the HAPI-FHIR dao's to process the
 					 * _text parameter, so we remove it from the map here
 					 */
@@ -158,7 +158,7 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 					/*
 					 * Handle other supported parameters
 					 */
-					if (myDaoConfig.isAdvancedLuceneIndexing()) {
+					if (myDaoConfig.isAdvancedLuceneIndexing() && theParams.getEverythingMode() == null) {
 						myAdvancedIndexQueryBuilder.addAndConsumeAdvancedQueryClauses(builder, theResourceType, theParams, mySearchParamRegistry);
 					}
 					//DROP EARLY HERE IF BOOL IS EMPTY?
@@ -181,26 +181,12 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 	}
 
 	@Override
-	public List<ResourcePersistentId> everything(String theResourceName, SearchParameterMap theParams, RequestDetails theRequest) {
+	public List<ResourcePersistentId> everything(String theResourceName, SearchParameterMap theParams, ResourcePersistentId theReferencingPid) {
 
-		ResourcePersistentId pid = null;
-		if (theParams.get(IAnyResource.SP_RES_ID) != null) {
-			String idParamValue;
-			IQueryParameterType idParam = theParams.get(IAnyResource.SP_RES_ID).get(0).get(0);
-			if (idParam instanceof TokenParam) {
-				TokenParam idParm = (TokenParam) idParam;
-				idParamValue = idParm.getValue();
-			} else {
-				StringParam idParm = (StringParam) idParam;
-				idParamValue = idParm.getValue();
-			}
-//			pid = myIdHelperService.translateForcedIdToPid_(theResourceName, idParamValue, theRequest);
-		}
 
-		ResourcePersistentId referencingPid = pid;
-		List<ResourcePersistentId> retVal = doSearch(null, theParams, referencingPid);
-		if (referencingPid != null) {
-			retVal.add(referencingPid);
+		List<ResourcePersistentId> retVal = doSearch(null, theParams, theReferencingPid);
+		if (theReferencingPid != null) {
+			retVal.add(theReferencingPid);
 		}
 		return retVal;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/IFulltextSearchSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/IFulltextSearchSvc.java
@@ -20,6 +20,7 @@ package ca.uhn.fhir.jpa.dao;
  * #L%
  */
 
+import java.util.Collection;
 import java.util.List;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -71,5 +72,13 @@ public interface IFulltextSearchSvc {
 	 void reindex(ResourceTable theEntity);
 
 	List<ResourcePersistentId> lastN(SearchParameterMap theParams, Integer theMaximumResults);
+
+	/**
+	 * Returns inlined resource stored along with index mappings for matched identifiers
+	 *
+	 * @param thePids
+	 * @return Resources list or empty if nothing found
+	 */
+	List<IBaseResource> getResources(Collection<ResourcePersistentId> thePids);
 
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/IFulltextSearchSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/IFulltextSearchSvc.java
@@ -20,10 +20,6 @@ package ca.uhn.fhir.jpa.dao;
  * #L%
  */
 
-import java.util.Collection;
-import java.util.List;
-
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.search.ExtendedLuceneIndexData;
 import ca.uhn.fhir.jpa.search.autocomplete.ValueSetAutocompleteOptions;
@@ -32,6 +28,9 @@ import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import java.util.Collection;
+import java.util.List;
 
 public interface IFulltextSearchSvc {
 
@@ -76,9 +75,9 @@ public interface IFulltextSearchSvc {
 	/**
 	 * Returns inlined resource stored along with index mappings for matched identifiers
 	 *
-	 * @param thePids
+	 * @param thePids raw pids - we dont support versioned references
 	 * @return Resources list or empty if nothing found
 	 */
-	List<IBaseResource> getResources(Collection<ResourcePersistentId> thePids);
+	List<IBaseResource> getResources(Collection<Long> thePids);
 
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/IFulltextSearchSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/IFulltextSearchSvc.java
@@ -25,7 +25,6 @@ import ca.uhn.fhir.jpa.model.search.ExtendedLuceneIndexData;
 import ca.uhn.fhir.jpa.search.autocomplete.ValueSetAutocompleteOptions;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
-import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -52,7 +51,7 @@ public interface IFulltextSearchSvc {
 	 */
 	IBaseResource tokenAutocompleteValueSetSearch(ValueSetAutocompleteOptions theOptions);
 
-	List<ResourcePersistentId> everything(String theResourceName, SearchParameterMap theParams, RequestDetails theRequest);
+	List<ResourcePersistentId> everything(String theResourceName, SearchParameterMap theParams, ResourcePersistentId theReferencingPid);
 
 	boolean isDisabled();
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/LegacySearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/LegacySearchBuilder.java
@@ -20,12 +20,12 @@ package ca.uhn.fhir.jpa.dao;
  * #L%
  */
 
-import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.context.ComboSearchParamType;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.Pointcut;
@@ -35,7 +35,6 @@ import ca.uhn.fhir.jpa.api.dao.IDao;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.dao.data.IResourceSearchViewDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceTagDao;
-import ca.uhn.fhir.jpa.dao.index.IdHelperService;
 import ca.uhn.fhir.jpa.dao.predicate.PredicateBuilder;
 import ca.uhn.fhir.jpa.dao.predicate.PredicateBuilderFactory;
 import ca.uhn.fhir.jpa.dao.predicate.SearchBuilderJoinEnum;
@@ -54,13 +53,10 @@ import ca.uhn.fhir.jpa.model.search.StorageProcessingMessage;
 import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
 import ca.uhn.fhir.jpa.search.lastn.IElasticsearchSvc;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
-import ca.uhn.fhir.rest.param.TokenParam;
-import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.jpa.searchparam.util.Dstu3DistanceHelper;
 import ca.uhn.fhir.jpa.searchparam.util.LastNParameterHelper;
 import ca.uhn.fhir.jpa.util.BaseIterator;
 import ca.uhn.fhir.jpa.util.CurrentThreadCaptureQueriesListener;
-import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
 import ca.uhn.fhir.jpa.util.QueryChunker;
 import ca.uhn.fhir.jpa.util.ScrollableResultsIterator;
 import ca.uhn.fhir.jpa.util.SqlQueryList;
@@ -80,8 +76,11 @@ import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
+import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.util.StopWatch;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -288,7 +287,7 @@ public class LegacySearchBuilder implements ISearchBuilder {
 				}
 
 				if (myParams.getEverythingMode() != null) {
-					pids = myFulltextSearchSvc.everything(myResourceName, myParams, theRequest);
+					pids = queryHibernateSearchForEverythingPids();
 				} else {
 					pids = myFulltextSearchSvc.search(myResourceName, myParams);
 				}
@@ -331,6 +330,25 @@ public class LegacySearchBuilder implements ISearchBuilder {
 		}
 
 		return myQueries;
+	}
+
+	private List<ResourcePersistentId> queryHibernateSearchForEverythingPids() {
+		ResourcePersistentId pid = null;
+		if (myParams.get(IAnyResource.SP_RES_ID) != null) {
+			String idParamValue;
+			IQueryParameterType idParam = myParams.get(IAnyResource.SP_RES_ID).get(0).get(0);
+			if (idParam instanceof TokenParam) {
+				TokenParam idParm = (TokenParam) idParam;
+				idParamValue = idParm.getValue();
+			} else {
+				StringParam idParm = (StringParam) idParam;
+				idParamValue = idParm.getValue();
+			}
+
+			pid = myIdHelperService.resolveResourcePersistentIds(myRequestPartitionId, myResourceName, idParamValue);
+		}
+		List<ResourcePersistentId> pids = myFulltextSearchSvc.everything(myResourceName, myParams, pid);
+		return pids;
 	}
 
 	private void doCreateChunkedQueries(List<Long> thePids, SortSpec sort, Integer theOffset, boolean theCount, RequestDetails theRequest, ArrayList<TypedQuery<Long>> theQueries) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneIndexExtractor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneIndexExtractor.java
@@ -61,6 +61,8 @@ public class ExtendedLuceneIndexExtractor {
 	public ExtendedLuceneIndexData extract(IBaseResource theResource, ResourceIndexedSearchParams theNewParams) {
 		ExtendedLuceneIndexData retVal = new ExtendedLuceneIndexData(myContext);
 
+		retVal.setForcedId(theResource.getIdElement().getIdPart());
+
 		extractAutocompleteTokens(theResource, retVal);
 
 		theNewParams.myStringParams.forEach(nextParam ->

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneResourceProjection.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneResourceProjection.java
@@ -1,0 +1,34 @@
+package ca.uhn.fhir.jpa.dao.search;
+
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.parser.IParser;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/**
+ * Query result when fetching full resources from Hibernate Search.
+ */
+public class ExtendedLuceneResourceProjection {
+	final long myPid;
+	final String myForcedId;
+	final String myResourceString;
+
+	public ExtendedLuceneResourceProjection(long thePid, String theForcedId, String theResourceString) {
+		myPid = thePid;
+		myForcedId = theForcedId;
+		myResourceString = theResourceString;
+	}
+
+	public IBaseResource toResource(IParser theParser) {
+		IBaseResource result = theParser.parseResource(myResourceString);
+
+		IdDt id;
+		if (myForcedId != null) {
+			id = new IdDt(myForcedId);
+		} else {
+			id = new IdDt(myPid);
+		}
+		result.setId(id);
+
+		return result;
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/package-info.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/package-info.java
@@ -16,6 +16,12 @@
  * This pid list is used as a narrowing where clause against the remaining unprocessed search parameters in a jdbc query.
  * The actual queries for the different search types (e.g. token, string, modifiers, etc.) are
  * generated in {@link ca.uhn.fhir.jpa.dao.search.ExtendedLuceneSearchBuilder}.
+ * <p>
+ *    Full resource bodies can be stored in the Hibernate Search index.
+ *    The {@link ca.uhn.fhir.jpa.dao.search.ExtendedLuceneResourceProjection} is used to extract these.
+ *    This is currently restricted to LastN, and misses tag changes from $meta-add and $meta-delete since those don't
+ *    update Hibernate Search.
+ * </p>
  *
  * <h2>Operation</h2>
  * During startup, Hibernate Search uses {@link ca.uhn.fhir.jpa.model.search.SearchParamTextPropertyBinder} to generate a schema.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/autocomplete/ValueSetAutocompleteSearch.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/autocomplete/ValueSetAutocompleteSearch.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.param.TokenParam;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.ValueSet;
 
 import java.util.List;
@@ -47,6 +48,7 @@ public class ValueSetAutocompleteSearch {
 		ValueSet result = new ValueSet();
 		ValueSet.ValueSetExpansionComponent expansion = new ValueSet.ValueSetExpansionComponent();
 		result.setExpansion(expansion);
+		result.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		aggEntries.stream()
 			.map(this::makeCoding)
 			.forEach(expansion::addContains);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/ISearchQueryExecutor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/ISearchQueryExecutor.java
@@ -1,0 +1,12 @@
+package ca.uhn.fhir.jpa.search.builder;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface ISearchQueryExecutor extends Iterator<Long>, Closeable {
+	/**
+	 * Narrow the signature - no IOException allowed.
+	 */
+	@Override
+	void close();
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -908,6 +908,8 @@ public class SearchBuilder implements ISearchBuilder {
 
 		// is storage enabled?
 		return myDaoConfig.isStoreResourceInLuceneIndex() &&
+			// only support lastN for now.
+			myParams.isLastN() &&
 			// do we need to worry about versions?
 			theIncludedPids.isEmpty() &&
 			// fixme What's this about Jaison?

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -348,6 +348,16 @@ public class SearchBuilder implements ISearchBuilder {
 					(!myPartitionSettings.isPartitioningEnabled() &&
 					// were there AND terms left?  Then we still need the db.
 						theParams.isEmpty() &&
+						// not every param is a param. :-(
+						theParams.getEverythingMode() == null &&
+						theParams.getCount() == null &&
+						theParams.getOffset() == null &&
+						theParams.getLastUpdated() == null &&
+						theParams.getSort() == null &&
+						theParams.getNearDistanceParam() == null &&
+						theParams.getLastUpdated() == null &&
+						// todo MB Ugh - review with someone else
+						//theParams.toNormalizedQueryString(myContext).length() <= 1 &&
 						// or sorting?
 						theParams.getSort() == null);
 
@@ -383,7 +393,7 @@ public class SearchBuilder implements ISearchBuilder {
 		}
 
 		// TODO MB someday we'll want a query planner to figure out if we _should_ or _must_ use the ft index, not just if we can.
-		return fulltextEnabled &&
+		return fulltextEnabled && myParams.getSearchContainedMode() == SearchContainedModeEnum.FALSE &&
 			myFulltextSearchSvc.supportsSomeOf(myParams);
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryExecutor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryExecutor.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.search.builder.sql;
  */
 
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.search.builder.ISearchQueryExecutor;
 import ca.uhn.fhir.jpa.util.ScrollableResultsIterator;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.IoUtil;
@@ -35,12 +36,10 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceContextType;
 import javax.persistence.Query;
-import java.io.Closeable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.util.Iterator;
 
-public class SearchQueryExecutor implements Iterator<Long>, Closeable {
+public class SearchQueryExecutor implements ISearchQueryExecutor {
 
 	private static final Long NO_MORE = -1L;
 	private static final SearchQueryExecutor NO_VALUE_EXECUTOR = new SearchQueryExecutor();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/TestDaoSearch.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/TestDaoSearch.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.server.method.SortParameter;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,6 +44,11 @@ public class TestDaoSearch {
 		myMatchUrlService = theMatchUrlService;
 		myDaoRegistry = theDaoRegistry;
 		myFhirCtx = theFhirCtx;
+	}
+
+	public List<IBaseResource> searchForResources(String theQueryUrl) {
+		IBundleProvider result = searchForBundleProvider(theQueryUrl);
+		return result.getAllResources();
 	}
 
 	public List<String> searchForIds(String theQueryUrl) {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/TestDaoSearch.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/TestDaoSearch.java
@@ -61,17 +61,29 @@ public class TestDaoSearch {
 
 	public IBundleProvider searchForBundleProvider(String theQueryUrl) {
 		ResourceSearch search = myMatchUrlService.getResourceSearch(theQueryUrl);
+		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(search.getResourceName());
+
 		SearchParameterMap map = search.getSearchParameterMap();
 		map.setLoadSynchronous(true);
-		SystemRequestDetails request = fakeRequestDetailsFromUrl(theQueryUrl);
-		SortSpec sort = (SortSpec) new SortParameter(myFhirCtx).translateQueryParametersIntoServerArgument(request, null);
+		SortSpec sort = (SortSpec) new SortParameter(myFhirCtx).translateQueryParametersIntoServerArgument(fakeRequestDetailsFromUrl(theQueryUrl), null);
 		if (sort != null) {
 			map.setSort(sort);
 		}
 
-		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(search.getResourceName());
-		IBundleProvider result = dao.search(map, request);
+		IBundleProvider result = dao.search(map, fakeRequestDetailsFromUrl(theQueryUrl));
 		return result;
+	}
+
+	public SearchParameterMap toSearchParameters(String theQueryUrl) {
+		ResourceSearch search = myMatchUrlService.getResourceSearch(theQueryUrl);
+
+		SearchParameterMap map = search.getSearchParameterMap();
+		map.setLoadSynchronous(true);
+		SortSpec sort = (SortSpec) new SortParameter(myFhirCtx).translateQueryParametersIntoServerArgument(fakeRequestDetailsFromUrl(theQueryUrl), null);
+		if (sort != null) {
+			map.setSort(sort);
+		}
+		return map;
 	}
 
 	@Nonnull

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchLastNUsingExtendedLuceneIndexIT.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchLastNUsingExtendedLuceneIndexIT.java
@@ -1,17 +1,37 @@
 package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
+import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Run entire @see {@link FhirResourceDaoR4SearchLastNIT} test suite this time
- * using Extended Lucene index as search target
+ * using Extended Lucene index as search target.
+ *
+ * The other implementation is obsolete, and we can merge these someday.
  */
 @ExtendWith(SpringExtension.class)
 public class FhirResourceDaoR4SearchLastNUsingExtendedLuceneIndexIT extends FhirResourceDaoR4SearchLastNIT {
+	// awkward override so we can spy
+	@SpyBean
+	@Autowired(required = false)
+	IFulltextSearchSvc myFulltestSearchSvc;
 
 	@BeforeEach
 	public void enableAdvancedLuceneIndexing() {
@@ -21,6 +41,27 @@ public class FhirResourceDaoR4SearchLastNUsingExtendedLuceneIndexIT extends Fhir
 	@AfterEach
 	public void disableAdvancedLuceneIndex() {
 		myDaoConfig.setAdvancedLuceneIndexing(new DaoConfig().isAdvancedLuceneIndexing());
+	}
+
+	/**
+	 * We pull the resources from Hibernate Search when LastN uses Hibernate Search.
+	 * Override the test verification
+	 */
+	@Override
+	void verifyResourcesLoadedFromElastic(List<IIdType> theObservationIds, List<String> theResults) {
+		List<Long> expectedArgumentPids =
+			theObservationIds.stream().map(IIdType::getIdPartAsLong).collect(Collectors.toList());
+
+		ArgumentCaptor<List<Long>> actualPids = ArgumentCaptor.forClass(List.class);
+
+		verify(myFulltestSearchSvc, times(1)).getResources(actualPids.capture());
+		assertThat(actualPids.getValue(), is(expectedArgumentPids));
+
+		// we don't include the type in the id returned from Hibernate Search for now.
+		List<String> expectedObservationList = theObservationIds.stream()
+			.map(id -> id.toUnqualifiedVersionless().getIdPart()).collect(Collectors.toList());
+		assertEquals(expectedObservationList, theResults);
+
 	}
 
 }

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -82,6 +82,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(SpringExtension.class)
 @RequiresDocker
@@ -822,6 +823,18 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 
 			assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		}
+
+		@Test
+		public void forcedIdSurvives() {
+			fail();
+		}
+
+		@Test
+		public void tagsSurvive() {
+			// do we need to support DSTU2?
+			fail();
+		}
+
 
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -440,6 +440,10 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 			map.add("code", new TokenParam("Bodum").setModifier(TokenParamModifier.TEXT));
 			assertObservationSearchMatchesNothing("search with shared prefix does not match", map);
 		}
+
+		{
+			assertObservationSearchMatches("empty params finds everything", "Observation?", id1, id2, id3, id4);
+		}
 	}
 
 	@Test
@@ -531,6 +535,11 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 
 	private void assertObservationSearchMatches(String message, SearchParameterMap map, IIdType... iIdTypes) {
 		assertThat(message, toUnqualifiedVersionlessIdValues(myObservationDao.search(map)), containsInAnyOrder(toValues(iIdTypes)));
+	}
+
+	private void assertObservationSearchMatches(String theMessage, String theSearch, IIdType... theIds) {
+		SearchParameterMap map = myTestDaoSearch.toSearchParameters(theSearch);
+		assertObservationSearchMatches(theMessage, map, theIds);
 	}
 
 	@Nested

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -781,12 +781,11 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 	}
 
 	/**
-	 * We have a fast path that skips the database entirely
-	 * when we can satisfy the queries completely from Hibernate Search.
+	 * Some queries can be satisfied directly from Hibernate Search.
+	 * We still need at least one query to fetch the resources.
 	 */
 	@Nested
 	public class FastPath {
-		// fixme clean this up.  New test for fast-ish path?
 		@BeforeEach
 		public void enableResourceStorage() {
 			myDaoConfig.setStoreResourceInLuceneIndex(false);
@@ -809,7 +808,7 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 
 			assertThat(ids, hasSize(1));
 			assertThat(ids, contains(id.getIdPart()));
-			assertEquals(1, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size(), "we build the bundle with no sql");
+			assertEquals(1, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size(), "sql just to fetch resources");
 		}
 
 		@Test
@@ -824,7 +823,7 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 			assertThat(ids, hasSize(1));
 			assertThat(ids, contains(id.getIdPart()));
 
-			assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size(), "the pids come from elastic, but we use sql to sort");
+			assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size(), "the pids come from elastic, but we use sql to sort, and fetch resources");
 		}
 
 		@Test
@@ -839,7 +838,7 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 
 			assertThat(ids, hasSize(0));
 
-			assertEquals(0, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size(), "the pids come from elastic");
+			assertEquals(0, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size(), "the pids come from elastic, and nothing to fetch");
 		}
 
 		@Test

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4StandardQueriesNoFTTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4StandardQueriesNoFTTest.java
@@ -190,7 +190,7 @@ public class FhirResourceDaoR4StandardQueriesNoFTTest extends BaseJpaTest {
 				withRiskAssessmentWithProbabilty(0.6);
 
 				assertNotFind("when gt", "/RiskAssessment?probability=0.5");
-				// fixme we break the spec here.
+				// TODO we break the spec here.  Default search should be approx
 				// assertFind("when a little gt - default is approx", "/RiskAssessment?probability=0.599");
 				// assertFind("when a little lt - default is approx", "/RiskAssessment?probability=0.601");
 				assertFind("when eq", "/RiskAssessment?probability=0.6");
@@ -301,10 +301,10 @@ public class FhirResourceDaoR4StandardQueriesNoFTTest extends BaseJpaTest {
 
 				assertNotFind("when gt", "/Observation?value-quantity=0.5||mmHg");
 				assertNotFind("when gt unitless", "/Observation?value-quantity=0.5");
-				// fixme we break the spec here.
+				// TODO we break the spec here.  Default search should be approx
 				// assertFind("when a little gt - default is approx", "/Observation?value-quantity=0.599");
 				// assertFind("when a little lt - default is approx", "/Observation?value-quantity=0.601");
-				// fixme we don't seem to support "units", only "code".
+				// TODO we don't seem to support "units", only "code".
 				assertFind("when eq with units", "/Observation?value-quantity=0.6||mm[Hg]");
 				assertFind("when eq unitless", "/Observation?value-quantity=0.6");
 				assertNotFind("when lt", "/Observation?value-quantity=0.7||mmHg");

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneResourceProjectionTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneResourceProjectionTest.java
@@ -1,0 +1,40 @@
+package ca.uhn.fhir.jpa.dao.search;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Observation;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+class ExtendedLuceneResourceProjectionTest {
+	final FhirContext myFhirContext = FhirContext.forR4();
+	final IParser myParser = myFhirContext.newJsonParser();
+	ExtendedLuceneResourceProjection myProjection;
+	IBaseResource myResource;
+
+	@Test
+	public void basicBodyReceivesId() {
+		myProjection = new ExtendedLuceneResourceProjection(22, null, "{ \"resourceType\":\"Observation\"}");
+
+		myResource = myProjection.toResource(myParser);
+
+		assertThat(myResource, instanceOf(Observation.class));
+		assertThat(myResource.getIdElement().getIdPart(), equalTo("22"));
+	}
+
+	@Test
+	public void forcedIdOverridesPid() {
+		myProjection = new ExtendedLuceneResourceProjection(22, "force-id", "{ \"resourceType\":\"Observation\"}");
+
+		myResource = myProjection.toResource(myParser);
+
+		assertThat(myResource, instanceOf(Observation.class));
+		assertThat(myResource.getIdElement().getIdPart(), equalTo("force-id"));
+	}
+
+
+}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/search/autocomplete/TokenAutocompleteElasticsearchIT.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/search/autocomplete/TokenAutocompleteElasticsearchIT.java
@@ -20,6 +20,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hibernate.search.mapper.orm.Search;
+import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Observation;
@@ -193,7 +194,7 @@ public class TokenAutocompleteElasticsearchIT extends BaseJpaTest{
 	}
 
 	@Nonnull
-	private Matcher<TokenAutocompleteHit> matchingSystemAndCode(Coding theCoding) {
+	private Matcher<TokenAutocompleteHit> matchingSystemAndCode(IBaseCoding theCoding) {
 		return new TypeSafeDiagnosingMatcher<TokenAutocompleteHit>() {
 			private final String mySystemAndCode = theCoding.getSystem() + "|" + theCoding.getCode();
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -140,7 +140,7 @@ public class ResourceTable extends BaseHasResource implements Serializable, IBas
 	@PropertyBinding(binder = @PropertyBinderRef(type = SearchParamTextPropertyBinder.class))
 	private ExtendedLuceneIndexData myLuceneIndexData;
 
-	// fixme mb move this to ExtendedLuceneIndexData
+	// todo mb move this to ExtendedLuceneIndexData
 	@Transient
 	@GenericField(name="myRawResource", projectable = Projectable.YES, searchable = Searchable.NO)
 	@IndexingDependency(derivedFrom = @ObjectPath(@PropertyValue(propertyName = "myVersion")))

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -40,6 +40,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextFi
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyBinding;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
@@ -139,6 +140,12 @@ public class ResourceTable extends BaseHasResource implements Serializable, IBas
 	@IndexingDependency(derivedFrom = @ObjectPath(@PropertyValue(propertyName = "myVersion")))
 	@PropertyBinding(binder = @PropertyBinderRef(type = SearchParamTextPropertyBinder.class))
 	private ExtendedLuceneIndexData myLuceneIndexData;
+
+	@Transient
+	@KeywordField(name="myRawResource")
+	@IndexingDependency(derivedFrom = @ObjectPath(@PropertyValue(propertyName = "myVersion")))
+	@OptimisticLock(excluded = true)
+	private String myRawResourceData;
 
 	@OneToMany(mappedBy = "myResource", cascade = {}, fetch = FetchType.LAZY, orphanRemoval = false)
 	@OptimisticLock(excluded = true)
@@ -774,5 +781,9 @@ public class ResourceTable extends BaseHasResource implements Serializable, IBas
 
 	public void setLuceneIndexData(ExtendedLuceneIndexData theLuceneIndexData) {
 		myLuceneIndexData = theLuceneIndexData;
+	}
+
+	public void setRawResourceData(String theResourceData) {
+		myRawResourceData = theResourceData;
 	}
 }

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -32,8 +32,10 @@ import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.OptimisticLock;
+import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.PropertyBinderRef;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
@@ -142,7 +144,7 @@ public class ResourceTable extends BaseHasResource implements Serializable, IBas
 	private ExtendedLuceneIndexData myLuceneIndexData;
 
 	@Transient
-	@KeywordField(name="myRawResource")
+	@GenericField(name="myRawResource", projectable = Projectable.YES, searchable = Searchable.NO)
 	@IndexingDependency(derivedFrom = @ObjectPath(@PropertyValue(propertyName = "myVersion")))
 	@OptimisticLock(excluded = true)
 	private String myRawResourceData;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -32,17 +32,14 @@ import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.OptimisticLock;
-import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
-import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.PropertyBinderRef;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyBinding;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
@@ -143,6 +140,7 @@ public class ResourceTable extends BaseHasResource implements Serializable, IBas
 	@PropertyBinding(binder = @PropertyBinderRef(type = SearchParamTextPropertyBinder.class))
 	private ExtendedLuceneIndexData myLuceneIndexData;
 
+	// fixme mb move this to ExtendedLuceneIndexData
 	@Transient
 	@GenericField(name="myRawResource", projectable = Projectable.YES, searchable = Searchable.NO)
 	@IndexingDependency(derivedFrom = @ObjectPath(@PropertyValue(propertyName = "myVersion")))

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/ExtendedLuceneIndexData.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/ExtendedLuceneIndexData.java
@@ -71,7 +71,6 @@ public class ExtendedLuceneIndexData {
 
 		ourLog.debug("Writing JPA index to Hibernate Search");
 
-		// fixme test this
 		theDocument.addValue("myForcedId", myForcedId);
 
 		mySearchParamStrings.forEach(ifNotContained(indexWriter::writeStringIndex));

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/ExtendedLuceneIndexData.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/ExtendedLuceneIndexData.java
@@ -45,6 +45,7 @@ public class ExtendedLuceneIndexData {
 	final SetMultimap<String, IBaseCoding> mySearchParamTokens = HashMultimap.create();
 	final SetMultimap<String, String> mySearchParamLinks = HashMultimap.create();
 	final SetMultimap<String, DateSearchIndexData> mySearchParamDates = HashMultimap.create();
+	String myForcedId;
 
 	public ExtendedLuceneIndexData(FhirContext theFhirContext) {
 		this.myFhirContext = theFhirContext;
@@ -58,10 +59,20 @@ public class ExtendedLuceneIndexData {
 			}
 		};
 	}
+
+	/**
+	 * Write the index document.
+	 *
+	 * Keep this in sync with the schema defined in {@link SearchParamTextPropertyBinder}
+	 * @param theDocument
+	 */
 	public void writeIndexElements(DocumentElement theDocument) {
 		HibernateSearchIndexWriter indexWriter = HibernateSearchIndexWriter.forRoot(myFhirContext, theDocument);
 
 		ourLog.debug("Writing JPA index to Hibernate Search");
+
+		// fixme test this
+		theDocument.addValue("myForcedId", myForcedId);
 
 		mySearchParamStrings.forEach(ifNotContained(indexWriter::writeStringIndex));
 		mySearchParamTokens.forEach(ifNotContained(indexWriter::writeTokenIndex));
@@ -97,4 +108,11 @@ public class ExtendedLuceneIndexData {
 		mySearchParamDates.put(theSpName, new DateSearchIndexData(theLowerBound, theLowerBoundOrdinal, theUpperBound, theUpperBoundOrdinal));
 	}
 
+	public void setForcedId(String theForcedId) {
+		myForcedId = theForcedId;
+	}
+
+	public String getForcedId() {
+		return myForcedId;
+	}
 }

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/SearchParamTextPropertyBinder.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/SearchParamTextPropertyBinder.java
@@ -100,10 +100,17 @@ public class SearchParamTextPropertyBinder implements PropertyBinder, PropertyBr
 			.projectable(Projectable.NO)
 			.sortable(Sortable.YES);
 
+		StringIndexFieldTypeOptionsStep<?> forcedIdType = indexFieldTypeFactory.asString()
+			.projectable(Projectable.YES)
+			.aggregable(Aggregable.NO);
+
 		// the old style for _text and _contains
 		indexSchemaElement
 			.fieldTemplate("SearchParamText", standardAnalyzer)
 			.matchingPathGlob(SEARCH_PARAM_TEXT_PREFIX + "*");
+
+
+		indexSchemaElement.field("myForcedId", forcedIdType).toReference();
 
 		// The following section is a bit ugly.  We need to enforce order and dependency or the object matches will be too big.
 		{


### PR DESCRIPTION
Some queries can be completely satisfied by Hibernate Search.
Before, every query was sent to the database, even when the query reduced to
```
select res_id from hfj_resource where res_id in (:res_id)
```

This change skips that redundant query when possible.
The database is still used for sorting, or when some query clauses can not be satisfied by Hibernate Search.

