### PR TITLE
Revert change to treat Canonical URLs as Locals

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/2843-revert-treat-canonicals-as-local.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/2843-revert-treat-canonicals-as-local.yaml
@@ -1,0 +1,6 @@
+---
+type: change
+issue: 2843
+title: "Reverting the change to treat canonical references as local when setting the flag `getTreatBaseUrlsAsLocal()`. This
+was added to address a bug in `_include` that didn't work for canonical URLs. This bug is now fixed
+by resolving the `_include` search operation and as a result this change is no longer required."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/2843-revert-treat-canonicals-as-local.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/2843-revert-treat-canonicals-as-local.yaml
@@ -2,5 +2,5 @@
 type: change
 issue: 2843
 title: "Reverting the change to treat canonical references as local when setting the flag `getTreatBaseUrlsAsLocal()`. This
-was added to address a bug in `_include` that didn't work for canonical URLs. This bug is now fixed
-by resolving the `_include` search operation and as a result this change is no longer required."
+was added to address a limitation in `_include` that did not process references by canonical URLs. 
+The `_include` search operation now includes canonical references without special configuration."

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -20,7 +20,6 @@ package ca.uhn.fhir.jpa.searchparam.extractor;
  * #L%
  */
 
-import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
@@ -28,6 +27,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.entity.BaseResourceIndexedSearchParam;
 import ca.uhn.fhir.jpa.model.entity.ModelConfig;
@@ -1413,11 +1413,6 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 					addUnexpectedDatatypeWarning(theParams, theSearchParam, theValue);
 					break;
 			}
-		}
-
-		private boolean isOrCanBeTreatedAsLocal(IIdType theId) {
-			boolean acceptableAsLocalReference = !theId.isAbsolute() || myModelConfig.getTreatBaseUrlsAsLocal().contains(theId.getBaseUrl());
-			return acceptableAsLocalReference;
 		}
 
 		public PathAndRef get(IBase theValue, String thePath) {


### PR DESCRIPTION
Revert change added in MR: #3050 to add support for treating Canonical Urls as locals. This is no longer needed as the issue reported in #2843 (_include not working for Canonicals) has been addressed in MR: #3440 

Test case to verify this is in: `ResourceProviderQuestionnaireResponseR4Test`