### PR TITLE
Fix accidental requirement for JDK15

### DIFF
--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -772,14 +772,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>15</source>
-					<target>15</target>
-				</configuration>
-			</plugin>
 		</plugins>
 		<resources>
 			<resource>


### PR DESCRIPTION
IntelliJ added a compiler configuration which should not have been committed.

This reverts the unwanted change.
