### PR TITLE
Add support for additional params with lastN operation on Observation

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/dstu3/BaseJpaResourceProviderObservationDstu3.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/dstu3/BaseJpaResourceProviderObservationDstu3.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.model.api.annotation.Description;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.annotation.RawParam;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateAndListParam;
@@ -15,6 +16,9 @@ import ca.uhn.fhir.rest.param.TokenAndListParam;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.UnsignedIntType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+
+import java.util.List;
+import java.util.Map;
 
 /*
  * #%L
@@ -75,9 +79,11 @@ public class BaseJpaResourceProviderObservationDstu3 extends JpaResourceProvider
 
 		@Description(shortDefinition="The maximum number of observations to return for each observation code")
 		@OperationParam(name = "max", typeName = "integer", min = 0, max = 1)
-			IPrimitiveType<Integer> theMax
+			IPrimitiveType<Integer> theMax,
 
-	) {
+		@RawParam
+			Map<String, List<String>> theAdditionalRawParams
+		) {
 		startRequest(theServletRequest);
 		try {
 			SearchParameterMap paramMap = new SearchParameterMap();
@@ -96,6 +102,8 @@ public class BaseJpaResourceProviderObservationDstu3 extends JpaResourceProvider
 			if (theCount != null) {
 				paramMap.setCount(theCount.getValue());
 			}
+
+			getDao().translateRawParameters(theAdditionalRawParams, paramMap);
 
 			return ((IFhirResourceDaoObservation<Observation>) getDao()).observationsLastN(paramMap, theRequestDetails, theServletResponse);
 		} finally {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderObservationR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/BaseJpaResourceProviderObservationR4.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.model.api.annotation.Description;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.annotation.RawParam;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateAndListParam;
@@ -15,6 +16,9 @@ import ca.uhn.fhir.rest.param.TokenAndListParam;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.UnsignedIntType;
+
+import java.util.List;
+import java.util.Map;
 
 /*
  * #%L
@@ -75,8 +79,10 @@ public class BaseJpaResourceProviderObservationR4 extends JpaResourceProviderR4<
 
 		@Description(shortDefinition="The maximum number of observations to return for each observation code")
 		@OperationParam(name = "max", typeName = "integer", min = 0, max = 1)
-			IPrimitiveType<Integer> theMax
+			IPrimitiveType<Integer> theMax,
 
+		@RawParam
+			Map<String, List<String>> theAdditionalRawParams
 		) {
 		startRequest(theServletRequest);
 		try {
@@ -96,6 +102,8 @@ public class BaseJpaResourceProviderObservationR4 extends JpaResourceProviderR4<
 			if (theCount != null) {
 				paramMap.setCount(theCount.getValue());
 			}
+
+			getDao().translateRawParameters(theAdditionalRawParams, paramMap);
 
 			return ((IFhirResourceDaoObservation<Observation>) getDao()).observationsLastN(paramMap, theRequestDetails, theServletResponse);
 		} finally {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r5/BaseJpaResourceProviderObservationR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r5/BaseJpaResourceProviderObservationR5.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.model.api.annotation.Description;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.annotation.RawParam;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateAndListParam;
@@ -15,6 +16,9 @@ import ca.uhn.fhir.rest.param.TokenAndListParam;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r5.model.Observation;
 import org.hl7.fhir.r5.model.UnsignedIntType;
+
+import java.util.List;
+import java.util.Map;
 
 /*
  * #%L
@@ -75,9 +79,11 @@ public class BaseJpaResourceProviderObservationR5 extends JpaResourceProviderR5<
 
 		@Description(shortDefinition="The maximum number of observations to return for each observation code")
 		@OperationParam(name = "max", typeName = "integer", min = 0, max = 1)
-			IPrimitiveType<Integer> theMax
+			IPrimitiveType<Integer> theMax,
 
-	) {
+		@RawParam
+			Map<String, List<String>> theAdditionalRawParams
+		) {
 		startRequest(theServletRequest);
 		try {
 			SearchParameterMap paramMap = new SearchParameterMap();
@@ -96,6 +102,8 @@ public class BaseJpaResourceProviderObservationR5 extends JpaResourceProviderR5<
 			if (theCount != null) {
 				paramMap.setCount(theCount.getValue());
 			}
+
+			getDao().translateRawParameters(theAdditionalRawParams, paramMap);
 
 			return ((IFhirResourceDaoObservation<Observation>) getDao()).observationsLastN(paramMap, theRequestDetails, theServletResponse);
 		} finally {


### PR DESCRIPTION
Fixes: #2780 

This adds support to use lastN params and additional Observation params as well to be reflected in the search result.