### PR TITLE
Add New Index On HFJ_RESOURCE For $reindex Operation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-add-index-on-hfj-resource-table-indexing-multiple-columns.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-add-index-on-hfj-resource-table-indexing-multiple-columns.yaml
@@ -1,0 +1,3 @@
+type: add
+issue: 3534
+title: "Added a new multi-column index on the HFJ_RESOURCE table indexing the columns RES_TYPE, RES_DELETED_AT, RES_UPDATED, PARTITION_ID and RES_ID and removed the existing single-column index on the RES_TYPE column. This new index will improve the performance of the $reindex operation and will be useful for some other queries a well."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-add-index-on-hfj-resource-table-indexing-multiple-columns.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-add-index-on-hfj-resource-table-indexing-multiple-columns.yaml
@@ -1,5 +1,3 @@
 type: add
 issue: 3534
-title: "Extended the existing indexes HFJ_RESOURCE table with more columns to cover the queries with PARTITION_ID and RES_ID and 
-   removed the existing single-column index on the RES_TYPE, and RES_UPDATED column. 
-   This new index will improve the performance of the $reindex operation and will be useful for some other queries a well."
+title: "Added a new multi-column index on the HFJ_RESOURCE table indexing the columns RES_TYPE, RES_DELETED_AT, RES_UPDATED, PARTITION_ID and RES_ID and removed the existing single-column index on the RES_TYPE column. This new index will improve the performance of the $reindex operation and will be useful for some other queries a well."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-add-index-on-hfj-resource-table-indexing-multiple-columns.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-add-index-on-hfj-resource-table-indexing-multiple-columns.yaml
@@ -1,3 +1,5 @@
 type: add
 issue: 3534
-title: "Added a new multi-column index on the HFJ_RESOURCE table indexing the columns RES_TYPE, RES_DELETED_AT, RES_UPDATED, PARTITION_ID and RES_ID and removed the existing single-column index on the RES_TYPE column. This new index will improve the performance of the $reindex operation and will be useful for some other queries a well."
+title: "Extended the existing indexes HFJ_RESOURCE table with more columns to cover the queries with PARTITION_ID and RES_ID and 
+   removed the existing single-column index on the RES_TYPE, and RES_UPDATED column. 
+   This new index will improve the performance of the $reindex operation and will be useful for some other queries a well."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-remove-migration-timeout.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3534-remove-migration-timeout.yaml
@@ -1,0 +1,5 @@
+type: change
+issue: 3534
+title: "Ensure that migration steps do not timeout.
+   Adding an index, and other migration steps can take exceed the default connection timeout.
+   This has been changed - migration steps now have no timeout and will run until completion."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -288,11 +288,6 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version
 			.onTable("HFJ_BLK_EXPORT_JOB").modifyColumn("20220423.1", "EXP_TIME").nullable().withType(ColumnTypeEnum.DATE_TIMESTAMP);
 
-			// Drop Index on HFJ_RESOURCE.INDEX_STATUS
-			version
-        .onTable("HFJ_RESOURCE")
-			.dropIndex("20220325.1", "IDX_INDEXSTATUS");
-
 		// New Index on HFJ_RESOURCE for $reindex Operation - hapi-fhir #3534
 		{
 			version.onTable("HFJ_RESOURCE")

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -278,6 +278,19 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
         version
         .onTable("HFJ_RESOURCE")
         .dropIndex("20220314.1", "IDX_INDEXSTATUS");
+
+        // New Index on HFJ_RESOURCE for $reindex Operation - hapi-fhir #3534
+		{
+			version.onTable("HFJ_RESOURCE")
+				.addIndex("20220413.1", "IDX_RES_TYPE_DEL_UPDATED")
+				.unique(false)
+				.withColumns("RES_TYPE", "RES_DELETED_AT", "RES_UPDATED", "RES_ID");
+
+			// Drop existing Index on HFJ_RESOURCE.RES_TYPE since the new Index will meet the overall Index Demand
+			version
+				.onTable("HFJ_RESOURCE")
+				.dropIndex("20220413.2", "IDX_RES_TYPE");
+		}
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -288,17 +288,29 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version
 			.onTable("HFJ_BLK_EXPORT_JOB").modifyColumn("20220423.1", "EXP_TIME").nullable().withType(ColumnTypeEnum.DATE_TIMESTAMP);
 
-		// New Index on HFJ_RESOURCE for $reindex Operation - hapi-fhir #3534
+		// New Indexes on HFJ_RESOURCE for $reindex Operation - hapi-fhir #3534
 		{
 			version.onTable("HFJ_RESOURCE")
 				.addIndex("20220425.1", "IDX_RES_TYPE_DEL_UPDATED")
 				.unique(false)
+				.online(true)
 				.withColumns("RES_TYPE", "RES_DELETED_AT", "RES_UPDATED", "PARTITION_ID", "RES_ID");
 
 			// Drop existing Index on HFJ_RESOURCE.RES_TYPE since the new Index will meet the overall Index Demand
 			version
 				.onTable("HFJ_RESOURCE")
-				.dropIndex("20220425.2", "IDX_RES_TYPE");
+				.dropIndexOnline("20220425.2", "IDX_RES_TYPE");
+
+			version.onTable("HFJ_RESOURCE")
+				.addIndex("20220425.3", "IDX_RES_UPDATED_V2")
+				.unique(false)
+				.online(true)
+				.withColumns("RES_UPDATED", "RES_ID", "PARTITION_ID");
+
+			// Drop existing Index on HFJ_RESOURCE.RES_UPDATED since the new Index will meet the overall Index Demand
+			version
+				.onTable("HFJ_RESOURCE")
+				.dropIndexOnline("20220425.4", "IDX_RES_DATE");
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -288,7 +288,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version
 			.onTable("HFJ_BLK_EXPORT_JOB").modifyColumn("20220423.1", "EXP_TIME").nullable().withType(ColumnTypeEnum.DATE_TIMESTAMP);
 
-		// New Indexes on HFJ_RESOURCE for $reindex Operation - hapi-fhir #3534
+		// New Index on HFJ_RESOURCE for $reindex Operation - hapi-fhir #3534
 		{
 			version.onTable("HFJ_RESOURCE")
 				.addIndex("20220425.1", "IDX_RES_TYPE_DEL_UPDATED")
@@ -300,17 +300,6 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			version
 				.onTable("HFJ_RESOURCE")
 				.dropIndexOnline("20220425.2", "IDX_RES_TYPE");
-
-			version.onTable("HFJ_RESOURCE")
-				.addIndex("20220425.3", "IDX_RES_UPDATED_V2")
-				.unique(false)
-				.online(true)
-				.withColumns("RES_UPDATED", "RES_ID", "PARTITION_ID");
-
-			// Drop existing Index on HFJ_RESOURCE.RES_UPDATED since the new Index will meet the overall Index Demand
-			version
-				.onTable("HFJ_RESOURCE")
-				.dropIndexOnline("20220425.4", "IDX_RES_DATE");
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -284,7 +284,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			version.onTable("HFJ_RESOURCE")
 				.addIndex("20220413.1", "IDX_RES_TYPE_DEL_UPDATED")
 				.unique(false)
-				.withColumns("RES_TYPE", "RES_DELETED_AT", "RES_UPDATED", "RES_ID");
+				.withColumns("RES_TYPE", "RES_DELETED_AT", "RES_UPDATED", "PARTITION_ID", "RES_ID");
 
 			// Drop existing Index on HFJ_RESOURCE.RES_TYPE since the new Index will meet the overall Index Demand
 			version

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "HFJ_RESOURCE", uniqueConstraints = {}, indexes = {
 	// Do not reuse previously used index name: IDX_INDEXSTATUS, IDX_RES_TYPE
-	@Index(name = "IDX_RES_UPDATED_V2", columnList = "RES_UPDATED,RES_ID,PARTITION_ID"),
+	@Index(name = "IDX_RES_DATE", columnList = "RES_UPDATED"),
 	@Index(name = "IDX_RES_TYPE_DEL_UPDATED", columnList = "RES_TYPE,RES_DELETED_AT,RES_UPDATED,PARTITION_ID,RES_ID"),
 })
 @NamedEntityGraph(name = "Resource.noJoins")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "HFJ_RESOURCE", uniqueConstraints = {}, indexes = {
 	// Do not reuse previously used index name: IDX_INDEXSTATUS, IDX_RES_TYPE
-	@Index(name = "IDX_RES_DATE", columnList = "RES_UPDATED"),
+	@Index(name = "IDX_RES_UPDATED_V2", columnList = "RES_UPDATED,RES_ID,PARTITION_ID"),
 	@Index(name = "IDX_RES_TYPE_DEL_UPDATED", columnList = "RES_TYPE,RES_DELETED_AT,RES_UPDATED,PARTITION_ID,RES_ID"),
 })
 @NamedEntityGraph(name = "Resource.noJoins")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -75,7 +75,7 @@ import java.util.stream.Collectors;
 @Table(name = "HFJ_RESOURCE", uniqueConstraints = {}, indexes = {
 	// Do not reuse previously used index name: IDX_INDEXSTATUS, IDX_RES_TYPE
 	@Index(name = "IDX_RES_DATE", columnList = "RES_UPDATED"),
-	@Index(name = "IDX_RES_TYPE_DEL_UPDATED", columnList = "RES_TYPE,RES_DELETED_AT,RES_UPDATED,RES_ID"),
+	@Index(name = "IDX_RES_TYPE_DEL_UPDATED", columnList = "RES_TYPE,RES_DELETED_AT,RES_UPDATED,PARTITION_ID,RES_ID"),
 })
 @NamedEntityGraph(name = "Resource.noJoins")
 public class ResourceTable extends BaseHasResource implements Serializable, IBasePersistedResource, IResourceLookup {

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -73,9 +73,9 @@ import java.util.stream.Collectors;
 @Indexed(routingBinder= @RoutingBinderRef(type = ResourceTableRoutingBinder.class))
 @Entity
 @Table(name = "HFJ_RESOURCE", uniqueConstraints = {}, indexes = {
-	// Do not reuse previously used index name: IDX_INDEXSTATUS
+	// Do not reuse previously used index name: IDX_INDEXSTATUS, IDX_RES_TYPE
 	@Index(name = "IDX_RES_DATE", columnList = "RES_UPDATED"),
-	@Index(name = "IDX_RES_TYPE", columnList = "RES_TYPE"),
+	@Index(name = "IDX_RES_TYPE_DEL_UPDATED", columnList = "RES_TYPE,RES_DELETED_AT,RES_UPDATED,RES_ID"),
 })
 @NamedEntityGraph(name = "Resource.noJoins")
 public class ResourceTable extends BaseHasResource implements Serializable, IBasePersistedResource, IResourceLookup {

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
@@ -162,6 +162,8 @@ public abstract class BaseTask {
 
 	private int doExecuteSql(@Language("SQL") String theSql, Object[] theArguments) {
 		JdbcTemplate jdbcTemplate = getConnectionProperties().newJdbcTemplate();
+		// 0 means no timeout -- we use this for index rebuilds that may take time.
+		jdbcTemplate.setQueryTimeout(0);
 		try {
 			int changesCount = jdbcTemplate.update(theSql, theArguments);
 			if (!"true".equals(System.getProperty("unit_test_mode"))) {


### PR DESCRIPTION
Add columns to hfj_resource indices to avoid random row reads.  Also change migration tasks to have no timeout since adding indices can be very slow.

Closes #3534.
