### PR TITLE
Issue 3537 Permit servlet requests to create resources when Client Id Strategy is set to NOT_ALLOWED

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3537-fix-post-with-client-id-not-allowed-should-create-resource.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3537-fix-post-with-client-id-not-allowed-should-create-resource.yaml
@@ -1,0 +1,5 @@
+type: fix
+issue: 3537
+jira: SMILE-3670
+title: "Fixed a bug where if Client Id Mode is set to `NOT_ALLOWED` and a Code System is trying to be uploaded with a 
+`POST` request, an error message would be returned instead of creating the resources."

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
@@ -28,8 +28,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.persistence.EntityManager;
+import javax.servlet.http.HttpServletRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -89,6 +91,33 @@ class BaseHapiFhirResourceDaoTest {
 	public void validateResourceIdCreation_asUser() {
 		Patient patient = new Patient();
 		RequestDetails sysRequest = new ServletRequestDetails();
+		mySvc.getConfig().setResourceClientIdStrategy(DaoConfig.ClientIdStrategyEnum.NOT_ALLOWED);
+		try {
+			mySvc.validateResourceIdCreation(patient, sysRequest);
+			fail();
+		} catch (ResourceNotFoundException e) {
+			assertEquals(Msg.code(959) + "failedToCreateWithClientAssignedIdNotAllowed", e.getMessage());
+		}
+	}
+
+	@Test
+	public void validateResourceIdCreation_asUserSendingPostRequest() {
+		Patient patient = new Patient();
+		MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+		httpRequest.setMethod("POST");
+		ServletRequestDetails sysRequest = new ServletRequestDetails();
+		sysRequest.setServletRequest(httpRequest);
+		mySvc.getConfig().setResourceClientIdStrategy(DaoConfig.ClientIdStrategyEnum.NOT_ALLOWED);
+		mySvc.validateResourceIdCreation(patient, sysRequest);
+	}
+
+	@Test
+	public void validateResourceIdCreation_asUserSendingUpdateRequest() {
+		Patient patient = new Patient();
+		MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+		httpRequest.setMethod("PUT");
+		ServletRequestDetails sysRequest = new ServletRequestDetails();
+		sysRequest.setServletRequest(httpRequest);
 		mySvc.getConfig().setResourceClientIdStrategy(DaoConfig.ClientIdStrategyEnum.NOT_ALLOWED);
 		try {
 			mySvc.validateResourceIdCreation(patient, sysRequest);


### PR DESCRIPTION
- Changed validation to allow for servlet requests to create resources when Client Id = NOT_ALLOWED
- Added tests
- Added changelog

Closes #3537
