### PR TITLE
3506 mdm log enhancement

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3506-enhance-mdm-logging.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3506-enhance-mdm-logging.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 3506
+title: "Changing the MDM logging to contain scores for each applied matcher field. Deleting summary score when creating MDM link."

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -100,6 +100,7 @@ public class MdmLinkDaoSvc {
 			mdmLink.setPartitionId(new PartitionablePartitionId(partitionId.getFirstPartitionIdOrNull(), partitionId.getPartitionDate()));
 		}
 
+		// FIXME Anna: NULL properties in theMatchOutcome is the issue here
 		String message = String.format("Creating MdmLink from %s to %s -> %s", theGoldenResource.getIdElement().toUnqualifiedVersionless(), theSourceResource.getIdElement().toUnqualifiedVersionless(), theMatchOutcome);
 		theMdmTransactionContext.addTransactionLogMessage(message);
 		ourLog.debug(message);

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -100,8 +100,7 @@ public class MdmLinkDaoSvc {
 			mdmLink.setPartitionId(new PartitionablePartitionId(partitionId.getFirstPartitionIdOrNull(), partitionId.getPartitionDate()));
 		}
 
-		// FIXME Anna: NULL properties in theMatchOutcome is the issue here
-		String message = String.format("Creating MdmLink from %s to %s -> %s", theGoldenResource.getIdElement().toUnqualifiedVersionless(), theSourceResource.getIdElement().toUnqualifiedVersionless(), theMatchOutcome);
+		String message = String.format("Creating MdmLink from %s to %s.", theGoldenResource.getIdElement().toUnqualifiedVersionless(), theSourceResource.getIdElement().toUnqualifiedVersionless());
 		theMdmTransactionContext.addTransactionLogMessage(message);
 		ourLog.debug(message);
 		save(mdmLink);

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchFinderSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchFinderSvcImpl.java
@@ -57,7 +57,7 @@ public class MdmMatchFinderSvcImpl implements IMdmMatchFinderSvc {
 			.map(candidate -> new MatchedTarget(candidate, myMdmResourceMatcherSvc.getMatchResult(theResource, candidate)))
 			.collect(Collectors.toList());
 
-		ourLog.info("Found {} matched targets for {}", matches.size(), theResourceType);
+		ourLog.info("Found {} matched targets for {}.", matches.size(), theResourceType);
 		return matches;
 	}
 

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
@@ -133,7 +133,6 @@ public class MdmMatchLinkSvc {
 		// 2. Create source resource for the MDM source
 		// 3. UPDATE MDM LINK TABLE
 
-		// FIXME Anna PART1: it is within this call that we will be generating the comment with the with the NULL/NULL values.
 		myMdmLinkSvc.updateLink(newGoldenResource, theResource, MdmMatchOutcome.NEW_GOLDEN_RESOURCE_MATCH, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 	}
 

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
@@ -133,12 +133,12 @@ public class MdmMatchLinkSvc {
 		// 2. Create source resource for the MDM source
 		// 3. UPDATE MDM LINK TABLE
 
-		// FIXME PART1: it is within this call that we will be generating the comment with the with the NULL/NULL values.
+		// FIXME Anna PART1: it is within this call that we will be generating the comment with the with the NULL/NULL values.
 		myMdmLinkSvc.updateLink(newGoldenResource, theResource, MdmMatchOutcome.NEW_GOLDEN_RESOURCE_MATCH, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 	}
 
 	private void handleMdmCreate(IAnyResource theTargetResource, MatchedGoldenResourceCandidate theGoldenResourceCandidate, MdmTransactionContext theMdmTransactionContext) {
-		// FIXME PART3: let's move this log bellow (see comment in next method)
+		// FIXME Anna PART3: Let's rework this log and move it to '//MOVE_HERE
 		log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
 		IAnyResource goldenResource = myMdmGoldenResourceFindingSvc.getGoldenResourceFromMatchedGoldenResourceCandidate(theGoldenResourceCandidate, theMdmTransactionContext.getResourceType());
 
@@ -149,6 +149,7 @@ public class MdmMatchLinkSvc {
 			myMdmLinkSvc.updateLink(newGoldenResource, theTargetResource, MdmMatchOutcome.NEW_GOLDEN_RESOURCE_MATCH, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 			myMdmLinkSvc.updateLink(newGoldenResource, goldenResource, MdmMatchOutcome.POSSIBLE_DUPLICATE, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 		} else {
+			//MOVE_HERE
 			if (theGoldenResourceCandidate.isMatch()) {
 				myGoldenResourceHelper.handleExternalEidAddition(goldenResource, theTargetResource, theMdmTransactionContext);
 				myEidUpdateService.applySurvivorshipRulesAndSaveGoldenResource(theTargetResource, goldenResource, theMdmTransactionContext);
@@ -159,14 +160,13 @@ public class MdmMatchLinkSvc {
 	}
 
 	private void handleMdmWithSingleCandidate(IAnyResource theResource, MatchedGoldenResourceCandidate theGoldenResourceCandidate, MdmTransactionContext theMdmTransactionContext) {
-		// FIXME PART3: this log should be moved within the if statement to mark that we will be updating. there is a log
-		// addressing the create in method handleMdmCreate.
-
+		// FIXME Anna PART3: this log should be moved within the if statement to mark that we will be updating. there is a log
 		log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
+
 		if (theMdmTransactionContext.getRestOperation().equals(MdmTransactionContext.OperationType.UPDATE_RESOURCE)) {
 			myEidUpdateService.handleMdmUpdate(theResource, theGoldenResourceCandidate, theMdmTransactionContext);
 		} else {
-			// FIXME PART3: move the logging from above here and enhance it
+			// FIXME Anna PART3: move the logging from above here and enhance it
 			handleMdmCreate(theResource, theGoldenResourceCandidate, theMdmTransactionContext);
 		}
 	}

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
@@ -132,10 +132,13 @@ public class MdmMatchLinkSvc {
 		// 1. Get the right helper
 		// 2. Create source resource for the MDM source
 		// 3. UPDATE MDM LINK TABLE
+
+		// FIXME PART1: it is within this call that we will be generating the comment with the with the NULL/NULL values.
 		myMdmLinkSvc.updateLink(newGoldenResource, theResource, MdmMatchOutcome.NEW_GOLDEN_RESOURCE_MATCH, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 	}
 
 	private void handleMdmCreate(IAnyResource theTargetResource, MatchedGoldenResourceCandidate theGoldenResourceCandidate, MdmTransactionContext theMdmTransactionContext) {
+		// FIXME PART3: let's move this log bellow (see comment in next method)
 		log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
 		IAnyResource goldenResource = myMdmGoldenResourceFindingSvc.getGoldenResourceFromMatchedGoldenResourceCandidate(theGoldenResourceCandidate, theMdmTransactionContext.getResourceType());
 
@@ -156,10 +159,14 @@ public class MdmMatchLinkSvc {
 	}
 
 	private void handleMdmWithSingleCandidate(IAnyResource theResource, MatchedGoldenResourceCandidate theGoldenResourceCandidate, MdmTransactionContext theMdmTransactionContext) {
+		// FIXME PART3: this log should be moved within the if statement to mark that we will be updating. there is a log
+		// addressing the create in method handleMdmCreate.
+
 		log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
 		if (theMdmTransactionContext.getRestOperation().equals(MdmTransactionContext.OperationType.UPDATE_RESOURCE)) {
 			myEidUpdateService.handleMdmUpdate(theResource, theGoldenResourceCandidate, theMdmTransactionContext);
 		} else {
+			// FIXME PART3: move the logging from above here and enhance it
 			handleMdmCreate(theResource, theGoldenResourceCandidate, theMdmTransactionContext);
 		}
 	}

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
@@ -138,8 +138,6 @@ public class MdmMatchLinkSvc {
 	}
 
 	private void handleMdmCreate(IAnyResource theTargetResource, MatchedGoldenResourceCandidate theGoldenResourceCandidate, MdmTransactionContext theMdmTransactionContext) {
-		// FIXME Anna PART3: Let's rework this log and move it to '//MOVE_HERE
-		log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
 		IAnyResource goldenResource = myMdmGoldenResourceFindingSvc.getGoldenResourceFromMatchedGoldenResourceCandidate(theGoldenResourceCandidate, theMdmTransactionContext.getResourceType());
 
 		if (myGoldenResourceHelper.isPotentialDuplicate(goldenResource, theTargetResource)) {
@@ -149,7 +147,8 @@ public class MdmMatchLinkSvc {
 			myMdmLinkSvc.updateLink(newGoldenResource, theTargetResource, MdmMatchOutcome.NEW_GOLDEN_RESOURCE_MATCH, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 			myMdmLinkSvc.updateLink(newGoldenResource, goldenResource, MdmMatchOutcome.POSSIBLE_DUPLICATE, MdmLinkSourceEnum.AUTO, theMdmTransactionContext);
 		} else {
-			//MOVE_HERE
+			log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
+
 			if (theGoldenResourceCandidate.isMatch()) {
 				myGoldenResourceHelper.handleExternalEidAddition(goldenResource, theTargetResource, theMdmTransactionContext);
 				myEidUpdateService.applySurvivorshipRulesAndSaveGoldenResource(theTargetResource, goldenResource, theMdmTransactionContext);

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvc.java
@@ -158,13 +158,10 @@ public class MdmMatchLinkSvc {
 	}
 
 	private void handleMdmWithSingleCandidate(IAnyResource theResource, MatchedGoldenResourceCandidate theGoldenResourceCandidate, MdmTransactionContext theMdmTransactionContext) {
-		// FIXME Anna PART3: this log should be moved within the if statement to mark that we will be updating. there is a log
-		log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
-
 		if (theMdmTransactionContext.getRestOperation().equals(MdmTransactionContext.OperationType.UPDATE_RESOURCE)) {
+			log(theMdmTransactionContext, "MDM has narrowed down to one candidate for matching.");
 			myEidUpdateService.handleMdmUpdate(theResource, theGoldenResourceCandidate, theMdmTransactionContext);
 		} else {
-			// FIXME Anna PART3: move the logging from above here and enhance it
 			handleMdmCreate(theResource, theGoldenResourceCandidate, theMdmTransactionContext);
 		}
 	}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/json/MdmRulesJson.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/json/MdmRulesJson.java
@@ -204,7 +204,7 @@ public class MdmRulesJson implements IModelJson {
 		return myVectorMatchResultMap.getFieldMatchNames(theVector);
 	}
 
-	public String getDetailedFieldMatchResultForUnmatchedVector(long theVector) {
+	public String getDetailedFieldMatchResultWithSuccessInformation(long theVector) {
 		List<String> fieldMatchResult = new ArrayList<>();
 		for (int i = 0; i < myMatchFieldJsonList.size(); ++i) {
 			if ((theVector & (1 << i)) == 0) {

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -92,10 +92,9 @@ public class MdmResourceMatcherSvc {
 		MdmMatchResultEnum matchResultEnum = myMdmRulesJson.getMatchResult(matchResult.vector);
 		matchResult.setMatchResultEnum(matchResultEnum);
 		if (ourLog.isDebugEnabled()) {
-			if (matchResult.isMatch() || matchResult.isPossibleMatch()) {
-				ourLog.debug("{} {} with field matchers {}", matchResult, theRightResource.getIdElement().toUnqualifiedVersionless(), myMdmRulesJson.getFieldMatchNamesForVector(matchResult.vector));
-			} else if (ourLog.isTraceEnabled()) {
-				ourLog.trace("{} {}.  Field matcher results: {}", matchResult, theRightResource.getIdElement().toUnqualifiedVersionless(), myMdmRulesJson.getDetailedFieldMatchResultForUnmatchedVector(matchResult.vector));
+				ourLog.debug("{} {}: {}", matchResult.getMatchResultEnum(), theRightResource.getIdElement().toUnqualifiedVersionless(), matchResult);
+			 if (ourLog.isTraceEnabled()) {
+				ourLog.trace("Field matcher results: \n{}", myMdmRulesJson.getDetailedFieldMatchResultWithSuccessInformation(matchResult.vector));
 			}
 		}
 		return matchResult;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -131,14 +131,13 @@ public class MdmResourceMatcherSvc {
 				ourLog.debug("Matcher {} is not valid for resource type: {}. Skipping it.", fieldComparator.getName(), resourceType);
 				continue;
 			}
-			// FIXME Part2: this is where we will determine what we want to log
 			ourLog.debug("Matcher {} is valid for resource type: {}. Evaluating match.", fieldComparator.getName(), resourceType);
 			MdmMatchEvaluation matchEvaluation = fieldComparator.match(theLeftResource, theRightResource);
 			if (matchEvaluation.match) {
 				vector |= (1 << i);
-				ourLog.debug("Match: Successfully matched Matcher {}.", fieldComparator.getName());
+				ourLog.trace("Match: Successfully matched matcher {} with score {}.", fieldComparator.getName(), matchEvaluation.score);
 			} else {
-				ourLog.debug("No Match: Matcher {} did not match.", fieldComparator.getName());
+				ourLog.trace("No match: Matcher {} did not match (score: {}).", fieldComparator.getName(), matchEvaluation.score);
 			}
 			score += matchEvaluation.score;
 			appliedRuleCount += 1;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -136,6 +136,9 @@ public class MdmResourceMatcherSvc {
 			MdmMatchEvaluation matchEvaluation = fieldComparator.match(theLeftResource, theRightResource);
 			if (matchEvaluation.match) {
 				vector |= (1 << i);
+				ourLog.debug("Match: Successfully matched Matcher {}.", fieldComparator.getName());
+			} else {
+				ourLog.debug("No Match: Matcher {} did not match.", fieldComparator.getName());
 			}
 			score += matchEvaluation.score;
 			appliedRuleCount += 1;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -94,7 +94,7 @@ public class MdmResourceMatcherSvc {
 		if (ourLog.isDebugEnabled()) {
 				ourLog.debug("{} {}: {}", matchResult.getMatchResultEnum(), theRightResource.getIdElement().toUnqualifiedVersionless(), matchResult);
 			 if (ourLog.isTraceEnabled()) {
-				ourLog.trace("Field matcher results: \n{}", myMdmRulesJson.getDetailedFieldMatchResultWithSuccessInformation(matchResult.vector));
+				ourLog.trace("Field matcher results:\n{}", myMdmRulesJson.getDetailedFieldMatchResultWithSuccessInformation(matchResult.vector));
 			}
 		}
 		return matchResult;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -131,6 +131,7 @@ public class MdmResourceMatcherSvc {
 				ourLog.debug("Matcher {} is not valid for resource type: {}. Skipping it.", fieldComparator.getName(), resourceType);
 				continue;
 			}
+			// FIXME Part2: this is where we will determine what we want to log
 			ourLog.debug("Matcher {} is valid for resource type: {}. Evaluating match.", fieldComparator.getName(), resourceType);
 			MdmMatchEvaluation matchEvaluation = fieldComparator.match(theLeftResource, theRightResource);
 			if (matchEvaluation.match) {

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
@@ -58,7 +58,7 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 	}
 
 	@Test
-	public void testMatchWillProvideSummaryOnMatchinSuccessForEachField() {
+	public void testMatchWillProvideSummaryOnMatchingSuccessForEachField() {
 		Patient someoneElse = buildSomeoneElse();
 		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
 		logger.setLevel(Level.TRACE);

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
@@ -68,8 +68,8 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 		MdmMatchOutcome result = myMdmResourceMatcherSvc.match(myJohn, someoneElse);
 		assertNotNull(result);
 
-		assertTrue(memoryAppender.contains("Field matcher results: patient-given: NO\n" +
-			"patient-last: YES", Level.TRACE));
+		assertTrue(memoryAppender.contains("NO_MATCH Patient/", Level.DEBUG));
+		assertTrue(memoryAppender.contains("Field matcher results:\npatient-given: NO\npatient-last: YES", Level.TRACE));
 	}
 
 	protected Patient buildSomeoneElse() {

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
@@ -2,7 +2,6 @@ package ca.uhn.fhir.mdm.rules.svc;
 
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.mdm.api.MdmMatchOutcome;
-import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.mdm.log.Logs;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -37,10 +36,14 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 
 		myJohn = buildJohn();
 		myJohny = buildJohny();
+
+		myJohn.addName().setFamily("LastName");
+		myJohny.addName().setFamily("DifferentLastName");
+
 	}
 
 	@Test
-	public void testMatchWillProvideLogsOnTraceLevel(){
+	public void testMatchWillProvideLogsAboutSuccessOnDebugLevel(){
 		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
 
 		MemoryAppender memoryAppender = createAndAssignMemoryAppender(logger);
@@ -49,8 +52,11 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 		assertNotNull(result);
 
 		assertTrue(memoryAppender.contains("Evaluating match", Level.DEBUG));
-
+		assertTrue(memoryAppender.contains("No Match: Matcher patient-last did not match.", Level.DEBUG));
+		assertTrue(memoryAppender.contains("Match: Successfully matched Matcher patient-given.", Level.DEBUG));
 	}
+
+	
 
 	protected MemoryAppender createAndAssignMemoryAppender(Logger theLogger){
 

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
@@ -43,7 +43,7 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 	}
 
 	@Test
-	public void testMatchWillProvideLogsAboutSuccessOnTraceLevel(){
+	public void testMatchWillProvideLogsAboutSuccessOnTraceLevel() {
 		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
 		logger.setLevel(Level.TRACE);
 
@@ -57,9 +57,8 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 		assertTrue(memoryAppender.contains("Match: Successfully matched matcher patient-given with score 0.8", Level.TRACE));
 	}
 
-	//problem not in matcher service!
 	@Test
-	public void testMatchWillProvideSummaryOnMatchinSuccessForEachField(){
+	public void testMatchWillProvideSummaryOnMatchinSuccessForEachField() {
 		Patient someoneElse = buildSomeoneElse();
 		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
 		logger.setLevel(Level.TRACE);
@@ -82,7 +81,7 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 	}
 
 
-	protected MemoryAppender createAndAssignMemoryAppender(Logger theLogger){
+	protected MemoryAppender createAndAssignMemoryAppender(Logger theLogger) {
 
 		MemoryAppender memoryAppender = new MemoryAppender();
 		memoryAppender.setContext(theLogger.getLoggerContext());
@@ -92,7 +91,7 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 		return memoryAppender;
 	}
 
-	public static class MemoryAppender extends ListAppender<ILoggingEvent>{
+	public static class MemoryAppender extends ListAppender<ILoggingEvent> {
 		public void reset() {
 			this.list.clear();
 		}

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
@@ -1,0 +1,78 @@
+package ca.uhn.fhir.mdm.rules.svc;
+
+import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.mdm.api.MdmMatchOutcome;
+import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
+import ca.uhn.fhir.mdm.log.Logs;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
+	private MdmResourceMatcherSvc myMdmResourceMatcherSvc;
+	private Patient myJohn;
+	private Patient myJohny;
+
+	@Override
+	@BeforeEach
+	public void before() {
+		super.before();
+
+		when(mySearchParamRetriever.getActiveSearchParam("Patient", "birthdate")).thenReturn(mock(RuntimeSearchParam.class));
+		when(mySearchParamRetriever.getActiveSearchParam("Patient", "identifier")).thenReturn(mock(RuntimeSearchParam.class));
+		when(mySearchParamRetriever.getActiveSearchParam("Practitioner", "identifier")).thenReturn(mock(RuntimeSearchParam.class));
+		when(mySearchParamRetriever.getActiveSearchParam("Medication", "identifier")).thenReturn(mock(RuntimeSearchParam.class));
+		when(mySearchParamRetriever.getActiveSearchParam("Patient", "active")).thenReturn(mock(RuntimeSearchParam.class));
+
+		myMdmResourceMatcherSvc = buildMatcher(buildActiveBirthdateIdRules());
+
+		myJohn = buildJohn();
+		myJohny = buildJohny();
+	}
+
+	@Test
+	public void testMatchWillProvideLogsOnTraceLevel(){
+		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
+
+		MemoryAppender memoryAppender = createAndAssignMemoryAppender(logger);
+
+		MdmMatchOutcome result = myMdmResourceMatcherSvc.match(myJohn, myJohny);
+		assertNotNull(result);
+
+		assertTrue(memoryAppender.contains("Evaluating match", Level.DEBUG));
+
+	}
+
+	protected MemoryAppender createAndAssignMemoryAppender(Logger theLogger){
+
+		MemoryAppender memoryAppender = new MemoryAppender();
+		memoryAppender.setContext(theLogger.getLoggerContext());
+		theLogger.addAppender(memoryAppender);
+		memoryAppender.start();
+
+		return memoryAppender;
+	}
+
+	public static class MemoryAppender extends ListAppender<ILoggingEvent>{
+		public void reset() {
+			this.list.clear();
+		}
+
+		public boolean contains(String string, Level level) {
+			return this.list.stream()
+				.anyMatch(event -> event.toString().contains(string)
+					&& event.getLevel().equals(level));
+		}
+
+	}
+
+}

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcLoggingTest.java
@@ -43,20 +43,44 @@ public class MdmResourceMatcherSvcLoggingTest extends BaseMdmRulesR4Test {
 	}
 
 	@Test
-	public void testMatchWillProvideLogsAboutSuccessOnDebugLevel(){
+	public void testMatchWillProvideLogsAboutSuccessOnTraceLevel(){
 		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
+		logger.setLevel(Level.TRACE);
 
 		MemoryAppender memoryAppender = createAndAssignMemoryAppender(logger);
 
 		MdmMatchOutcome result = myMdmResourceMatcherSvc.match(myJohn, myJohny);
 		assertNotNull(result);
 
-		assertTrue(memoryAppender.contains("Evaluating match", Level.DEBUG));
-		assertTrue(memoryAppender.contains("No Match: Matcher patient-last did not match.", Level.DEBUG));
-		assertTrue(memoryAppender.contains("Match: Successfully matched Matcher patient-given.", Level.DEBUG));
+		//this test assumes, that the defined algorithm for calculating scores doesn't change
+		assertTrue(memoryAppender.contains("No match: Matcher patient-last did not match (score: 0.4", Level.TRACE));
+		assertTrue(memoryAppender.contains("Match: Successfully matched matcher patient-given with score 0.8", Level.TRACE));
 	}
 
-	
+	//problem not in matcher service!
+	@Test
+	public void testMatchWillProvideSummaryOnMatchinSuccessForEachField(){
+		Patient someoneElse = buildSomeoneElse();
+		Logger logger = (Logger) Logs.getMdmTroubleshootingLog();
+		logger.setLevel(Level.TRACE);
+
+		MemoryAppender memoryAppender = createAndAssignMemoryAppender(logger);
+
+		MdmMatchOutcome result = myMdmResourceMatcherSvc.match(myJohn, someoneElse);
+		assertNotNull(result);
+
+		assertTrue(memoryAppender.contains("Field matcher results: patient-given: NO\n" +
+			"patient-last: YES", Level.TRACE));
+	}
+
+	protected Patient buildSomeoneElse() {
+		Patient patient = new Patient();
+		patient.addName().addGiven("SomeOneElse");
+		patient.addName().setFamily("LastName");
+		patient.setId("Patient/3");
+		return patient;
+	}
+
 
 	protected MemoryAppender createAndAssignMemoryAppender(Logger theLogger){
 


### PR DESCRIPTION
this pull request is instead of https://github.com/hapifhir/hapi-fhir/pull/3539 to be consistent with ticket numbers and naming.

Matcher fields now contain scores in TRACE level:
```
DEBUG Matcher patient-given is valid for resource type: Patient. Evaluating match.
TRACE No match: Matcher patient-given did not match (score: 0.0).
DEBUG Matcher patient-last is valid for resource type: Patient. Evaluating match.
TRACE Match: Successfully matched matcher patient-last with score 1.0.
```
The summary now contains information on success for each matcher field:
```
DEBUG NO_MATCH Patient/3503: MdmMatchOutcome[vector=1,score=1.4642857015132904,myCreatedNewResource=false,myEidMatch=false,myMatchResultEnum=NO_MATCH]
TRACE Field matcher results: 
birthday: YES
phone: NO
firstname-meta: NO
lastname-meta: NO
firstname-jaro: NO
lastname-jaro: NO
```
