### PR TITLE
Supported search

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3548-has-query-parameter-resolution
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3548-has-query-parameter-resolution
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 3548
+jira: SMILE-4023
+title: "A recent change caused searches that use _has in conjuction with a `Resource` search param (e.g. _id, _text) to fail. This has been fixed."
+

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -546,11 +546,11 @@ public class QueryStack {
 				//Ensure that the name of the search param
 				// (e.g. the `code` in Patient?_has:Observation:subject:code=sys|val)
 				// exists on the target resource type.
-				RuntimeSearchParam owningParameterDef = getRuntimeSearchParam(targetResourceType, paramName, 1209);
+				RuntimeSearchParam owningParameterDef = mySearchParamRegistry.getRuntimeSearchParam(targetResourceType, paramName);
 
 				//Ensure that the name of the back-referenced search param on the target (e.g. the `subject` in Patient?_has:Observation:subject:code=sys|val)
 				//exists on the target resource, or in the top-level Resource resource.
-				getRuntimeSearchParam(targetResourceType, paramReference, 1210);
+				mySearchParamRegistry.getRuntimeSearchParam(targetResourceType, paramReference);
 
 
 				IQueryParameterAnd<?> parsedParam = JpaParamUtil.parseQueryParams(mySearchParamRegistry, myFhirContext, owningParameterDef, paramName, parameters);
@@ -588,25 +588,6 @@ public class QueryStack {
 		}
 
 		return toAndPredicate(andPredicates);
-	}
-
-	/**
-	 * Find a search param for a resource. First, check the resource itself, then check the top-level `Resource` resource.
-	 * @param theResourceType
-	 * @param theParamName
-	 * @param theFailureCodeIfAbsent
-	 *
-	 * @return the {@link RuntimeSearchParam} that is found.
-	 */
-	private RuntimeSearchParam getRuntimeSearchParam(String theResourceType, String theParamName, int theFailureCodeIfAbsent) {
-		RuntimeSearchParam availableSearchParamDef = mySearchParamRegistry.getActiveSearchParam(theResourceType, theParamName);
-		if (availableSearchParamDef == null) {
-			availableSearchParamDef = mySearchParamRegistry.getActiveSearchParam("Resource", theParamName);
-		}
-		if (availableSearchParamDef == null) {
-			throw new InvalidRequestException(Msg.code(theFailureCodeIfAbsent) + "Unknown parameter name: " + theResourceType + ':' + theParamName);
-		}
-		return availableSearchParamDef;
 	}
 
 	public Condition createPredicateNumber(@Nullable DbColumn theSourceJoinColumn, String theResourceName,

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoDstu3SearchNoFtTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoDstu3SearchNoFtTest.java
@@ -499,7 +499,7 @@ public class FhirResourceDaoDstu3SearchNoFtTest extends BaseJpaDstu3Test {
 			myPatientDao.search(params);
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals(Msg.code(1210) + "Unknown parameter name: Observation:soooooobject", e.getMessage());
+			assertEquals(Msg.code(1209) + "Unknown parameter name: Observation:soooooobject", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchNoFtTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchNoFtTest.java
@@ -1157,7 +1157,7 @@ public class FhirResourceDaoR4SearchNoFtTest extends BaseJpaR4Test {
 			myPatientDao.search(params);
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals(Msg.code(1210) + "Unknown parameter name: Observation:soooooobject", e.getMessage());
+			assertEquals(Msg.code(1209) + "Unknown parameter name: Observation:soooooobject", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchNoHashesTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchNoHashesTest.java
@@ -639,7 +639,7 @@ public class FhirResourceDaoR4SearchNoHashesTest extends BaseJpaR4Test {
 			myPatientDao.search(params);
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals(Msg.code(1210) + "Unknown parameter name: Observation:soooooobject", e.getMessage());
+			assertEquals(Msg.code(1209) + "Unknown parameter name: Observation:soooooobject", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerConfiguration.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerConfiguration.java
@@ -54,6 +54,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -424,6 +425,12 @@ public class RestfulServerConfiguration implements ISearchParamRegistry {
 	@Override
 	public RuntimeSearchParam getActiveSearchParam(String theResourceName, String theParamName) {
 		return getActiveSearchParams(theResourceName).get(theParamName);
+	}
+
+	@Override
+	public boolean isSupportedForSearch(String theResourceName, String theParamName) {
+		RuntimeSearchParam activeSearchParam = getActiveSearchParam(theResourceName, theParamName);
+		return activeSearchParam != null || getActiveSearchParam("Resource", theParamName) != null;
 	}
 
 	@Override

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerConfiguration.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerConfiguration.java
@@ -428,12 +428,6 @@ public class RestfulServerConfiguration implements ISearchParamRegistry {
 	}
 
 	@Override
-	public boolean isSupportedForSearch(String theResourceName, String theParamName) {
-		RuntimeSearchParam activeSearchParam = getActiveSearchParam(theResourceName, theParamName);
-		return activeSearchParam != null || getActiveSearchParam("Resource", theParamName) != null;
-	}
-
-	@Override
 	public ResourceSearchParams getActiveSearchParams(@Nonnull String theResourceName) {
 		Validate.notBlank(theResourceName, "theResourceName must not be null or blank");
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
@@ -106,8 +106,8 @@ public interface ISearchParamRegistry {
 	/**
 	 * Find a search param for a resource. First, check the resource itself, then check the top-level `Resource` resource.
 	 *
-	 * @param theResourceType
-	 * @param theParamName
+	 * @param theResourceType the resource type.
+	 * @param theParamName the search parameter name.
 	 *
 	 * @return the {@link RuntimeSearchParam} that is found.
 	 */

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
@@ -22,7 +22,9 @@ package ca.uhn.fhir.rest.server.util;
 
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.context.phonetic.IPhoneticEncoder;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 
 import javax.annotation.Nullable;
@@ -101,4 +103,22 @@ public interface ISearchParamRegistry {
 	@Nullable
 	RuntimeSearchParam getActiveSearchParamByUrl(String theUrl);
 
+	/**
+	 * Find a search param for a resource. First, check the resource itself, then check the top-level `Resource` resource.
+	 *
+	 * @param theResourceType
+	 * @param theParamName
+	 *
+	 * @return the {@link RuntimeSearchParam} that is found.
+	 */
+	default RuntimeSearchParam getRuntimeSearchParam(String theResourceType, String theParamName) {
+		RuntimeSearchParam availableSearchParamDef = getActiveSearchParam(theResourceType, theParamName);
+		if (availableSearchParamDef == null) {
+			availableSearchParamDef = getActiveSearchParam("Resource", theParamName);
+		}
+		if (availableSearchParamDef == null) {
+			throw new InvalidRequestException(Msg.code(1209) + "Unknown parameter name: " + theResourceType + ':' + theParamName);
+		}
+		return availableSearchParamDef;
+	}
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
@@ -41,6 +41,17 @@ public interface ISearchParamRegistry {
 	RuntimeSearchParam getActiveSearchParam(String theResourceName, String theParamName);
 
 	/**
+	 * indicates if the search parameter can be used for the given resource.
+	 *
+	 * @param theResourceName the resource name, e.g. Patient
+	 * @param theParamName The name of the search parameter, e.g. given, _id, _text, name.
+	 *
+	 * @return a boolean indicating if the search parameter can be used for the given resource.
+	 */
+	boolean isSupportedForSearch(String theResourceName, String theParamName);
+
+
+	/**
 	 * @return Returns all active search params for the given resource
 	 */
 	ResourceSearchParams getActiveSearchParams(String theResourceName);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ISearchParamRegistry.java
@@ -40,16 +40,6 @@ public interface ISearchParamRegistry {
 	 */
 	RuntimeSearchParam getActiveSearchParam(String theResourceName, String theParamName);
 
-	/**
-	 * indicates if the search parameter can be used for the given resource.
-	 *
-	 * @param theResourceName the resource name, e.g. Patient
-	 * @param theParamName The name of the search parameter, e.g. given, _id, _text, name.
-	 *
-	 * @return a boolean indicating if the search parameter can be used for the given resource.
-	 */
-	boolean isSupportedForSearch(String theResourceName, String theParamName);
-
 
 	/**
 	 * @return Returns all active search params for the given resource
@@ -67,7 +57,6 @@ public interface ISearchParamRegistry {
 	 */
 	default void requestRefresh() {
 	}
-
 
 	/**
 	 * When indexing a HumanName, if a StringEncoder is set in the context, then the "phonetic" search parameter will normalize


### PR DESCRIPTION
Closes #3548 

* When resolving a _has parameter, use more than just the SPs from the resourcetype itself. Also use the `Resource` search params.