### PR TITLE
Add implementation and changelog, and test.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3553-prevent-deexternalize.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3553-prevent-deexternalize.yaml
@@ -1,0 +1,4 @@
+type: fix
+issue: 3553
+jira: SMILE-3964
+title: "Added a new setting to BinaryStorageInterceptor which allows you to disable binary de-externalization during resource reads."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -263,8 +263,8 @@ public class JpaConfig {
 	@Lazy
 	public BinaryStorageInterceptor binaryStorageInterceptor(DaoConfig theDaoConfig) {
 		BinaryStorageInterceptor interceptor = new BinaryStorageInterceptor();
-		interceptor.setAllowAutoDeExternalizingBinaries(theDaoConfig.isAllowAutoDeExternalizingBinaries());
-		interceptor.setAutoDeExternalizeMaximumBytes(theDaoConfig.getAutoDeExternalizeMaximumBytes());
+		interceptor.setAllowAutoInflateBinaries(theDaoConfig.isAllowAutoInflateBinaries());
+		interceptor.setAutoInflateBinariesMaximumSize(theDaoConfig.getAutoInflateBinariesMaximumBytes());
 		return interceptor;
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -261,8 +261,11 @@ public class JpaConfig {
 
 	@Bean(name = "myBinaryStorageInterceptor")
 	@Lazy
-	public BinaryStorageInterceptor binaryStorageInterceptor() {
-		return new BinaryStorageInterceptor();
+	public BinaryStorageInterceptor binaryStorageInterceptor(DaoConfig theDaoConfig) {
+		BinaryStorageInterceptor interceptor = new BinaryStorageInterceptor();
+		interceptor.setAllowAutoDeExternalizingBinaries(theDaoConfig.isAllowAutoDeExternalizingBinaries());
+		interceptor.setAutoDeExternalizeMaximumBytes(theDaoConfig.getAutoDeExternalizeMaximumBytes());
+		return interceptor;
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
@@ -59,8 +59,8 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		super.after();
 		myStorageSvc.setMinimumBinarySize(0);
 		myDaoConfig.setExpungeEnabled(new DaoConfig().isExpungeEnabled());
-		myBinaryStorageInterceptor.setAutoDeExternalizeMaximumBytes(new BinaryStorageInterceptor().getAutoDeExternalizeMaximumBytes());
-		myBinaryStorageInterceptor.setAllowAutoDeExternalizingBinaries(new BinaryStorageInterceptor().isAllowAutoDeExternalizingBinaries());
+		myBinaryStorageInterceptor.setAutoInflateBinariesMaximumSize(new BinaryStorageInterceptor().getAutoInflateBinariesMaximumSize());
+		myBinaryStorageInterceptor.setAllowAutoInflateBinaries(new BinaryStorageInterceptor().isAllowAutoInflateBinaries());
 
 		MemoryBinaryStorageSvcImpl binaryStorageSvc = (MemoryBinaryStorageSvcImpl) myBinaryStorageSvc;
 		binaryStorageSvc.clear();
@@ -115,7 +115,7 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	public void testCreateAndRetrieveBinary_ServerAssignedId_ExternalizedBinary_DoNotRehydrate() {
-		myBinaryStorageInterceptor.setAllowAutoDeExternalizingBinaries(false);
+		myBinaryStorageInterceptor.setAllowAutoInflateBinaries(false);
 
 		// Create a resource with a big enough binary
 		Binary binary = new Binary();
@@ -321,7 +321,7 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	public void testRetrieveBinaryAboveRetrievalThreshold() {
-		myBinaryStorageInterceptor.setAutoDeExternalizeMaximumBytes(5);
+		myBinaryStorageInterceptor.setAutoInflateBinariesMaximumSize(5);
 
 		// Create a resource with a big enough binary
 		Binary binary = new Binary();

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
@@ -49,6 +49,7 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		super.before();
 		myStorageSvc.setMinimumBinarySize(10);
 		myDaoConfig.setExpungeEnabled(true);
+
 		myInterceptorRegistry.registerInterceptor(myBinaryStorageInterceptor);
 	}
 
@@ -59,6 +60,7 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		myStorageSvc.setMinimumBinarySize(0);
 		myDaoConfig.setExpungeEnabled(new DaoConfig().isExpungeEnabled());
 		myBinaryStorageInterceptor.setAutoDeExternalizeMaximumBytes(new BinaryStorageInterceptor().getAutoDeExternalizeMaximumBytes());
+		myBinaryStorageInterceptor.setAllowAutoDeExternalizingBinaries(new BinaryStorageInterceptor().isAllowAutoDeExternalizingBinaries());
 
 		MemoryBinaryStorageSvcImpl binaryStorageSvc = (MemoryBinaryStorageSvcImpl) myBinaryStorageSvc;
 		binaryStorageSvc.clear();
@@ -113,7 +115,6 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	public void testCreateAndRetrieveBinary_ServerAssignedId_ExternalizedBinary_DoNotRehydrate() {
-
 		myBinaryStorageInterceptor.setAllowAutoDeExternalizingBinaries(false);
 
 		// Create a resource with a big enough binary
@@ -129,7 +130,7 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		assertThat(encoded, containsString(HapiExtensions.EXT_EXTERNALIZED_BINARY_ID));
 		assertThat(encoded, not(containsString("\"data\"")));
 
-		// Now read it back and make sure it was de-externalized
+		// Now read it back and make sure it was not  de-externalized
 		Binary output = myBinaryDao.read(id, mySrd);
 		assertEquals("application/octet-stream", output.getContentType());
 		assertArrayEquals(null, output.getData());

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
@@ -302,11 +302,11 @@ public class DaoConfig {
 	/**
 	 * Since 6.0.0
 	 */
-	private boolean myAllowAutoDeExternalizingBinaries = true;
+	private boolean myAllowAutoInflateBinaries = true;
 	/**
 	 * Since 6.0.0
 	 */
-	private long myAutoDeExternalizeMaximumBytes = 10 * FileUtils.ONE_MB;
+	private long myAutoInflateBinariesMaximumBytes = 10 * FileUtils.ONE_MB;
 
 	/**
 	 * Constructor
@@ -2812,50 +2812,50 @@ public class DaoConfig {
 
 	/**
 	 *
-	 * This setting indicates whether binaries are allowed to be de-externalized automatically during requests.
+	 * This setting indicates whether binaries are allowed to be automatically inflated from external storage during requests.
 	 * Default is true.
 	 *
 	 * @since 6.0.0
-	 * @return whether binaries are allowed to be de-externalized automatically during requests.
+	 * @return whether binaries are allowed to be automatically inflated from external storage during requests.
 	 */
-	public boolean isAllowAutoDeExternalizingBinaries() {
-		return myAllowAutoDeExternalizingBinaries;
+	public boolean isAllowAutoInflateBinaries() {
+		return myAllowAutoInflateBinaries;
 	}
 
 
 	/**
-	 * This setting indicates whether binaries are allowed to be de-externalized automatically during requests.
+	 * This setting indicates whether binaries are allowed to be automatically inflated from external storage during requests.
 	 * Default is true.
 	 *
 	 * @since 6.0.0
 	 * @param theAllowAutoDeExternalizingBinaries the value to set.
 	 */
-	public void setAllowAutoDeExternalizingBinaries(boolean theAllowAutoDeExternalizingBinaries) {
-		myAllowAutoDeExternalizingBinaries = theAllowAutoDeExternalizingBinaries;
+	public void setAllowAutoInflateBinaries(boolean theAllowAutoDeExternalizingBinaries) {
+		myAllowAutoInflateBinaries = theAllowAutoDeExternalizingBinaries;
 	}
 
 	/**
-	 * This setting controls how many bytes of binaries will be de-externalized automatically when you query resources
+	 * This setting controls how many bytes of binaries will be automatically inflated from external storage during requests.
 	 * which contain binary data.
 	 * Default is 10MB
 	 *
 	 * @since 6.0.0
-	 * @param theAutoDeExternalizeMaximumBytes the maximum number of bytes to de-externalize.
+	 * @param theAutoInflateBinariesMaximumBytes the maximum number of bytes to de-externalize.
 	 */
-	public void setAutoDeExternalizeMaximumBytes(long theAutoDeExternalizeMaximumBytes) {
-		myAutoDeExternalizeMaximumBytes = theAutoDeExternalizeMaximumBytes;
+	public void setAutoInflateBinariesMaximumBytes(long theAutoInflateBinariesMaximumBytes) {
+		myAutoInflateBinariesMaximumBytes = theAutoInflateBinariesMaximumBytes;
 	}
 
 	/**
-	 * This setting controls how many bytes of binaries will be de-externalized automatically when you query resources
+	 * This setting controls how many bytes of binaries will be automatically inflated from external storage during requests.
 	 * which contain binary data.
 	 * Default is 10MB
 	 *
 	 * @since 6.0.0
 	 * @return the number of bytes to de-externalize during requests.
 	 */
-	public long getAutoDeExternalizeMaximumBytes() {
-		return myAutoDeExternalizeMaximumBytes;
+	public long getAutoInflateBinariesMaximumBytes() {
+		return myAutoInflateBinariesMaximumBytes;
 	}
 
 	public enum StoreMetaSourceInformationEnum {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
@@ -9,6 +9,7 @@ import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.validation.FhirValidator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
@@ -297,6 +298,15 @@ public class DaoConfig {
 	 * @since 5.7.0
 	 */
 	private boolean myConcurrentBundleValidation;
+
+	/**
+	 * Since 6.0.0
+	 */
+	private boolean myAllowAutoDeExternalizingBinaries = true;
+	/**
+	 * Since 6.0.0
+	 */
+	private long myAutoDeExternalizeMaximumBytes = 10 * FileUtils.ONE_MB;
 
 	/**
 	 * Constructor
@@ -2793,10 +2803,59 @@ public class DaoConfig {
 	 * This setting indicates if a cross-partition subscription can be made.
 	 *
 	 * @see ModelConfig#setCrossPartitionSubscription(boolean)
-	 * @since 7.5.0
+	 * @since 5.7.0
 	 */
 	public void setCrossPartitionSubscription(boolean theAllowCrossPartitionSubscription) {
 		this.myModelConfig.setCrossPartitionSubscription(theAllowCrossPartitionSubscription);
+	}
+
+
+	/**
+	 *
+	 * This setting indicates whether binaries are allowed to be de-externalized automatically during requests.
+	 * Default is true.
+	 *
+	 * @since 6.0.0
+	 * @return whether binaries are allowed to be de-externalized automatically during requests.
+	 */
+	public boolean isAllowAutoDeExternalizingBinaries() {
+		return myAllowAutoDeExternalizingBinaries;
+	}
+
+
+	/**
+	 * This setting indicates whether binaries are allowed to be de-externalized automatically during requests.
+	 * Default is true.
+	 *
+	 * @since 6.0.0
+	 * @param theAllowAutoDeExternalizingBinaries the value to set.
+	 */
+	public void setAllowAutoDeExternalizingBinaries(boolean theAllowAutoDeExternalizingBinaries) {
+		myAllowAutoDeExternalizingBinaries = theAllowAutoDeExternalizingBinaries;
+	}
+
+	/**
+	 * This setting controls how many bytes of binaries will be de-externalized automatically when you query resources
+	 * which contain binary data.
+	 * Default is 10MB
+	 *
+	 * @since 6.0.0
+	 * @param theAutoDeExternalizeMaximumBytes the maximum number of bytes to de-externalize.
+	 */
+	public void setAutoDeExternalizeMaximumBytes(long theAutoDeExternalizeMaximumBytes) {
+		myAutoDeExternalizeMaximumBytes = theAutoDeExternalizeMaximumBytes;
+	}
+
+	/**
+	 * This setting controls how many bytes of binaries will be de-externalized automatically when you query resources
+	 * which contain binary data.
+	 * Default is 10MB
+	 *
+	 * @since 6.0.0
+	 * @return the number of bytes to de-externalize during requests.
+	 */
+	public long getAutoDeExternalizeMaximumBytes() {
+		return myAutoDeExternalizeMaximumBytes;
 	}
 
 	public enum StoreMetaSourceInformationEnum {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
@@ -77,6 +77,7 @@ public class BinaryStorageInterceptor {
 	private Class<? extends IPrimitiveType<byte[]>> myBinaryType;
 	private String myDeferredListKey;
 	private long myAutoDeExternalizeMaximumBytes = 10 * FileUtils.ONE_MB;
+	private boolean myAllowAutoDeExternalizingBinaries = true;
 
 	/**
 	 * Any externalized binaries will be rehydrated if their size is below this thhreshold when
@@ -248,6 +249,10 @@ public class BinaryStorageInterceptor {
 
 	@Hook(Pointcut.STORAGE_PRESHOW_RESOURCES)
 	public void preShow(IPreResourceShowDetails theDetails) throws IOException {
+		if (!isAllowAutoDeExternalizingBinaries()) {
+			return;
+		}
+
 		long unmarshalledByteCount = 0;
 
 		for (IBaseResource nextResource : theDetails) {
@@ -293,6 +298,14 @@ public class BinaryStorageInterceptor {
 			}
 		});
 		return binaryTargets;
+	}
+
+	public void setAllowAutoDeExternalizingBinaries(boolean theAllowAutoDeExternalizingBinaries) {
+		myAllowAutoDeExternalizingBinaries = theAllowAutoDeExternalizingBinaries;
+	}
+
+	public boolean isAllowAutoDeExternalizingBinaries() {
+		return myAllowAutoDeExternalizingBinaries;
 	}
 
 	private static class DeferredBinaryTarget {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
@@ -76,23 +76,23 @@ public class BinaryStorageInterceptor {
 	private BinaryAccessProvider myBinaryAccessProvider;
 	private Class<? extends IPrimitiveType<byte[]>> myBinaryType;
 	private String myDeferredListKey;
-	private long myAutoDeExternalizeMaximumBytes = 10 * FileUtils.ONE_MB;
-	private boolean myAllowAutoDeExternalizingBinaries = true;
+	private long myAutoInflateBinariesMaximumBytes = 10 * FileUtils.ONE_MB;
+	private boolean myAllowAutoInflateBinaries = true;
 
 	/**
 	 * Any externalized binaries will be rehydrated if their size is below this thhreshold when
 	 * reading the resource back. Default is 10MB.
 	 */
-	public long getAutoDeExternalizeMaximumBytes() {
-		return myAutoDeExternalizeMaximumBytes;
+	public long getAutoInflateBinariesMaximumSize() {
+		return myAutoInflateBinariesMaximumBytes;
 	}
 
 	/**
 	 * Any externalized binaries will be rehydrated if their size is below this thhreshold when
 	 * reading the resource back. Default is 10MB.
 	 */
-	public void setAutoDeExternalizeMaximumBytes(long theAutoDeExternalizeMaximumBytes) {
-		myAutoDeExternalizeMaximumBytes = theAutoDeExternalizeMaximumBytes;
+	public void setAutoInflateBinariesMaximumSize(long theAutoInflateBinariesMaximumBytes) {
+		myAutoInflateBinariesMaximumBytes = theAutoInflateBinariesMaximumBytes;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -249,7 +249,7 @@ public class BinaryStorageInterceptor {
 
 	@Hook(Pointcut.STORAGE_PRESHOW_RESOURCES)
 	public void preShow(IPreResourceShowDetails theDetails) throws IOException {
-		if (!isAllowAutoDeExternalizingBinaries()) {
+		if (!isAllowAutoInflateBinaries()) {
 			return;
 		}
 
@@ -270,7 +270,7 @@ public class BinaryStorageInterceptor {
 						throw new InvalidRequestException(Msg.code(1330) + msg);
 					}
 
-					if ((unmarshalledByteCount + blobDetails.getBytes()) < myAutoDeExternalizeMaximumBytes) {
+					if ((unmarshalledByteCount + blobDetails.getBytes()) < myAutoInflateBinariesMaximumBytes) {
 
 						byte[] bytes = myBinaryStorageSvc.fetchBlob(resourceId, attachmentId.get());
 						nextTarget.setData(bytes);
@@ -300,12 +300,12 @@ public class BinaryStorageInterceptor {
 		return binaryTargets;
 	}
 
-	public void setAllowAutoDeExternalizingBinaries(boolean theAllowAutoDeExternalizingBinaries) {
-		myAllowAutoDeExternalizingBinaries = theAllowAutoDeExternalizingBinaries;
+	public void setAllowAutoInflateBinaries(boolean theAllowAutoInflateBinaries) {
+		myAllowAutoInflateBinaries = theAllowAutoInflateBinaries;
 	}
 
-	public boolean isAllowAutoDeExternalizingBinaries() {
-		return myAllowAutoDeExternalizingBinaries;
+	public boolean isAllowAutoInflateBinaries() {
+		return myAllowAutoInflateBinaries;
 	}
 
 	private static class DeferredBinaryTarget {


### PR DESCRIPTION
Closes #3553 

* Add 2 new DaoConfig options: 
  * `setAllowAutoInflateBinaries`
  * `setAutoInflateBinariesMaximumBytes`
* In BinaryStorageInterceptor, if we detect that it is disabled, or the binary size is set to 0, just skip iteration completely. This should improve processing speed for servers who never need to automatically de-externalize binaries. 
