### PR TITLE
3523 vs expand implicit

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/i18n/Msg.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/i18n/Msg.java
@@ -25,7 +25,7 @@ public final class Msg {
 
 	/**
 	 * IMPORTANT: Please update the following comment after you add a new code
-	 * Last code value: 2078
+	 * Last code value: 2079
 	 */
 
 	private Msg() {}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/i18n/Msg.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/i18n/Msg.java
@@ -25,7 +25,7 @@ public final class Msg {
 
 	/**
 	 * IMPORTANT: Please update the following comment after you add a new code
-	 * Last code value: 2076
+	 * Last code value: 2078
 	 */
 
 	private Msg() {}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
@@ -133,8 +133,12 @@ public class JpaPersistedResourceValidationSupport implements IValidationSupport
 			Optional<IBaseResource> currentVSOpt = getValueSetCurrentVersion(new UriType(theSystem));
 			return currentVSOpt.orElse(null);
 		}
-
-		return fetchResource(myValueSetType, theSystem);
+		IBaseResource returnVs = fetchResource(myValueSetType, theSystem);
+		if (returnVs == null) {
+			ourLog.debug("Did not find an explicit ValueSet resource from the URL {}; trying CodeSystem.valueSet", theSystem);
+			return myTermReadSvc.expandValueSetFromCodeSystem(theSystem);
+		}
+		return returnVs;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/ITermCodeSystemVersionDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/ITermCodeSystemVersionDao.java
@@ -50,4 +50,7 @@ public interface ITermCodeSystemVersionDao extends JpaRepository<TermCodeSystemV
 	@Query("SELECT cs FROM TermCodeSystemVersion cs WHERE cs.myCodeSystemHavingThisVersionAsCurrentVersionIfAny.myResource.myId = :resource_id")
 	TermCodeSystemVersion findCurrentVersionForCodeSystemResourcePid(@Param("resource_id") Long theCodeSystemResourcePid);
 
+	@Query("SELECT cs FROM TermCodeSystemVersion cs WHERE cs.myCodeSystemValueSet = :codesystem_valueset")
+	List<TermCodeSystemVersion> findByCodeSystemValueset(@Param("codesystem_valueset") String theCodeSystemValueSet);
+
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermCodeSystemVersion.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermCodeSystemVersion.java
@@ -57,6 +57,7 @@ import static org.apache.commons.lang3.StringUtils.length;
 public class TermCodeSystemVersion implements Serializable {
 	public static final String IDX_CODESYSTEM_AND_VER = "IDX_CODESYSTEM_AND_VER";
 	public static final int MAX_VERSION_LENGTH = 200;
+	public static final int MAX_URL_LENGTH = 200;
 	private static final long serialVersionUID = 1L;
 
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "myCodeSystem")
@@ -95,6 +96,9 @@ public class TermCodeSystemVersion implements Serializable {
 
 	@Column(name = "CS_DISPLAY", nullable = true, updatable = true, length = MAX_VERSION_LENGTH)
 	private String myCodeSystemDisplayName;
+
+	@Column(name = "CS_VS_URL", nullable = true, updatable = true, length = MAX_URL_LENGTH)
+	private String myCodeSystemValueSet;
 
 	/**
 	 * Constructor
@@ -150,6 +154,13 @@ public class TermCodeSystemVersion implements Serializable {
 		return this;
 	}
 
+	public String getCodeSystemValueSet() { return myCodeSystemValueSet; }
+
+	public TermCodeSystemVersion setCodeSystemValueSet(String codeSystemValueSet) {
+		myCodeSystemValueSet = codeSystemValueSet;
+		return this;
+	}
+
 	@Override
 	public boolean equals(Object theO) {
 		if (this == theO) {
@@ -202,6 +213,7 @@ public class TermCodeSystemVersion implements Serializable {
 		b.append("codeSystemResourcePid", myResourcePid);
 		b.append("codeSystemPid", myCodeSystemPid);
 		b.append("codeSystemVersionId", myCodeSystemVersionId);
+		b.append("codeSystemValueSet", myCodeSystemValueSet);
 		return b.toString();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
@@ -548,7 +548,7 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 		List<TermCodeSystemVersion> matchingValueSets = myCodeSystemVersionDao.findByCodeSystemValueset(theValueSetUri);
 		if (matchingValueSets.size() == 0) return null; //nothing was found, continue
 		if (matchingValueSets.size() > 1) {
-			String message = Msg.code(2077) + "More than one CodeSystem resource was found matching the provided implicit ValueSet URI: " +
+			String message = Msg.code(2079) + "More than one CodeSystem resource was found matching the provided implicit ValueSet URI: " +
 				matchingValueSets.stream().map(v -> v.getCodeSystem().getCodeSystemUri()).sorted().collect(Collectors.joining("; "));
 			throw new UnprocessableEntityException(message);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
@@ -548,7 +548,7 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 		List<TermCodeSystemVersion> matchingValueSets = myCodeSystemVersionDao.findByCodeSystemValueset(theValueSetUri);
 		if (matchingValueSets.size() == 0) return null; //nothing was found, continue
 		if (matchingValueSets.size() > 1) {
-			String message = Msg.code(2075) + "More than one CodeSystem resource was found matching the provided implicit ValueSet URI: " +
+			String message = Msg.code(2077) + "More than one CodeSystem resource was found matching the provided implicit ValueSet URI: " +
 				matchingValueSets.stream().map(v -> v.getCodeSystem().getCodeSystemUri()).sorted().collect(Collectors.joining("; "));
 			throw new UnprocessableEntityException(message);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
@@ -677,6 +677,7 @@ public class TermCodeSystemStorageSvcImpl implements ITermCodeSystemStorageSvc {
 		theCodeSystemVersion.setResource(theResourceTable);
 		theCodeSystemVersion.setCodeSystemDisplayName(theCodeSystemResource.getName());
 		theCodeSystemVersion.setCodeSystemVersionId(theCodeSystemResource.getVersion());
+		theCodeSystemVersion.setCodeSystemValueSet(theCodeSystemResource.getValueSet());
 	}
 
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu2.java
@@ -98,7 +98,7 @@ public class TermReadSvcDstu2 extends BaseTermReadSvcImpl {
 
 	@Override
 	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
-		throw new UnsupportedOperationException(Msg.code(2074));
+		throw new UnsupportedOperationException(Msg.code(2078));
 	}
 
 	private void findCodesAbove(ca.uhn.fhir.model.dstu2.resource.ValueSet theSystem, String theSystemString, String theCode, List<FhirVersionIndependentConcept> theListToPopulate) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu2.java
@@ -96,6 +96,11 @@ public class TermReadSvcDstu2 extends BaseTermReadSvcImpl {
 		throw new UnsupportedOperationException(Msg.code(856));
 	}
 
+	@Override
+	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
+		throw new UnsupportedOperationException(Msg.code(2074));
+	}
+
 	private void findCodesAbove(ca.uhn.fhir.model.dstu2.resource.ValueSet theSystem, String theSystemString, String theCode, List<FhirVersionIndependentConcept> theListToPopulate) {
 		List<ca.uhn.fhir.model.dstu2.resource.ValueSet.CodeSystemConcept> conceptList = theSystem.getCodeSystem().getConcept();
 		for (ca.uhn.fhir.model.dstu2.resource.ValueSet.CodeSystemConcept next : conceptList) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu3.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu3.java
@@ -134,8 +134,8 @@ public class TermReadSvcDstu3 extends BaseTermReadSvcImpl implements IValidation
 
 	@Override
 	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
-		// TODO: 08/04/22 NYI
-		throw new NotImplementedException("expansion for DSTU3 from CodeSystem is not yet implemented");
+		org.hl7.fhir.r4.model.ValueSet expandedR4 = (org.hl7.fhir.r4.model.ValueSet) super.expandValueSetFromCodeSystem(theValueSetUri);
+		return VersionConvertorFactory_30_40.convertResource(expandedR4, new BaseAdvisor_30_40(false));
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu3.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcDstu3.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.term.api.ITermReadSvcDstu3;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.ValidateUtil;
+import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_30_40;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
 import org.hl7.fhir.dstu3.model.CodeSystem;
@@ -129,6 +130,12 @@ public class TermReadSvcDstu3 extends BaseTermReadSvcImpl implements IValidation
 		} catch (FHIRException e) {
 			throw new InternalErrorException(Msg.code(835) + e);
 		}
+	}
+
+	@Override
+	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
+		// TODO: 08/04/22 NYI
+		throw new NotImplementedException("expansion for DSTU3 from CodeSystem is not yet implemented");
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR4.java
@@ -5,14 +5,9 @@ import ca.uhn.fhir.context.support.ConceptValidationOptions;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.context.support.ValueSetExpansionOptions;
-import ca.uhn.fhir.i18n.Msg;
-import ca.uhn.fhir.jpa.entity.TermCodeSystem;
-import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
-import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.term.api.ITermReadSvcR4;
 import ca.uhn.fhir.jpa.term.ex.ExpansionTooCostlyException;
-import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -25,9 +20,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.annotation.Nonnull;
 import javax.transaction.Transactional;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /*
  * #%L

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR4.java
@@ -68,29 +68,7 @@ public class TermReadSvcR4 extends BaseTermReadSvcImpl implements ITermReadSvcR4
 
 	@Override
 	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
-		List<TermCodeSystemVersion> matchingValueSets = super.myCodeSystemVersionDao.findByCodeSystemValueset(theValueSetUri);
-		if (matchingValueSets.size() == 0) return null; //nothing was found, continue
-		if (matchingValueSets.size() > 1) {
-			String message = Msg.code(2075) + "More than one CodeSystem resource was found matching the provided implicit ValueSet URI: " +
-				matchingValueSets.stream().map(v -> v.getCodeSystem().getCodeSystemUri()).sorted().collect(Collectors.joining("; "));
-			throw new UnprocessableEntityException(message);
-		}
-		// we have exactly one CS
-		TermCodeSystem ourCodeSystem = matchingValueSets.get(0).getCodeSystem();
-		Collection<TermConcept> ourConcepts = matchingValueSets.get(0).getConcepts();
-		ValueSet toReturn = new ValueSet();
-		toReturn.setUrl(theValueSetUri);
-		toReturn.getCompose().addInclude()
-			.setSystem(ourCodeSystem.getCodeSystemUri())
-			.setVersion(ourCodeSystem.getCurrentVersion().getCodeSystemVersionId());
-
-		for (TermConcept ourConcept : ourConcepts) {
-			toReturn.getExpansion().addContains()
-				.setSystem(ourCodeSystem.getCodeSystemUri())
-				.setCode(ourConcept.getCode())
-				.setDisplay(ourConcept.getDisplay());
-		}
-		return toReturn;
+		return super.expandValueSetFromCodeSystem(theValueSetUri);
 	}
 
 	@Transactional(dontRollbackOn = {ExpansionTooCostlyException.class})

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR5.java
@@ -78,8 +78,8 @@ public class TermReadSvcR5 extends BaseTermReadSvcImpl implements IValidationSup
 
 	@Override
 	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
-		// TODO: 08/04/22 NYI
-		throw new NotImplementedException("expansion for R5 from CodeSystem is not yet implemented");
+		org.hl7.fhir.r4.model.ValueSet valueSetR4 = (org.hl7.fhir.r4.model.ValueSet) super.expandValueSetFromCodeSystem(theValueSetUri);
+		return VersionConvertorFactory_40_50.convertResource(valueSetR4, new BaseAdvisor_40_50(false));
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcR5.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.term.api.ITermReadSvcR5;
 import ca.uhn.fhir.jpa.term.ex.ExpansionTooCostlyException;
 import ca.uhn.fhir.util.ValidateUtil;
+import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -73,6 +74,12 @@ public class TermReadSvcR5 extends BaseTermReadSvcImpl implements IValidationSup
 	public void expandValueSet(ValueSetExpansionOptions theExpansionOptions, IBaseResource theValueSetToExpand, IValueSetConceptAccumulator theValueSetCodeAccumulator) {
 		org.hl7.fhir.r4.model.ValueSet valueSetToExpand = toCanonicalValueSet(theValueSetToExpand);
 		super.expandValueSet(theExpansionOptions, valueSetToExpand, theValueSetCodeAccumulator);
+	}
+
+	@Override
+	public IBaseResource expandValueSetFromCodeSystem(String theValueSetUri) {
+		// TODO: 08/04/22 NYI
+		throw new NotImplementedException("expansion for R5 from CodeSystem is not yet implemented");
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/api/ITermReadSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/api/ITermReadSvc.java
@@ -70,6 +70,8 @@ public interface ITermReadSvc extends IValidationSupport {
 
 	void expandValueSet(@Nullable ValueSetExpansionOptions theExpansionOptions, IBaseResource theValueSetToExpand, IValueSetConceptAccumulator theValueSetCodeAccumulator);
 
+	IBaseResource expandValueSetFromCodeSystem(String theValueSetUri);
+
 	List<FhirVersionIndependentConcept> expandValueSetIntoConceptList(ValueSetExpansionOptions theExpansionOptions, String theValueSetCanonicalUrl);
 
 	Optional<TermConcept> findCode(String theCodeSystem, String theCode);


### PR DESCRIPTION
Fixing #3523 

This PR allows expansion of ValueSets using `ValueSet/$expand` from the `CodeSystem.valueSet` parameter, as long as the URL is unique. It is implemented primarily for R4, but also for DSTU3 and R5 (converting from R4). DSTU2 did not yet separate CodeSystem and ValueSet, so this operation throws on DSTU2.

The issue was discussed in [FHIR Chat](https://chat.fhir.org/#narrow/stream/179202-terminology/topic/CodeSystem.20URI.20as.20ValueSet.20URI)