### PR TITLE
Add res_id, and partition_id to string norm and exact indexes

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3569-extend-string-index.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3569-extend-string-index.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 3569
+title: "The normalized and exact string database indexes have been changed to provide faster string searches."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -301,6 +301,33 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.onTable("HFJ_RESOURCE")
 				.dropIndexOnline("20220425.2", "IDX_RES_TYPE");
 		}
+
+		/**
+		 * Update string indexing
+		 * @see ca.uhn.fhir.jpa.search.builder.predicate.StringPredicateBuilder
+		 * @see ResourceIndexedSearchParamString
+		 */
+		{
+			Builder.BuilderWithTableName tokenTable = version.onTable("HFJ_SPIDX_STRING");
+
+			// add res_id, and partition_id so queries are covered without row-reads.
+			tokenTable
+				.addIndex("20220428.1", "IDX_SP_STRING_HASH_NRM_V2")
+				.unique(false)
+				.online(true)
+				.withColumns("HASH_NORM_PREFIX", "SP_VALUE_NORMALIZED", "RES_ID", "PARTITION_ID");
+			tokenTable.dropIndexOnline("20220428.2", "IDX_SP_STRING_HASH_NRM");
+
+			tokenTable
+				.addIndex("20220428.3", "IDX_SP_STRING_HASH_EXCT_V2")
+				.unique(false)
+				.online(true)
+				.withColumns("HASH_EXACT", "RES_ID", "PARTITION_ID");
+			tokenTable.dropIndexOnline("20220428.4", "IDX_SP_STRING_HASH_EXCT");
+
+			// we will drop the updated column.  Start with the index.
+			tokenTable.dropIndexOnline("20220428.5", "IDX_SP_STRING_UPDATED");
+		}
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -59,10 +59,9 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 	// This is used for sorting, and for :contains queries currently
 	@Index(name = "IDX_SP_STRING_HASH_IDENT", columnList = "HASH_IDENTITY"),
 
-	@Index(name = "IDX_SP_STRING_HASH_NRM", columnList = "HASH_NORM_PREFIX,SP_VALUE_NORMALIZED"),
-	@Index(name = "IDX_SP_STRING_HASH_EXCT", columnList = "HASH_EXACT"),
+	@Index(name = "IDX_SP_STRING_HASH_NRM_V2", columnList = "HASH_NORM_PREFIX,SP_VALUE_NORMALIZED,RES_ID,PARTITION_ID"),
+	@Index(name = "IDX_SP_STRING_HASH_EXCT_V2", columnList = "HASH_EXACT,RES_ID,PARTITION_ID"),
 
-	@Index(name = "IDX_SP_STRING_UPDATED", columnList = "SP_UPDATED"),
 	@Index(name = "IDX_SP_STRING_RESID", columnList = "RES_ID")
 })
 public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchParam {


### PR DESCRIPTION
The current string search indexes require row reads for each match, and these will be random blocks.
We add res_id, and partition_id so the queries can be satisfied directly by an index scan.
