### PR TITLE
Fix tag db migration

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3578-fix-tag-index.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3578-fix-tag-index.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 3578
+title: "The tag index migration failed on Postres and Oracle.  These have been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -345,9 +345,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.addIndex("20220429.2", "IDX_RES_TAG_TAG_RES")
 				.unique(false)
 				.online(true)
-				.withColumns("RES_ID", "TAG_ID", "PARTITION_ID");
+				.withColumns("TAG_ID", "RES_ID", "PARTITION_ID");
 
-			resTagTable.dropIndexOnline("20220429.4", "IDX_RESTAG_TAGID");
+			resTagTable.dropIndex("20220429.4", "IDX_RESTAG_TAGID");
 			// Weird that we don't have addConstraint.  No time to do it today.
 			Map<DriverTypeEnum, String> addResTagConstraint = new HashMap<>();
 			addResTagConstraint.put(DriverTypeEnum.H2_EMBEDDED, "ALTER TABLE HFJ_RES_TAG ADD CONSTRAINT IDX_RESTAG_TAGID UNIQUE (RES_ID, TAG_ID)");
@@ -365,8 +365,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.online(false)
 				.withColumns("TAG_TYPE", "TAG_CODE", "TAG_SYSTEM", "TAG_ID");
 			// move constraint to new index
-			// note the constraint has fewer columns than the index.  But these engines can enforce a constraint narrower than the index.
-			tagTable.dropIndexOnline("20220429.8", "IDX_TAGDEF_TYPESYSCODE");
+			// Ugh.  Only oracle supports using IDX_TAG_DEF_TP_CD_SYS to enforce this constraint.  The others will create another index.
+			// For Sql Server, should change the index to be unique with include columns.  Do this in 6.1
+			tagTable.dropIndex("20220429.8", "IDX_TAGDEF_TYPESYSCODE");
 			Map<DriverTypeEnum, String> addTagDefConstraint = new HashMap<>();
 			addTagDefConstraint.put(DriverTypeEnum.H2_EMBEDDED, "ALTER TABLE HFJ_TAG_DEF ADD CONSTRAINT IDX_TAGDEF_TYPESYSCODE UNIQUE (TAG_TYPE, TAG_CODE, TAG_SYSTEM)");
 			addTagDefConstraint.put(DriverTypeEnum.MARIADB_10_1, "ALTER TABLE HFJ_TAG_DEF ADD CONSTRAINT IDX_TAGDEF_TYPESYSCODE UNIQUE (TAG_TYPE, TAG_CODE, TAG_SYSTEM)");


### PR DESCRIPTION
PG doesn't support drop index online.  
Change migrations to reflect this.
Also fix wrong column order.
