### PR TITLE
Fix regression of 3411 - _lastUpdated gets clobbered during $reindex job

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
@@ -61,6 +61,7 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 	/**
 	 * Copy constructor.
 	 */
+	@SuppressWarnings("CopyConstructorMissesField")
 	public DateRangeParam(DateRangeParam theDateRangeParam) {
 		super();
 		Validate.notNull(theDateRangeParam);
@@ -246,7 +247,7 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 	 * are the same value. As such, even though the prefixes for the lower and
 	 * upper bounds default to <code>ge</code> and <code>le</code> respectively,
 	 * the resulting prefix is effectively <code>eq</code> where only a single
-	 * date is provided - as required by the FHIR specificiation (i.e. "If no
+	 * date is provided - as required by the FHIR specification (i.e. "If no
 	 * prefix is present, the prefix <code>eq</code> is assumed").
 	 * </p>
 	 */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.QualifiedParamList;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.DateUtils;
+import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import java.util.ArrayList;
@@ -55,6 +56,16 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 	 */
 	public DateRangeParam() {
 		super();
+	}
+
+	/**
+	 * Copy constructor.
+	 */
+	public DateRangeParam(DateRangeParam theDateRangeParam) {
+		super();
+		Validate.notNull(theDateRangeParam);
+		setLowerBound(theDateRangeParam.getLowerBound());
+		setUpperBound(theDateRangeParam.getUpperBound());
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/DateRangeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/DateRangeUtil.java
@@ -1,0 +1,41 @@
+package ca.uhn.fhir.util;
+
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import com.sun.istack.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.Date;
+
+public class DateRangeUtil {
+
+	/**
+	 * Narrow the DateRange to be within theStartInclusive, and theEndExclusive, if provided.
+	 * @param theDateRangeParam the initial range, null for unconstrained
+	 * @param theStartInclusive a lower bound to apply, or null for unchanged.
+	 * @param theEndExclusive an upper bound to apply, or null for unchanged.
+	 * @return a DateRange within the original range, and between theStartInclusive and theEnd
+	 */
+	@NotNull
+	public static DateRangeParam narrowDateRange(@Nullable DateRangeParam theDateRangeParam, @Nullable Date theStartInclusive, @Nullable Date theEndExclusive) {
+		if (theStartInclusive == null && theEndExclusive == null) {
+			return theDateRangeParam;
+		}
+		DateRangeParam result = theDateRangeParam==null?new DateRangeParam():new DateRangeParam(theDateRangeParam);
+
+		if (theStartInclusive != null) {
+			Date inputStart = result.getLowerBoundAsInstant();
+			if (theDateRangeParam == null || inputStart == null || inputStart.before(theStartInclusive)) {
+				result.setLowerBoundInclusive(theStartInclusive);
+			}
+		}
+		if (theEndExclusive != null) {
+			Date inputEnd = result.getUpperBound() == null? null : result.getUpperBound().getValue();
+			if (theDateRangeParam == null || inputEnd == null || inputEnd.after(theEndExclusive)) {
+				result.setUpperBoundExclusive(theEndExclusive);
+			}
+		}
+
+		return result;
+	}
+
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/DateRangeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/DateRangeUtil.java
@@ -1,8 +1,8 @@
 package ca.uhn.fhir.util;
 
 import ca.uhn.fhir.rest.param.DateRangeParam;
-import com.sun.istack.NotNull;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Date;
 
@@ -15,7 +15,7 @@ public class DateRangeUtil {
 	 * @param theEndExclusive an upper bound to apply, or null for unchanged.
 	 * @return a DateRange within the original range, and between theStartInclusive and theEnd
 	 */
-	@NotNull
+	@Nonnull
 	public static DateRangeParam narrowDateRange(@Nullable DateRangeParam theDateRangeParam, @Nullable Date theStartInclusive, @Nullable Date theEndExclusive) {
 		if (theStartInclusive == null && theEndExclusive == null) {
 			return theDateRangeParam;

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -123,4 +125,18 @@ public class DateRangeParamTest {
 		assertEquals(ParamPrefixEnum.NOT_EQUAL, dateRangeParam.getLowerBound().getPrefix());
 		assertEquals(ParamPrefixEnum.NOT_EQUAL, dateRangeParam.getUpperBound().getPrefix());
 	}
+
+	@Test
+	public void testCopyConstructor() {
+		DateParam dateStart = new DateParam("gt2021-01-01");
+		DateParam dateEnd = new DateParam("lt2021-02-01");
+		DateRangeParam input = new DateRangeParam(dateStart, dateEnd);
+
+		DateRangeParam copy = new DateRangeParam(input);
+
+		assertEquals(dateStart, copy.getLowerBound());
+		assertEquals(dateEnd, copy.getUpperBound());
+
+	}
+
 }

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/DateRangeUtilTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/DateRangeUtilTest.java
@@ -5,7 +5,6 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ParamPrefixEnum;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -14,7 +13,9 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.GREATERTHAN;
 import static ca.uhn.fhir.rest.param.ParamPrefixEnum.GREATERTHAN_OR_EQUALS;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.LESSTHAN;
 import static ca.uhn.fhir.rest.param.ParamPrefixEnum.LESSTHAN_OR_EQUALS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -49,7 +50,7 @@ class DateRangeUtilTest {
 		static NarrowCase from(String theMessage, DateRangeParam theRange, Date theNarrowStart, Date theNarrowEnd, Date theResultStart, Date theResultEnd) {
 			return new NarrowCase(theMessage, theRange, theNarrowStart, theNarrowEnd,
 				theResultStart == null?null:new DateParam(GREATERTHAN_OR_EQUALS, theResultStart),
-				theResultEnd == null?null:new DateParam(ParamPrefixEnum.LESSTHAN, theResultEnd));
+				theResultEnd == null?null:new DateParam(LESSTHAN, theResultEnd));
 		}
 
 		static NarrowCase from(String theMessage, DateRangeParam theRange, Date theNarrowStart, Date theNarrowEnd,
@@ -87,7 +88,10 @@ class DateRangeUtilTest {
 			NarrowCase.from("end inside narrows end", new DateRangeParam(dateTwo, dateFive),  dateOne, dateFour, dateTwo, dateFour),
 			// half-open cases
 			NarrowCase.from("end inside open end", new DateRangeParam(dateTwo, null),  null, dateFour, dateTwo, dateFour),
-			NarrowCase.from("start inside open start", new DateRangeParam(null, dateFour),  dateTwo, null, GREATERTHAN_OR_EQUALS, dateTwo, LESSTHAN_OR_EQUALS, dateFour)
+			NarrowCase.from("start inside open start", new DateRangeParam(null, dateFour),  dateTwo, null, GREATERTHAN_OR_EQUALS, dateTwo, LESSTHAN_OR_EQUALS, dateFour),
+			NarrowCase.from("gt case preserved", new DateRangeParam(new DateParam(GREATERTHAN, dateTwo), null),  null, dateFour, GREATERTHAN, dateTwo, LESSTHAN, dateFour)
+
+
 		);
 	}
 

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/DateRangeUtilTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/DateRangeUtilTest.java
@@ -1,0 +1,108 @@
+package ca.uhn.fhir.util;
+
+import ca.uhn.fhir.rest.param.DateParam;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ParamPrefixEnum;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.GREATERTHAN_OR_EQUALS;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.LESSTHAN_OR_EQUALS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class DateRangeUtilTest {
+
+	static Date dateOne = Date.from(Instant.parse("2021-01-01T01:00:00Z"));
+	static Date dateTwo = Date.from(Instant.parse("2021-01-01T02:00:00Z"));
+	static Date dateThree = Date.from(Instant.parse("2021-01-01T03:00:00Z"));
+	static Date dateFour = Date.from(Instant.parse("2021-01-01T04:00:00Z"));
+	static Date dateFive = Date.from(Instant.parse("2021-01-01T05:00:00Z"));
+	static Date dateSix = Date.from(Instant.parse("2021-01-01T06:00:00Z"));
+
+	static class NarrowCase {
+		final String message;
+		final DateRangeParam range;
+		final Date narrowStart;
+		final Date narrowEnd;
+		final DateParam resultStart;
+		final DateParam resultEnd;
+
+		public NarrowCase(String theMessage, DateRangeParam theRange, Date theNarrowStart, Date theNarrowEnd, DateParam theResultStart, DateParam theResultEnd) {
+			message = theMessage;
+			range = theRange;
+			narrowStart = theNarrowStart;
+			narrowEnd = theNarrowEnd;
+			resultStart = theResultStart;
+			resultEnd = theResultEnd;
+		}
+
+
+		static NarrowCase from(String theMessage, DateRangeParam theRange, Date theNarrowStart, Date theNarrowEnd, Date theResultStart, Date theResultEnd) {
+			return new NarrowCase(theMessage, theRange, theNarrowStart, theNarrowEnd,
+				theResultStart == null?null:new DateParam(GREATERTHAN_OR_EQUALS, theResultStart),
+				theResultEnd == null?null:new DateParam(ParamPrefixEnum.LESSTHAN, theResultEnd));
+		}
+
+		static NarrowCase from(String theMessage, DateRangeParam theRange, Date theNarrowStart, Date theNarrowEnd,
+									  ParamPrefixEnum theResultStartPrefix, Date theResultStart, ParamPrefixEnum theResultEndPrefix, Date theResultEnd) {
+			return new NarrowCase(theMessage, theRange, theNarrowStart, theNarrowEnd,
+				new DateParam(theResultStartPrefix, theResultStart), new DateParam(theResultEndPrefix, theResultEnd));
+		}
+
+		@Override
+		public String toString() {
+			return new ToStringBuilder(this, ToStringStyle.SIMPLE_STYLE)
+				.append(message)
+				.append("range", range)
+				.append("narrowStart", narrowStart)
+				.append("narrowEnd", narrowEnd)
+				.append("resultStart", resultStart)
+				.append("resultEnd", resultEnd)
+				.toString();
+		}
+	}
+
+	static public List<NarrowCase> narrowCases() {
+
+		return Arrays.asList(
+			// null range cases
+			new NarrowCase("nulls on null yields null", null,  null,null, null, null),
+			NarrowCase.from("start and end narrow null", null,  dateTwo,dateThree, dateTwo, dateThree),
+			NarrowCase.from("start on null provides open range", null,  dateTwo, null, dateTwo, null),
+			NarrowCase.from("end on null provides open range", null,  null,dateThree, null, dateThree),
+			// middle range
+			// default range is inclusive at top
+			NarrowCase.from("start and end outside leaves range unchanged", new DateRangeParam(dateTwo, dateFive),  dateOne, dateSix, GREATERTHAN_OR_EQUALS, dateTwo, LESSTHAN_OR_EQUALS ,dateFive),
+			NarrowCase.from("start inside narrows start", new DateRangeParam(dateTwo, dateFive),  dateThree, dateSix, GREATERTHAN_OR_EQUALS, dateThree, LESSTHAN_OR_EQUALS ,dateFive),
+
+			NarrowCase.from("end inside narrows end", new DateRangeParam(dateTwo, dateFive),  dateOne, dateFour, dateTwo, dateFour),
+			// half-open cases
+			NarrowCase.from("end inside open end", new DateRangeParam(dateTwo, null),  null, dateFour, dateTwo, dateFour),
+			NarrowCase.from("start inside open start", new DateRangeParam(null, dateFour),  dateTwo, null, GREATERTHAN_OR_EQUALS, dateTwo, LESSTHAN_OR_EQUALS, dateFour)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("narrowCases")
+	public void testNarrowCase(NarrowCase c) {
+		DateRangeParam result = DateRangeUtil.narrowDateRange(c.range, c.narrowStart, c.narrowEnd);
+
+		if (c.resultStart == null && c.resultEnd == null) {
+			assertThat(result, nullValue());
+		} else {
+			assertThat(result, notNullValue());
+			assertThat("range start", result.getLowerBound(), equalTo(c.resultStart));
+			assertThat("range end", result.getUpperBound(), equalTo(c.resultEnd));
+		}
+	}
+
+}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
@@ -2,5 +2,5 @@
 type: fix
 issue: 3441, 3586
 jira: SMILE-3441
-title: "Regression of issue 3441. Reindexing jobs were not respected the passed in date range in SearchParams.
+title: "While converting the reindexing job to the new batch framework, a regression of [#3441](https://github.com/hapifhir/hapi-fhir/issues/3441) was introduced. Reindexing jobs were not respecting the passed in `_lastUpdated` parameter.
   We now take date these date ranges into account when running re-indexing jobs."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 3586
+jira: SMILE-3441
+title: "Regression of issue 3441. Reindexing jobs were not respected the passed in date range in SearchParams. We now take date these date ranges
+into account when running re-indexing jobs."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
@@ -1,6 +1,6 @@
 ---
 type: fix
-issue: 3586
+issue: 3441, 3586
 jira: SMILE-3441
-title: "Regression of issue 3441. Reindexing jobs were not respected the passed in date range in SearchParams. We now take date these date ranges
-into account when running re-indexing jobs."
+title: "Regression of issue 3441. Reindexing jobs were not respected the passed in date range in SearchParams.
+  We now take date these date ranges into account when running re-indexing jobs."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3586-lastIndex-reindex-fix.yaml
@@ -1,6 +1,6 @@
 ---
 type: fix
-issue: 3441, 3586
+issue: 3586
 jira: SMILE-3441
 title: "While converting the reindexing job to the new batch framework, a regression of [#3441](https://github.com/hapifhir/hapi-fhir/issues/3441) was introduced. Reindexing jobs were not respecting the passed in `_lastUpdated` parameter.
   We now take date these date ranges into account when running re-indexing jobs."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/ResourceReindexSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/ResourceReindexSvcImpl.java
@@ -35,6 +35,7 @@ import ca.uhn.fhir.rest.api.SortOrderEnum;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.storage.ResourcePersistentId;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.util.DateRangeUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -85,7 +86,8 @@ public class ResourceReindexSvcImpl implements IResourceReindexSvc {
 
 		SearchParameterMap searchParamMap = myMatchUrlService.translateMatchUrl(theUrl, def);
 		searchParamMap.setSort(new SortSpec(Constants.PARAM_LASTUPDATED, SortOrderEnum.ASC));
-		searchParamMap.setLastUpdated(new DateRangeParam(theStart, theEnd));
+		DateRangeParam chunkDateRange = DateRangeUtil.narrowDateRange(searchParamMap.getLastUpdated(), theStart, theEnd);
+		searchParamMap.setLastUpdated(chunkDateRange);
 		searchParamMap.setCount(thePageSize);
 
 		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(resourceType);


### PR DESCRIPTION
This bug #3441  came back with the rewrite to the new job framework.

https://github.com/hapifhir/hapi-fhir/pull/3451