### PR TITLE
3584 case sensitive string elasticsearch

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3584-case-sensitive-elasticsearch.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_0_0/3584-case-sensitive-elasticsearch.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 3584
+title: "Unmodified string searches and string `:contains` search were incorrectly case-sensitive 
+  when configured with recent versions of Lucene/Elasticsearch.  This has been corrected."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneClauseBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneClauseBuilder.java
@@ -52,6 +52,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -250,7 +251,9 @@ public class ExtendedLuceneClauseBuilder {
 			ourLog.debug("addStringContainsSearch {} {}", theSearchParamName, terms);
 			List<? extends PredicateFinalStep> orTerms = terms.stream()
 				.map(s ->
-					myPredicateFactory.wildcard().field(fieldPath).matching("*" + s + "*"))
+					myPredicateFactory.wildcard().field(fieldPath)
+						// wildcard is a term-level query, so it isn't analyzed.  Do our own case-folding to match the normStringAnalyzer
+						.matching("*" + s.toLowerCase(Locale.ROOT) + "*"))
 				.collect(Collectors.toList());
 
 			myRootClause.must(orPredicateOrSingle(orTerms));
@@ -264,7 +267,10 @@ public class ExtendedLuceneClauseBuilder {
 			ourLog.debug("addStringUnmodifiedSearch {} {}", theSearchParamName, terms);
 			List<? extends PredicateFinalStep> orTerms = terms.stream()
 				.map(s ->
-					myPredicateFactory.wildcard().field(fieldPath).matching(s + "*"))
+					myPredicateFactory.wildcard()
+						.field(fieldPath)
+						// wildcard is a term-level query, so it isn't analyzed.  Do our own case-folding to match the normStringAnalyzer
+						.matching(s.toLowerCase(Locale.ROOT) + "*"))
 				.collect(Collectors.toList());
 
 			myRootClause.must(orPredicateOrSingle(orTerms));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneClauseBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/ExtendedLuceneClauseBuilder.java
@@ -37,6 +37,7 @@ import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.DateUtils;
+import ca.uhn.fhir.util.StringUtil;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -215,7 +216,7 @@ public class ExtendedLuceneClauseBuilder {
 		for (List<? extends IQueryParameterType> nextAnd : stringAndOrTerms) {
 			Set<String> terms = extractOrStringParams(nextAnd);
 			ourLog.debug("addStringTextSearch {}, {}", theSearchParamName, terms);
-			if (terms.size() >= 1) {
+			if (!terms.isEmpty()) {
 				String query = terms.stream()
 					.map(s -> "( " + s + " )")
 					.collect(Collectors.joining(" | "));
@@ -250,10 +251,11 @@ public class ExtendedLuceneClauseBuilder {
 			Set<String> terms = extractOrStringParams(nextAnd);
 			ourLog.debug("addStringContainsSearch {} {}", theSearchParamName, terms);
 			List<? extends PredicateFinalStep> orTerms = terms.stream()
-				.map(s ->
-					myPredicateFactory.wildcard().field(fieldPath)
-						// wildcard is a term-level query, so it isn't analyzed.  Do our own case-folding to match the normStringAnalyzer
-						.matching("*" + s.toLowerCase(Locale.ROOT) + "*"))
+				// wildcard is a term-level query, so queries aren't analyzed.  Do our own normalization first.
+				.map(s-> StringUtil.normalizeStringForSearchIndexing(s).toLowerCase(Locale.ROOT))
+				.map(s -> myPredicateFactory
+					.wildcard().field(fieldPath)
+					.matching("*" + s + "*"))
 				.collect(Collectors.toList());
 
 			myRootClause.must(orPredicateOrSingle(orTerms));
@@ -361,8 +363,8 @@ public class ExtendedLuceneClauseBuilder {
 	 * }
 	 * </pre>
 	 *
-	 * @param theSearchParamName
-	 * @param theDateAndOrTerms
+	 * @param theSearchParamName e.g code
+	 * @param theDateAndOrTerms The and/or list of DateParam values
 	 */
 	public void addDateUnmodifiedSearch(String theSearchParamName, List<List<IQueryParameterType>> theDateAndOrTerms) {
 		for (List<? extends IQueryParameterType> nextAnd : theDateAndOrTerms) {

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/HibernateSearchIndexWriter.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/search/HibernateSearchIndexWriter.java
@@ -74,6 +74,7 @@ public class HibernateSearchIndexWriter {
 	public void writeStringIndex(String theSearchParam, String theValue) {
 		DocumentElement stringIndexNode = getSearchParamIndexNode(theSearchParam, "string");
 
+		// we are assuming that our analyzer matches  StringUtil.normalizeStringForSearchIndexing(theValue).toLowerCase(Locale.ROOT))
 		stringIndexNode.addValue(IDX_STRING_NORMALIZED, theValue);// for default search
 		stringIndexNode.addValue(IDX_STRING_EXACT, theValue);
 		stringIndexNode.addValue(IDX_STRING_TEXT, theValue);

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestElasticsearchContainerHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestElasticsearchContainerHelper.java
@@ -29,7 +29,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 public class TestElasticsearchContainerHelper {
 
 
-	public static final String ELASTICSEARCH_VERSION = "7.16.3";
+	public static final String ELASTICSEARCH_VERSION = "7.17.3";
 	public static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:" + ELASTICSEARCH_VERSION;
 
 	public static ElasticsearchContainer getEmbeddedElasticSearch() {

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -588,7 +588,25 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 		}
 	}
 
+	/**
+	 * Verify unmodified, :contains, and :text searches are case-insensitive;
+	 * https://github.com/hapifhir/hapi-fhir/issues/3584
+	 */
+	@Test
+	void testStringCaseFolding() {
+		IIdType kelly = myTestDataBuilder.createPatient(myTestDataBuilder.withGiven("Kelly"));
 
+		myTestDaoSearch.assertSearchFinds("lowercase matches capitalized", "/Patient?name=kelly", kelly);
+		myTestDaoSearch.assertSearchFinds("uppercase matches capitalized", "/Patient?name=KELLY", kelly);
+		myTestDaoSearch.assertSearchFinds("contains also case-insensitive", "/Patient?name:contains=elly", kelly);
+		myTestDaoSearch.assertSearchFinds("contains also case-insensitive", "/Patient?name:contains=ELLY", kelly);
+		myTestDaoSearch.assertSearchFinds("text also case-insensitive", "/Patient?name:text=kelly", kelly);
+		myTestDaoSearch.assertSearchFinds("text also case-insensitive", "/Patient?name:text=KELLY", kelly);
+		myTestDaoSearch.assertSearchFinds("exact case sensitive", "/Patient?name:exact=Kelly", kelly);
+		myTestDaoSearch.assertSearchNotFound("exact case sensitive", "/Patient?name:exact=KELLY", kelly);
+		myTestDaoSearch.assertSearchNotFound("exact case sensitive", "/Patient?name:exact=kelly", kelly);
+
+	}
 
 	private void assertObservationSearchMatchesNothing(String message, SearchParameterMap map) {
 		assertObservationSearchMatches(message, map);

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -599,21 +599,25 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 		IIdType kelly = myTestDataBuilder.createPatient(myTestDataBuilder.withGiven("Kelly"));
 		IIdType keely = myTestDataBuilder.createPatient(myTestDataBuilder.withGiven("Kélly"));
 
-		// unmodifed, :contains, and :text are all ascii normalized, and case-folded
+		// un-modifed, :contains, and :text are all ascii normalized, and case-folded
 		myTestDaoSearch.assertSearchFinds("lowercase matches capitalized", "/Patient?name=kelly", kelly, keely);
 		myTestDaoSearch.assertSearchFinds("uppercase matches capitalized", "/Patient?name=KELLY", kelly, keely);
-		myTestDaoSearch.assertSearchFinds("contains also case-insensitive", "/Patient?name:contains=elly", kelly, keely);
-		myTestDaoSearch.assertSearchFinds("contains also case-insensitive", "/Patient?name:contains=ELLY", kelly, keely);
+		myTestDaoSearch.assertSearchFinds("unmodified is accent insensitive", "/Patient?name=" + urlencode("Kélly"), kelly, keely);
+
+		myTestDaoSearch.assertSearchFinds("contains case-insensitive", "/Patient?name:contains=elly", kelly, keely);
+		myTestDaoSearch.assertSearchFinds("contains case-insensitive", "/Patient?name:contains=ELLY", kelly, keely);
 		myTestDaoSearch.assertSearchFinds("contains accent-insensitive", "/Patient?name:contains=ELLY", kelly, keely);
 		myTestDaoSearch.assertSearchFinds("contains accent-insensitive", "/Patient?name:contains=" + urlencode("éLLY"), kelly, keely);
-		myTestDaoSearch.assertSearchFinds("text also case-insensitive", "/Patient?name:text=kelly", kelly, keely);
-		myTestDaoSearch.assertSearchFinds("text also case-insensitive", "/Patient?name:text=KELLY", kelly, keely);
 
-		myTestDaoSearch.assertSearchFinds("exact case sensitive", "/Patient?name:exact=Kelly", kelly);
+		myTestDaoSearch.assertSearchFinds("text also accent and case-insensitive", "/Patient?name:text=kelly", kelly, keely);
+		myTestDaoSearch.assertSearchFinds("text also accent and case-insensitive", "/Patient?name:text=KELLY", kelly, keely);
+		myTestDaoSearch.assertSearchFinds("text also accent and case-insensitive", "/Patient?name:text=" + urlencode("KÉLLY"), kelly, keely);
+
+		myTestDaoSearch.assertSearchFinds("exact case and accent sensitive", "/Patient?name:exact=Kelly", kelly);
 		// ugh.  Our url parser won't handle raw utf8 urls.  It requires everything to be single-byte encoded.
-		myTestDaoSearch.assertSearchFinds("exact case sensitive", "/Patient?name:exact=" + urlencode("Kélly"), keely);
-		myTestDaoSearch.assertSearchNotFound("exact case sensitive", "/Patient?name:exact=KELLY,kelly", kelly);
-		myTestDaoSearch.assertSearchNotFound("exact case sensitive",
+		myTestDaoSearch.assertSearchFinds("exact case and accent sensitive", "/Patient?name:exact=" + urlencode("Kélly"), keely);
+		myTestDaoSearch.assertSearchNotFound("exact case and accent sensitive", "/Patient?name:exact=KELLY,kelly", kelly);
+		myTestDaoSearch.assertSearchNotFound("exact case and accent sensitive",
 			"/Patient?name:exact=" + urlencode("KÉLLY,kélly"),
 			keely);
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -591,7 +591,8 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 	}
 
 	/**
-	 * Verify unmodified, :contains, and :text searches are case-insensitive;
+	 * Verify unmodified, :contains, and :text searches are case-insensitive and normalized;
+	 * :exact is still sensitive
 	 * https://github.com/hapifhir/hapi-fhir/issues/3584
 	 */
 	@Test
@@ -599,7 +600,7 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest {
 		IIdType kelly = myTestDataBuilder.createPatient(myTestDataBuilder.withGiven("Kelly"));
 		IIdType keely = myTestDataBuilder.createPatient(myTestDataBuilder.withGiven("Kélly"));
 
-		// un-modifed, :contains, and :text are all ascii normalized, and case-folded
+		// un-modified, :contains, and :text are all ascii normalized, and case-folded
 		myTestDaoSearch.assertSearchFinds("lowercase matches capitalized", "/Patient?name=kelly", kelly, keely);
 		myTestDaoSearch.assertSearchFinds("uppercase matches capitalized", "/Patient?name=KELLY", kelly, keely);
 		myTestDaoSearch.assertSearchFinds("unmodified is accent insensitive", "/Patient?name=" + urlencode("Kélly"), kelly, keely);

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/ITestDataBuilder.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/ITestDataBuilder.java
@@ -74,6 +74,13 @@ public interface ITestDataBuilder {
 		};
 	}
 
+
+	/** Patient.name.given */
+	default <T extends IBaseResource>  Consumer<T> withGiven(String theName) {
+		return withPrimitiveAttribute("name.given", theName);
+	}
+
+
 	/**
 	 * Set Patient.birthdate
 	 */
@@ -293,5 +300,4 @@ public interface ITestDataBuilder {
 		booleanType.setValueAsString(theValue);
 		activeChild.getMutator().addValue(theTarget, booleanType);
 	}
-
 }


### PR DESCRIPTION
Closes #3584 
Recent elasticsearch is stricter about when to apply the analyzer to search terms.  As a result, string searches became case and ascii-normalization sensitive.

Fixed by doing applying our own case-folding and ascii-normalization to the search expressions for unmodified string, and contains.