### PR TITLE
add `displayLanguage` to the `ValueSet/$expand`

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/support/ValueSetExpansionOptions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/support/ValueSetExpansionOptions.java
@@ -35,6 +35,8 @@ public class ValueSetExpansionOptions {
 	private boolean myIncludeHierarchy;
 	private String myFilter;
 
+	private String theDisplayLanguage;
+
 	public String getFilter() {
 		return myFilter;
 	}
@@ -117,5 +119,13 @@ public class ValueSetExpansionOptions {
 		return new ValueSetExpansionOptions()
 			.setOffset(theOffset)
 			.setCount(theCount);
+	}
+
+	public String getTheDisplayLanguage() {
+		return theDisplayLanguage;
+	}
+
+	public void setTheDisplayLanguage(String theDisplayLanguage) {
+		this.theDisplayLanguage = theDisplayLanguage;
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/ValueSetOperationProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/ValueSetOperationProvider.java
@@ -50,6 +50,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.hl7.fhir.r4.model.CodeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,6 +109,7 @@ public class ValueSetOperationProvider extends BaseJpaProvider {
 		@OperationParam(name = "contextDirection", min = 0, max = 1, typeName = "string") IPrimitiveType<String> theContextDirection,
 		@OperationParam(name = "offset", min = 0, max = 1, typeName = "integer") IPrimitiveType<Integer> theOffset,
 		@OperationParam(name = "count", min = 0, max = 1, typeName = "integer") IPrimitiveType<Integer> theCount,
+		@OperationParam(name = "displayLanguage", min=0, max=1) CodeType theDisplayLanguage,
 		@OperationParam(name = JpaConstants.OPERATION_EXPAND_PARAM_INCLUDE_HIERARCHY, min = 0, max = 1, typeName = "boolean") IPrimitiveType<Boolean> theIncludeHierarchy,
 		RequestDetails theRequestDetails) {
 
@@ -140,7 +142,7 @@ public class ValueSetOperationProvider extends BaseJpaProvider {
 			throw new InvalidRequestException(Msg.code(1134) + "$expand must EITHER be invoked at the instance level, or have a url specified, or have a ValueSet specified. Can not combine these options.");
 		}
 
-		ValueSetExpansionOptions options = createValueSetExpansionOptions(myDaoConfig, theOffset, theCount, theIncludeHierarchy, theFilter);
+		ValueSetExpansionOptions options = createValueSetExpansionOptions(myDaoConfig, theOffset, theCount, theIncludeHierarchy, theFilter, theDisplayLanguage);
 
 		startRequest(theServletRequest);
 		try {
@@ -262,7 +264,7 @@ public class ValueSetOperationProvider extends BaseJpaProvider {
 	}
 
 
-	public static ValueSetExpansionOptions createValueSetExpansionOptions(DaoConfig theDaoConfig, IPrimitiveType<Integer> theOffset, IPrimitiveType<Integer> theCount, IPrimitiveType<Boolean> theIncludeHierarchy, IPrimitiveType<String> theFilter) {
+	public static ValueSetExpansionOptions createValueSetExpansionOptions(DaoConfig theDaoConfig, IPrimitiveType<Integer> theOffset, IPrimitiveType<Integer> theCount, IPrimitiveType<Boolean> theIncludeHierarchy, IPrimitiveType<String> theFilter, CodeType theDisplayLanguage) {
 		int offset = theDaoConfig.getPreExpandValueSetsDefaultOffset();
 		if (theOffset != null && theOffset.hasValue()) {
 			if (theOffset.getValue() >= 0) {
@@ -294,6 +296,10 @@ public class ValueSetOperationProvider extends BaseJpaProvider {
 
 		if (theFilter != null) {
 			options.setFilter(theFilter.getValue());
+		}
+
+		if( !theDisplayLanguage.isEmpty() ) {
+			options.setTheDisplayLanguage(theDisplayLanguage.getValue());
 		}
 
 		return options;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseTermReadSvcImpl.java
@@ -309,6 +309,7 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 				.collect(joining(" "));
 		}
 
+
 		Collection<TermConceptDesignation> designations = theConcept.getDesignations();
 		if (StringUtils.isNotEmpty(theValueSetIncludeVersion)) {
 			return addCodeIfNotAlreadyAdded(theValueSetCodeAccumulator, theAddedCodes, designations, theAdd, codeSystem + "|" + theValueSetIncludeVersion, code, display, sourceConceptPid, directParentPids, codeSystemVersion);
@@ -527,7 +528,7 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 		String expansionTimestamp = toHumanReadableExpansionTimestamp(termValueSet);
 		String msg = myContext.getLocalizer().getMessage(BaseTermReadSvcImpl.class, "valueSetExpandedUsingPreExpansion", expansionTimestamp);
 		theAccumulator.addMessage(msg);
-		expandConcepts(theAccumulator, termValueSet, theFilter, theAdd, isOracleDialect());
+		expandConcepts(theExpansionOptions, theAccumulator, termValueSet, theFilter, theAdd, isOracleDialect());
 	}
 
 	@Nonnull
@@ -544,7 +545,7 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 		return myHibernatePropertiesProvider.getDialect() instanceof org.hibernate.dialect.Oracle12cDialect;
 	}
 
-	private void expandConcepts(IValueSetConceptAccumulator theAccumulator, TermValueSet theTermValueSet, ExpansionFilter theFilter, boolean theAdd, boolean theOracle) {
+	private void expandConcepts(ValueSetExpansionOptions theExpansionOptions, IValueSetConceptAccumulator theAccumulator, TermValueSet theTermValueSet, ExpansionFilter theFilter, boolean theAdd, boolean theOracle) {
 		// NOTE: if you modifiy the logic here, look to `expandConceptsOracle` and see if your new code applies to its copy pasted sibling
 		Integer offset = theAccumulator.getSkipCountRemaining();
 		offset = ObjectUtils.defaultIfNull(offset, 0);
@@ -613,12 +614,15 @@ public abstract class BaseTermReadSvcImpl implements ITermReadSvc {
 			// TODO: DM 2019-08-17 - Implement includeDesignations parameter for $expand operation to designations optional.
 			if (conceptView.getDesignationPid() != null) {
 				TermConceptDesignation designation = new TermConceptDesignation();
-				designation.setUseSystem(conceptView.getDesignationUseSystem());
-				designation.setUseCode(conceptView.getDesignationUseCode());
-				designation.setUseDisplay(conceptView.getDesignationUseDisplay());
-				designation.setValue(conceptView.getDesignationVal());
-				designation.setLanguage(conceptView.getDesignationLang());
-				pidToDesignations.put(conceptPid, designation);
+
+				if(isDisplayLanguageMatch(theExpansionOptions.getTheDisplayLanguage(),conceptView.getDesignationLang() )) {
+					designation.setUseSystem(conceptView.getDesignationUseSystem());
+					designation.setUseCode(conceptView.getDesignationUseCode());
+					designation.setUseDisplay(conceptView.getDesignationUseDisplay());
+					designation.setValue(conceptView.getDesignationVal());
+					designation.setLanguage(conceptView.getDesignationLang());
+					pidToDesignations.put(conceptPid, designation);
+				}
 
 				if (++designationsExpanded % 250 == 0) {
 					logDesignationsExpanded("Expansion of designations in progress. ", theTermValueSet, designationsExpanded);


### PR DESCRIPTION
this PR should enable something like : 
```
curl --location --request GET 'http://localhost:8080/fhir/ValueSet/$expand?url=http://terminology.hl7.org/CodeSystem/emdn/vs&filter=text&count=100&displayLanguage=en-IT'
```
on a ValueSet with designations 