### PR TITLE
Batch 2 Fast-track single chunks

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3631-fasttrack-single-chunk-jobs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3631-fasttrack-single-chunk-jobs.yaml
@@ -1,5 +1,5 @@
 ---
 type: add
 issue: 3631
-title: "If a Batch 2 step and all prior steps produced only a single chunk of work, notify the next step immediately
+title: "If a gated Batch 2 job step and all prior steps produced only a single chunk of work, notify the next step immediately
 instead of waiting for the scheduled job maintenance to advance it."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3631-fasttrack-single-chunk-jobs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3631-fasttrack-single-chunk-jobs.yaml
@@ -1,5 +1,5 @@
 ---
 type: add
 issue: 3631
-title: "If a gated Batch 2 job step and all prior steps produced only a single chunk of work, notify the next step immediately
+title: "If a gated Batch job step and all prior steps produced only a single chunk of work, notify the next step immediately
 instead of waiting for the scheduled job maintenance to advance it."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3631-fasttrack-single-chunk-jobs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3631-fasttrack-single-chunk-jobs.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 3631
+title: "If a Batch 2 step and all prior steps produced only a single chunk of work, notify the next step immediately
+instead of waiting for the scheduled job maintenance to advance it."

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class Batch2JobHelper {
@@ -77,8 +76,7 @@ public class Batch2JobHelper {
 		assertNull(myJobCoordinator.getInstance(theInstanceId).getCurrentGatedStepId());
 	}
 
-	public void assertGatedStep(String theExpectedGatedStepId, String theInstanceId) {
-		String actualGatedStepId = myJobCoordinator.getInstance(theInstanceId).getCurrentGatedStepId();
-		assertEquals(theExpectedGatedStepId, actualGatedStepId);
+	public void awaitGatedStepId(String theExpectedGatedStepId, String theInstanceId) {
+		await().until(() -> theExpectedGatedStepId.equals(myJobCoordinator.getInstance(theInstanceId).getCurrentGatedStepId()));
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -38,14 +38,14 @@ public class Batch2JobHelper {
 	@Autowired
 	private IJobCoordinator myJobCoordinator;
 
-	public void awaitJobCompletion(String theId) {
+	public void awaitJobCompletionWithMaintenance(String theId) {
 		await().until(() -> {
 			myJobMaintenanceService.runMaintenancePass();
 			return myJobCoordinator.getInstance(theId).getStatus();
 		}, equalTo(StatusEnum.COMPLETED));
 	}
 
-	public void awaitJobCompletionNoMaintenance(String theId) {
+	public void awaitJobCompletion(String theId) {
 		await().until(() -> myJobCoordinator.getInstance(theId).getStatus() == StatusEnum.COMPLETED);
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -29,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class Batch2JobHelper {
 
@@ -38,14 +40,14 @@ public class Batch2JobHelper {
 	@Autowired
 	private IJobCoordinator myJobCoordinator;
 
-	public void awaitJobCompletionWithMaintenance(String theId) {
+	public void awaitMultipleChunkJobCompletion(String theId) {
 		await().until(() -> {
 			myJobMaintenanceService.runMaintenancePass();
 			return myJobCoordinator.getInstance(theId).getStatus();
 		}, equalTo(StatusEnum.COMPLETED));
 	}
 
-	public void awaitJobCompletion(String theId) {
+	public void awaitSingleChunkJobCompletion(String theId) {
 		await().until(() -> myJobCoordinator.getInstance(theId).getStatus() == StatusEnum.COMPLETED);
 	}
 
@@ -69,5 +71,14 @@ public class Batch2JobHelper {
 			myJobMaintenanceService.runMaintenancePass();
 			return myJobCoordinator.getInstance(theId).getStatus();
 		}, equalTo(StatusEnum.IN_PROGRESS));
+	}
+
+	public void assertNoGatedStep(String theInstanceId) {
+		assertNull(myJobCoordinator.getInstance(theInstanceId).getCurrentGatedStepId());
+	}
+
+	public void assertGatedStep(String theExpectedGatedStepId, String theInstanceId) {
+		String actualGatedStepId = myJobCoordinator.getInstance(theInstanceId).getCurrentGatedStepId();
+		assertEquals(theExpectedGatedStepId, actualGatedStepId);
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -45,6 +45,10 @@ public class Batch2JobHelper {
 		}, equalTo(StatusEnum.COMPLETED));
 	}
 
+	public void awaitJobCompletionNoMaintenance(String theId) {
+		await().until(() -> myJobCoordinator.getInstance(theId).getStatus() == StatusEnum.COMPLETED);
+	}
+
 	public JobInstance awaitJobFailure(String theId) {
 		await().until(() -> {
 			myJobMaintenanceService.runMaintenancePass();

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
@@ -80,7 +80,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 		myLastStepLatch.setExpectedCount(1);
 		// Since there was only one chunk, the job should proceed without requiring a maintenance pass
 		myLastStepLatch.awaitExpected();
-		myBatch2JobHelper.awaitJobCompletionNoMaintenance(instanceId);
+		myBatch2JobHelper.awaitJobCompletion(instanceId);
 	}
 
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
@@ -109,7 +109,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 		String instanceId = myJobCoordinator.startInstance(request);
 		myFirstStepLatch.awaitExpected();
 
-		myBatch2JobHelper.assertGatedStep(FIRST_STEP_ID, instanceId);
+		myBatch2JobHelper.awaitGatedStepId(FIRST_STEP_ID, instanceId);
 
 		myLastStepLatch.setExpectedCount(2);
 		myBatch2JobHelper.awaitMultipleChunkJobCompletion(instanceId);

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
@@ -171,9 +171,9 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		}
 
 		List<WorkChunk> chunks = mySvc.fetchWorkChunksWithoutData(instanceId, 3, 0);
-		assertEquals(null, chunks.get(0).getData());
-		assertEquals(null, chunks.get(1).getData());
-		assertEquals(null, chunks.get(2).getData());
+		assertNull(chunks.get(0).getData());
+		assertNull(chunks.get(1).getData());
+		assertNull(chunks.get(2).getData());
 		assertThat(chunks.stream().map(t -> t.getId()).collect(Collectors.toList()),
 			contains(ids.get(0), ids.get(1), ids.get(2)));
 
@@ -207,7 +207,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		String id = storeWorkChunk(JOB_DEFINITION_ID, TARGET_STEP_ID, instanceId, 0, null);
 
 		WorkChunk chunk = mySvc.fetchWorkChunkSetStartTimeAndMarkInProgress(id).orElseThrow(() -> new IllegalArgumentException());
-		assertEquals(null, chunk.getData());
+		assertNull(chunk.getData());
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/delete/job/ReindexJobTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/delete/job/ReindexJobTest.java
@@ -62,7 +62,7 @@ public class ReindexJobTest extends BaseJpaR4Test {
 		startRequest.setJobDefinitionId(ReindexAppCtx.JOB_REINDEX);
 		startRequest.setParameters(parameters);
 		String id = myJobCoordinator.startInstance(startRequest);
-		myBatch2JobHelper.awaitJobCompletion(id);
+		myBatch2JobHelper.awaitSingleChunkJobCompletion(id);
 
 		// validate
 		assertEquals(2, myObservationDao.search(SearchParameterMap.newSynchronous()).size());
@@ -95,7 +95,7 @@ public class ReindexJobTest extends BaseJpaR4Test {
 		startRequest.setJobDefinitionId(ReindexAppCtx.JOB_REINDEX);
 		startRequest.setParameters(new ReindexJobParameters());
 		String id = myJobCoordinator.startInstance(startRequest);
-		myBatch2JobHelper.awaitJobCompletion(id);
+		myBatch2JobHelper.awaitSingleChunkJobCompletion(id);
 
 		// validate
 		assertEquals(50, myObservationDao.search(SearchParameterMap.newSynchronous()).size());

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantBatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantBatchOperationR4Test.java
@@ -16,9 +16,7 @@ import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.test.utilities.BatchJobHelper;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.hapi.rest.server.helper.BatchHelperR4;
-import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
@@ -156,7 +154,7 @@ public class MultitenantBatchOperationR4Test extends BaseMultitenantResourceProv
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(response));
 		StringType jobId = (StringType) response.getParameter(ProviderConstants.OPERATION_REINDEX_RESPONSE_JOB_ID);
 
-		myBatch2JobHelper.awaitJobCompletion(jobId.getValue());
+		myBatch2JobHelper.awaitSingleChunkJobCompletion(jobId.getValue());
 
 		// validate
 		List<String> alleleObservationIds = reindexTestHelper.getAlleleObservationIds(myClient);
@@ -180,7 +178,7 @@ public class MultitenantBatchOperationR4Test extends BaseMultitenantResourceProv
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(response));
 		jobId = (StringType) response.getParameter(ProviderConstants.OPERATION_REINDEX_RESPONSE_JOB_ID);
 
-		myBatch2JobHelper.awaitJobCompletion(jobId.getValue());
+		myBatch2JobHelper.awaitSingleChunkJobCompletion(jobId.getValue());
 
 
 		myTenantClientInterceptor.setTenantId(DEFAULT_PARTITION_NAME);
@@ -223,7 +221,7 @@ public class MultitenantBatchOperationR4Test extends BaseMultitenantResourceProv
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(response));
 		StringType jobId = (StringType) response.getParameter(ProviderConstants.OPERATION_REINDEX_RESPONSE_JOB_ID);
 
-		myBatch2JobHelper.awaitJobCompletion(jobId.getValue());
+		myBatch2JobHelper.awaitSingleChunkJobCompletion(jobId.getValue());
 
 		// validate
 		List<String> alleleObservationIds = reindexTestHelper.getAlleleObservationIds(myClient);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/config/Batch2JobRegisterer.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/config/Batch2JobRegisterer.java
@@ -45,8 +45,9 @@ public class Batch2JobRegisterer {
 		JobDefinitionRegistry jobRegistry = myApplicationContext.getBean(JobDefinitionRegistry.class);
 
 		for (Map.Entry<String, JobDefinition> next : batchJobs.entrySet()) {
-			ourLog.info("Registering Batch2 Job Definition: {} / {}", next.getValue().getJobDefinitionId(), next.getValue().getJobDefinitionVersion());
-			jobRegistry.addJobDefinition(next.getValue());
+			JobDefinition<?> jobDefinition = next.getValue();
+			ourLog.info("Registering Batch2 Job Definition: {} / {}", jobDefinition.getJobDefinitionId(), jobDefinition.getJobDefinitionVersion());
+			jobRegistry.addJobDefinition(jobDefinition);
 		}
 	}
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobDataSink.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobDataSink.java
@@ -22,11 +22,7 @@ package ca.uhn.fhir.batch2.coordinator;
 
 import ca.uhn.fhir.batch2.api.IJobPersistence;
 import ca.uhn.fhir.batch2.channel.BatchJobSender;
-import ca.uhn.fhir.batch2.model.JobDefinition;
-import ca.uhn.fhir.batch2.model.JobDefinitionStep;
-import ca.uhn.fhir.batch2.model.JobWorkCursor;
-import ca.uhn.fhir.batch2.model.JobWorkNotification;
-import ca.uhn.fhir.batch2.model.WorkChunkData;
+import ca.uhn.fhir.batch2.model.*;
 import ca.uhn.fhir.model.api.IModelJson;
 import ca.uhn.fhir.util.JsonUtil;
 
@@ -79,7 +75,7 @@ class JobDataSink<PT extends IModelJson, IT extends IModelJson, OT extends IMode
 
 	public String getOnlyChunkId() {
 		if (getWorkChunkCount() != 1) {
-			String msg = String.format("Expected this sink to have exactly one work chunk.  Job %s v%s step %s", myJobDefinitionId, myJobDefinitionVersion, myTargetStep);
+			String msg = String.format("Expected this sink to have exactly one work chunk but there are %d.  Job %s v%s step %s", getWorkChunkCount(), myJobDefinitionId, myJobDefinitionVersion, myTargetStep);
 			throw new IllegalStateException(msg);
 		}
 		return myLastChunkId.get();

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobStepExecutor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobStepExecutor.java
@@ -81,7 +81,7 @@ public class JobStepExecutor<PT extends IModelJson, IT extends IModelJson, OT ex
 						myJobPersistence.updateInstance(jobInstance);
 					}
 				} else {
-					JobWorkNotification workNotification = new JobWorkNotification(jobInstance, myCursor.nextStep.getStepId(), ((JobDataSink) dataSink).getOnlyChunkId());
+					JobWorkNotification workNotification = new JobWorkNotification(jobInstance, myCursor.nextStep.getStepId(), ((JobDataSink<PT,IT,OT>) dataSink).getOnlyChunkId());
 					myBatchJobSender.sendWorkChannelMessage(workNotification);
 				}
 			}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/WorkChannelMessageHandler.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/WorkChannelMessageHandler.java
@@ -76,6 +76,6 @@ class WorkChannelMessageHandler implements MessageHandler {
 
 		JobDefinition<?> definition = myJobDefinitionRegistry.getJobDefinitionOrThrowException(jobDefinitionId, jobDefinitionVersion);
 
-		return JobWorkCursor.fromJobDefinitionAndWorkNotification(definition, workNotification);
+		return JobWorkCursor.fromJobDefinitionAndRequestedStepId(definition, workNotification.getTargetStepId());
 	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/InstanceProgress.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/InstanceProgress.java
@@ -2,7 +2,6 @@ package ca.uhn.fhir.batch2.maintenance;
 
 import ca.uhn.fhir.batch2.api.IJobCompletionHandler;
 import ca.uhn.fhir.batch2.api.JobCompletionDetails;
-import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
 import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.StatusEnum;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.EnumSet;
 import java.util.List;
 
-class JobInstanceProcessor {
+public class JobInstanceProcessor {
 	private static final Logger ourLog = LoggerFactory.getLogger(JobInstanceProcessor.class);
 	public static final long PURGE_THRESHOLD = 7L * DateUtils.MILLIS_PER_DAY;
 
@@ -123,7 +123,7 @@ class JobInstanceProcessor {
 
 	}
 
-	static boolean updateInstanceStatus(JobInstance myInstance, StatusEnum newStatus) {
+	public static boolean updateInstanceStatus(JobInstance myInstance, StatusEnum newStatus) {
 		if (myInstance.getStatus() != newStatus) {
 			ourLog.info("Marking job instance {} of type {} as {}", myInstance.getInstanceId(), myInstance.getJobDefinitionId(), newStatus);
 			myInstance.setStatus(newStatus);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProgressCalculator.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProgressCalculator.java
@@ -1,20 +1,15 @@
 package ca.uhn.fhir.batch2.maintenance;
 
 import ca.uhn.fhir.batch2.api.IJobPersistence;
-import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.batch2.model.WorkChunk;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 import static ca.uhn.fhir.batch2.maintenance.JobInstanceProcessor.updateInstanceStatus;
 
 class JobInstanceProgressCalculator {
-	private static final Logger ourLog = LoggerFactory.getLogger(JobInstanceProgressCalculator.class);
-
 	private final IJobPersistence myJobPersistence;
 	private final JobInstance myInstance;
 	private final JobChunkProgressAccumulator myProgressAccumulator;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
@@ -31,8 +31,6 @@ import ca.uhn.fhir.jpa.model.sched.ScheduledJobDefinition;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
 import org.quartz.JobExecutionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.Nonnull;
@@ -68,7 +66,7 @@ import java.util.Set;
 public class JobMaintenanceServiceImpl implements IJobMaintenanceService {
 
 	public static final int INSTANCES_PER_PASS = 100;
-	private static final Logger ourLog = LoggerFactory.getLogger(JobMaintenanceServiceImpl.class);
+
 	private final IJobPersistence myJobPersistence;
 	private final ISchedulerService mySchedulerService;
 	private final JobDefinitionRegistry myJobDefinitionRegistry;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
@@ -307,14 +307,4 @@ public class JobInstance extends JobInstanceStartRequest implements IModelJson {
 	public boolean hasGatedStep() {
 		return !isBlank(myCurrentGatedStepId);
 	}
-
-	/**
-	 * If a job is normally gated but does not have a gated step set, then so far it has produced fewer than 1 chunk
-	 * at every step and so we will treat the job instance as a non-gated job.
-	 */
-	public boolean isFastTracking() {
-		return myJobDefinition != null &&
-			myJobDefinition.isGatedExecution() &&
-			!hasGatedStep();
-	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
@@ -20,7 +20,6 @@ package ca.uhn.fhir.batch2.model;
  * #L%
  */
 
-import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
 import ca.uhn.fhir.jpa.util.JsonDateDeserializer;
 import ca.uhn.fhir.jpa.util.JsonDateSerializer;
 import ca.uhn.fhir.model.api.IModelJson;
@@ -32,6 +31,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Date;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class JobInstance extends JobInstanceStartRequest implements IModelJson {
 
@@ -305,5 +306,19 @@ public class JobInstance extends JobInstanceStartRequest implements IModelJson {
 		return myStatus == StatusEnum.COMPLETED ||
 			myStatus == StatusEnum.FAILED ||
 			myStatus == StatusEnum.CANCELLED;
+	}
+
+	public boolean hasGatedStep() {
+		return !isBlank(myCurrentGatedStepId);
+	}
+
+	/**
+	 * If a job is normally gated but does not have a gated step set, then so far it has produced fewer than 1 chunk
+	 * at every step and so we will treat the job instance as a non-gated job.
+	 */
+	public boolean isFastTracking() {
+		return myJobDefinition != null &&
+			myJobDefinition.isGatedExecution() &&
+			!hasGatedStep();
 	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
@@ -123,10 +123,6 @@ public class JobInstance extends JobInstanceStartRequest implements IModelJson {
 	public static JobInstance fromJobDefinition(JobDefinition<?> theJobDefinition) {
 		JobInstance instance = new JobInstance();
 		instance.setJobDefinition(theJobDefinition);
-
-		if (theJobDefinition.isGatedExecution()) {
-			instance.setCurrentGatedStepId(theJobDefinition.getFirstStepId());
-		}
 		return instance;
 	}
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobWorkCursor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobWorkCursor.java
@@ -20,7 +20,6 @@ import java.util.List;
  */
 public class JobWorkCursor<PT extends IModelJson, IT extends IModelJson, OT extends IModelJson> {
 	private static final Logger ourLog = LoggerFactory.getLogger(JobWorkCursor.class);
-
 	public final JobDefinition<PT> jobDefinition;
 	public final boolean isFirstStep;
 	public final JobDefinitionStep<PT, IT, OT> currentStep;
@@ -45,8 +44,7 @@ public class JobWorkCursor<PT extends IModelJson, IT extends IModelJson, OT exte
 		}
 	}
 
-	public static <PT extends IModelJson> JobWorkCursor<PT,?,?> fromJobDefinitionAndWorkNotification(JobDefinition<PT> theJobDefinition, JobWorkNotification theWorkNotification) {
-		String requestedStepId = theWorkNotification.getTargetStepId();
+	public static <PT extends IModelJson> JobWorkCursor<PT,?,?> fromJobDefinitionAndRequestedStepId(JobDefinition<PT> theJobDefinition, String theRequestedStepId) {
 		boolean isFirstStep = false;
 		JobDefinitionStep<PT,?,?> currentStep = null;
 		JobDefinitionStep<PT,?,?> nextStep = null;
@@ -54,7 +52,7 @@ public class JobWorkCursor<PT extends IModelJson, IT extends IModelJson, OT exte
 		List<JobDefinitionStep<PT, ?, ?>> steps = theJobDefinition.getSteps();
 		for (int i = 0; i < steps.size(); i++) {
 			JobDefinitionStep<PT, ?, ?> step = steps.get(i);
-			if (step.getStepId().equals(requestedStepId)) {
+			if (step.getStepId().equals(theRequestedStepId)) {
 				currentStep = step;
 				if (i == 0) {
 					isFirstStep = true;
@@ -67,7 +65,7 @@ public class JobWorkCursor<PT extends IModelJson, IT extends IModelJson, OT exte
 		}
 
 		if (currentStep == null) {
-			String msg = "Unknown step[" + requestedStepId + "] for job definition ID[" + theJobDefinition.getJobDefinitionId() + "] version[" + theJobDefinition.getJobDefinitionVersion() + "]";
+			String msg = "Unknown step[" + theRequestedStepId + "] for job definition ID[" + theJobDefinition.getJobDefinitionId() + "] version[" + theJobDefinition.getJobDefinitionVersion() + "]";
 			ourLog.warn(msg);
 			throw new InternalErrorException(Msg.code(2042) + msg);
 		}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobWorkNotification.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobWorkNotification.java
@@ -53,7 +53,11 @@ public class JobWorkNotification implements IModelJson {
 		setTargetStepId(theTargetStepId);
 	}
 
-	public static JobWorkNotification firstStepNotification(JobDefinition<?> theJobDefinition, String theInstanceId, String theChunkId) {
+    public JobWorkNotification(JobInstance theInstance, String theNextStepId, String theNextChunkId) {
+		this(theInstance.getJobDefinitionId(), theInstance.getJobDefinitionVersion(), theInstance.getInstanceId(), theNextStepId, theNextChunkId);
+    }
+
+    public static JobWorkNotification firstStepNotification(JobDefinition<?> theJobDefinition, String theInstanceId, String theChunkId) {
 		String firstStepId = theJobDefinition.getFirstStepId();
 		String jobDefinitionId = theJobDefinition.getJobDefinitionId();
 		int jobDefinitionVersion = theJobDefinition.getJobDefinitionVersion();

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/model/JobWorkCursorTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/model/JobWorkCursorTest.java
@@ -21,12 +21,8 @@ class JobWorkCursorTest extends BaseBatch2Test {
 
 	@Test
 	public void createCursorStep1() {
-		// setup
-		JobWorkNotification workNotification = new JobWorkNotification();
-		workNotification.setTargetStepId(STEP_1);
-
 		// execute
-		JobWorkCursor<TestJobParameters, ?, ?> cursor = JobWorkCursor.fromJobDefinitionAndWorkNotification(myDefinition, workNotification);
+		JobWorkCursor<TestJobParameters, ?, ?> cursor = JobWorkCursor.fromJobDefinitionAndRequestedStepId(myDefinition, STEP_1);
 
 		// verify
 		assertCursor(cursor, true, false, STEP_1, STEP_2);
@@ -34,12 +30,8 @@ class JobWorkCursorTest extends BaseBatch2Test {
 
 	@Test
 	public void createCursorStep2() {
-		// setup
-		JobWorkNotification workNotification = new JobWorkNotification();
-		workNotification.setTargetStepId(STEP_2);
-
 		// execute
-		JobWorkCursor<TestJobParameters, ?, ?> cursor = JobWorkCursor.fromJobDefinitionAndWorkNotification(myDefinition, workNotification);
+		JobWorkCursor<TestJobParameters, ?, ?> cursor = JobWorkCursor.fromJobDefinitionAndRequestedStepId(myDefinition, STEP_2);
 
 		// verify
 		assertCursor(cursor, false, false, STEP_2, STEP_3);
@@ -47,12 +39,8 @@ class JobWorkCursorTest extends BaseBatch2Test {
 
 	@Test
 	public void createCursorStep3() {
-		// setup
-		JobWorkNotification workNotification = new JobWorkNotification();
-		workNotification.setTargetStepId(STEP_3);
-
 		// execute
-		JobWorkCursor<TestJobParameters, ?, ?> cursor = JobWorkCursor.fromJobDefinitionAndWorkNotification(myDefinition, workNotification);
+		JobWorkCursor<TestJobParameters, ?, ?> cursor = JobWorkCursor.fromJobDefinitionAndRequestedStepId(myDefinition, STEP_3);
 
 		// verify
 		assertCursor(cursor, false, true, STEP_3, null);
@@ -61,13 +49,11 @@ class JobWorkCursorTest extends BaseBatch2Test {
 	@Test
 	public void unknownStep() {
 		// setup
-		JobWorkNotification workNotification = new JobWorkNotification();
 		String targetStepId = "Made a searching and fearless moral inventory of ourselves";
-		workNotification.setTargetStepId(targetStepId);
 
 		// execute
 		try {
-			JobWorkCursor.fromJobDefinitionAndWorkNotification(myDefinition, workNotification);
+			JobWorkCursor.fromJobDefinitionAndRequestedStepId(myDefinition, targetStepId);
 
 			// verify
 			fail();


### PR DESCRIPTION
If a step and all prior steps produced only a single chunk of work, notify the next step immediately instead of waiting for the scheduled job maintenance to advance it.