### PR TITLE
Group Bulk Export rules exiting too early. 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3642-group-bulk-export-failure.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3642-group-bulk-export-failure.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 3642
+title: "Previously, the RuleBuilder's rules surrounding Group Bulk Export would return failures too early in the case of multiple permissions. This has been corrected, and the rule will no longer prematurely
+return a DENY verdict, instead opting to delegate to future rules."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3642-group-bulk-export-failure.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3642-group-bulk-export-failure.yaml
@@ -1,5 +1,6 @@
 ---
 type: fix
 issue: 3642
+jira: SMILE-4383
 title: "Previously, the RuleBuilder's rules surrounding Group Bulk Export would return failures too early in the case of multiple permissions. This has been corrected, and the rule will no longer prematurely
 return a DENY verdict, instead opting to delegate to future rules."

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/AuthorizationInterceptorJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/AuthorizationInterceptorJpaR4Test.java
@@ -105,6 +105,7 @@ public class AuthorizationInterceptorJpaR4Test extends BaseResourceProviderR4Tes
 			public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
 				return new RuleBuilder()
 					.allow().bulkExport().groupExportOnGroup(new IdType("Group/123")).andThen()
+					.allow().bulkExport().groupExportOnGroup(new IdType("Group/789")).andThen()
 					.build();
 			}
 		};
@@ -115,12 +116,26 @@ public class AuthorizationInterceptorJpaR4Test extends BaseResourceProviderR4Tes
 		 */
 		{
 			BulkDataExportOptions bulkDataExportOptions = new BulkDataExportOptions();
-			bulkDataExportOptions.setGroupId(new IdType("Group/123"));
+			bulkDataExportOptions.setGroupId(new IdType("Group/789"));
 			bulkDataExportOptions.setExportStyle(BulkDataExportOptions.ExportStyle.GROUP);
 
 			ServletRequestDetails requestDetails = new ServletRequestDetails().setServletRequest(new MockHttpServletRequest());
 			IBulkDataExportSvc.JobInfo jobDetails = myBulkDataExportSvc.submitJob(bulkDataExportOptions, true, requestDetails);
 			assertEquals(BulkExportJobStatusEnum.SUBMITTED, jobDetails.getStatus());
+		}
+
+		/*
+		 * Second matching group ID
+		 */
+		{
+		 BulkDataExportOptions bulkDataExportOptions = new BulkDataExportOptions();
+		 bulkDataExportOptions.setGroupId(new IdType("Group/789"));
+		 bulkDataExportOptions.setExportStyle(BulkDataExportOptions.ExportStyle.GROUP);
+
+		 ServletRequestDetails requestDetails = new ServletRequestDetails().setServletRequest(new MockHttpServletRequest());
+		 IBulkDataExportSvc.JobInfo jobDetails = myBulkDataExportSvc.submitJob(bulkDataExportOptions, true, requestDetails);
+		 assertEquals(BulkExportJobStatusEnum.SUBMITTED, jobDetails.getStatus());
+
 		}
 
 		/*

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBulkExportImpl.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBulkExportImpl.java
@@ -80,11 +80,8 @@ public class RuleBulkExportImpl extends BaseRule {
 			String actualGroupId = options.getGroupId().toUnqualifiedVersionless().getValue();
 			if (Objects.equals(expectedGroupId, actualGroupId)) {
 				return newVerdict(theOperation, theRequestDetails, theInputResource, theInputResourceId, theOutputResource);
-			} else {
-				return new AuthorizationInterceptor.Verdict(PolicyEnum.DENY,this);
 			}
 		}
-
 		return null;
 	}
 

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBuilderTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBuilderTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
@@ -47,6 +48,19 @@ public class RuleBuilderTest {
 			new IdDt("Patient/WRITE-3"),
 			new IdDt("Patient/WRITE-4")
 		));
+	}
+
+	@Test
+	public void testBulkExportPermitsIfASingleGroupMatches() {
+		RuleBuilder builder = new RuleBuilder();
+		List<String> resourceTypes = new ArrayList<>();
+		resourceTypes.add("Patient");
+		resourceTypes.add("Organization");
+
+		builder.allow().bulkExport().groupExportOnGroup("group1").withResourceTypes(resourceTypes);
+		builder.allow().bulkExport().groupExportOnGroup("group2").withResourceTypes(resourceTypes);
+		List<IAuthRule> build = builder.build();
+
 	}
 
 	@Test

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBulkExportImplTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBulkExportImplTest.java
@@ -73,7 +73,7 @@ public class RuleBulkExportImplTest {
 	}
 
 	@Test
-	public void testDenyBulkRequestWithInvalidGroupId() {
+	public void testWrongGroupIdDelegatesToNextRule() {
 		RuleBulkExportImpl myRule = new RuleBulkExportImpl("a");
 		myRule.setAppliesToGroupExportOnGroup("invalid group");
 		myRule.setMode(PolicyEnum.ALLOW);
@@ -85,7 +85,7 @@ public class RuleBulkExportImplTest {
 		when(myRequestDetails.getAttribute(any())).thenReturn(options);
 
 		AuthorizationInterceptor.Verdict verdict = myRule.applyRule(myOperation, myRequestDetails, null, null, null, myRuleApplier, myFlags, myPointcut);
-		assertEquals(PolicyEnum.DENY, verdict.getDecision());
+		assertEquals(null, verdict);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #3642 

* Make RuleBulkExportImpl return null instead of DENY if group ID does not match. Default implementation will DENY if no rules match. 
* This will allow a failed bulk export rule to delegate to further ones
* Fix tests, add test component.
* Add changelog. 

