### PR TITLE
pom changes to publish checkstyle to sonatype

### DIFF
--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -8,7 +8,6 @@
 		<version>6.0.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
-	<version>0.0.1-TEST</version>
 
 	<artifactId>hapi-fhir-checkstyle</artifactId>
 	<packaging>jar</packaging>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -8,6 +8,7 @@
 		<version>6.0.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+	<version>0.0.1-TEST</version>
 
 	<artifactId>hapi-fhir-checkstyle</artifactId>
 	<packaging>jar</packaging>
@@ -39,11 +40,36 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-jar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>javadoc-jar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>javadoc</classifier>
+						</configuration>
+					</execution>
+					<execution>
+						<id>sources-jar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>sources</classifier>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Sonatype would not allow for checkstyle to upload as there are no javadocs or published source packages. This change fixes that.