### PR TITLE
Upgrade okhttp_version to 4.9.3.

### DIFF
--- a/hapi-fhir-android/src/test/java/ca/uhn/fhir/android/client/GenericClientDstu3IT.java
+++ b/hapi-fhir-android/src/test/java/ca/uhn/fhir/android/client/GenericClientDstu3IT.java
@@ -81,7 +81,7 @@ public class GenericClientDstu3IT {
 	}
 
 	private String expectedUserAgent() {
-		return "HAPI-FHIR/" + VersionUtil.getVersion() + " (FHIR Client; FHIR " + FhirVersionEnum.DSTU3.getFhirVersionString() + "/DSTU3; okhttp/3.8.1)";
+		return "HAPI-FHIR/" + VersionUtil.getVersion() + " (FHIR Client; FHIR " + FhirVersionEnum.DSTU3.getFhirVersionString() + "/DSTU3; okhttp/4.9.3)";
 	}
 
 

--- a/hapi-fhir-android/src/test/java/ca/uhn/fhir/android/client/GenericClientDstu3IT.java
+++ b/hapi-fhir-android/src/test/java/ca/uhn/fhir/android/client/GenericClientDstu3IT.java
@@ -81,7 +81,7 @@ public class GenericClientDstu3IT {
 	}
 
 	private String expectedUserAgent() {
-		return "HAPI-FHIR/" + VersionUtil.getVersion() + " (FHIR Client; FHIR " + FhirVersionEnum.DSTU3.getFhirVersionString() + "/DSTU3; okhttp/4.9.3)";
+		return "HAPI-FHIR/" + VersionUtil.getVersion() + " (FHIR Client; FHIR " + FhirVersionEnum.DSTU3.getFhirVersionString() + "/DSTU3; okhttp)";
 	}
 
 

--- a/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulClient.java
+++ b/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulClient.java
@@ -126,7 +126,7 @@ public class OkHttpRestfulClient implements IHttpClient {
     }
 
     private void addUserAgentHeader(OkHttpRestfulRequest theHttpRequest, FhirContext theContext) {
-        theHttpRequest.addHeader("User-Agent", HttpClientUtil.createUserAgentString(theContext, "okhttp/" + OkHttp.VERSION));
+        theHttpRequest.addHeader("User-Agent", HttpClientUtil.createUserAgentString(theContext, "okhttp"));
     }
 
     private void addAcceptCharsetHeader(OkHttpRestfulRequest theHttpRequest) {

--- a/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulClient.java
+++ b/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulClient.java
@@ -32,7 +32,6 @@ import ca.uhn.fhir.rest.client.api.*;
 import ca.uhn.fhir.rest.client.impl.BaseHttpClientInvocation;
 import ca.uhn.fhir.rest.client.method.MethodUtil;
 import okhttp3.*;
-import okhttp3.internal.Version;
 
 /**
  * A Http Request based on OkHttp. This is an adapter around the class
@@ -127,7 +126,7 @@ public class OkHttpRestfulClient implements IHttpClient {
     }
 
     private void addUserAgentHeader(OkHttpRestfulRequest theHttpRequest, FhirContext theContext) {
-        theHttpRequest.addHeader("User-Agent", HttpClientUtil.createUserAgentString(theContext, Version.userAgent()));
+        theHttpRequest.addHeader("User-Agent", HttpClientUtil.createUserAgentString(theContext, OkHttp.VERSION));
     }
 
     private void addAcceptCharsetHeader(OkHttpRestfulRequest theHttpRequest) {

--- a/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulClient.java
+++ b/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulClient.java
@@ -126,7 +126,7 @@ public class OkHttpRestfulClient implements IHttpClient {
     }
 
     private void addUserAgentHeader(OkHttpRestfulRequest theHttpRequest, FhirContext theContext) {
-        theHttpRequest.addHeader("User-Agent", HttpClientUtil.createUserAgentString(theContext, OkHttp.VERSION));
+        theHttpRequest.addHeader("User-Agent", HttpClientUtil.createUserAgentString(theContext, "okhttp/" + OkHttp.VERSION));
     }
 
     private void addAcceptCharsetHeader(OkHttpRestfulRequest theHttpRequest) {

--- a/pom.xml
+++ b/pom.xml
@@ -814,7 +814,7 @@
         <jackson_databind_version>2.13.2.2</jackson_databind_version>
         <maven_assembly_plugin_version>3.3.0</maven_assembly_plugin_version>
         <maven_license_plugin_version>1.8</maven_license_plugin_version>
-        <okhttp_version>3.8.1</okhttp_version>
+        <okhttp_version>4.9.3</okhttp_version>
         <poi_version>4.1.2</poi_version>
         <poi_ooxml_schemas_version>1.4</poi_ooxml_schemas_version>
         <resteasy_version>5.0.2.Final</resteasy_version>


### PR DESCRIPTION
Remove dependency on okhttp.internal package.

Fixes https://github.com/hapifhir/hapi-fhir/issues/3682