### PR TITLE
Make a unique log folder name on publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
             condition: always()
             inputs:
                targetPath: '$(Build.ArtifactStagingDirectory)/'
-               artifactName: 'full_logs_$(Build.BuildId).zip'
+               artifactName: 'full_logs_$(Build.BuildId)_$(Build.BuildNumber).zip'
          -  script: bash <(curl https://codecov.io/bash) -t $(CODECOV_TOKEN)
             displayName: 'codecov'
          -  task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
             condition: always()
             inputs:
                targetPath: '$(Build.ArtifactStagingDirectory)/'
-               artifactName: 'full_logs.zip'
+               artifactName: 'full_logs_$(Build.BuildId).zip'
          -  script: bash <(curl https://codecov.io/bash) -t $(CODECOV_TOKEN)
             displayName: 'codecov'
          -  task: PublishTestResults@2


### PR DESCRIPTION
* Modify pipeline script to add BuildId as a suffix to generated log zip file to prevent collisions on subsequent runs,