### PR TITLE
3693 Search by id is returning a deleted resource with a client-generated id

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>6.1.0-PRE8-SNAPSHOT</version>
+		 <version>6.1.0-PRE9-SNAPSHOT</version>
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>
 

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-batch/pom.xml
+++ b/hapi-fhir-batch/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -3,14 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ca.uhn.hapi.fhir</groupId>
     <artifactId>hapi-fhir-bom</artifactId>
-    <version>6.1.0-PRE8-SNAPSHOT</version>
+    <version>6.1.0-PRE9-SNAPSHOT</version>
     <packaging>pom</packaging>
 	 <name>HAPI FHIR BOM</name>
 
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
     

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/hapi-fhir-cli-jpaserver/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-jpaserver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../../hapi-deployable-pom</relativePath>
 	</parent>
 

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3693-exclude-deleted-resources-with-forced-ids-from-bundle-total-in-searches.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3693-exclude-deleted-resources-with-forced-ids-from-bundle-total-in-searches.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 3693
+jira: SMILE-4185
+title: "Previously, deleted resources with client generated ids were being included in the 
+bundle total when searching by _id. This has been corrected by adding functionality to optionally filter
+out deleted resources when resolving forced ids to persistent ids."

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IForcedIdDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IForcedIdDao.java
@@ -1,6 +1,6 @@
 package ca.uhn.fhir.jpa.dao.data;
 
-import ca.uhn.fhir.jpa.dao.data.custom.IForcedIdDaoCustom;
+import ca.uhn.fhir.jpa.dao.data.custom.IForcedIdQueries;
 import ca.uhn.fhir.jpa.model.entity.ForcedId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +31,7 @@ import java.util.Optional;
  * #L%
  */
 @Repository
-public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJpaRepository, IForcedIdDaoCustom {
+public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJpaRepository, IForcedIdQueries {
 
 	@Query("SELECT f FROM ForcedId f WHERE myResourcePid IN (:resource_pids)")
 	List<ForcedId> findAllByResourcePid(@Param("resource_pids") List<Long> theResourcePids);
@@ -43,42 +42,4 @@ public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJp
 	@Modifying
 	@Query("DELETE FROM ForcedId t WHERE t.myId = :pid")
 	void deleteByPid(@Param("pid") Long theId);
-
-	/**
-	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
-	 * is an object array, where the order matters (the array represents columns returned by the query).
-	 * Deleted resources should not be filtered.
-	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeIncludeDeleted(String theResourceType, Collection<String> theForcedIds);
-
-	/**
-	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
-	 * is an object array, where the order matters (the array represents columns returned by the query).
-	 * Deleted resources are optionally filtered.
-	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted);
-
-	/**
-	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
-	 * is an object array, where the order matters (the array represents columns returned by the query).
-	 * Deleted resources are optionally filtered.
-	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theFilterDeleted);
-
-
-	/**
-	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
-	 * is an object array, where the order matters (the array represents columns returned by the query).
-	 * Deleted resources are optionally filtered.
-	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionNull(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted);
-
-	/**
-	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
-	 * is an object array, where the order matters (the array represents columns returned by the query).
-	 * Deleted resources are optionally filtered.
-	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theNextResourceType, Collection<String> theNextIds, List<Integer> thePartitionIdsWithoutDefault, boolean theFilterDeleted);
-
-
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IForcedIdDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IForcedIdDao.java
@@ -49,7 +49,7 @@ public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJp
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources should not be filtered.
 	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds);
+	Collection<Object[]> findAndResolveByForcedIdWithNoTypeIncludeDeleted(String theResourceType, Collection<String> theForcedIds);
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IForcedIdDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IForcedIdDao.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 @Repository
 public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJpaRepository, IForcedIdQueries {
 
-	@Query("SELECT f FROM ForcedId f WHERE myResourcePid IN (:resource_pids)")
+	@Query("SELECT f FROM ForcedId f WHERE f.myResourcePid IN (:resource_pids)")
 	List<ForcedId> findAllByResourcePid(@Param("resource_pids") List<Long> theResourcePids);
 
 	@Query("SELECT f FROM ForcedId f WHERE f.myResourcePid = :resource_pid")

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoCustom.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoCustom.java
@@ -30,7 +30,7 @@ public interface IForcedIdDaoCustom {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources should not be filtered.
 	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds);
+	Collection<Object[]> findAndResolveByForcedIdWithNoTypeIncludeDeleted(String theResourceType, Collection<String> theForcedIds);
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoCustom.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoCustom.java
@@ -1,16 +1,7 @@
-package ca.uhn.fhir.jpa.dao.data;
-
-import ca.uhn.fhir.jpa.dao.data.custom.IForcedIdDaoCustom;
-import ca.uhn.fhir.jpa.model.entity.ForcedId;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
+package ca.uhn.fhir.jpa.dao.data.custom;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 /*
  * #%L
@@ -31,18 +22,8 @@ import java.util.Optional;
  * limitations under the License.
  * #L%
  */
-@Repository
-public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJpaRepository, IForcedIdDaoCustom {
 
-	@Query("SELECT f FROM ForcedId f WHERE myResourcePid IN (:resource_pids)")
-	List<ForcedId> findAllByResourcePid(@Param("resource_pids") List<Long> theResourcePids);
-
-	@Query("SELECT f FROM ForcedId f WHERE f.myResourcePid = :resource_pid")
-	Optional<ForcedId> findByResourcePid(@Param("resource_pid") Long theResourcePid);
-
-	@Modifying
-	@Query("DELETE FROM ForcedId t WHERE t.myId = :pid")
-	void deleteByPid(@Param("pid") Long theId);
+public interface IForcedIdDaoCustom {
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
@@ -65,7 +46,6 @@ public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJp
 	 */
 	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theFilterDeleted);
 
-
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
 	 * is an object array, where the order matters (the array represents columns returned by the query).
@@ -79,6 +59,5 @@ public interface IForcedIdDao extends JpaRepository<ForcedId, Long>, IHapiFhirJp
 	 * Deleted resources are optionally filtered.
 	 */
 	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theNextResourceType, Collection<String> theNextIds, List<Integer> thePartitionIdsWithoutDefault, boolean theFilterDeleted);
-
 
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
@@ -1,0 +1,122 @@
+package ca.uhn.fhir.jpa.dao.data.custom;
+
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceContextType;
+import java.util.Collection;
+import java.util.List;
+
+@Component
+public class IForcedIdDaoImpl implements IForcedIdDaoCustom {
+
+	@PersistenceContext(type = PersistenceContextType.TRANSACTION)
+	private EntityManager myEntityManager;
+
+	/**
+	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
+	 * is an object array, where the order matters (the array represents columns returned by the query).
+	 * Deleted resources are not filtered.
+	 */
+	public Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds){
+		return findAndResolveByForcedIdWithNoType(theResourceType, theForcedIds, false);
+	}
+
+	/**
+	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
+	 * is an object array, where the order matters (the array represents columns returned by the query).
+	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
+	 */
+	public Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted){
+		String query = "" +
+			"SELECT " +
+			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
+			"FROM ForcedId f " +
+			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
+			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id )";
+
+		if(theFilterDeleted){
+			query += " AND t.myDeleted IS NULL";
+		}
+
+		return myEntityManager.createQuery(query)
+			.setParameter("resource_type", theResourceType)
+			.setParameter("forced_id", theForcedIds)
+			.getResultList();
+	}
+
+	/**
+	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
+	 * is an object array, where the order matters (the array represents columns returned by the query).
+	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
+	 */
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theFilterDeleted){
+		String query = "" +
+			"SELECT " +
+			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
+			"FROM ForcedId f " +
+			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
+			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND f.myPartitionIdValue IN :partition_id";
+
+
+		if(theFilterDeleted){
+			query += " AND t.myDeleted IS NULL";
+		}
+
+		return myEntityManager.createQuery(query)
+			.setParameter("resource_type", theResourceType)
+			.setParameter("forced_id", theForcedIds)
+			.setParameter("partition_id", thePartitionId)
+			.getResultList();
+	}
+
+
+	/**
+	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
+	 * is an object array, where the order matters (the array represents columns returned by the query).
+	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
+	 */
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionNull(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted){
+		String query = "" +
+			"SELECT " +
+			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
+			"FROM ForcedId f " +
+			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
+			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND f.myPartitionIdValue IS NULL";
+
+
+		if(theFilterDeleted){
+			query += " AND t.myDeleted IS NULL";
+		}
+
+		return myEntityManager.createQuery(query)
+			.setParameter("resource_type", theResourceType)
+			.setParameter("forced_id", theForcedIds)
+			.getResultList();
+	}
+
+	/**
+	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
+	 * is an object array, where the order matters (the array represents columns returned by the query).
+	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
+	 */
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theResourceType, Collection<String> theForcedIds, List<Integer> thePartitionIdsWithoutDefault, boolean theFilterDeleted){
+		String query = "" +
+			"SELECT " +
+			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
+			"FROM ForcedId f " +
+			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
+			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND (f.myPartitionIdValue IS NULL OR f.myPartitionIdValue IN :partition_id)";
+
+		if(theFilterDeleted){
+			query += " AND t.myDeleted IS NULL";
+		}
+
+		return myEntityManager.createQuery(query)
+			.setParameter("resource_type", theResourceType)
+			.setParameter("forced_id", theForcedIds)
+			.setParameter("partition_id", thePartitionIdsWithoutDefault)
+			.getResultList();
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Component
-public class IForcedIdDaoImpl implements IForcedIdDaoCustom {
+public class IForcedIdDaoImpl implements IForcedIdQueries {
 
 	@PersistenceContext(type = PersistenceContextType.TRANSACTION)
 	private EntityManager myEntityManager;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
@@ -4,14 +4,15 @@ import org.springframework.stereotype.Component;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.PersistenceContextType;
 import java.util.Collection;
 import java.util.List;
 
 @Component
+// Don't change the name of this class.  Spring Data requires the name to match.
+// See https://stackoverflow.com/questions/11880924/how-to-add-custom-method-to-spring-data-jpa
 public class IForcedIdDaoImpl implements IForcedIdQueries {
 
-	@PersistenceContext(type = PersistenceContextType.TRANSACTION)
+	@PersistenceContext
 	private EntityManager myEntityManager;
 
 	/**
@@ -19,7 +20,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are not filtered.
 	 */
-	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeIncludeDeleted(String theResourceType, Collection<String> theForcedIds){
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeIncludeDeleted(String theResourceType, Collection<String> theForcedIds) {
 		return findAndResolveByForcedIdWithNoType(theResourceType, theForcedIds, false);
 	}
 
@@ -28,7 +29,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
 	 */
-	public Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted){
+	public Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds, boolean theExcludeDeleted) {
 		String query = "" +
 			"SELECT " +
 			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
@@ -36,7 +37,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
 			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id )";
 
-		if(theFilterDeleted){
+		if (theExcludeDeleted) {
 			query += " AND t.myDeleted IS NULL";
 		}
 
@@ -51,7 +52,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
 	 */
-	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theFilterDeleted){
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theExcludeDeleted) {
 		String query = "" +
 			"SELECT " +
 			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
@@ -60,7 +61,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND f.myPartitionIdValue IN ( :partition_id )";
 
 
-		if(theFilterDeleted){
+		if (theExcludeDeleted) {
 			query += " AND t.myDeleted IS NULL";
 		}
 
@@ -77,7 +78,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
 	 */
-	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionNull(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted){
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionNull(String theResourceType, Collection<String> theForcedIds, boolean theExcludeDeleted) {
 		String query = "" +
 			"SELECT " +
 			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
@@ -86,7 +87,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND f.myPartitionIdValue IS NULL";
 
 
-		if(theFilterDeleted){
+		if (theExcludeDeleted) {
 			query += " AND t.myDeleted IS NULL";
 		}
 
@@ -101,7 +102,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered. Be careful if you change this query in any way.
 	 */
-	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theResourceType, Collection<String> theForcedIds, List<Integer> thePartitionIdsWithoutDefault, boolean theFilterDeleted){
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theResourceType, Collection<String> theForcedIds, List<Integer> thePartitionIdsWithoutDefault, boolean theExcludeDeleted) {
 		String query = "" +
 			"SELECT " +
 			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
@@ -109,7 +110,7 @@ public class IForcedIdDaoImpl implements IForcedIdQueries {
 			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
 			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND (f.myPartitionIdValue IS NULL OR f.myPartitionIdValue IN ( :partition_id ))";
 
-		if(theFilterDeleted){
+		if (theExcludeDeleted) {
 			query += " AND t.myDeleted IS NULL";
 		}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
@@ -57,7 +57,7 @@ public class IForcedIdDaoImpl implements IForcedIdDaoCustom {
 			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
 			"FROM ForcedId f " +
 			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
-			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND f.myPartitionIdValue IN :partition_id";
+			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND f.myPartitionIdValue IN ( :partition_id )";
 
 
 		if(theFilterDeleted){
@@ -107,7 +107,7 @@ public class IForcedIdDaoImpl implements IForcedIdDaoCustom {
 			"   f.myResourceType, f.myResourcePid, f.myForcedId, t.myDeleted " +
 			"FROM ForcedId f " +
 			"JOIN ResourceTable t ON t.myId = f.myResourcePid " +
-			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND (f.myPartitionIdValue IS NULL OR f.myPartitionIdValue IN :partition_id)";
+			"WHERE f.myResourceType = :resource_type AND f.myForcedId IN ( :forced_id ) AND (f.myPartitionIdValue IS NULL OR f.myPartitionIdValue IN ( :partition_id ))";
 
 		if(theFilterDeleted){
 			query += " AND t.myDeleted IS NULL";

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdDaoImpl.java
@@ -19,7 +19,7 @@ public class IForcedIdDaoImpl implements IForcedIdDaoCustom {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are not filtered.
 	 */
-	public Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds){
+	public Collection<Object[]> findAndResolveByForcedIdWithNoTypeIncludeDeleted(String theResourceType, Collection<String> theForcedIds){
 		return findAndResolveByForcedIdWithNoType(theResourceType, theForcedIds, false);
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdQueries.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdQueries.java
@@ -23,7 +23,7 @@ import java.util.List;
  * #L%
  */
 
-public interface IForcedIdDaoCustom {
+public interface IForcedIdQueries {
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdQueries.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/custom/IForcedIdQueries.java
@@ -37,27 +37,27 @@ public interface IForcedIdQueries {
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered.
 	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted);
+	Collection<Object[]> findAndResolveByForcedIdWithNoType(String theResourceType, Collection<String> theForcedIds, boolean theExcludeDeleted);
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered.
 	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theFilterDeleted);
+	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartition(String theResourceType, Collection<String> theForcedIds, Collection<Integer> thePartitionId, boolean theExcludeDeleted);
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered.
 	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionNull(String theResourceType, Collection<String> theForcedIds, boolean theFilterDeleted);
+	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionNull(String theResourceType, Collection<String> theForcedIds, boolean theExcludeDeleted);
 
 	/**
 	 * This method returns a Collection where each row is an element in the collection. Each element in the collection
 	 * is an object array, where the order matters (the array represents columns returned by the query).
 	 * Deleted resources are optionally filtered.
 	 */
-	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theNextResourceType, Collection<String> theNextIds, List<Integer> thePartitionIdsWithoutDefault, boolean theFilterDeleted);
+	Collection<Object[]> findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(String theNextResourceType, Collection<String> theNextIds, List<Integer> thePartitionIdsWithoutDefault, boolean theExcludeDeleted);
 
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -493,27 +493,22 @@ public class IdHelperService implements IIdHelperService {
 				assert isNotBlank(nextResourceType);
 
 				if (requestPartitionId.isAllPartitions()) {
-					views = myForcedIdDao.findAndResolveByForcedIdWithNoType(nextResourceType, nextIds);
+					views = myForcedIdDao.findAndResolveByForcedIdWithNoType(nextResourceType, nextIds, theFilterDeleted);
 				} else {
 					if (requestPartitionId.isDefaultPartition()) {
-						views = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(nextResourceType, nextIds);
+						views = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(nextResourceType, nextIds, theFilterDeleted);
 					} else if (requestPartitionId.hasDefaultPartitionId()) {
-						views = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(nextResourceType, nextIds, requestPartitionId.getPartitionIdsWithoutDefault());
+						views = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(nextResourceType, nextIds, requestPartitionId.getPartitionIdsWithoutDefault(), theFilterDeleted);
 					} else {
-						views = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(nextResourceType, nextIds, requestPartitionId.getPartitionIds());
+						views = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(nextResourceType, nextIds, requestPartitionId.getPartitionIds(), theFilterDeleted);
 					}
 				}
 
 				for (Object[] next : views) {
-					Date deletedAt = (Date) next[3];
-					boolean isResourceDeleted = deletedAt != null;
-					if(theFilterDeleted && isResourceDeleted){
-						continue;
-					}
-
 					String resourceType = (String) next[0];
 					Long resourcePid = (Long) next[1];
 					String forcedId = (String) next[2];
+					Date deletedAt = (Date) next[3];
 
 					ResourceLookup lookup = new ResourceLookup(resourceType, resourcePid, deletedAt);
 					if (!retVal.containsKey(forcedId)) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -128,12 +128,26 @@ public class IdHelperService implements IIdHelperService {
 	@Override
 	@Nonnull
 	public IResourceLookup resolveResourceIdentity(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theResourceId) throws ResourceNotFoundException {
+		return resolveResourceIdentity(theRequestPartitionId, theResourceType, theResourceId, false);
+	}
+
+	/**
+	 * Given a forced ID, convert it to its Long value. Since you are allowed to use string IDs for resources, we need to
+	 * convert those to the underlying Long values that are stored, for lookup and comparison purposes.
+	 * Optionally filters out deleted resources.
+	 *
+	 * @throws ResourceNotFoundException If the ID can not be found
+	 */
+	@Override
+	@Nonnull
+	public IResourceLookup resolveResourceIdentity(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theResourceId, boolean theFilterDeleted) throws ResourceNotFoundException {
 		assert myDontCheckActiveTransactionForUnitTest || TransactionSynchronizationManager.isSynchronizationActive();
 		assert theRequestPartitionId != null;
 
 		IdDt id = new IdDt(theResourceType, theResourceId);
 		Map<String, List<IResourceLookup>> matches = translateForcedIdToPids(theRequestPartitionId,
-			Collections.singletonList(id));
+			Collections.singletonList(id),
+			theFilterDeleted);
 
 		// We only pass 1 input in so only 0..1 will come back
 		if (matches.isEmpty() || !matches.containsKey(theResourceId)) {
@@ -155,14 +169,27 @@ public class IdHelperService implements IIdHelperService {
 
 	/**
 	 * Returns a mapping of Id -> ResourcePersistentId.
-	 * If any resource is not found, it will throw ResourceNotFound exception
-	 * (and no map will be returned)
+	 * If any resource is not found, it will throw ResourceNotFound exception (and no map will be returned)
 	 */
 	@Override
 	@Nonnull
 	public Map<String, ResourcePersistentId> resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId,
 																								 String theResourceType,
 																								 List<String> theIds) {
+		return resolveResourcePersistentIds(theRequestPartitionId, theResourceType, theIds, false);
+	}
+
+	/**
+	 * Returns a mapping of Id -> ResourcePersistentId.
+	 * If any resource is not found, it will throw ResourceNotFound exception (and no map will be returned)
+	 * Optionally filters out deleted resources.
+	 */
+	@Override
+	@Nonnull
+	public Map<String, ResourcePersistentId> resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId,
+																								 String theResourceType,
+																								 List<String> theIds,
+																								 boolean theFilterDeleted) {
 		assert myDontCheckActiveTransactionForUnitTest || TransactionSynchronizationManager.isSynchronizationActive();
 		Validate.notNull(theIds, "theIds cannot be null");
 		Validate.isTrue(!theIds.isEmpty(), "theIds must not be empty");
@@ -179,7 +206,7 @@ public class IdHelperService implements IIdHelperService {
 				// is a forced id
 				// we must resolve!
 				if (myDaoConfig.isDeleteEnabled()) {
-					retVal = new ResourcePersistentId(resolveResourceIdentity(theRequestPartitionId, theResourceType, id).getResourceId());
+					retVal = new ResourcePersistentId(resolveResourceIdentity(theRequestPartitionId, theResourceType, id, theFilterDeleted).getResourceId());
 					retVals.put(id, retVal);
 				} else {
 					// fetch from cache... adding to cache if not available
@@ -209,11 +236,22 @@ public class IdHelperService implements IIdHelperService {
 	@Override
 	@Nonnull
 	public ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId) {
+		return resolveResourcePersistentIds(theRequestPartitionId, theResourceType, theId, false);
+	}
+
+	/**
+	 * Given a resource type and ID, determines the internal persistent ID for the resource.
+	 * Optionally filters out deleted resources.
+	 *
+	 * @throws ResourceNotFoundException If the ID can not be found
+	 */
+	public ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId, boolean theFilterDeleted){
 		Validate.notNull(theId, "theId must not be null");
 
 		Map<String, ResourcePersistentId> retVal = resolveResourcePersistentIds(theRequestPartitionId,
 			theResourceType,
-			Collections.singletonList(theId));
+			Collections.singletonList(theId),
+			theFilterDeleted);
 		return retVal.get(theId); // should be only one
 	}
 
@@ -406,7 +444,7 @@ public class IdHelperService implements IIdHelperService {
 		return typeToIds;
 	}
 
-	private Map<String, List<IResourceLookup>> translateForcedIdToPids(@Nonnull RequestPartitionId theRequestPartitionId, Collection<IIdType> theId) {
+	private Map<String, List<IResourceLookup>> translateForcedIdToPids(@Nonnull RequestPartitionId theRequestPartitionId, Collection<IIdType> theId, boolean theFilterDeleted) {
 		assert theRequestPartitionId != null;
 
 		theId.forEach(id -> Validate.isTrue(id.hasIdPart()));
@@ -471,6 +509,12 @@ public class IdHelperService implements IIdHelperService {
 					Long resourcePid = (Long) next[1];
 					String forcedId = (String) next[2];
 					Date deletedAt = (Date) next[3];
+
+					boolean isResourceDeleted = deletedAt != null;
+					if(theFilterDeleted && isResourceDeleted){
+						continue;
+					}
+
 					ResourceLookup lookup = new ResourceLookup(resourceType, resourcePid, deletedAt);
 					if (!retVal.containsKey(forcedId)) {
 						retVal.put(forcedId, new ArrayList<>());

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -505,15 +505,15 @@ public class IdHelperService implements IIdHelperService {
 				}
 
 				for (Object[] next : views) {
-					String resourceType = (String) next[0];
-					Long resourcePid = (Long) next[1];
-					String forcedId = (String) next[2];
 					Date deletedAt = (Date) next[3];
-
 					boolean isResourceDeleted = deletedAt != null;
 					if(theFilterDeleted && isResourceDeleted){
 						continue;
 					}
+
+					String resourceType = (String) next[0];
+					Long resourcePid = (Long) next[1];
+					String forcedId = (String) next[2];
 
 					ResourceLookup lookup = new ResourceLookup(resourceType, resourcePid, deletedAt);
 					if (!retVal.containsKey(forcedId)) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
@@ -83,7 +83,8 @@ public class ResourceIdPredicateBuilder extends BasePredicateBuilder {
 					}
 					haveValue = true;
 					try {
-						ResourcePersistentId pid = myIdHelperService.resolveResourcePersistentIds(theRequestPartitionId, theResourceName, valueAsId.getIdPart());
+						boolean filterDeleted = true;
+						ResourcePersistentId pid = myIdHelperService.resolveResourcePersistentIds(theRequestPartitionId, theResourceName, valueAsId.getIdPart(), filterDeleted);
 						orPids.add(pid);
 					} catch (ResourceNotFoundException e) {
 						// This is not an error in a search, it just results in no matches

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
@@ -22,7 +22,6 @@ package ca.uhn.fhir.jpa.search.builder.predicate;
 
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
-import ca.uhn.fhir.jpa.dao.index.IdHelperService;
 import ca.uhn.fhir.jpa.dao.predicate.SearchFilterParser;
 import ca.uhn.fhir.jpa.search.builder.QueryStack;
 import ca.uhn.fhir.jpa.search.builder.sql.SearchQueryBuilder;
@@ -83,8 +82,8 @@ public class ResourceIdPredicateBuilder extends BasePredicateBuilder {
 					}
 					haveValue = true;
 					try {
-						boolean filterDeleted = true;
-						ResourcePersistentId pid = myIdHelperService.resolveResourcePersistentIds(theRequestPartitionId, theResourceName, valueAsId.getIdPart(), filterDeleted);
+						boolean excludeDeleted = true;
+						ResourcePersistentId pid = myIdHelperService.resolveResourcePersistentIds(theRequestPartitionId, theResourceName, valueAsId.getIdPart(), excludeDeleted);
 						orPids.add(pid);
 					} catch (ResourceNotFoundException e) {
 						// This is not an error in a search, it just results in no matches

--- a/hapi-fhir-jpaserver-cql/pom.xml
+++ b/hapi-fhir-jpaserver-cql/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/index/IdHelperServiceTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/index/IdHelperServiceTest.java
@@ -91,7 +91,7 @@ public class IdHelperServiceTest {
 		Mockito.when(myDaoConfig.isDeleteEnabled())
 			.thenReturn(true);
 		Mockito.when(myForcedIdDao.findAndResolveByForcedIdWithNoType(Mockito.anyString(),
-			Mockito.anyList()))
+			Mockito.anyList(), Mockito.anyBoolean()))
 			.thenReturn(Collections.singletonList(redView))
 			.thenReturn(Collections.singletonList(blueView));
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
@@ -892,14 +892,10 @@ public class FhirResourceDaoR4SearchOptimizedTest extends BaseJpaR4Test {
 			assertEquals(0, outcome.getResources(0, 999).size());
 			myCaptureQueriesListener.logSelectQueriesForCurrentThread();
 
+			assertEquals(1, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 			String selectQuery = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
 			assertEquals(1, StringUtils.countMatches(selectQuery.toLowerCase(), "forcedid0_.resource_type='observation'"), selectQuery);
 			assertEquals(1, StringUtils.countMatches(selectQuery.toLowerCase(), "forcedid0_.forced_id in ('a')"), selectQuery);
-
-			selectQuery = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(1).getSql(true, false);
-			assertEquals(1, StringUtils.countMatches(selectQuery.toLowerCase(), "select t0.res_id from hfj_resource t0"), selectQuery);
-			assertEquals(0, StringUtils.countMatches(selectQuery.toLowerCase(), "t0.res_type = 'observation'"), selectQuery);
-			assertEquals(0, StringUtils.countMatches(selectQuery.toLowerCase(), "t0.res_deleted_at is null"), selectQuery);
 		}
 
 		// Search by ID where at least one ID is a numeric ID

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
@@ -877,8 +877,8 @@ public class FhirResourceDaoR4SearchOptimizedTest extends BaseJpaR4Test {
 			assertEquals(1, StringUtils.countMatches(selectQuery.toLowerCase(), "t0.res_deleted_at is null"), selectQuery);
 		}
 
-		// Delete the resource - The searches should generate similar SQL now, but
-		// not actually return the result
+		// Delete the resource - There should only be one search performed because deleted resources will
+		//		be filtered out in the query that resolves forced ids to persistent ids
 		myObservationDao.delete(new IdType("Observation/A"));
 		myObservationDao.delete(new IdType("Observation/" + obs2id));
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
@@ -161,7 +161,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 
 		// Search and include deleted
 		runInTransaction(() -> {
-			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeIncludeDeleted(
 				"Patient", Arrays.asList(patientId)
 			);
 			verifySingleForcedIdFound(forcedIds, patientId);
@@ -180,7 +180,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 
 		// Search and include deleted
 		runInTransaction(() -> {
-			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeIncludeDeleted(
 				"Patient", Arrays.asList(patientId)
 			);
 			verifySingleForcedIdFound(forcedIds, patientId);

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
@@ -36,6 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -149,6 +151,187 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 		} catch (ResourceNotFoundException e) {
 			// good
 		}
+	}
+
+	@Test
+	public void testFindAndResolveByForcedIdWithNoType() {
+		// Create patients
+		String patientId = "AAA";
+		IIdType idA = createPatient(withId(patientId));
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
+				"Patient", Arrays.asList(patientId)
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
+				"Patient", Arrays.asList(patientId), true
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Delete resource
+		deletePatient(JpaConstants.DEFAULT_PARTITION_NAME, idA);
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
+				"Patient", Arrays.asList(patientId)
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
+				"Patient", Arrays.asList(patientId), true
+			);
+			assertEquals(0, forcedIds.size());
+		});
+	}
+
+	@Test
+	public void findAndResolveByForcedIdWithNoTypeInPartitionNull() {
+		// Create patients
+		String patientId = "AAA";
+		IIdType idA = createPatient(withId(patientId));
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
+				"Patient", Arrays.asList(patientId), false
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
+				"Patient", Arrays.asList(patientId), true
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Delete resource
+		deletePatient(JpaConstants.DEFAULT_PARTITION_NAME, idA);
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
+				"Patient", Arrays.asList(patientId), false
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
+				"Patient", Arrays.asList(patientId), true
+			);
+			assertEquals(0, forcedIds.size());
+		});
+	}
+
+	@Test
+	public void testFindAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(){
+		// Create patients
+		String patientId = "AAA";
+		IIdType idA = createPatient(withTenant(TENANT_A), withId(patientId));
+
+		createPatient(withId("BBB"));
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), false
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), true
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		deletePatient(TENANT_A, idA);
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), false
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), true
+			);
+			assertEquals(0, forcedIds.size());
+		});
+	}
+
+	@Test
+	public void testFindAndResolveByForcedIdWithNoTypeInPartition() throws IOException {
+		// Create patients
+		String patientId = "AAA";
+		IIdType idA = createPatient(withTenant(TENANT_A), withId(patientId));
+
+		createPatient(withTenant(TENANT_B), withId("BBB"));
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), false
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), true
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		deletePatient(TENANT_A, idA);
+
+		// Search and include deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), false
+			);
+			verifySingleForcedIdFound(forcedIds, patientId);
+		});
+
+		// Search and filter deleted
+		runInTransaction(() -> {
+			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
+				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), true
+			);
+			assertEquals(0, forcedIds.size());
+		});
+	}
+
+	private void verifySingleForcedIdFound(Collection<Object[]> forcedIds, String patientId){
+		assertEquals(1, forcedIds.size());
+		assertEquals(patientId, forcedIds.stream().toList().get(0)[2]);
+	}
+
+	private void deletePatient(String tenantId, IIdType patientId){
+		SystemRequestDetails requestDetails = new SystemRequestDetails();
+		requestDetails.setTenantId(tenantId);
+		myPatientDao.delete(patientId, requestDetails);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
@@ -164,7 +164,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeIncludeDeleted(
 				"Patient", Arrays.asList(patientId)
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -172,7 +172,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
 				"Patient", Arrays.asList(patientId), true
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Delete resource
@@ -183,7 +183,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeIncludeDeleted(
 				"Patient", Arrays.asList(patientId)
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -191,7 +191,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoType(
 				"Patient", Arrays.asList(patientId), true
 			);
-			assertEquals(0, forcedIds.size());
+			assertThat(forcedIds, hasSize(0));
 		});
 	}
 
@@ -206,7 +206,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
 				"Patient", Arrays.asList(patientId), false
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -214,7 +214,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
 				"Patient", Arrays.asList(patientId), true
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Delete resource
@@ -225,7 +225,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionNull(
 				"Patient", Arrays.asList(patientId), false
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -250,7 +250,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
 				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), false
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -258,7 +258,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
 				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), true
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		deletePatient(TENANT_A, idA);
@@ -268,7 +268,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartitionIdOrNullPartitionId(
 				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID), false
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -293,7 +293,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
 				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), false
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -301,7 +301,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
 				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), true
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		deletePatient(TENANT_A, idA);
@@ -311,7 +311,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 			Collection<Object[]> forcedIds = myForcedIdDao.findAndResolveByForcedIdWithNoTypeInPartition(
 				"Patient", Arrays.asList(patientId), Arrays.asList(TENANT_A_ID, TENANT_B_ID), false
 			);
-			verifySingleForcedIdFound(forcedIds, patientId);
+			assertContainsSingleForcedId(forcedIds, patientId);
 		});
 
 		// Search and filter deleted
@@ -323,7 +323,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 		});
 	}
 
-	private void verifySingleForcedIdFound(Collection<Object[]> forcedIds, String patientId){
+	private void assertContainsSingleForcedId(Collection<Object[]> forcedIds, String patientId){
 		assertEquals(1, forcedIds.size());
 		assertEquals(patientId, forcedIds.stream().toList().get(0)[2]);
 	}

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -3993,6 +3993,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		Patient p = new Patient();
 		p.setId("AAA");
 		String encoded = myFhirContext.newJsonParser().encodeResourceToString(p);
+		// FIXME ND please switch to using myFhirClient here.  Distinguish between 200 and 201 by checking methodOutcome.getCreated()
 		HttpPut httpPut = new HttpPut(ourServerBase + "/Patient/AAA");
 		httpPut.setEntity(new StringEntity(encoded, ContentType.parse("application/json+fhir")));
 		try (CloseableHttpResponse status = ourHttpClient.execute(httpPut)) {

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-okhttp</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-server-jersey</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-samples</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>6.1.0-PRE8-SNAPSHOT</version>
+      <version>6.1.0-PRE9-SNAPSHOT</version>
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>
 

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IIdHelperService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IIdHelperService.java
@@ -61,12 +61,29 @@ public interface IIdHelperService {
 	ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId);
 
 	/**
+	 * Given a resource type and ID, determines the internal persistent ID for a resource. Excludes deleted resources if filterDeleted is set to true.
+	 * Optionally filters out deleted resources.
+	 *
+	 * @throws ResourceNotFoundException If the ID can not be found
+	 */
+	@Nonnull
+	ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId, boolean theFilterDeleted);
+
+	/**
 	 * Returns a mapping of Id -> ResourcePersistentId.
 	 * If any resource is not found, it will throw ResourceNotFound exception
 	 * (and no map will be returned)
 	 */
 	@Nonnull
 	Map<String, ResourcePersistentId> resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, List<String> theIds);
+
+	/**
+	 * Returns a mapping of Id -> ResourcePersistentId.
+	 * If any resource is not found, it will throw ResourceNotFound exception (and no map will be returned)
+	 * Optionally filters out deleted resources.
+	 */
+	@Nonnull
+	Map<String, ResourcePersistentId> resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, List<String> theIds, boolean theFilterDeleted);
 
 	/**
 	 * Given a persistent ID, returns the associated resource ID
@@ -82,6 +99,16 @@ public interface IIdHelperService {
 	 */
 	@Nonnull
 	IResourceLookup resolveResourceIdentity(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theResourceId) throws ResourceNotFoundException;
+
+	/**
+	 * Given a forced ID, convert it to it's Long value. Since you are allowed to use string IDs for resources, we need to
+	 * convert those to the underlying Long values that are stored, for lookup and comparison purposes.
+	 * Optionally filters out deleted resources.
+	 *
+	 * @throws ResourceNotFoundException If the ID can not be found
+	 */
+	@Nonnull
+	IResourceLookup resolveResourceIdentity(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theResourceId, boolean theFilterDeleted) throws ResourceNotFoundException;
 
 	/**
 	 * Returns true if the given resource ID should be stored in a forced ID. Under default config

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IIdHelperService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IIdHelperService.java
@@ -67,7 +67,7 @@ public interface IIdHelperService {
 	 * @throws ResourceNotFoundException If the ID can not be found
 	 */
 	@Nonnull
-	ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId, boolean theFilterDeleted);
+	ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId, boolean theExcludeDeleted);
 
 	/**
 	 * Returns a mapping of Id -> ResourcePersistentId.
@@ -83,7 +83,7 @@ public interface IIdHelperService {
 	 * Optionally filters out deleted resources.
 	 */
 	@Nonnull
-	Map<String, ResourcePersistentId> resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, List<String> theIds, boolean theFilterDeleted);
+	Map<String, ResourcePersistentId> resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, List<String> theIds, boolean theExcludeDeleted);
 
 	/**
 	 * Given a persistent ID, returns the associated resource ID
@@ -108,7 +108,7 @@ public interface IIdHelperService {
 	 * @throws ResourceNotFoundException If the ID can not be found
 	 */
 	@Nonnull
-	IResourceLookup resolveResourceIdentity(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theResourceId, boolean theFilterDeleted) throws ResourceNotFoundException;
+	IResourceLookup resolveResourceIdentity(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theResourceId, boolean theExcludeDeleted) throws ResourceNotFoundException;
 
 	/**
 	 * Returns true if the given resource ID should be stored in a forced ID. Under default config

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IIdHelperService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IIdHelperService.java
@@ -61,7 +61,7 @@ public interface IIdHelperService {
 	ResourcePersistentId resolveResourcePersistentIds(@Nonnull RequestPartitionId theRequestPartitionId, String theResourceType, String theId);
 
 	/**
-	 * Given a resource type and ID, determines the internal persistent ID for a resource. Excludes deleted resources if filterDeleted is set to true.
+	 * Given a resource type and ID, determines the internal persistent ID for a resource.
 	 * Optionally filters out deleted resources.
 	 *
 	 * @throws ResourceNotFoundException If the ID can not be found

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -58,37 +58,37 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r5</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-dstu2</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-dstu3</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-r4</artifactId>
-			<version>6.1.0-PRE8-SNAPSHOT</version>
+			<version>6.1.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.velocity</groupId>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>6.1.0-PRE8-SNAPSHOT</version>
+	<version>6.1.0-PRE9-SNAPSHOT</version>
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>
 	<url>https://hapifhir.io</url>
@@ -2011,7 +2011,7 @@
                             <groupId>ca.uhn.hapi.fhir</groupId>
                             <artifactId>hapi-fhir-checkstyle</artifactId>
 									<!-- Remember to bump this when you upgrade the version -->
-                            <version>6.1.0-PRE8-SNAPSHOT</version>
+                            <version>6.1.0-PRE9-SNAPSHOT</version>
                         </dependency>
 					</dependencies>
 				</plugin>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.1.0-PRE8-SNAPSHOT</version>
+		<version>6.1.0-PRE9-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
- Added functionality to optionally filter out deleted resources when resolving forced ids to persistent ids
- Bumps version

Closes #3693 