### PR TITLE
Add changelog, implement HEAD

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3696-head-on-get-and-metadata.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3696-head-on-get-and-metadata.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 3696
+title: "HEAD operations are now supported on searches and the /metadata endpoint."

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -53,6 +53,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -278,6 +279,20 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 			String output = IOUtils.toString(resp.getEntity().getContent(), Charsets.UTF_8);
 			assertThat(output, containsString("Unknown search parameter &quot;a&quot;"));
 			assertEquals(400, resp.getStatusLine().getStatusCode());
+		}
+	}
+
+	@Test
+	public void testHttpHeadIsPermittedWhereGetsAre() throws IOException {
+		HttpHead httpHead = new HttpHead(ourServerBase + "/CodeSystem");
+		try (CloseableHttpResponse resp = ourHttpClient.execute(httpHead)) {
+			assertEquals(200, resp.getStatusLine().getStatusCode());
+		}
+
+		MethodOutcome methodOutcome = myClient.create().resource(new CodeSystem()).execute();
+		httpHead = new HttpHead(ourServerBase + "/CodeSystem/" + methodOutcome.getId().getIdPart());
+		try (CloseableHttpResponse resp = ourHttpClient.execute(httpHead)) {
+			assertEquals(200, resp.getStatusLine().getStatusCode());
 		}
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ConformanceMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ConformanceMethodBinding.java
@@ -213,10 +213,10 @@ public class ConformanceMethodBinding extends BaseResourceReturningMethodBinding
 		}
 
 		if ("metadata".equals(theRequest.getOperation())) {
-			if (theRequest.getRequestType() == RequestTypeEnum.GET) {
+			if (theRequest.getRequestType() == RequestTypeEnum.GET || theRequest.getRequestType() == RequestTypeEnum.HEAD) {
 				return MethodMatchEnum.EXACT;
 			}
-			throw new MethodNotAllowedException(Msg.code(388) + "/metadata request must use HTTP GET", RequestTypeEnum.GET);
+			throw new MethodNotAllowedException(Msg.code(388) + "/metadata request must use HTTP GET or HTTP HEAD", RequestTypeEnum.GET);
 		}
 
 		return MethodMatchEnum.NONE;

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/SearchMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/SearchMethodBinding.java
@@ -276,7 +276,7 @@ public class SearchMethodBinding extends BaseResourceReturningMethodBinding {
 		if (theRequest.getRequestType() == RequestTypeEnum.POST && !Constants.PARAM_SEARCH.equals(theRequest.getOperation())) {
 			return false;
 		}
-		if (theRequest.getRequestType() != RequestTypeEnum.GET && theRequest.getRequestType() != RequestTypeEnum.POST) {
+		if (theRequest.getRequestType() != RequestTypeEnum.GET && theRequest.getRequestType() != RequestTypeEnum.POST && theRequest.getRequestType() != RequestTypeEnum.HEAD) {
 			return false;
 		}
 		if (theRequest.getParameters().get(Constants.PARAM_PAGINGACTION) != null) {

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/MetadataCapabilityStatementDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/MetadataCapabilityStatementDstu3Test.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.util.VersionUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -40,6 +41,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MetadataCapabilityStatementDstu3Test {
 
@@ -92,13 +94,21 @@ public class MetadataCapabilityStatementDstu3Test {
 			IOUtils.closeQuietly(status.getEntity().getContent());
 		}
 
+		HttpRequestBase httpHead = new HttpHead("http://localhost:" + ourPort + "/metadata");
+		try {
+			status = ourClient.execute(httpHead);
+			assertEquals(200, status.getStatusLine().getStatusCode());
+		} catch (Exception e) {
+			fail();
+		}
+
 		try {
 			httpPost = new HttpPost("http://localhost:" + ourPort + "/metadata");
 			status = ourClient.execute(httpPost);
 			output = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
 			assertEquals(405, status.getStatusLine().getStatusCode());
 			assertEquals(
-				"<OperationOutcome xmlns=\"http://hl7.org/fhir\"><issue><severity value=\"error\"/><code value=\"processing\"/><diagnostics value=\""+ Msg.code(388) + "/metadata request must use HTTP GET\"/></issue></OperationOutcome>",
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\"><issue><severity value=\"error\"/><code value=\"processing\"/><diagnostics value=\""+ Msg.code(388) + "/metadata request must use HTTP GET or HTTP HEAD\"/></issue></OperationOutcome>",
 				output);
 		} finally {
 			IOUtils.closeQuietly(status.getEntity().getContent());

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/MetadataConformanceDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/MetadataConformanceDstu3Test.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.util.VersionUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -110,6 +111,11 @@ public class MetadataConformanceDstu3Test {
 			assertThat(output, containsString("<CapabilityStatement"));
 			assertThat(status.getFirstHeader("X-Powered-By").getValue(), containsString("HAPI FHIR " + VersionUtil.getVersion()));
 			assertThat(status.getFirstHeader("X-Powered-By").getValue(), containsString("REST Server (FHIR Server; FHIR " + ourCtx.getVersion().getVersion().getFhirVersionString() + "/" + ourCtx.getVersion().getVersion().name() + ")"));
+		}
+
+		HttpRequestBase httpHead = new HttpHead("http://localhost:" + ourPort + "/metadata");
+		try (CloseableHttpResponse status = ourClient.execute(httpHead)) {
+			assertEquals(200, status.getStatusLine().getStatusCode());
 		}
 
 		httpOperation = new HttpOptions("http://localhost:" + ourPort);


### PR DESCRIPTION
Closes #3696 

* Add changelog
* Permit HEAD on /metadata
* Permit HEAD on searches.
* Given the discussion requirements [here](https://build.fhir.org/http.html#head) , we do not short-circuit when we detect a head, but instead do all processing, and simply return no body. (spring seems to automatically do this when it detects the incoming request is a HEAD operation)