### PR TITLE
Prevent over-exporting groups during bulk export

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3700-group-export-overshare.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3700-group-export-overshare.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 3700
+jira: SMILE-4488
+title: "Previously, Group Bulk Export would expand into other groups, due to the nature of `Group.member` being part of the patient search compartment.
+This has been fixed, and now, Group Bulk Export will only ever export the Group resource specified in the request, regardless of patient membership."


### PR DESCRIPTION
* Change GroupBulkItemReader to short-circuit if we are exporting "Group" resources. Change behaviour so that it only returns the requested group, and does not expand to other groups based on membership 
* Add test 
* Add changelog 

Closes #3700