### PR TITLE
Unknown resource type error message contains plain providers

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3711-unknown-resource-type-error-message-includes-plain-providers.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3711-unknown-resource-type-error-message-includes-plain-providers.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 3710
+title: "Changing the `Unknown resource type` error message to include only resource provider classes and 
+exclude plain providers classes."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3711-unknown-resource-type-error-message-includes-plain-providers.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3711-unknown-resource-type-error-message-includes-plain-providers.yaml
@@ -1,5 +1,6 @@
 ---
 type: fix
 issue: 3710
+jira: SMILE-4230
 title: "Changing the `Unknown resource type` error message to include only resource provider classes and 
 exclude plain providers classes."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -1904,7 +1904,10 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	}
 
 	protected void throwUnknownResourceTypeException(String theResourceName) {
-		throw new ResourceNotFoundException(Msg.code(302) + "Unknown resource type '" + theResourceName + "' - Server knows how to handle: " + myResourceNameToBinding.keySet());
+		List<String> knownResourceTypes = myResourceProviders.stream()
+			.map(v -> v.getResourceType().getSimpleName())
+			.toList();
+		throw new ResourceNotFoundException(Msg.code(302) + "Unknown resource type '" + theResourceName + "' - Server knows how to handle: " + knownResourceTypes);
 	}
 
 	/**

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -1906,7 +1906,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 
 	protected void throwUnknownResourceTypeException(String theResourceName) {
 		List<String> knownResourceTypes = myResourceProviders.stream()
-			.map(v -> v.getResourceType().getSimpleName())
+			.map(t -> t.getResourceType().getSimpleName())
 			.collect(toList());
 		throw new ResourceNotFoundException(Msg.code(302) + "Unknown resource type '" + theResourceName + "' - Server knows how to handle: " + knownResourceTypes);
 	}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -108,6 +108,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.util.StringUtil.toUtf8String;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -681,7 +682,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 			.stream()
 			.filter(t -> t instanceof IServerInterceptor)
 			.map(t -> (IServerInterceptor) t)
-			.collect(Collectors.toList());
+			.collect(toList());
 		return Collections.unmodifiableList(retVal);
 	}
 
@@ -1906,7 +1907,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	protected void throwUnknownResourceTypeException(String theResourceName) {
 		List<String> knownResourceTypes = myResourceProviders.stream()
 			.map(v -> v.getResourceType().getSimpleName())
-			.toList();
+			.collect(toList());
 		throw new ResourceNotFoundException(Msg.code(302) + "Unknown resource type '" + theResourceName + "' - Server knows how to handle: " + knownResourceTypes);
 	}
 

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/SearchPreferHandlingInterceptorTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/SearchPreferHandlingInterceptorTest.java
@@ -79,7 +79,7 @@ public class SearchPreferHandlingInterceptorTest {
 			try (CloseableHttpResponse result = client.execute(new HttpGet("http://localhost:" + myPort + "/BadResource?foo=bar"))) {
 				assertEquals(404, result.getStatusLine().getStatusCode());
 				String response = IOUtils.toString(result.getEntity().getContent(), StandardCharsets.UTF_8);
-				assertThat(response, containsString("Unknown resource type 'BadResource' - Server knows how to handle: [Patient, OperationDefinition]"));
+				assertThat(response, containsString("Unknown resource type 'BadResource' - Server knows how to handle: [Patient]"));
 			}
 		}
 	}


### PR DESCRIPTION
- Modify error message to include only known resource providers
- Modify a test to ensure plain providers are not included in error message
- Modify expected value of `testSearchWithUnknownResourceType` to reflect this change. Reasoning is: this test expected the error message to contain `server knows how to handle ... OperationDefinition` but it shouldn't since the server doesn't actually know how to handle `OperationDefinition` for CRUD operations. `OperationDefinition` is (in that case) set to be a plain provider and can only be used for system-level operations, but `testSearchWithUnknownResourceType` is testing a `GET` operation which is not a system-level operation.

Closes #3710 