### PR TITLE
replace UNION with UNION ALL in chained search query

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3714-improve-chained-search-performance.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3714-improve-chained-search-performance.yaml
@@ -1,0 +1,4 @@
+type: perf
+issue: 3714
+jira: SMILE-4484
+title: "Chained searches have been sped up for configurations where the `Index Contained Resources` feature is enabled."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -933,7 +933,7 @@ public class QueryStack {
 		EnumSet<PredicateBuilderTypeEnum> cachedReusePredicateBuilderTypes = EnumSet.copyOf(myReusePredicateBuilderTypes);
 		myReusePredicateBuilderTypes.clear();
 
-		UnionQuery union = new UnionQuery(SetOperationQuery.Type.UNION);
+		UnionQuery union = new UnionQuery(SetOperationQuery.Type.UNION_ALL);
 
 		ReferenceChainExtractor chainExtractor = new ReferenceChainExtractor();
 		chainExtractor.deriveChains(theResourceName, theSearchParam, theList);


### PR DESCRIPTION
Some chained searches were performing slowly because the UNION operation was forcing the database to fully materialize the results of the subselects. Replacing this with a UNION ALL operation allows the planner to select a more efficient strategy.