### PR TITLE
Add unique run number to the published artifact

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
             condition: always()
             inputs:
                targetPath: '$(Build.ArtifactStagingDirectory)/'
-               artifactName: 'full_logs_$(Build.BuildId)_$(Build.BuildNumber).zip'
+               artifactName: 'full_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobId).zip'
          -  script: bash <(curl https://codecov.io/bash) -t $(CODECOV_TOKEN)
             displayName: 'codecov'
          -  task: PublishTestResults@2


### PR DESCRIPTION
This will prevent multiple runs from failing while uploading the pipeline artifacts. 