### PR TITLE
Fix sort in hsearch - use full millis

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3787-fix-hsearch-date-sort.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3787-fix-hsearch-date-sort.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 3787
+title: "FHIR queries using date sort were ignoring seconds and milliseconds when using lucene/elasticsearch SearchParameter indexing.
+  This has been corrected."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/HSearchSortHelperImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/search/HSearchSortHelperImpl.java
@@ -59,7 +59,7 @@ public class HSearchSortHelperImpl implements IHSearchSortHelper {
 			String.join(".", NESTED_SEARCH_PARAM_ROOT, "*", "token", "system"),
 			String.join(".", NESTED_SEARCH_PARAM_ROOT, "*", "token", "code") ),
 		RestSearchParameterTypeEnum.REFERENCE, List.of(SEARCH_PARAM_ROOT + ".*.reference.value"),
-		RestSearchParameterTypeEnum.DATE, 		List.of(SEARCH_PARAM_ROOT + ".*.dt.lower-ord"),
+		RestSearchParameterTypeEnum.DATE, 		List.of(SEARCH_PARAM_ROOT + ".*.dt.lower"),
 		RestSearchParameterTypeEnum.QUANTITY, 	List.of(
 			String.join(".", NESTED_SEARCH_PARAM_ROOT, "*", QTY_PARAM_NAME, QTY_VALUE_NORM),
 			String.join(".", NESTED_SEARCH_PARAM_ROOT, "*", QTY_PARAM_NAME, QTY_VALUE) ),

--- a/hapi-fhir-jpaserver-test-utilities/src/test/resources/logback-test.xml
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/resources/logback-test.xml
@@ -1,8 +1,5 @@
 <configuration>
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-			<level>INFO</level>
-		</filter>
 		<encoder>
 			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
 		</encoder>
@@ -27,10 +24,6 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="org.elasticsearch.client" additivity="true" level="trace">
-		<appender-ref ref="STDOUT" />
-	</logger>
-
 	<logger name="org.eclipse" additivity="false" level="error">
 	</logger>
 
@@ -43,7 +36,7 @@
 	</logger>
 
 	<!-- set to debug to enable term expansion logs -->
-	<logger name="ca.uhn.fhir.jpa.term" additivity="false" level="debug">
+	<logger name="ca.uhn.fhir.jpa.term" additivity="false" level="info">
 		<appender-ref ref="STDOUT" />
 	</logger>
 
@@ -56,15 +49,17 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="org.hibernate.search.elasticsearch.request" additivity="false" level="trace">
-		<appender-ref ref="STDOUT" />
-	</logger>
 	<!--
-	<logger name="ca.uhn.fhir.jpa.model.search" additivity="false" level="debug">
-		<appender-ref ref="STDOUT" />
-	</logger>
-	-->
-	<logger name="org.springframework.test.context.cache" additivity="false" level="debug">
+	<logger name="ca.uhn.fhir.jpa.model.search" additivity="false" level="debug"/>
+	<logger name="org.elasticsearch.client" additivity="true" level="trace"/>
+	<logger name="org.hibernate.search.elasticsearch.request" additivity="false" level="trace"/>
+	<logger name="org.hibernate.search" level="TRACE"/>
+	<logger name="org.hibernate.search.query" level="TRACE"/>
+	<logger name="org.hibernate.search.elasticsearch.request" level="TRACE"/>
+	 -->
+	<!-- See https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#backend-lucene-io-writer-infostream for lucene logging
+	<logger name="org.hibernate.search.backend.lucene.infostream" level="TRACE"/>  -->
+	<logger name="org.springframework.test.context.cache" additivity="false" level="info">
 		<appender-ref ref="STDOUT" />
 	</logger>
 

--- a/hapi-fhir-storage-test-utilities/src/main/java/ca/uhn/fhir/storage/test/DaoTestDataBuilder.java
+++ b/hapi-fhir-storage-test-utilities/src/main/java/ca/uhn/fhir/storage/test/DaoTestDataBuilder.java
@@ -37,6 +37,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Implements ITestDataBuilder via a live DaoRegistry.
+ *
+ * Add the inner {@link Config} to your spring context to inject this.
+ * For convenience, you can still implement ITestDataBuilder on your test class, and delegate the missing methods to this bean.
+ */
 public class DaoTestDataBuilder implements ITestDataBuilder, AfterEachCallback {
 	private static final Logger ourLog = LoggerFactory.getLogger(DaoTestDataBuilder.class);
 
@@ -84,6 +90,7 @@ public class DaoTestDataBuilder implements ITestDataBuilder, AfterEachCallback {
 		ourLog.info("cleanup {}", myIds);
 
 		myIds.keySet().forEach(nextType->{
+			// todo do this in a bundle for perf.
 			IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(nextType);
 			myIds.get(nextType).forEach(dao::delete);
 		});


### PR DESCRIPTION
We were sorting on the date ordinal, not the timestamp.
