### PR TITLE
3859 hapi fhir doc snippet link referring a file as opposed to classpath

### DIFF
--- a/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/interceptor/PatientNameModifierMdmPreProcessingInterceptor.java
+++ b/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/interceptor/PatientNameModifierMdmPreProcessingInterceptor.java
@@ -32,7 +32,8 @@ import static java.util.Arrays.asList;
 
 // START SNIPPET: patientInterceptor
 /**
- * This is a simple interceptor that will remove a humanName when it is black listed.
+ * This is a simple interceptor that will remove a humanName when it is found to be
+ * black listed.
  */
 public class PatientNameModifierMdmPreProcessingInterceptor {
 	List<String> myNamesToIgnore = asList("John Doe", "Jane Doe");

--- a/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/interceptor/PatientNameModifierMdmPreProcessingInterceptor.java
+++ b/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/interceptor/PatientNameModifierMdmPreProcessingInterceptor.java
@@ -1,0 +1,54 @@
+package ca.uhn.hapi.fhir.docs.interceptor;
+
+/*-
+ * #%L
+ * HAPI FHIR - Docs
+ * %%
+ * Copyright (C) 2014 - 2022 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Patient;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+
+// START SNIPPET: patientInterceptor
+/**
+ * This is a simple interceptor that will remove a humanName when it is black listed.
+ */
+public class PatientNameModifierMdmPreProcessingInterceptor {
+	List<String> myNamesToIgnore = asList("John Doe", "Jane Doe");
+
+	@Hook(Pointcut.MDM_BEFORE_PERSISTED_RESOURCE_CHECKED)
+	public void invoke(IBaseResource theResource) {
+
+		Patient patient = (Patient) theResource;
+		List<HumanName> nameList = patient.getName();
+
+		List<HumanName> validHumanNameList = nameList.stream()
+			.filter(theHumanName -> !myNamesToIgnore.contains(theHumanName.getNameAsSingleString()))
+			.collect(Collectors.toList());
+
+		patient.setName(validHumanNameList);
+	}
+}
+
+// END SNIPPET: patientInterceptor

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_customizations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_customizations.md
@@ -17,7 +17,7 @@ In a scenario where a patient was given a placeholder name(John Doe), it would b
 The following provides a full implementation of an interceptor that prevents matching on a patient name when it detects  a placeholder value.  
 
 ```java
-{{snippet:file:hapi-fhir/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/PatientNameModifierMdmPreProcessingInterceptor.java}}
+{{snippet:classpath:/ca/uhn/hapi/fhir/docs/interceptor/PatientNameModifierMdmPreProcessingInterceptor.java|patientInterceptor}}
 ```
 
 See the [Pointcut](/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html) JavaDoc for further details on the pointcut MDM_BEFORE_PERSISTED_RESOURCE_CHECKED.


### PR DESCRIPTION
What was done:

- Using snippet of type 'classpath' instead of 'file' in md file;
- Providing the interceptor class as part of the hapi-fhir-doc project as opposed to the hapi-fhir-jpaserver-mdm.