### PR TITLE
Use released version of core so we have javadoc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,7 +767,7 @@
 
     <properties>
 
-        <fhir_core_version>5.6.54-SNAPSHOT</fhir_core_version>
+        <fhir_core_version>5.6.54</fhir_core_version>
         <ucum_version>1.0.3</ucum_version>
 
         <surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>


### PR DESCRIPTION
PRE builds are failing because the declared core library dependency of 5.6.54-SNAPSHOT doesn't have javadoc published.  So the hapi site fails.

Updating to the released version.
