### PR TITLE
Fix illegalstateexception when an exception is thrown during stream response

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3881-stream-errors.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3881-stream-errors.yaml
@@ -1,0 +1,5 @@
+type: fix
+issue: 3881
+jira: SMILE-4083
+title: "Previously, if an error was thrown after the outgoing response stream had started being written to, an OperationOutcome was not being returned. Instead, an HTML 
+servlet error was being thrown. This has been corrected."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
@@ -108,7 +108,6 @@ public class ExceptionHandlingInterceptor {
 			resetOutputStreamIfPossible(response);
 		} catch (Throwable t) {
 			ourLog.error("HAPI-FHIR was unable to reset the output stream during exception handling. The root causes follows:", t);
-			return null;
 		}
 
 		return response.streamResponseAsResource(oo, true, Collections.singleton(SummaryEnum.FALSE), statusCode, statusMessage, false, false);
@@ -121,8 +120,9 @@ public class ExceptionHandlingInterceptor {
 	 * Also, it strips the content-encoding header if present, as the method outcome will negotiate its own.
 	 */
 	private void resetOutputStreamIfPossible(IRestfulResponse response) {
-		if (response instanceof HttpServletResponse) {
-			HttpServletResponse servletResponse = ((ServletRestfulResponse) response).getRequestDetails().getServletResponse();
+		if (response.getClass().isAssignableFrom(ServletRestfulResponse.class)) {
+			ServletRestfulResponse servletRestfulResponse = (ServletRestfulResponse) response;
+			HttpServletResponse servletResponse = servletRestfulResponse.getRequestDetails().getServletResponse();
 			Collection<String> headerNames = servletResponse.getHeaderNames();
 			Map<String, Collection<String>> oldHeaders = new HashedMap<>();
 			for (String headerName : headerNames) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
@@ -121,7 +121,7 @@ public class ExceptionHandlingInterceptor {
 	 * Also, it strips the content-encoding header if present, as the method outcome will negotiate its own.
 	 */
 	private void resetOutputStreamIfPossible(IRestfulResponse response) {
-		if (response instanceof ServletRestfulResponse) {
+		if (response instanceof HttpServletResponse) {
 			HttpServletResponse servletResponse = ((ServletRestfulResponse) response).getRequestDetails().getServletResponse();
 			Collection<String> headerNames = servletResponse.getHeaderNames();
 			Map<String, Collection<String>> oldHeaders = new HashedMap<>();

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/servlet/ServletRestfulResponse.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/servlet/ServletRestfulResponse.java
@@ -74,6 +74,8 @@ public class ServletRestfulResponse extends RestfulResponse<ServletRequestDetail
 			theHttpResponse.addHeader(Constants.HEADER_CONTENT_ENCODING, Constants.ENCODING_GZIP);
 			return new OutputStreamWriter(new GZIPOutputStream(theHttpResponse.getOutputStream()), StandardCharsets.UTF_8);
 		}
+
+//		return new OutputStreamWriter(new GZIPOutputStream(theHttpResponse.getOutputStream()), StandardCharsets.UTF_8);
 		return theHttpResponse.getWriter();
 	}
 


### PR DESCRIPTION
* Previously, if an error was thrown after the output stream had been opened, the ExceptionHandlingInterceptor's attempt to open the stream was causing an IllegalStateException that was bubbling up to clients. 
* Now, the stream is reset, and an OperationOutcome is returned as intended. 
* Add changelog
* Add test

Closes #3881 

