### PR TITLE
Add OperationOutcome to AuthenticationException

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/exceptions/AuthenticationException.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/exceptions/AuthenticationException.java
@@ -62,6 +62,14 @@ public class AuthenticationException extends BaseServerResponseException {
 		super(STATUS_CODE, theMessage, theCause);
 	}
 	
+	public AuthenticationException(String theMessage, IBaseOperationOutcome theBaseOperationOutcome){
+		super(STATUS_CODE, theMessage, theBaseOperationOutcome);
+	}
+	
+	public AuthenticationException(String theMessage, Throwable theCause, IBaseOperationOutcome theBaseOperationOutcome){
+		super(STATUS_CODE, theCause, IBaseOperationOutcome theBaseOperationOutcome);
+	}
+	
 	/**
 	 * Adds a <code>WWW-Authenticate</code> header to the response, of the form:<br/>
 	 * <code>WWW-Authenticate: Basic realm="theRealm"</code> 


### PR DESCRIPTION
Add constructor overloads with IBaseOperationOutcome parameters to AuthenticationException.

NOTE: I typed this in Github, so someone should compile it before merging.

Fixes #3892