### PR TITLE
Fix for caching appearing broken in batch2 for bulkexport jobs

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/PartitionIdRequestDetails.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/PartitionIdRequestDetails.java
@@ -1,5 +1,25 @@
 package ca.uhn.fhir.interceptor.model;
 
+/*-
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2022 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 public class PartitionIdRequestDetails {
 
 	/**

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3911-bulk-export-caching.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_1_0/3911-bulk-export-caching.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 3911
+title: "Fixed a bug where repeated calls to the same Bulk Export request would not return the cached result, but would instead start a new Bulk Export job."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -160,13 +160,12 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 	}
 
 	@Override
-	public List<JobInstance> fetchInstances(FetchJobInstancesRequest theRequest, int theStart, int theBatchSize) {
+	public List<JobInstance> fetchInstances(FetchJobInstancesRequest theRequest, int thePage, int theBatchSize) {
 		String definitionId = theRequest.getJobDefinition();
 		String params = theRequest.getParameters();
 		Set<StatusEnum> statuses = theRequest.getStatuses();
 
-		Pageable pageable = Pageable.ofSize(theBatchSize).withPage(theStart);
-
+		Pageable pageable = PageRequest.of(thePage, theBatchSize);
 
 		List<Batch2JobInstanceEntity> instanceEntities;
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
@@ -23,6 +23,7 @@ package ca.uhn.fhir.jpa.dao.data;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.jpa.entity.Batch2JobInstanceEntity;
+import org.hibernate.engine.jdbc.batch.spi.Batch;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -46,22 +47,16 @@ public interface IBatch2JobInstanceRepository extends JpaRepository<Batch2JobIns
 	@Query("UPDATE Batch2JobInstanceEntity e SET e.myCurrentGatedStepId = :currentGatedStepId WHERE e.myId = :id")
 	void updateInstanceCurrentGatedStepId(@Param("id") String theInstanceId, @Param("currentGatedStepId") String theCurrentGatedStepId);
 
-	@Query(
-		value = "SELECT * from Batch2JobInstanceEntity WHERE DEFINITION_ID = :defId AND PARAMS_JSON = :params AND STAT IN( :stats )",
-		nativeQuery = true
-	)
-	List<JobInstance> findInstancesByJobIdParamsAndStatus(
+	@Query("SELECT b from Batch2JobInstanceEntity b WHERE b.myDefinitionId = :defId AND b.myParamsJson = :params AND b.myStatus IN( :stats )")
+	List<Batch2JobInstanceEntity> findInstancesByJobIdParamsAndStatus(
 		@Param("defId") String theDefinitionId,
 		@Param("params") String theParams,
 		@Param("stats") Set<StatusEnum> theStatus,
 		Pageable thePageable
 	);
 
-	@Query(
-		value = "SELECT * from Batch2JobInstanceEntity WHERE DEFINITION_ID = :defId AND PARAMS_JSON = :params",
-		nativeQuery = true
-	)
-	List<JobInstance> findInstancesByJobIdAndParams(
+	@Query("SELECT b from Batch2JobInstanceEntity b WHERE b.myDefinitionId = :defId AND b.myParamsJson = :params")
+	List<Batch2JobInstanceEntity> findInstancesByJobIdAndParams(
 		@Param("defId") String theDefinitionId,
 		@Param("params") String theParams,
 		Pageable thePageable

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
@@ -254,10 +254,11 @@ class JpaJobPersistenceImplTest {
 		// setup
 		int pageStart = 1;
 		int pageSize = 132;
-		JobInstance job1 = createJobInstanceWithDemoData();
-		FetchJobInstancesRequest req = new FetchJobInstancesRequest(job1.getInstanceId(), "params");
-		JobInstance job2 = createJobInstanceWithDemoData();
-		List<JobInstance> instances = Arrays.asList(job1, job2);
+		Batch2JobInstanceEntity job1 = createBatch2JobInstanceEntity();
+		FetchJobInstancesRequest req = new FetchJobInstancesRequest(job1.getId(), "params");
+		Batch2JobInstanceEntity job2 = createBatch2JobInstanceEntity();
+
+		List<Batch2JobInstanceEntity> instances = Arrays.asList(job1, job2);
 
 		// when
 		when(myJobInstanceRepository

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
@@ -272,7 +272,8 @@ class JpaJobPersistenceImplTest {
 
 		// verify
 		assertEquals(instances.size(), retInstances.size());
-		assertEquals(instances, retInstances);
+		assertEquals(instances.get(0).getId(),  retInstances.get(0).getInstanceId());
+		assertEquals(instances.get(1).getId(),  retInstances.get(1).getInstanceId());
 
 		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
 		verify(myJobInstanceRepository)

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/JobInstanceRepositoryTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/JobInstanceRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -31,6 +32,7 @@ public class JobInstanceRepositoryTest extends BaseJpaR4Test {
 
 		instance.setId(instanceId);
 		instance.setStatus(StatusEnum.IN_PROGRESS);
+		instance.setCreateTime(new Date());
 		instance.setDefinitionId(definitionId);
 		instance.setParams(params);
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/JobInstanceRepositoryTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/batch2/JobInstanceRepositoryTest.java
@@ -1,0 +1,46 @@
+package ca.uhn.fhir.jpa.batch2;
+
+import ca.uhn.fhir.batch2.config.BaseBatch2Config;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.StatusEnum;
+import ca.uhn.fhir.jpa.dao.data.IBatch2JobInstanceRepository;
+import ca.uhn.fhir.jpa.entity.Batch2JobInstanceEntity;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+public class JobInstanceRepositoryTest extends BaseJpaR4Test {
+
+	@Autowired
+	private IBatch2JobInstanceRepository myJobInstanceRepository;
+
+	@Test
+	public void testQueryWorks() {
+
+		Batch2JobInstanceEntity instance= new Batch2JobInstanceEntity();
+		String instanceId = "abc-123";
+		String definitionId = "my-job-def-id";
+		String params = "{\"param1\":\"value1\"}";
+
+		instance.setId(instanceId);
+		instance.setStatus(StatusEnum.IN_PROGRESS);
+		instance.setDefinitionId(definitionId);
+		instance.setParams(params);
+
+
+		myJobInstanceRepository.save(instance);
+		Set<StatusEnum> statuses = Set.of(StatusEnum.IN_PROGRESS);
+		List<JobInstance> instancesByJobIdParamsAndStatus = myJobInstanceRepository.findInstancesByJobIdParamsAndStatus(definitionId, params, statuses, PageRequest.of(0, 10));
+
+		assertThat(instancesByJobIdParamsAndStatus, hasSize(1));
+
+	}
+
+}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/services/Batch2JobRunnerImpl.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/services/Batch2JobRunnerImpl.java
@@ -113,6 +113,7 @@ public class Batch2JobRunnerImpl implements IBatch2JobRunner {
 	private JobInstanceStartRequest createStartRequest(Batch2BaseJobParameters theParameters) {
 		JobInstanceStartRequest request = new JobInstanceStartRequest();
 		request.setJobDefinitionId(theParameters.getJobDefinitionId());
+		request.setUseCache(theParameters.isUseExistingJobsFirst());
 		return request;
 	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
@@ -107,12 +107,7 @@ public class JobCoordinatorImpl implements IJobCoordinator {
 			List<JobInstance> existing = myJobPersistence.fetchInstances(request, 1, 1000);
 			if (!existing.isEmpty()) {
 				// we'll look for completed ones first... otherwise, take any of the others
-				Collections.sort(existing, new Comparator<JobInstance>() {
-					@Override
-					public int compare(JobInstance o1, JobInstance o2) {
-						return -(o1.getStatus().ordinal() - o2.getStatus().ordinal());
-					}
-				});
+				Collections.sort(existing, (o1, o2) -> -(o1.getStatus().ordinal() - o2.getStatus().ordinal()));
 
 				JobInstance first = existing.stream().findFirst().get();
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
@@ -104,7 +104,7 @@ public class JobCoordinatorImpl implements IJobCoordinator {
 			request.addStatus(StatusEnum.IN_PROGRESS);
 			request.addStatus(StatusEnum.COMPLETED);
 
-			List<JobInstance> existing = myJobPersistence.fetchInstances(request, 1, 1000);
+			List<JobInstance> existing = myJobPersistence.fetchInstances(request, 0, 1000);
 			if (!existing.isEmpty()) {
 				// we'll look for completed ones first... otherwise, take any of the others
 				Collections.sort(existing, (o1, o2) -> -(o1.getStatus().ordinal() - o2.getStatus().ordinal()));

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobStepExecutor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobStepExecutor.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.JobWorkCursor;
 import ca.uhn.fhir.batch2.model.JobWorkNotification;
+import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.batch2.progress.JobInstanceProgressCalculator;
 import ca.uhn.fhir.model.api.IModelJson;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Date;
 import java.util.Optional;
 
 public class JobStepExecutor<PT extends IModelJson, IT extends IModelJson, OT extends IModelJson> {
@@ -80,8 +82,10 @@ public class JobStepExecutor<PT extends IModelJson, IT extends IModelJson, OT ex
 		}
 
 		if (stepExecutorOutput.getDataSink().firstStepProducedNothing()) {
-			ourLog.info("First step of job myInstance {} produced no work chunks, marking as completed", myInstanceId);
-			myJobPersistence.markInstanceAsCompleted(myInstanceId);
+			ourLog.info("First step of job myInstance {} produced no work chunks, marking as completed and setting end date", myInstanceId);
+			myInstance.setEndTime(new Date());
+			myInstance.setStatus(StatusEnum.COMPLETED);
+			myJobPersistence.updateInstance(myInstance);
 		}
 
 		if (myDefinition.isGatedExecution()) {

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstance.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Date;
+import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImplTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImplTest.java
@@ -208,7 +208,7 @@ public class JobCoordinatorImplTest extends BaseBatch2Test {
 		assertEquals(PARAM_2_VALUE, params.getParam2());
 		assertEquals(PASSWORD_VALUE, params.getPassword());
 
-		verify(myJobInstancePersister, times(1)).markInstanceAsCompleted(eq(INSTANCE_ID));
+		verify(myJobInstancePersister, times(1)).updateInstance(any());
 	}
 
 	@Test

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/searchparam/submit/config/SearchParamSubmitterConfig.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/searchparam/submit/config/SearchParamSubmitterConfig.java
@@ -2,7 +2,7 @@ package ca.uhn.fhir.jpa.searchparam.submit.config;
 
 /*-
  * #%L
- * HAPI FHIR Subscription Server
+ * HAPI FHIR Storage api
  * %%
  * Copyright (C) 2014 - 2022 Smile CDR, Inc.
  * %%

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/searchparam/submit/interceptor/SearchParamSubmitInterceptorLoader.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/searchparam/submit/interceptor/SearchParamSubmitInterceptorLoader.java
@@ -2,7 +2,7 @@ package ca.uhn.fhir.jpa.searchparam.submit.interceptor;
 
 /*-
  * #%L
- * HAPI FHIR Subscription Server
+ * HAPI FHIR Storage api
  * %%
  * Copyright (C) 2014 - 2022 Smile CDR, Inc.
  * %%

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/searchparam/submit/interceptor/SearchParamValidatingInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/searchparam/submit/interceptor/SearchParamValidatingInterceptor.java
@@ -2,7 +2,7 @@ package ca.uhn.fhir.jpa.searchparam.submit.interceptor;
 
 /*-
  * #%L
- * HAPI FHIR Subscription Server
+ * HAPI FHIR Storage api
  * %%
  * Copyright (C) 2014 - 2022 Smile CDR, Inc.
  * %%


### PR DESCRIPTION
* Propagate cache property to job starter. 
* If job exits early with no work chunks, set completed date. 
* Fix broken HQL queries
* Fix paging bug. 
* Test
* Changelog

Closes #3911