### PR TITLE
re-ordering projects to respect module order in IJ

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,100 +2,123 @@
 
 variables:
    MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
-   #MAVEN_CACHE_FOLDER: $(Agent.TempDirectory)/.m2/repository
-   #MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
    MAVEN_OPTS: ''
+   NEW_RELEASE_VERSION:
+   BRANCH:
 
-trigger:
-   - master
+trigger: none
 
 pool:
-   vmImage: 'ubuntu-latest'
+   vmImage: ubuntu-latest
 
-jobs:
-   -  job: Build
-      timeoutInMinutes: 360
-      container: maven:3.8-openjdk-17
-      steps:
-         -  task: Cache@2
-            inputs:
-               key: 'maven | "$(Agent.OS)" | ./pom.xml'
-               path: $(MAVEN_CACHE_FOLDER)
-         -  task: Maven@3
-            env:
-               JAVA_HOME_11_X64: /usr/java/openjdk-17
-            displayName: Checkstyle Build
-            inputs:
-               mavenPomFile: 'hapi-fhir-checkstyle/pom.xml'
-               goals: 'clean install'
-               options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-               jdkVersionOption: 1.11
-         -  task: DockerInstaller@0
-            displayName: Docker Installer
-            inputs:
-               dockerVersion: 17.09.0-ce
-               releaseType: stable
-         -  task: Bash@3
-            inputs:
-               targetType: 'inline'
-               script: mkdir -p $(MAVEN_CACHE_FOLDER); pwd; ls -al $(MAVEN_CACHE_FOLDER)
-         -  task: Maven@3
-            env:
-               JAVA_HOME_11_X64: /usr/java/openjdk-17
-            inputs:
-               goals: 'clean install'
-               # These are Maven CLI options (and show up in the build logs) - "-nsu"=Don't update snapshots. We can remove this when Maven OSS is more healthy
-               options: '-P ALLMODULES,JACOCO,CI,ERRORPRONE -e -B -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.wagon.http.pool=false -Dhttp.keepAlive=false -Dstyle.color=always -Djansi.force=true'
-               # These are JVM options (and don't show up in the build logs)
-               mavenOptions: '-Xmx2048m $(MAVEN_OPTS) -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Duser.timezone=America/Toronto'
-               jdkVersionOption: 1.11
-         -  task: CopyFiles@2
-            condition: always()
-            inputs:
-               sourceFolder: '$(System.DefaultWorkingDirectory)/'
-               contents: '**/target/*-reports/*.txt'
-               targetFolder: '$(Build.ArtifactStagingDirectory)'
-         -  task: PublishPipelineArtifact@1
-            displayName: 'Publish Full Test Output'
-            condition: always()
-            inputs:
-               targetPath: '$(Build.ArtifactStagingDirectory)/'
-               artifactName: 'full_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobId).zip'
-         -  script: bash <(curl https://codecov.io/bash) -t $(CODECOV_TOKEN)
-            displayName: 'codecov'
-         -  task: PublishTestResults@2
-            inputs:
-               testResultsFormat: 'JUnit'
-               testResultsFiles: '**/TEST-*.xml'
-         -  task: PublishCodeCoverageResults@1
-            inputs:
-               codeCoverageTool: 'JaCoCo'
-               summaryFileLocation: $(System.DefaultWorkingDirectory)/hapi-fhir-jacoco/target/site/jacoco-report/jacoco.xml
-               reportDirectory: $(System.DefaultWorkingDirectory)/hapi-fhir-jacoco/target/site/jacoco-report/
-               failIfCoverageEmpty: false
-
-# Potential Additional Maven3 Options:
-#publishJUnitResults: true
-#testResultsFiles: '**/surefire-reports/TEST-*.xml' # Required when publishJUnitResults == True
-#testRunTitle: # Optional
-#codeCoverageToolOption: 'None' # Optional. Options: none, cobertura, jaCoCo. Enabling code coverage inserts the `clean` goal into the Maven goals list when Maven runs.
-#codeCoverageClassFilter: # Optional. Comma-separated list of filters to include or exclude classes from collecting code coverage. For example: +:com.*,+:org.*,-:my.app*.*
-#codeCoverageClassFilesDirectories: # Optional
-#codeCoverageSourceDirectories: # Optional
-#codeCoverageFailIfEmpty: false # Optional
-#javaHomeOption: 'JDKVersion' # Options: jDKVersion, path
-#jdkVersionOption: 'default' # Optional. Options: default, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6
-#jdkDirectory: # Required when javaHomeOption == Path
-#jdkArchitectureOption: 'x64' # Optional. Options: x86, x64
-#mavenVersionOption: 'Default' # Options: default, path
-#mavenDirectory: # Required when mavenVersionOption == Path
-#mavenSetM2Home: false # Required when mavenVersionOption == Path
-#mavenAuthenticateFeed: false
-#effectivePomSkip: false
-#sonarQubeRunAnalysis: false
-#sqMavenPluginVersionChoice: 'latest' # Required when sonarQubeRunAnalysis == True# Options: latest, pom
-#checkStyleRunAnalysis: false # Optional
-#pmdRunAnalysis: false # Optional
-#findBugsRunAnalysis: false # Optional
-
-
+stages:
+   -  stage:
+      displayName: "module-tests"
+      jobs:
+         -  template: test-job-template.yml
+            parameters:
+               modules:
+                  -  name: hapi_deployable_pom
+                     module: hapi-deployable-pom
+                  -  name: hapi_fhir_android
+                     module: hapi-fhir-android
+                  -  name: hapi_fhir_base
+                     module: hapi-fhir-base
+                  -  name: hapi_fhir_batch
+                     module: hapi-fhir-batch
+                  -  name: hapi_fhir_bom
+                     module: hapi-fhir-bom
+                  -  name: hapi_fhir_checkstyle
+                     module: hapi-fhir-checkstyle
+                  -  name: hapi_fhir_cli
+                     module: hapi-fhir-cli
+                  -  name: hapi_fhir_client
+                     module: hapi-fhir-client
+                  -  name: hapi_fhir_client_okhttp
+                     module: hapi-fhir-client-okhttp
+                  -  name: hapi_fhir_converter
+                     module: hapi-fhir-converter
+                  -  name: hapi_fhir_dist
+                     module: hapi-fhir-dist
+                  -  name: hapi_fhir_docs
+                     module: hapi-fhir-docs
+                  -  name: hapi_fhir_jaxrsserver_base
+                     module: hapi-fhir-jaxrsserver-base
+                  -  name: hapi_fhir_jpa
+                     module: hapi-fhir-jpa
+                  -  name: hapi_fhir_jpaserver_base
+                     module: hapi-fhir-jpaserver-base
+                  -  name: hapi_fhir_jpaserver_cql
+                     module: hapi-fhir-jpaserver-cql
+                  -  name: hapi_fhir_jpaserver_elastic_test_utilities
+                     module: hapi-fhir-jpaserver-elastic-test-utilities
+                  -  name: hapi_fhir_jpaserver_mdm
+                     module: hapi-fhir-jpaserver-mdm
+                  -  name: hapi_fhir_jpaserver_model
+                     module: hapi-fhir-jpaserver-model
+                  -  name: hapi_fhir_jpaserver_searchparam
+                     module: hapi-fhir-jpaserver-searchparam
+                  -  name: hapi_fhir_jpaserver_subscription
+                     module: hapi-fhir-jpaserver-subscription
+                  -  name: hapi_fhir_jpaserver_test_utilities
+                     module: hapi-fhir-jpaserver-test-utilities
+                  -  name: hapi_fhir_jpaserver_uhnfhirtest
+                     module: hapi-fhir-jpaserver-uhnfhirtest
+                  -  name: hapi_fhir_server
+                     module: hapi-fhir-server
+                  -  name: hapi_fhir_server_mdm
+                     module: hapi-fhir-server-mdm
+                  -  name: hapi_fhir_server_openapi
+                     module: hapi-fhir-server-openapi
+                  -  name: hapi_fhir_spring_boot
+                     module: hapi-fhir-spring-boot
+                  -  name: hapi_fhir_sql_migrate
+                     module: hapi-fhir-sql-migrate
+                  -  name: hapi_fhir_storage
+                     module: hapi-fhir-storage
+                  -  name: hapi_fhir_storage_batch2
+                     module: hapi-fhir-storage-batch2
+                  -  name: hapi_fhir_storage_batch2_jobs
+                     module: hapi-fhir-storage-batch2-jobs
+                  -  name: hapi_fhir_storage_mdm
+                     module: hapi-fhir-storage-mdm
+                  -  name: hapi_fhir_storage_test_utilities
+                     module: hapi-fhir-storage-test-utilities
+                  -  name: hapi_fhir_structures_dstu2
+                     module: hapi-fhir-structures-dstu2
+                  -  name: hapi_fhir_structures_dstu2_1
+                     module: hapi-fhir-structures-dstu2.1
+                  -  name: hapi_fhir_structures_dstu3
+                     module: hapi-fhir-structures-dstu3
+                  -  name: hapi_fhir_structures_hl7org_dstu2
+                     module: hapi-fhir-structures-hl7org-dstu2
+                  -  name: hapi_fhir_structures_r4
+                     module: hapi-fhir-structures-r4
+                  -  name: hapi_fhir_structures_r5
+                     module: hapi-fhir-structures-r5
+                  -  name: hapi_fhir_test_utilities
+                     module: hapi-fhir-test-utilities
+                  -  name: hapi_fhir_testpage_overlay
+                     module: hapi-fhir-testpage-overlay
+                  -  name: hapi_fhir_validation
+                     module: hapi-fhir-validation
+                  -  name: hapi_fhir_validation_resources_dstu2
+                     module: hapi-fhir-validation-resources-dstu2
+                  -  name: hapi_fhir_validation_resources_dstu2_1
+                     module: hapi-fhir-validation-resources-dstu2.1
+                  -  name: hapi_fhir_validation_resources_dstu3
+                     module: hapi-fhir-validation-resources-dstu3
+                  -  name: hapi_fhir_validation_resources_r4
+                     module: hapi-fhir-validation-resources-r4
+                  -  name: hapi_fhir_validation_resources_r5
+                     module: hapi-fhir-validation-resources-r5
+                  -  name: hapi_tinder_plugin
+                     module: hapi-tinder-plugin
+                  -  name: hapi_tinder_test
+                     module: hapi-tinder-test
+                  -  name: tests_hapi_fhir_base_test_jaxrsserver_kotlin
+                     module: tests/hapi-fhir-base-test-jaxrsserver-kotlin
+                  -  name: tests_hapi_fhir_base_test_mindeps_client
+                     module: tests/hapi-fhir-base-test-mindeps-client
+                  -  name: tests_hapi_fhir_base_test_mindeps_server
+                     module: tests/hapi-fhir-base-test-mindeps-server

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,12 @@ stages:
          -  template: test-job-template.yml
             parameters:
                modules:
+                  -  name: hapi_fhir_jpaserver_test_utilities
+                     module: hapi-fhir-jpaserver-test-utilities
+                  -  name: hapi_fhir_structures_r4
+                     module: hapi-fhir-structures-r4
+                  -  name: hapi_fhir_jpaserver_base
+                     module: hapi-fhir-jpaserver-base
                   -  name: hapi_deployable_pom
                      module: hapi-deployable-pom
                   -  name: hapi_fhir_android
@@ -46,8 +52,9 @@ stages:
                      module: hapi-fhir-jaxrsserver-base
                   -  name: hapi_fhir_jpa
                      module: hapi-fhir-jpa
-                  -  name: hapi_fhir_jpaserver_base
-                     module: hapi-fhir-jpaserver-base
+#                  Put to top, but kept in order here
+#                  -  name: hapi_fhir_jpaserver_base
+#                     module: hapi-fhir-jpaserver-base
                   -  name: hapi_fhir_jpaserver_cql
                      module: hapi-fhir-jpaserver-cql
                   -  name: hapi_fhir_jpaserver_elastic_test_utilities
@@ -60,8 +67,9 @@ stages:
                      module: hapi-fhir-jpaserver-searchparam
                   -  name: hapi_fhir_jpaserver_subscription
                      module: hapi-fhir-jpaserver-subscription
-                  -  name: hapi_fhir_jpaserver_test_utilities
-                     module: hapi-fhir-jpaserver-test-utilities
+#                  Put to top, but kept in order here
+#                  -  name: hapi_fhir_jpaserver_test_utilities
+#                     module: hapi-fhir-jpaserver-test-utilities
                   -  name: hapi_fhir_jpaserver_uhnfhirtest
                      module: hapi-fhir-jpaserver-uhnfhirtest
                   -  name: hapi_fhir_server
@@ -92,8 +100,9 @@ stages:
                      module: hapi-fhir-structures-dstu3
                   -  name: hapi_fhir_structures_hl7org_dstu2
                      module: hapi-fhir-structures-hl7org-dstu2
-                  -  name: hapi_fhir_structures_r4
-                     module: hapi-fhir-structures-r4
+#                  Put to top, but kept in order here
+#                  -  name: hapi_fhir_structures_r4
+#                     module: hapi-fhir-structures-r4
                   -  name: hapi_fhir_structures_r5
                      module: hapi-fhir-structures-r5
                   -  name: hapi_fhir_test_utilities

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -137,21 +137,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-batch/pom.xml
+++ b/hapi-fhir-batch/pom.xml
@@ -69,19 +69,5 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -96,27 +96,5 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -40,21 +40,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -215,23 +215,6 @@
 					</additionalDependencies>
 				</configuration>
 			</plugin>
-
-
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -167,27 +167,4 @@
 			</plugin>
 		</plugins>
 	</reporting>
-
-	<build>
-		<plugins>
-
-			<plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <configuration>
-               <dumpOnExit>true</dumpOnExit>
-            </configuration>
-            <executions>
-               <execution>
-                  <id>default-prepare-agent</id>
-                  <goals>
-                     <goal>prepare-agent</goal>
-                  </goals>
-               </execution>
-            </executions>
-         </plugin>
-
-		</plugins>
-	</build>
-
 </project>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -438,21 +438,6 @@
 				</dependencies>
 			</plugin>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-tinder-plugin</artifactId>
 				<version>${project.version}</version>

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -244,21 +244,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -117,18 +117,6 @@
 					</dependency>
 				</dependencies>
 			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -155,19 +155,5 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -160,18 +160,6 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -135,19 +135,5 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -244,21 +244,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -131,18 +131,6 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -115,21 +115,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -107,22 +107,6 @@
 		</pluginManagement>
 
 		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 			<!-- The configuration here tells the WAR plugin to include the FHIR Tester overlay. You can omit it if you are not using that feature. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -103,19 +103,5 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -169,19 +169,5 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -251,21 +251,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -210,21 +210,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -262,21 +262,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -332,21 +332,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -317,21 +317,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -334,21 +334,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -415,21 +415,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<dumpOnExit>true</dumpOnExit>
-				</configuration>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/test-job-template.yml
+++ b/test-job-template.yml
@@ -1,0 +1,147 @@
+# HAPI FHIR Build Pipeline
+
+parameters:
+   param: [ ]
+
+jobs:
+   -  job: setup
+      displayName: setup-and-cache-build
+      timeoutInMinutes: 60
+      container: maven:3.8-openjdk-17
+      pool:
+         vmImage: ubuntu-latest
+      steps:
+         -  task: Cache@2
+            inputs:
+               key: 'maven | "$(Agent.OS)" | ./pom.xml'
+               path: $(MAVEN_CACHE_FOLDER)
+         -  task: Bash@3
+            inputs:
+               targetType: 'inline'
+               script: mkdir -p $(MAVEN_CACHE_FOLDER); pwd; ls -al $(MAVEN_CACHE_FOLDER)
+         -  task: Maven@3
+            env:
+               JAVA_HOME_11_X64: /usr/java/openjdk-17
+            inputs:
+               goals: 'install'
+               # These are Maven CLI options (and show up in the build logs) - "-nsu"=Don't update snapshots. We can remove this when Maven OSS is more healthy
+               options: '-P ALLMODULES,CI,FASTINSTALL -e -B -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.javadoc.skip=true -Dmaven.wagon.http.pool=false -Dhttp.keepAlive=false -Dstyle.color=always -Djansi.force=true'
+               # These are JVM options (and don't show up in the build logs)
+               mavenOptions: '-Xmx1024m $(MAVEN_OPTS) -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Duser.timezone=America/Toronto'
+               jdkVersionOption: 1.11
+   -  ${{ each p in parameters.modules }}:
+      -  job: ${{ p.name }}
+         timeoutInMinutes: 60
+         displayName: ${{ p.name }}
+         dependsOn: [ 'setup' ]
+         container: maven:3.8-openjdk-17
+         pool:
+            vmImage: ubuntu-latest
+         steps:
+            -  script: echo testing module ${{ p.module }}
+            -  task: DockerInstaller@0
+               displayName: Docker Installer
+               inputs:
+                  dockerVersion: 17.09.0-ce
+                  releaseType: stable
+            -  task: Cache@2
+               inputs:
+                  key: 'maven | "$(Agent.OS)" | ./pom.xml'
+                  path: $(MAVEN_CACHE_FOLDER)
+#            -  task: Maven@3
+#               env:
+#                  JAVA_HOME_11_X64: /usr/java/openjdk-17
+#               displayName: Checkstyle Build
+#               inputs:
+#                  mavenPomFile: 'hapi-fhir-checkstyle/pom.xml'
+#                  goals: 'clean install'
+#                  options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+#                  jdkVersionOption: 1.11
+            -  task: Maven@3
+               env:
+                  JAVA_HOME_11_X64: /usr/java/openjdk-17
+               inputs:
+                  mavenPomFile: '$(System.DefaultWorkingDirectory)/pom.xml'
+                  goals: 'clean test jacoco:report -pl ${{ p.module }}'
+                  # These are Maven CLI options (and show up in the build logs) - "-nsu"=Don't update snapshots. We can remove this when Maven OSS is more healthy
+                  options: '-P ALLMODULES,JACOCO,CI -e -B -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.wagon.http.pool=false -Dhttp.keepAlive=false -Dstyle.color=always -Djansi.force=true'
+                  # These are JVM options (and don't show up in the build logs)
+                  mavenOptions: '-Xmx1024m $(MAVEN_OPTS) -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Duser.timezone=America/Toronto'
+                  jdkVersionOption: 1.11
+            # Copy testing log files and publish to pipeline run on Azure.
+            -  task: CopyFiles@2
+               condition: always()
+               inputs:
+                  sourceFolder: '$(System.DefaultWorkingDirectory)/'
+                  contents: '**/target/*-reports/*.txt'
+                  targetFolder: '$(Build.ArtifactStagingDirectory)'
+            -  task: PublishPipelineArtifact@1
+               displayName: 'Publish Full Test Output'
+               condition: always()
+               inputs:
+                  targetPath: '$(Build.ArtifactStagingDirectory)/'
+                  artifactName: '${{p.name}}_full_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobId).zip'
+            # Publish target directory
+            -  task: PublishBuildArtifacts@1
+               displayName: 'Publish generated build files'
+               continueOnError: true
+               inputs:
+                  pathToPublish: '$(System.DefaultWorkingDirectory)/${{ p.module }}/target/'
+                  parallel: true
+                  artifactName: '${{ p.name }}_target'
+   -  job:
+      pool:
+         vmImage: ubuntu-latest
+      timeoutInMinutes: 60
+      displayName: generate_test_reports
+      container: maven:3.8-openjdk-17
+      dependsOn:
+         -  ${{ each p in parameters.modules }}:
+            - ${{ p.name }}
+      steps:
+         -  ${{ each p in parameters.modules }}:
+            -  task: Bash@3
+               inputs:
+                  targetType: 'inline'
+                  script: mkdir -p $(System.DefaultWorkingDirectory)/${{ p.module }}/target/
+            -  task: DownloadBuildArtifacts@0
+               displayName: 'Download jacoco test coverage result exec file for ${{ p.name }}'
+               continueOnError: true
+               inputs:
+                  buildType: 'current'
+                  downloadType: 'single'
+                  artifactName: '${{ p.name }}_target'
+                  downloadPath: '$(System.DefaultWorkingDirectory)/'
+            # Copy contents from downloaded artifact directory to final target directory.
+            -  task: CopyFiles@2
+               condition: always()
+               inputs:
+                  sourceFolder: '$(System.DefaultWorkingDirectory)/${{ p.name }}_target/'
+                  contents: '**'
+                  targetFolder: '$(System.DefaultWorkingDirectory)/${{ p.module }}/target/'
+         -  task: Maven@3
+            env:
+               JAVA_HOME_11_X64: /usr/java/openjdk-17
+            inputs:
+               mavenPomFile: '$(System.DefaultWorkingDirectory)/pom.xml'
+               goals: 'jacoco:report-aggregate'
+               # These are Maven CLI options (and show up in the build logs) - "-nsu"=Don't update snapshots. We can remove this when Maven OSS is more healthy
+               options: '-P ALLMODULES,JACOCO'
+               # These are JVM options (and don't show up in the build logs)
+               mavenOptions: '-Xmx1024m $(MAVEN_OPTS) -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Duser.timezone=America/Toronto'
+               jdkVersionOption: 1.11
+         -  bash: |
+               curl -Os https://uploader.codecov.io/latest/linux/codecov
+               chmod +x codecov
+               ./codecov -t ca6ed1e9-373f-4eac-8848-45c814772d3f -R hapi-fhir-jacoco/target/site/jacoco-aggregate/
+            displayName: 'codecov'
+         -  task: PublishTestResults@2
+            inputs:
+               testResultsFormat: 'JUnit'
+               testResultsFiles: '**/TEST-*.xml'
+         -  task: PublishCodeCoverageResults@1
+            inputs:
+               codeCoverageTool: 'JaCoCo'
+               summaryFileLocation: $(System.DefaultWorkingDirectory)/hapi-fhir-jacoco/target/site/jacoco-aggregate/jacoco.xml
+               reportDirectory: $(System.DefaultWorkingDirectory)/hapi-fhir-jacoco/target/site/jacoco-report/
+               failIfCoverageEmpty: true

--- a/test-job-template.yml
+++ b/test-job-template.yml
@@ -133,7 +133,7 @@ jobs:
          -  bash: |
                curl -Os https://uploader.codecov.io/latest/linux/codecov
                chmod +x codecov
-               ./codecov -t ca6ed1e9-373f-4eac-8848-45c814772d3f -R hapi-fhir-jacoco/target/site/jacoco-aggregate/
+               ./codecov -t $(CODECOV_TOKEN) -R hapi-fhir-jacoco/target/site/jacoco-aggregate/
             displayName: 'codecov'
          -  task: PublishTestResults@2
             inputs:


### PR DESCRIPTION
This PR changes the way HAPI is built by Azure pipelines. Instead of a FIFO queue for all tests in the project, the entire project is quickly built and cached without testing, then the individual modules are built and tested in separate jobs which can be run in parallel from each other. Each of these jobs then uploads the test coverage for that module as a build artifact. Finally, a last stage downloads all the archived tests results and aggregates them using jacoco so they can be uploaded to codecov. 

This has two key benefits:
1. If there is a failing test because of an intermittent, the individual failing module can be re-run instead of having to re-run the whole project build.
2. The build time is decreased substantially (90min -> 45min).

This is the first run at this, I will be iterating to further reduce build times going forward.


