### PR TITLE
New field for definition on Operation annotation

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/Operation.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/Operation.java
@@ -139,4 +139,9 @@ public @interface Operation {
 	 */
 	boolean global() default false;
 
+	/**
+	 * Used to manually define canonical URI for operation. If not supplied, will fall back to normal
+	 * generation of name & operation definition.
+	 */
+	String definition() default "";
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/OperationMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/OperationMethodBinding.java
@@ -53,6 +53,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -67,6 +68,8 @@ public class OperationMethodBinding extends BaseResourceReturningMethodBinding {
 	private final ReturnTypeEnum myReturnType;
 	private final String myShortDescription;
 	private boolean myGlobal;
+
+	private String myDefinition;
 	private BundleTypeEnum myBundleType;
 	private boolean myCanOperateAtInstanceLevel;
 	private boolean myCanOperateAtServerLevel;
@@ -87,8 +90,8 @@ public class OperationMethodBinding extends BaseResourceReturningMethodBinding {
 
 		myManualRequestMode = theAnnotation.manualRequest();
 		myManualResponseMode = theAnnotation.manualResponse();
+		myDefinition = theAnnotation.definition() == null || theAnnotation.definition().trim().isEmpty() ? null: theAnnotation.definition();
 	}
-
 	protected OperationMethodBinding(Class<?> theReturnResourceType, Class<? extends IBaseResource> theReturnTypeFromRp, Method theMethod, FhirContext theContext, Object theProvider,
 												boolean theIdempotent, String theOperationName, Class<? extends IBaseResource> theOperationType, String theOperationTypeName,
 												OperationParam[] theReturnParams, BundleTypeEnum theBundleType, boolean theGlobal) {
@@ -194,6 +197,10 @@ public class OperationMethodBinding extends BaseResourceReturningMethodBinding {
 	@Override
 	public boolean isGlobalMethod() {
 		return myGlobal;
+	}
+
+	public Optional<String> getDefinition() {
+		return Optional.ofNullable(myDefinition);
 	}
 
 	public String getDescription() {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
@@ -554,7 +554,7 @@ public class ServerCapabilityStatementProvider implements IServerConformanceProv
 	private void populateOperation(RequestDetails theRequestDetails, FhirTerser theTerser, OperationMethodBinding theMethodBinding, String theOpName, IBase theOperation) {
 		String operationName = theMethodBinding.getName().substring(1);
 		theTerser.addElement(theOperation, "name", operationName);
-		theTerser.addElement(theOperation, "definition", createOperationUrl(theRequestDetails, theOpName));
+		theTerser.addElement(theOperation, "definition", theMethodBinding.getDefinition().orElse(createOperationUrl(theRequestDetails, theOpName)));
 		if (isNotBlank(theMethodBinding.getDescription())) {
 			theTerser.addElement(theOperation, "documentation", theMethodBinding.getDescription());
 		}


### PR DESCRIPTION
Added optional "definition" field to @Operation annotation which can be used to refer to a well defined OperationDefinition by canonical URI according to https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.rest.resource.operation.definition

If omitted, a local OperationDefinition will be generated as before.