### PR TITLE
Full text search should not reindex if disabled

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/reindex/ResourceReindexer.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/reindex/ResourceReindexer.java
@@ -105,7 +105,7 @@ public class ResourceReindexer {
 		Class<T> resourceClass = (Class<T>) resourceDefinition.getImplementingClass();
 		final IFhirResourceDao<T> dao = myDaoRegistry.getResourceDao(resourceClass);
 		dao.reindex(theResource, theResourceTable);
-		if (myFulltextSearchSvc != null) {
+		if (myFulltextSearchSvc != null && !myFulltextSearchSvc.isDisabled()) {
 			// update the full-text index, if active.
 			myFulltextSearchSvc.reindex(theResourceTable);
 		}


### PR DESCRIPTION
I spun up a new instance of 6.0.1 on Friday (with existing data in Postgres) and was almost immediately met with the following log sample in a tight loop (note that we have `hibernate.search.enabled: false` as it was having a severe impact on ingest performance, and we have no need of full text search). It ended up wiping out ~6 million rows in the `hfj_res_link` table, so now we can't retrieve included resources (though the entries in `hfj_resource` still exist can can be accessed directly). I haven't yet dug deeply enough to know definitively that this additional conditional will prevent the removal from `hfj_res_link`, but at the very least it should prevent millions of lines of logspam.

```
2022-08-28 10:37:56.902 [ResourceReindex-174] ERROR c.u.f.j.s.r.ResourceReindexingSvcImpl [ResourceReindexingSvcImpl.java:515] Failed to index resource Patient/8651420/_history/1: {}
org.hibernate.search.util.common.SearchException: HSEARCH800001: Hibernate Search was not initialized.
        at org.hibernate.search.mapper.orm.mapping.impl.HibernateSearchContextProviderService.get(HibernateSearchContextProviderService.java:51)
        at org.hibernate.search.mapper.orm.mapping.impl.HibernateSearchContextProviderService.get(HibernateSearchContextProviderService.java:23)
        at org.hibernate.search.mapper.orm.session.impl.DelegatingSearchSession.getDelegate(DelegatingSearchSession.java:109)
        at org.hibernate.search.mapper.orm.session.impl.DelegatingSearchSession.indexingPlan(DelegatingSearchSession.java:94)
        at ca.uhn.fhir.jpa.dao.FulltextSearchSvcImpl.reindex(FulltextSearchSvcImpl.java:127)
        at ca.uhn.fhir.jpa.dao.FulltextSearchSvcImpl$$FastClassBySpringCGLIB$$3a1d320d.invoke(<generated>)
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
        at org.springframework.aop.framework.CglibAopProxy.invokeMethod(CglibAopProxy.java:386)
        at org.springframework.aop.framework.CglibAopProxy.access$000(CglibAopProxy.java:85)
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:704)
        at ca.uhn.fhir.jpa.dao.FulltextSearchSvcImpl$$EnhancerBySpringCGLIB$$d0775042.reindex(<generated>)
        at ca.uhn.fhir.jpa.search.reindex.ResourceReindexer.doReindex(ResourceReindexer.java:107)
        at ca.uhn.fhir.jpa.search.reindex.ResourceReindexer.reindexResourceEntity(ResourceReindexer.java:96)
        at ca.uhn.fhir.jpa.search.reindex.ResourceReindexingSvcImpl$ResourceReindexingTask.lambda$readResourceAndReindex$0(ResourceReindexingSvcImpl.java:510)
        at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140)
        at ca.uhn.fhir.jpa.search.reindex.ResourceReindexingSvcImpl$ResourceReindexingTask.readResourceAndReindex(ResourceReindexingSvcImpl.java:505)
        at ca.uhn.fhir.jpa.search.reindex.ResourceReindexingSvcImpl$ResourceReindexingTask.call(ResourceReindexingSvcImpl.java:481)
        at ca.uhn.fhir.jpa.search.reindex.ResourceReindexingSvcImpl$ResourceReindexingTask.call(ResourceReindexingSvcImpl.java:466)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
2022-08-28 10:37:56.903 [ResourceReindex-174] INFO  o.h.c.i.AbstractPersistentCollection [AbstractPersistentCollection.java:656] HHH000496: Detaching an uninitialized collection with queued operations from a session: [ca.uhn.fhir.jpa.model.entity.ResourceTable.myParamsCoords#8651420]
2022-08-28 10:37:56.903 [ResourceReindex-174] INFO  o.h.c.i.AbstractPersistentCollection [AbstractPersistentCollection.java:656] HHH000496: Detaching an uninitialized collection with queued operations from a session: [ca.uhn.fhir.jpa.model.entity.ResourceTable.myParamsUri#8651420]
2022-08-28 10:37:56.903 [ResourceReindex-174] INFO  c.u.f.j.s.r.ResourceReindexingSvcImpl [ResourceReindexingSvcImpl.java:495] Setting resource PID[8651420] status to ERRORED
2022-08-28 10:37:56.903 [ResourceReindex-174] INFO  c.u.f.j.s.r.ResourceReindexingSvcImpl [ResourceReindexingSvcImpl.java:414] Marking resource with PID 8651420 as indexing_failed
```

I should also note that I'm currently poking around to try to figure out why this task was kicked off to begin with, as I didn't trigger a reindex job. I spun up the instance, checked that I could run a couple of simple search queries, and then noticed the error accumulating in the logs. If anyone has insight into what's triggering it, that would be wonderful.