### PR TITLE
add ability to skip loading package resources that already exists, to…

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallationSpec.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallationSpec.java
@@ -34,12 +34,10 @@ import java.util.List;
 import java.util.function.Supplier;
 
 @Schema(
-	name = "PackageInstallationSpec",
-	description =
-		"Defines a set of instructions for package installation"
-)
+	name = "PackageInstallationSpec", description = "Defines a set of instructions for package installation"
+	)
 @JsonPropertyOrder({
-	"name", "version", "packageUrl", "installMode", "installResourceTypes", "validationMode"
+	"name", "version", "packageUrl", "installMode", "installResourceTypes", "validationMode", "reloadExisting"
 })
 @ExampleSupplier({PackageInstallationSpec.ExampleSupplier.class, PackageInstallationSpec.ExampleSupplier2.class})
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -64,6 +62,9 @@ public class PackageInstallationSpec {
 	@Schema(description = "Should dependencies be automatically resolved, fetched and installed with the same settings")
 	@JsonProperty("fetchDependencies")
 	private boolean myFetchDependencies;
+	@Schema(description = "Should existing resources be reloaded. Defaults to true, but can be set to false to avoid re-index operations for existing search parameters")
+	@JsonProperty("reloadExisting")
+	private boolean myReloadExisting = true;
 	@Schema(description = "Any values provided here will be interpreted as a regex. Dependencies with an ID matching any regex will be skipped.")
 	private List<String> myDependencyExcludes;
 	@JsonIgnore
@@ -143,6 +144,14 @@ public class PackageInstallationSpec {
 	public PackageInstallationSpec setPackageContents(byte[] thePackageContents) {
 		myPackageContents = thePackageContents;
 		return this;
+	}
+
+	public boolean isReloadExisting() {
+		return myReloadExisting;
+	}
+
+	public void setReloadExisting(boolean reloadExisting) {
+		this.myReloadExisting = reloadExisting;
 	}
 
 	public PackageInstallationSpec addDependencyExclude(String theExclude) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -92,7 +92,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		"ConceptMap",
 		"SearchParameter",
 		"Subscription"
-	));
+		));
 
 	boolean enabled = true;
 	@Autowired
@@ -225,7 +225,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 
 				try {
 					next = isStructureDefinitionWithoutSnapshot(next) ? generateSnapshot(next) : next;
-					create(next, theOutcome);
+					create(next, theInstallationSpec, theOutcome);
 				} catch (Exception e) {
 					ourLog.warn("Failed to upload resource of type {} with ID {} - Error: {}", myFhirContext.getResourceType(next), next.getIdElement().getValue(), e.toString());
 					throw new ImplementationGuideInstallationException(Msg.code(1286) + String.format("Error installing IG %s#%s: %s", name, version, e), e);
@@ -323,7 +323,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		return resources;
 	}
 
-	private void create(IBaseResource theResource, PackageInstallOutcomeJson theOutcome) {
+	private void create(IBaseResource theResource, PackageInstallationSpec theInstallationSpec, PackageInstallOutcomeJson theOutcome) {
 		IFhirResourceDao dao = myDaoRegistry.getResourceDao(theResource.getClass());
 		SearchParameterMap map = createSearchParameterMapFor(theResource);
 		IBundleProvider searchResult = searchResource(dao, map);
@@ -347,11 +347,15 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 					ourLog.info("Created resource with existing id");
 				}
 			} else {
-			ourLog.info("Updating existing resource matching {}", map.toNormalizedQueryString(myFhirContext));
-				theResource.setId(searchResult.getResources(0, 1).get(0).getIdElement().toUnqualifiedVersionless());
-				DaoMethodOutcome outcome = updateResource(dao, theResource);
-				if (!outcome.isNop()) {
-					theOutcome.incrementResourcesInstalled(myFhirContext.getResourceType(theResource));
+				if (theInstallationSpec.isReloadExisting()) {
+					ourLog.info("Updating existing resource matching {}", map.toNormalizedQueryString(myFhirContext));
+					theResource.setId(searchResult.getResources(0, 1).get(0).getIdElement().toUnqualifiedVersionless());
+					DaoMethodOutcome outcome = updateResource(dao, theResource);
+					if (!outcome.isNop()) {
+						theOutcome.incrementResourcesInstalled(myFhirContext.getResourceType(theResource));
+					}
+				} else {
+					ourLog.info("Skipping update of existing resource matching {}", map.toNormalizedQueryString(myFhirContext));
 				}
 			}
 		}


### PR DESCRIPTION
This is to pave the way to config the JPA starter to skip re-saving package resources when loading an IG via the implementationguides config param. If you leave that param in the config file - every time the server restarts it reloads search parameters and then re-indexes affected resources. This makes it difficult to script automated deployments since first-time and subsequent deployments need a different config. 