### PR TITLE
Avoid NPE when run in IJ

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4018-avoid-npe-in-ij.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4018-avoid-npe-in-ij.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4018
+title: "When running HAPI FHIR inside intellij with runtime Nonnull assertions enabled, a sequencing issue in OperationMethodBinding could cause a null pointer exception. This has been corrected."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
@@ -76,7 +76,7 @@ public abstract class BaseMethodBinding<T> {
 		myMethod = theMethod;
 		myContext = theContext;
 		myProvider = theProvider;
-		myParameters = MethodUtil.getResourceParameters(theContext, theMethod, theProvider, getRestOperationType());
+		myParameters = MethodUtil.getResourceParameters(theContext, theMethod, theProvider);
 		myQueryParameters = myParameters
 			.stream()
 			.filter(t -> t instanceof BaseQueryParameter)

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ConditionalParamBinder.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ConditionalParamBinder.java
@@ -35,12 +35,9 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 
 class ConditionalParamBinder implements IParameter {
 
-	private RestOperationTypeEnum myOperationType;
 	private boolean mySupportsMultiple;
 
-	ConditionalParamBinder(RestOperationTypeEnum theOperationType, boolean theSupportsMultiple) {
-		Validate.notNull(theOperationType, "theOperationType can not be null");
-		myOperationType = theOperationType;
+	ConditionalParamBinder(boolean theSupportsMultiple) {
 		mySupportsMultiple = theSupportsMultiple;
 	}
 
@@ -57,7 +54,7 @@ class ConditionalParamBinder implements IParameter {
 
 	@Override
 	public Object translateQueryParametersIntoServerArgument(RequestDetails theRequest, BaseMethodBinding<?> theMethodBinding) throws InternalErrorException, InvalidRequestException {
-		return theRequest.getConditionalUrl(myOperationType);
+		return theRequest.getConditionalUrl(theMethodBinding.getRestOperationType());
 	}
 
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/MethodUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/MethodUtil.java
@@ -72,7 +72,7 @@ public class MethodUtil {
 
 
 	@SuppressWarnings("unchecked")
-	public static List<IParameter> getResourceParameters(final FhirContext theContext, Method theMethod, Object theProvider, RestOperationTypeEnum theRestfulOperationTypeEnum) {
+	public static List<IParameter> getResourceParameters(final FhirContext theContext, Method theMethod, Object theProvider) {
 		List<IParameter> parameters = new ArrayList<>();
 
 		Class<?>[] parameterTypes = theMethod.getParameterTypes();
@@ -240,7 +240,7 @@ public class MethodUtil {
 					} else if (nextAnnotation instanceof TransactionParam) {
 						param = new TransactionParameter(theContext);
 					} else if (nextAnnotation instanceof ConditionalUrlParam) {
-						param = new ConditionalParamBinder(theRestfulOperationTypeEnum, ((ConditionalUrlParam) nextAnnotation).supportsMultiple());
+						param = new ConditionalParamBinder(((ConditionalUrlParam) nextAnnotation).supportsMultiple());
 					} else if (nextAnnotation instanceof OperationParam) {
 						Operation op = theMethod.getAnnotation(Operation.class);
 						if (op == null) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/OperationMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/OperationMethodBinding.java
@@ -222,6 +222,7 @@ public class OperationMethodBinding extends BaseResourceReturningMethodBinding {
 	@Nonnull
 	@Override
 	public RestOperationTypeEnum getRestOperationType() {
+		assert myOtherOperationType != null;
 		return myOtherOperationType;
 	}
 


### PR DESCRIPTION
When running HAPI FHIR inside intellij with runtime Nonnull assertions enabled, a sequencing issue in OperationMethodBinding could cause a null pointer exception. This has been corrected.