### PR TITLE
Add test and changelog

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/UploadTerminologyCommandTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/UploadTerminologyCommandTest.java
@@ -38,9 +38,11 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -452,7 +454,8 @@ public class UploadTerminologyCommandTest {
 				UploadTerminologyCommand.UPLOAD_TERMINOLOGY,
 				"-v", theFhirVersion,
 				"-u", myICD10URL,
-				"-d", myICD10FileName
+				"-d", myICD10FileName,
+				"-s", "1GB"
 			},
 			"-t", theIncludeTls, myBaseRestServerHelper
 		));
@@ -463,6 +466,10 @@ public class UploadTerminologyCommandTest {
 		assertEquals(1, listOfDescriptors.size());
 		assertThat(listOfDescriptors.get(0).getFilename(), matchesPattern("^file:.*files.*\\.zip$"));
 		assertThat(IOUtils.toByteArray(listOfDescriptors.get(0).getInputStream()).length, greaterThan(100));
+
+		long transferSizeLimitForUnitTest = UploadTerminologyCommand.getTransferSizeLimitForUnitTest();
+		long gigaByteInBytes = 1073741824L;
+		assertThat(transferSizeLimitForUnitTest, is(equalTo(gigaByteInBytes)));
 	}
 
 	private synchronized void writeConceptAndHierarchyFiles() throws IOException {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/3276-modifiable-maximum-transmit-size.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/3276-modifiable-maximum-transmit-size.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 3276
+title: "Added a new optional parameter to the `upload-terminology` operation of the HAPI-FHIR CLI. you can pass the `-s` or `--size` parameter to specify
+the maximum size that will be transmitted to the server, before a local file reference is used. This parameter can be filled in using human-readable format, for example: 
+ `upload-terminology -s \"1GB\"` will permit zip files up to 1 gigabyte, and anything larger than that would default to using a local file reference."


### PR DESCRIPTION
Works on #3276 

* Add `-s` or `--size` flag to Upload Terminology command to increase the limit of size before the CLI tool uses a local file descriptor. 
* Add changelog
* Test Behaviour. 