### PR TITLE
Fix content negotiation on binary streaming

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4051-content-type-negotiation-binaries.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4051-content-type-negotiation-binaries.yaml
@@ -2,6 +2,6 @@
 type: fix
 issue: 4051
 jira: SMILE-5170
-title: "There was previously a bug in content-type negotiation when reading Binary resources. Previously, if a client requested a Binary and used an `Accept` 
-header that matched the Binary resource's `contentType`, the server would return an XML representation of the Binary resource. This has been fixed, and using a matching `Accept` header will cause
-the Binary's data to be returned directly in the requested content type."
+title: "There was a bug in content-type negotiation when reading Binary resources. Previously, when a client requested a Binary resource and with an `Accept` 
+header that matched the `contentType` of the stored resource, the server would return an XML representation of the Binary resource. This has been fixed, and a request with a matching `Accept` header will receive
+the stored binary data directly as the requested content type."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4051-content-type-negotiation-binaries.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4051-content-type-negotiation-binaries.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 4051
+jira: SMILE-5170
+title: "There was previously a bug in content-type negotiation when reading Binary resources. Previously, if a client requested a Binary and used an `Accept` 
+header that matched the Binary resource's `contentType`, the server would return an XML representation of the Binary resource. This has been fixed, and using a matching `Accept` header will cause
+the Binary's data to be returned directly in the requested content type."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
@@ -268,6 +268,7 @@ public class BulkDataExportTest extends BaseResourceProviderR4Test {
 		verifyBulkExportResults(options, List.of("\"P1\"", "\"" + obsId + "\"", "\"" + encId + "\"", "\"P2\"", "\"" + obsId2 + "\"", "\"" + encId2 + "\""), List.of("\"P3\"", "\"" + obsId3 + "\"", "\"" + encId3 + "\""));
 	}
 
+
 	private void verifyBulkExportResults(BulkDataExportOptions theOptions, List<String> theContainedList, List<String> theExcludedList) {
 		Batch2JobStartResponse startResponse = myJobRunner.startNewJob(BulkExportUtils.createBulkExportJobParametersFromExportOptions(theOptions));
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkExportUseCaseTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkExportUseCaseTest.java
@@ -87,8 +87,6 @@ public class BulkExportUseCaseTest extends BaseResourceProviderR4Test {
 				}
 			}
 
-
-
 			{ //Test with the Accept Header set to application/fhir+ndjson should stream out the results.
 				HttpGet expandGet = new HttpGet(ourServerBase + "/" + replace);
 				expandGet.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_NDJSON);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -1033,10 +1033,10 @@ public class RestfulServerUtils {
 		return response.sendWriterResponse(theStatusCode, contentType, charset, writer);
 	}
 
-	private static String getBinaryContentTypeOrDefault(IBaseBinary bin) {
+	private String getBinaryContentTypeOrDefault(IBaseBinary theBinary) {
 		String contentType;
-		if (isNotBlank(bin.getContentType())) {
-			contentType = bin.getContentType();
+		if (isNotBlank(theBinary.getContentType())) {
+			contentType = theBinary.getContentType();
 		} else {
 			contentType = Constants.CT_OCTET_STREAM;
 		}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -1033,7 +1033,7 @@ public class RestfulServerUtils {
 		return response.sendWriterResponse(theStatusCode, contentType, charset, writer);
 	}
 
-	private String getBinaryContentTypeOrDefault(IBaseBinary theBinary) {
+	private static String getBinaryContentTypeOrDefault(IBaseBinary theBinary) {
 		String contentType;
 		if (isNotBlank(theBinary.getContentType())) {
 			contentType = theBinary.getContentType();

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -944,15 +944,10 @@ public class RestfulServerUtils {
 
 			// If the user didn't explicitly request FHIR as a response, return binary
 			// content directly
-			if (responseEncoding == null || matchesBinaryContentType(responseEncoding, bin)) {
-				if (isNotBlank(bin.getContentType())) {
-					contentType = bin.getContentType();
-				} else {
-					contentType = Constants.CT_OCTET_STREAM;
-				}
-
+			if (shouldStreamContents(responseEncoding, bin)) {
 				// Force binary resources to download - This is a security measure to prevent
 				// malicious images or HTML blocks being served up as content.
+				contentType = getBinaryContentTypeOrDefault(bin);
 				response.addHeader(Constants.HEADER_CONTENT_DISPOSITION, "Attachment;");
 
 				return response.sendAttachmentResponse(bin, theStatusCode, contentType);
@@ -1038,6 +1033,16 @@ public class RestfulServerUtils {
 		return response.sendWriterResponse(theStatusCode, contentType, charset, writer);
 	}
 
+	private static String getBinaryContentTypeOrDefault(IBaseBinary bin) {
+		String contentType;
+		if (isNotBlank(bin.getContentType())) {
+			contentType = bin.getContentType();
+		} else {
+			contentType = Constants.CT_OCTET_STREAM;
+		}
+		return contentType;
+	}
+
 	/**
 	 * Determines whether we should stream out Binary resource content based on the content-type. Logic is:
 	 * - If they request octet-stream, return true;
@@ -1049,16 +1054,17 @@ public class RestfulServerUtils {
 	 * @param theBinary  the {@link IBaseBinary} resource to be streamed out.
 	 * @return True if response can be streamed as the requested encoding type, false otherwise.
 	 */
-	private static boolean matchesBinaryContentType(ResponseEncoding theResponseEncoding, IBaseBinary theBinary) {
+	private static boolean shouldStreamContents(ResponseEncoding theResponseEncoding, IBaseBinary theBinary) {
 		String contentType = theBinary.getContentType();
-		if (isBlank(contentType)) {
+		if (theResponseEncoding == null) {
+			return true;
+		} if (isBlank(contentType)) {
 			return Constants.CT_OCTET_STREAM.equals(theResponseEncoding.getContentType());
 		} else if (contentType.equalsIgnoreCase(theResponseEncoding.getContentType())) {
 			return true;
 		} else {
 			return Objects.equals(EncodingEnum.forContentType(contentType), theResponseEncoding.getEncoding());
 		}
-
 	}
 
 	public static String createEtag(String theVersionId) {


### PR DESCRIPTION
Works on #4051 

* Fixes content-type negotiation when using `Accept` header.
* Add test
* Add changelog

Now, when using an `Accept` header that resolves to the same content-type as the binary, this will cause the binary contents to be streamed out, instead of an XML representation of the binary being returned. 

