### PR TITLE
fix generate-multi-file and generate-single-file goals with R5

### DIFF
--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -91,6 +91,11 @@
 			<version>6.2.0-PRE9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-validation-resources-r5</artifactId>
+			<version>6.2.0-PRE9-SNAPSHOT</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity-engine-core</artifactId>
 		</dependency>

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/AbstractGenerator.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/AbstractGenerator.java
@@ -53,7 +53,7 @@ public abstract class AbstractGenerator {
 			fhirContext = FhirContext.forR4();
 			packageSuffix = ".r4";
 		} else if ("r5".equals(context.getVersion())) {
-			fhirContext = FhirContext.forR4();
+			fhirContext = FhirContext.forR5();
 			packageSuffix = ".r5";
 		} else {
 			throw new FailureException(Msg.code(95) + "Unknown version configured: " + context.getVersion());

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/AbstractGenerator.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/AbstractGenerator.java
@@ -52,6 +52,9 @@ public abstract class AbstractGenerator {
 		} else if ("r4".equals(context.getVersion())) {
 			fhirContext = FhirContext.forR4();
 			packageSuffix = ".r4";
+		} else if ("r5".equals(context.getVersion())) {
+			fhirContext = FhirContext.forR4();
+			packageSuffix = ".r5";
 		} else {
 			throw new FailureException(Msg.code(95) + "Unknown version configured: " + context.getVersion());
 		}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/Configuration.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/Configuration.java
@@ -45,6 +45,10 @@ public class Configuration {
 				fhirContext = FhirContext.forR4();
 				packageSuffix = ".r4";
 				break;
+			case "r5":
+				fhirContext = FhirContext.forR5();
+				packageSuffix = ".r5";
+				break;
 			default:
 				throw new IllegalArgumentException(Msg.code(92) + "Unknown version configured: " + version);
 		}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericMultiFileMojo.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericMultiFileMojo.java
@@ -43,7 +43,7 @@ import ca.uhn.fhir.tinder.parser.TargetType;
  *     <td valign="top">version</td>
  *     <td valign="top">The FHIR version whose resource metadata
  *     is to be used to generate the files<br>
- *     Valid values:&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code>&nbsp;|&nbsp;<code><b>r4</b></code></td>
+ *     Valid values:&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code>&nbsp;|&nbsp;<code><b>r4</b></code>&nbsp;|&nbsp;<code><b>r5</b></code></td>
  *     <td valign="top" align="center">Yes</td>
  *   </tr>
  *   <tr>

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericSingleFileMojo.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericSingleFileMojo.java
@@ -53,7 +53,7 @@ import ca.uhn.fhir.tinder.parser.TargetType;
  *     <td valign="top">version</td>
  *     <td valign="top">The FHIR version whose resource metadata
  *     is to be used to generate the files<br>
- *     Valid values:&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code>&nbsp;|&nbsp;<code><b>r4</b></code></td>
+ *     Valid values:&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code>&nbsp;|&nbsp;<code><b>r4</b></code>&nbsp;|&nbsp;<code><b>r5</b></code></td>
  *     <td valign="top" align="center">Yes</td>
  *   </tr>
  *   <tr>

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ant/TinderGeneratorTask.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ant/TinderGeneratorTask.java
@@ -73,7 +73,7 @@ import ca.uhn.fhir.tinder.parser.TargetType;
  *     <td valign="top">version</td>
  *     <td valign="top">The FHIR version whose resource metadata
  *     is to be used to generate the files<br>
- *     Valid values:&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code>&nbsp;|&nbsp;<code><b>r4</b></code></td>
+ *     Valid values:&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code>&nbsp;|&nbsp;<code><b>r4</b></code>&nbsp;|&nbsp;<code><b>r5</b></code></td>
  *     <td valign="top" align="center">Yes</td>
  *   </tr>
  *   <tr>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -106,6 +106,11 @@
 					</dependency>
 					<dependency>
 						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-structures-r5</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
 						<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
 						<version>${project.version}</version>
 					</dependency>
@@ -122,6 +127,11 @@
 					<dependency>
 						<groupId>ca.uhn.hapi.fhir</groupId>
 						<artifactId>hapi-fhir-validation-resources-r4</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-validation-resources-r5</artifactId>
 						<version>${project.version}</version>
 					</dependency>
 				</dependencies>
@@ -235,6 +245,25 @@
 						</configuration>
 					</execution>
 					<execution>
+						<id>generic_multi_r5</id>
+						<goals>
+							<goal>generate-multi-files</goal>
+						</goals>
+						<configuration>
+							<version>r5</version>
+							<generateResources>true</generateResources>
+							<resourceSource>model</resourceSource>
+							<templateFile>${project.basedir}/src/test/resources/templates/resource_test.vm</templateFile>
+							<targetSourceDirectory>${project.build.directory}/generated-sources/tinder</targetSourceDirectory>
+							<targetPackage>ca.uhn.test.generic.multi.r5</targetPackage>
+							<filenameSuffix>ResourceTest.java</filenameSuffix>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
+						</configuration>
+					</execution>
+					<execution>
 						<id>generic_multi_json</id>
 						<goals>
 							<goal>generate-multi-files</goal>
@@ -276,6 +305,26 @@
 						</configuration>
 					</execution>
 					<execution>
+						<id>generic_single_dstu3</id>
+						<goals>
+							<goal>generate-single-file</goal>
+						</goals>
+						<configuration>
+							<version>dstu3</version>
+							<generateResources>true</generateResources>
+							<resourceSource>model</resourceSource>
+							<templateFile>${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm</templateFile>
+							<targetSourceDirectory>${project.build.directory}/generated-sources/tinder</targetSourceDirectory>
+							<targetPackage>ca.uhn.test.generic.single</targetPackage>
+							<packageBase>ca.uhn.test.generic.multi</packageBase>
+							<targetFile>TestConfigDstu3.java</targetFile>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
+						</configuration>
+					</execution>
+					<execution>
 						<id>generic_single_r4</id>
 						<goals>
 							<goal>generate-single-file</goal>
@@ -289,6 +338,26 @@
 							<targetPackage>ca.uhn.test.generic.single.r4</targetPackage>
 							<packageBase>ca.uhn.test.generic.multi.r4</packageBase>
 							<targetFile>TestConfigR4.java</targetFile>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>generic_single_r5</id>
+						<goals>
+							<goal>generate-single-file</goal>
+						</goals>
+						<configuration>
+							<version>r5</version>
+							<generateResources>true</generateResources>
+							<resourceSource>model</resourceSource>
+							<templateFile>${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm</templateFile>
+							<targetSourceDirectory>${project.build.directory}/generated-sources/tinder</targetSourceDirectory>
+							<targetPackage>ca.uhn.test.generic.single.r5</targetPackage>
+							<packageBase>ca.uhn.test.generic.multi.r5</packageBase>
+							<targetFile>TestConfigR5.java</targetFile>
 							<includeResources>
 								<includeResource>patient</includeResource>
 								<includeResource>organization</includeResource>
@@ -331,11 +400,46 @@
 							<target>
 								<taskdef name="hapi-tinder" classname="ca.uhn.fhir.tinder.ant.TinderGeneratorTask" classpathref="maven.plugin.classpath" />
 
-								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test.vm" generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
-									targetPackage="ca.uhn.test.ant.multi" filenameSuffix="ResourceTest.java" projectHome="${project.basedir}/.." version="dstu2" includeResources="patient,organization" />
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test.vm" 
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetPackage="ca.uhn.test.ant.multi" filenameSuffix="ResourceTest.java" projectHome="${project.basedir}/.." 
+									         version="dstu2" includeResources="patient,organization" />
 
-								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm" generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
-									targetFile="TestConfigDstu2.java" targetPackage="ca.uhn.test.ant.single" packageBase="ca.uhn.test.ant.multi" projectHome="${project.basedir}/.." version="dstu2" includeResources="patient,organization" />
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test.vm" resourceSource="model"
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetPackage="ca.uhn.test.ant.multi.dstu3" filenameSuffix="ResourceTest.java" projectHome="${project.basedir}/.." 
+									         version="dstu3" includeResources="patient,organization" />
+
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test.vm" resourceSource="model" 
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetPackage="ca.uhn.test.ant.multi.r4" filenameSuffix="ResourceTest.java" projectHome="${project.basedir}/.." 
+									         version="r4" includeResources="patient,organization" />
+
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test.vm" resourceSource="model"
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetPackage="ca.uhn.test.ant.multi.r5" filenameSuffix="ResourceTest.java" projectHome="${project.basedir}/.." 
+									         version="r5" includeResources="patient,organization" />
+
+									         
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm" 
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetFile="TestConfigDstu2.java" targetPackage="ca.uhn.test.ant.single" packageBase="ca.uhn.test.ant.multi" 
+									         projectHome="${project.basedir}/.." version="dstu2" includeResources="patient,organization" />
+									         
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm"  resourceSource="model"
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetFile="TestConfigDstu3.java" targetPackage="ca.uhn.test.ant.single" packageBase="ca.uhn.test.ant.multi.dstu3" 
+									         projectHome="${project.basedir}/.." version="dstu3" includeResources="patient,organization" />
+
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm"  resourceSource="model"
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetFile="TestConfigR4.java" targetPackage="ca.uhn.test.ant.single" packageBase="ca.uhn.test.ant.multi.r4" 
+									         projectHome="${project.basedir}/.." version="r4" includeResources="patient,organization" />
+
+								<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm"  resourceSource="model"
+								             generateResources="true" targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									         targetFile="TestConfigR5.java" targetPackage="ca.uhn.test.ant.single" packageBase="ca.uhn.test.ant.multi.r5" 
+									         projectHome="${project.basedir}/.." version="r5" includeResources="patient,organization" />
 
 							</target>
 						</configuration>
@@ -370,6 +474,16 @@
 					</dependency>
 					<dependency>
 						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-structures-r4</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-structures-r5</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
 						<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
 						<version>${project.version}</version>
 					</dependency>
@@ -381,6 +495,16 @@
 					<dependency>
 						<groupId>ca.uhn.hapi.fhir</groupId>
 						<artifactId>hapi-fhir-validation-resources-dstu3</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-validation-resources-r4</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-validation-resources-r5</artifactId>
 						<version>${project.version}</version>
 					</dependency>
 					<dependency>


### PR DESCRIPTION
The tinder-plugin does not work for R5 and the generic generate-multi-file and generate-single-file Mojo plugins. This PR fixes that and adds more tests to insure the generic plugins continue to work for all supported FHIR versions.