### PR TITLE
Fix 2 issues with has reverse chaining

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4139-reverse-chaining-fixes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4139-reverse-chaining-fixes.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4139
+title: "Two issues with reverse chaining (i.e. the `_has` search parameter) have been addressed:
+   * Searching for a reverse chain with a target search parameter of `_id` did not work correctly, e.g. `Patient?_has:Observation:subject:_id=Patient/123`
+   * Searching with a combination of a forward chain and a reverse chain did not work correctly if indexing contained resources was enabled, e.g. `Observation?subject._has:Group:member:_id=Group/123`"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -129,6 +129,7 @@ import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toEqualToOrInPredicate;
 import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toOperation;
 import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toOrPredicate;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_HAS;
+import static ca.uhn.fhir.rest.api.Constants.PARAM_ID;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.split;
 
@@ -732,7 +733,7 @@ public class QueryStack {
 					orValues.add(nextHasParam);
 				}
 
-			} else if (paramName.equals("_id")) {
+			} else if (paramName.equals(PARAM_ID)) {
 
 				for (IQueryParameterType next : nextOrList) {
 					orValues.add(new TokenParam(next.getValueAsQueryToken(myFhirContext)));

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -1828,7 +1828,7 @@ public class QueryStack {
 				.filter(t -> t instanceof ReferenceParam)
 				.map(t -> ((ReferenceParam) t).getChain())
 				.filter(StringUtils::isNotBlank)
-				// Chains on _has can't be indexed for contained searches yet
+				// Chains on _has can't be indexed for contained searches - At least not yet. It's not clear to me if we ever want to support this, it would be really hard to do.
 				.anyMatch(t->!t.startsWith(PARAM_HAS + ":"));
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -128,6 +128,7 @@ import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toAndPredicate;
 import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toEqualToOrInPredicate;
 import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toOperation;
 import static ca.uhn.fhir.jpa.util.QueryParameterUtils.toOrPredicate;
+import static ca.uhn.fhir.rest.api.Constants.PARAM_HAS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.split;
 
@@ -256,7 +257,7 @@ public class QueryStack {
 
 		TokenPredicateBuilder tokenPredicateBuilder = mySqlBuilder.createTokenPredicateBuilder();
 		Condition hashIdentityPredicate = tokenPredicateBuilder.createHashIdentityPredicate(theResourceName, theParamName);
-		
+
 		addSortCustomJoin(firstPredicateBuilder, tokenPredicateBuilder, hashIdentityPredicate);
 
 		mySqlBuilder.addSortString(tokenPredicateBuilder.getColumnSystem(), theAscending);
@@ -727,8 +728,14 @@ public class QueryStack {
 				String qualifier = paramName.substring(4);
 				for (IQueryParameterType next : nextOrList) {
 					HasParam nextHasParam = new HasParam();
-					nextHasParam.setValueAsQueryToken(myFhirContext, Constants.PARAM_HAS, qualifier, next.getValueAsQueryToken(myFhirContext));
+					nextHasParam.setValueAsQueryToken(myFhirContext, PARAM_HAS, qualifier, next.getValueAsQueryToken(myFhirContext));
 					orValues.add(nextHasParam);
+				}
+
+			} else if (paramName.equals("_id")) {
+
+				for (IQueryParameterType next : nextOrList) {
+					orValues.add(new TokenParam(next.getValueAsQueryToken(myFhirContext)));
 				}
 
 			} else {
@@ -959,7 +966,7 @@ public class QueryStack {
 		}
 
 		public String getPath() { return myPath; }
-		
+
 		public String getSearchParameterName() { return mySearchParameterName; }
 
 		@Override
@@ -1006,7 +1013,6 @@ public class QueryStack {
 					String targetValue = nextOr.getValueAsQueryToken(myFhirContext);
 					if (nextOr instanceof ReferenceParam) {
 						ReferenceParam referenceParam = (ReferenceParam) nextOr;
-
 						if (!isReferenceParamValid(referenceParam)) {
 							throw new InvalidRequestException(Msg.code(2007) +
 								"The search chain " + theSearchParam.getName() + "." + referenceParam.getChain() +
@@ -1538,11 +1544,11 @@ public class QueryStack {
 													  String theSpnamePrefix, RuntimeSearchParam theSearchParam, List<? extends IQueryParameterType> theList,
 													  SearchFilterParser.CompareOperation theOperation, RequestPartitionId theRequestPartitionId, SearchQueryBuilder theSqlBuilder) {
 
-		List<IQueryParameterType> tokens = new ArrayList<>(); 
-		
+		List<IQueryParameterType> tokens = new ArrayList<>();
+
 		boolean paramInverted = false;
 		TokenParamModifier modifier;
-		
+
 		for (IQueryParameterType nextOr : theList) {
 			if (nextOr instanceof TokenParam) {
 				if (!((TokenParam) nextOr).isEmpty()) {
@@ -1561,8 +1567,8 @@ public class QueryStack {
 							throw new MethodNotAllowedException(Msg.code(1219) + msg);
 						}
 						return createPredicateString(theSourceJoinColumn, theResourceName, theSpnamePrefix, theSearchParam, theList, null, theRequestPartitionId, theSqlBuilder);
-					} 
-					
+					}
+
 					modifier = id.getModifier();
 					// for :not modifier, create a token and remove the :not modifier
 					if (modifier == TokenParamModifier.NOT) {
@@ -1584,23 +1590,23 @@ public class QueryStack {
 		String paramName = getParamNameWithPrefix(theSpnamePrefix, theSearchParam.getName());
 		Condition predicate;
 		BaseJoiningPredicateBuilder join;
-		
+
 		if (paramInverted) {
 			SearchQueryBuilder sqlBuilder = theSqlBuilder.newChildSqlBuilder();
 			TokenPredicateBuilder tokenSelector = sqlBuilder.addTokenPredicateBuilder(null);
 			sqlBuilder.addPredicate(tokenSelector.createPredicateToken(tokens, theResourceName, theSpnamePrefix, theSearchParam, theRequestPartitionId));
 			SelectQuery sql = sqlBuilder.getSelect();
 			Expression subSelect = new Subquery(sql);
-			
+
 			join = theSqlBuilder.getOrCreateFirstPredicateBuilder();
-			
+
 			if (theSourceJoinColumn == null) {
 				predicate = new InCondition(join.getResourceIdColumn(), subSelect).setNegate(true);
 			} else {
 				//-- for the resource link, need join with target_resource_id
 			    predicate = new InCondition(theSourceJoinColumn, subSelect).setNegate(true);
 			}
-						
+
 		} else {
 			Boolean isMissing = theList.get(0).getMissing();
 			if (isMissing != null) {
@@ -1620,9 +1626,9 @@ public class QueryStack {
 			TokenPredicateBuilder tokenJoin = createOrReusePredicateBuilder(PredicateBuilderTypeEnum.TOKEN, theSourceJoinColumn, paramName, () -> theSqlBuilder.addTokenPredicateBuilder(theSourceJoinColumn)).getResult();
 
 			predicate = tokenJoin.createPredicateToken(tokens, theResourceName, theSpnamePrefix, theSearchParam, theOperation, theRequestPartitionId);
-			join = tokenJoin; 
-		} 
-		
+			join = tokenJoin;
+		}
+
 		return join.combineWithRequestPartitionIdPredicate(theRequestPartitionId, predicate);
 	}
 
@@ -1676,7 +1682,7 @@ public class QueryStack {
 			case IAnyResource.SP_RES_ID:
 				return createPredicateResourceId(theSourceJoinColumn, theAndOrParams, theResourceName, null, theRequestPartitionId);
 
-			case Constants.PARAM_HAS:
+			case PARAM_HAS:
 				return createPredicateHas(theSourceJoinColumn, theResourceName, theAndOrParams, theRequest, theRequestPartitionId);
 
 			case Constants.PARAM_TAG:
@@ -1820,7 +1826,9 @@ public class QueryStack {
 			nextAnd.stream()
 				.filter(t -> t instanceof ReferenceParam)
 				.map(t -> ((ReferenceParam) t).getChain())
-				.anyMatch(StringUtils::isNotBlank);
+				.filter(StringUtils::isNotBlank)
+				// Chains on _has can't be indexed for contained searches yet
+				.anyMatch(t->!t.startsWith(PARAM_HAS + ":"));
 	}
 
 	public void addPredicateCompositeUnique(String theIndexString, RequestPartitionId theRequestPartitionId) {

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/RestServerR4Helper.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/RestServerR4Helper.java
@@ -33,6 +33,7 @@ import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.provider.HashMapResourceProvider;
 import org.eclipse.jetty.server.Request;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
@@ -89,9 +90,11 @@ public class RestServerR4Helper extends BaseRestServerHelper implements BeforeEa
 	}
 
 	public List<Bundle> getTransactions() {
-		return myRestServer
+		// Make a copy to avoid syncronization issues
+		List<IBaseBundle> transactions = new ArrayList<>(myRestServer
 			.getPlainProvider()
-			.getTransactions()
+			.getTransactions());
+		return transactions
 			.stream()
 			.map(t -> (Bundle) t)
 			.collect(Collectors.toList());

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/RestServerR4Helper.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/RestServerR4Helper.java
@@ -90,10 +90,11 @@ public class RestServerR4Helper extends BaseRestServerHelper implements BeforeEa
 	}
 
 	public List<Bundle> getTransactions() {
-		// Make a copy to avoid syncronization issues
-		List<IBaseBundle> transactions = new ArrayList<>(myRestServer
-			.getPlainProvider()
-			.getTransactions());
+		List<IBaseBundle> transactions = myRestServer.getPlainProvider().getTransactions();
+
+		// Make a copy to avoid synchronization issues
+		transactions = new ArrayList<>(transactions);
+
 		return transactions
 			.stream()
 			.map(t -> (Bundle) t)


### PR DESCRIPTION
Two issues with reverse chaining (i.e. the `_has` search parameter) have been addressed:
* Searching for a reverse chain with a target search parameter of `_id` did not work correctly, e.g. `Patient?_has:Observation:subject:_id=Patient/123`
* Searching with a combination of a forward chain and a reverse chain did not work correctly if indexing contained resources was enabled, e.g. `Observation?subject._has:Group:member:_id=Group/123`