### PR TITLE
4142 resource contents are written to logs on subscription failure

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4142-resource-contents-written-to-logs-on-subscription-failure.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4142-resource-contents-written-to-logs-on-subscription-failure.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4142
+jira: SMILE-5312
+title: "Upon hitting a subscription delivery failure, we currently log the failing payload which could be considered PHI. Resource content is no longer written to logs on subscription failure."

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
@@ -94,7 +94,7 @@ public abstract class BaseSubscriptionDeliverySubscriber implements MessageHandl
 				return;
 			}
 
-			throw new MessagingException(theMessage, Msg.code(2) + errorMsg, e);
+			throw new MessagingException(Msg.code(2) + errorMsg, e);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
@@ -322,8 +322,10 @@ public class BaseSubscriptionDeliverySubscriberTest {
 	public void testRestHookDeliveryFails_raisedExceptionShouldNotIncludeSubmittedResource() {
 		when(myInterceptorBroadcaster.callHooks(any(), any())).thenReturn(true);
 
+		String familyName = "FAMILY";
+
 		Patient patient = generatePatient();
-		patient.setBirthDate(new Date());
+		patient.addName().setFamily(familyName);
 		CanonicalSubscription subscription = generateSubscription();
 
 		ResourceDeliveryMessage payload = new ResourceDeliveryMessage();
@@ -337,9 +339,8 @@ public class BaseSubscriptionDeliverySubscriberTest {
 			mySubscriber.handleMessage(new ResourceDeliveryJsonMessage(payload));
 			fail();
 		} catch (MessagingException e) {
-			String patientAsString = myCtx.newJsonParser().encodeResourceToString(patient);
 			String messageExceptionAsString = e.toString();
-			assertFalse(messageExceptionAsString.contains(patientAsString));
+			assertFalse(messageExceptionAsString.contains(familyName));
 		}
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,6 +49,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -314,6 +316,31 @@ public class BaseSubscriptionDeliverySubscriberTest {
 
 		assertNotNull(jsonMessage.getPayload().getRequestPartitionId());
 		assertEquals(jsonMessage.getPayload().getRequestPartitionId().toJson(), RequestPartitionId.defaultPartition().toJson());
+	}
+
+	@Test
+	public void testRestHookDeliveryFails_raisedExceptionShouldNotIncludeSubmittedResource() {
+		when(myInterceptorBroadcaster.callHooks(any(), any())).thenReturn(true);
+
+		Patient patient = generatePatient();
+		patient.setBirthDate(new Date());
+		CanonicalSubscription subscription = generateSubscription();
+
+		ResourceDeliveryMessage payload = new ResourceDeliveryMessage();
+		payload.setSubscription(subscription);
+		payload.setPayload(myCtx, patient, EncodingEnum.JSON);
+		payload.setOperationType(ResourceModifiedMessage.OperationTypeEnum.CREATE);
+
+		when(myGenericClient.update()).thenThrow(new InternalErrorException("FOO"));
+
+		try {
+			mySubscriber.handleMessage(new ResourceDeliveryJsonMessage(payload));
+			fail();
+		} catch (MessagingException e) {
+			String patientAsString = myCtx.newJsonParser().encodeResourceToString(patient);
+			String messageExceptionAsString = e.toString();
+			assertFalse(messageExceptionAsString.contains(patientAsString));
+		}
 	}
 
 	@Nonnull


### PR DESCRIPTION
What was done:
1- No longer including the subscription message when creating an exception handling subscription processing failures;
2- Adding relevant test;
3- Adding changelog.
