### PR TITLE
ResourceIndexedSearchParamString:  equals() and hashCode():  Add normalized String and use same fields for both calls.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/3113-search-param-phonetic-update-on-reindex-same-letter-normalized-string-no-db-update.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/3113-search-param-phonetic-update-on-reindex-same-letter-normalized-string-no-db-update.yaml
@@ -1,5 +1,0 @@
----
-type: fix
-issue: 3276
-jira: SMILE-4256
-title: "When updating a phonetic search parameter, any existing patient will not have its search parameter String updated upon reindex if the normalized String is the same letter as under the old algorithm (ex JN to JAN).  Searching on the new normalized String will fail to return results.  This MR fixes the issue by ensuring the search parameter gets updated in the DB during reindex."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/3113-search-param-phonetic-update-on-reindex-same-letter-normalized-string-no-db-update.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/3113-search-param-phonetic-update-on-reindex-same-letter-normalized-string-no-db-update.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 3276
+jira: SMILE-4256
+title: "When updating a phonetic search parameter, any existing patient will not have its search parameter String updated upon reindex if the normalized String is the same letter as under the old algorithm (ex JN to JAN).  Searching on the new normalized String will fail to return results.  This MR fixes the issue by ensuring the search parameter gets updated in the DB during reindex."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4147-search-param-phonetic-update-on-reindex-same-letter-normalized-string-no-db-update.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4147-search-param-phonetic-update-on-reindex-same-letter-normalized-string-no-db-update.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4147
+jira: SMILE-4256
+title: "Previously when updating a phonetic search parameter, any existing resource will not have its search parameter String updated upon reindex if the normalized String is the same letter as under the old algorithm (ex JN to JAN).  Searching on the new normalized String was failing to return results. This has been corrected."

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -171,6 +171,9 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getHashIdentity(), obj.getHashIdentity());
 		b.append(getHashExact(), obj.getHashExact());
 		b.append(getHashNormalizedPrefix(), obj.getHashNormalizedPrefix());
+		// TODO:  is this performant?
+		b.append(getValueNormalized(), obj.getValueNormalized());
+
 		return b.isEquals();
 	}
 
@@ -243,6 +246,8 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getHashIdentity());
 		b.append(getHashExact());
 		b.append(getHashNormalizedPrefix());
+		// TODO:  is this performant?
+		b.append(getValueNormalized());
 		// TODO:  3113:  END FIX
 		final int hashCode = b.toHashCode();
 		return b.toHashCode();

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -171,7 +171,6 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getHashIdentity(), obj.getHashIdentity());
 		b.append(getHashExact(), obj.getHashExact());
 		b.append(getHashNormalizedPrefix(), obj.getHashNormalizedPrefix());
-		// TODO:  is this performant?
 		b.append(getValueNormalized(), obj.getValueNormalized());
 
 		return b.isEquals();
@@ -242,13 +241,10 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getResourceType());
 		b.append(getParamName());
 		b.append(getValueExact());
-		// TODO:  3113:  START FIX
 		b.append(getHashIdentity());
 		b.append(getHashExact());
 		b.append(getHashNormalizedPrefix());
-		// TODO:  is this performant?
 		b.append(getValueNormalized());
-		// TODO:  3113:  END FIX
 		final int hashCode = b.toHashCode();
 		return b.toHashCode();
 	}

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -239,6 +239,12 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getResourceType());
 		b.append(getParamName());
 		b.append(getValueExact());
+		// TODO:  3113:  START FIX
+		b.append(getHashIdentity());
+		b.append(getHashExact());
+		b.append(getHashNormalizedPrefix());
+		// TODO:  3113:  END FIX
+		final int hashCode = b.toHashCode();
 		return b.toHashCode();
 	}
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -172,7 +172,6 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getHashExact(), obj.getHashExact());
 		b.append(getHashNormalizedPrefix(), obj.getHashNormalizedPrefix());
 		b.append(getValueNormalized(), obj.getValueNormalized());
-
 		return b.isEquals();
 	}
 
@@ -245,7 +244,6 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 		b.append(getHashExact());
 		b.append(getHashNormalizedPrefix());
 		b.append(getValueNormalized());
-		final int hashCode = b.toHashCode();
 		return b.toHashCode();
 	}
 

--- a/hapi-fhir-jpaserver-model/src/test/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamStringTest.java
+++ b/hapi-fhir-jpaserver-model/src/test/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamStringTest.java
@@ -45,7 +45,8 @@ public class ResourceIndexedSearchParamStringTest {
 		token2.calculateHashes();
 
 		assertAll(
-			() -> assertNotEquals(token1.getHashNormalizedPrefix(), token2.getHashNormalizedPrefix()),
+			// We only hash on the first letter for performance reasons
+			() -> assertEquals(token1.getHashNormalizedPrefix(), token2.getHashNormalizedPrefix()),
 			() -> assertEquals(token1.getHashExact(), token2.getHashExact()),
 			() -> assertNotEquals(token1.hashCode(), token2.hashCode())
 		);

--- a/hapi-fhir-jpaserver-model/src/test/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamStringTest.java
+++ b/hapi-fhir-jpaserver-model/src/test/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamStringTest.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.model.entity;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -33,6 +34,39 @@ public class ResourceIndexedSearchParamStringTest {
 		assertEquals(7045214018927566109L, token.getHashExact().longValue());
 	}
 
+	@Test
+	public void testHashFunctionsPrefixOnly_John_JN_vs_JAN() {
+		final ResourceIndexedSearchParamString token1 = new ResourceIndexedSearchParamString(new PartitionSettings(), new ModelConfig(), "Patient", "query-1-param", "JN", "John");
+		token1.setResource(new ResourceTable().setResourceType("Patient"));
+		token1.calculateHashes();
+
+		final ResourceIndexedSearchParamString token2 = new ResourceIndexedSearchParamString(new PartitionSettings(), new ModelConfig(), "Patient", "query-1-param", "JAN", "John");
+		token2.setResource(new ResourceTable().setResourceType("Patient"));
+		token2.calculateHashes();
+
+		assertAll(
+			() -> assertNotEquals(token1.getHashNormalizedPrefix(), token2.getHashNormalizedPrefix()),
+			() -> assertEquals(token1.getHashExact(), token2.getHashExact()),
+			() -> assertNotEquals(token1.hashCode(), token2.hashCode())
+		);
+	}
+
+	@Test
+	public void testHashFunctionsPrefixOnly_Doe_T_vs_D() {
+		final ResourceIndexedSearchParamString token1 = new ResourceIndexedSearchParamString(new PartitionSettings(), new ModelConfig(), "Patient", "query-1-param", "T", "Doe");
+		token1.setResource(new ResourceTable().setResourceType("Patient"));
+		token1.calculateHashes();
+
+		final ResourceIndexedSearchParamString token2 = new ResourceIndexedSearchParamString(new PartitionSettings(), new ModelConfig(), "Patient", "query-1-param", "D", "Doe");
+		token2.setResource(new ResourceTable().setResourceType("Patient"));
+		token2.calculateHashes();
+
+		assertAll(
+			() -> assertNotEquals(token1.getHashNormalizedPrefix(), token2.getHashNormalizedPrefix()),
+			() -> assertEquals(token1.getHashExact(), token2.getHashExact()),
+			() -> assertNotEquals(token1.hashCode(), token2.hashCode())
+		);
+	}
 
 	@Test
 	public void testEquals() {


### PR DESCRIPTION
Closes [4147](https://github.com/hapifhir/hapi-fhir/issues/4147)