### PR TITLE
DatabaseBlobBinaryStorage service will only store blob up to Integer.MAX_VALUE

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4166-database-blob-binary-service-may-store-blob-size-as-being-much-less-than-actual-blob-size.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4166-database-blob-binary-service-may-store-blob-size-as-being-much-less-than-actual-blob-size.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4166
+title: "When storing a blob, the database blob binary storage service may store the blob size as being much smaller than the actual blob size.  This issue has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/binstore/DatabaseBlobBinaryStorageSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/binstore/DatabaseBlobBinaryStorageSvcImpl.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.jpa.dao.data.IBinaryStorageEntityDao;
 import ca.uhn.fhir.jpa.model.entity.BinaryStorageEntity;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import com.google.common.hash.HashingInputStream;
+import com.google.common.io.ByteStreams;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CountingInputStream;
 import org.hibernate.LobHelper;
@@ -94,7 +95,7 @@ public class DatabaseBlobBinaryStorageSvcImpl extends BaseBinaryStorageSvcImpl {
 		// Update the entity with the final byte count and hash
 		long bytes = countingInputStream.getByteCount();
 		String hash = hashingInputStream.hash().toString();
-		entity.setSize((int) bytes);
+		entity.setSize(bytes);
 		entity.setHash(hash);
 
 		// Save the entity
@@ -161,9 +162,8 @@ public class DatabaseBlobBinaryStorageSvcImpl extends BaseBinaryStorageSvcImpl {
 	}
 
 	byte[] copyBlobToByteArray(BinaryStorageEntity theEntity) throws IOException {
-		int size = theEntity.getSize();
 		try {
-			return IOUtils.toByteArray(theEntity.getBlob().getBinaryStream(), size);
+			return ByteStreams.toByteArray(theEntity.getBlob().getBinaryStream());
 		} catch (SQLException e) {
 			throw new IOException(Msg.code(1342) + e);
 		}

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/BinaryStorageEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/BinaryStorageEntity.java
@@ -41,7 +41,7 @@ public class BinaryStorageEntity {
 	@Column(name = "RESOURCE_ID", length = 100, nullable = false)
 	private String myResourceId;
 	@Column(name = "BLOB_SIZE", nullable = true)
-	private int mySize;
+	private long mySize;
 	@Column(name = "CONTENT_TYPE", nullable = false, length = 100)
 	private String myBlobContentType;
 	@Lob
@@ -73,7 +73,7 @@ public class BinaryStorageEntity {
 		myResourceId = theResourceId;
 	}
 
-	public int getSize() {
+	public long getSize() {
 		return mySize;
 	}
 
@@ -97,7 +97,7 @@ public class BinaryStorageEntity {
 		return myBlobId;
 	}
 
-	public void setSize(int theSize) {
+	public void setSize(long theSize) {
 		mySize = theSize;
 	}
 


### PR DESCRIPTION
what was done:
- Changed BinaryStorageEntity.mySize from int to long to support blob of size up to long.max_value;
- Swap IOUtils to ByteStream utility as IOUtils.toByteArray would only support inputStream up to size Integer.max_value;
- Added changeLog.