### PR TITLE
#4078 Fix BinaryAccessProvider empty stream check

### DIFF
--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/binstore/BinaryAccessProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/binstore/BinaryAccessProviderTest.java
@@ -26,12 +26,11 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -247,43 +247,17 @@ public class BinaryAccessProviderTest {
 
 		DaoMethodOutcome daoOutcome = new DaoMethodOutcome();
 		daoOutcome.setResource(docRef);
-		ServletInputStream sis = new ServletInputStream() {
-			@Override
-			public boolean isFinished() {
-				return false;
-			}
-
-			@Override
-			public boolean isReady() {
-				return false;
-			}
-
-			@Override
-			public void setReadListener(ReadListener readListener) {
-
-			}
-
-			@Override
-			public int read() throws IOException {
-				return 0;
-			}
-
-			@Override
-			public int available() throws IOException {
-				return 15;
-			}
-		};
 		StoredDetails sd = spy(StoredDetails.class);
 		sd.setBlobId("123");
+		sd.setBytes(15);
 		when(myDaoRegistry.getResourceDao(eq("DocumentReference"))).thenReturn(myResourceDao);
 		when(myResourceDao.read(any(), any(), anyBoolean())).thenReturn(docRef);
 		when(myResourceDao.update(docRef, myRequestDetails)).thenReturn(daoOutcome);
 		when(theServletRequest.getContentType()).thenReturn("Integer");
 		when(theServletRequest.getContentLength()).thenReturn(15);
 		when(myBinaryStorageSvc.shouldStoreBlob(15, docRef.getIdElement(), "Integer")).thenReturn(true);
-		when(theServletRequest.getInputStream()).thenReturn(sis);
 		myRequestDetails.setServletRequest(theServletRequest);
-		when(myBinaryStorageSvc.storeBlob(docRef.getIdElement(), null, "Integer", myRequestDetails.getInputStream())).thenReturn(sd);
+		when(myBinaryStorageSvc.storeBlob(eq(docRef.getIdElement()), isNull(), eq("Integer"), any(InputStream.class))).thenReturn(sd);
 		myRequestDetails.setRequestContents(SOME_BYTES);
 
 		try {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/provider/BinaryAccessProvider.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/provider/BinaryAccessProvider.java
@@ -19,6 +19,7 @@ package ca.uhn.fhir.jpa.binary.provider;
  * limitations under the License.
  * #L%
  */
+
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
@@ -42,6 +43,7 @@ import ca.uhn.fhir.util.BinaryUtil;
 import ca.uhn.fhir.util.DateUtils;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -59,8 +61,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.util.Optional;
 
 import static ca.uhn.fhir.util.UrlUtil.sanitizeUrlPart;
@@ -102,7 +106,7 @@ public class BinaryAccessProvider {
 		Optional<String> attachmentId = target.getAttachmentId();
 
 		//for unit test only
-		if (addTargetAttachmentIdForTest){
+		if (addTargetAttachmentIdForTest) {
 			attachmentId = Optional.of("1");
 		}
 
@@ -186,24 +190,22 @@ public class BinaryAccessProvider {
 		ourLog.trace("Request specified content length: {}", size);
 
 		String blobId = null;
+		byte[] bytes = theRequestDetails.loadRequestContents();
 
-		if (size > 0) {
-			if (myBinaryStorageSvc != null) {
-				InputStream inputStream = theRequestDetails.getInputStream();
-				if (inputStream.available() == 0 ) {
-					throw new IllegalStateException(Msg.code(2073) + "Input stream is empty! Ensure that you are uploading data, and if so, ensure that no interceptors are in use that may be consuming the input stream");
-				}
-				if (myBinaryStorageSvc.shouldStoreBlob(size, theResourceId, requestContentType)) {
-					StoredDetails storedDetails = myBinaryStorageSvc.storeBlob(theResourceId, null, requestContentType, inputStream);
-					size = storedDetails.getBytes();
-					blobId = storedDetails.getBlobId();
-					Validate.notBlank(blobId, "BinaryStorageSvc returned a null blob ID"); // should not happen
-				}
+		if (size > 0 && myBinaryStorageSvc != null) {
+			if (bytes == null || bytes.length == 0) {
+				throw new IllegalStateException(Msg.code(2073) + "Input stream is empty! Ensure that you are uploading data, and if so, ensure that no interceptors are in use that may be consuming the input stream");
+			}
+			if (myBinaryStorageSvc.shouldStoreBlob(size, theResourceId, requestContentType)) {
+				StoredDetails storedDetails = myBinaryStorageSvc.storeBlob(theResourceId, null, requestContentType, new ByteArrayInputStream(bytes));
+				size = storedDetails.getBytes();
+				blobId = storedDetails.getBlobId();
+				Validate.notBlank(blobId, "BinaryStorageSvc returned a null blob ID"); // should not happen
+				Validate.isTrue(size == theServletRequest.getContentLength(), "Unexpected stored size"); // Sanity check
 			}
 		}
 
 		if (blobId == null) {
-			byte[] bytes = theRequestDetails.loadRequestContents();
 			size = bytes.length;
 			target.setData(bytes);
 		} else {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/provider/BinaryAccessProvider.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/provider/BinaryAccessProvider.java
@@ -43,7 +43,6 @@ import ca.uhn.fhir.util.BinaryUtil;
 import ca.uhn.fhir.util.DateUtils;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -63,8 +62,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.PushbackInputStream;
 import java.util.Optional;
 
 import static ca.uhn.fhir.util.UrlUtil.sanitizeUrlPart;


### PR DESCRIPTION
Fix #4078 by using a PushbackInputStream to check if the input stream is empty or not.