### PR TITLE
4197 - Fixed header on the server_jpa/elastic docs page

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/elastic.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/elastic.md
@@ -1,4 +1,4 @@
-**# HAPI FHIR JPA Lucene/Elasticsearch Indexing
+# HAPI FHIR JPA Lucene/Elasticsearch Indexing
 
 The HAPI JPA Server supports optional indexing via Hibernate Search when configured to use Lucene or Elasticsearch.
 This is required to support the `_content`, or `_text` search parameters.


### PR DESCRIPTION
Closes #4197 
