### PR TITLE
4207-getpagesoffset-set-to-total-number-of-resources-results-in-inconsistent-amount-of-entries-when-requests-are-sent-consecutively

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4207-getpagesoffset-set-to-total-number-of-resources-results-in-inconsistent-amount-of-entries-when-requests-are-sent-consecutively.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4207-getpagesoffset-set-to-total-number-of-resources-results-in-inconsistent-amount-of-entries-when-requests-are-sent-consecutively.yaml
@@ -1,6 +1,6 @@
 ---
 type: fix
 issue: 4207
-title: "Previously to improve performance, if the total number of resources was less than the _getpagesoffset given, it would default to 
-         the offset for the last resource available. This would result in one entry being displayed in some requests, especially when they are sent consecutively,
-          even when there should be none. This has been fixed."
+title:  "Previously to improve performance, if the total number of resources was less than the _getpageoffset, 
+      the results would default to last resource offset. This is especially evident when requests are consecutive 
+      resulting in one entry being displayed in some requests. This issue is now fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4207-getpagesoffset-set-to-total-number-of-resources-results-in-inconsistent-amount-of-entries-when-requests-are-sent-consecutively.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4207-getpagesoffset-set-to-total-number-of-resources-results-in-inconsistent-amount-of-entries-when-requests-are-sent-consecutively.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4207
+title: "Previously to improve performance, if the total number of resources was less than the _getpagesoffset given, it would default to 
+         the offset for the last resource available. This would result in one entry being displayed in some requests, especially when they are sent consecutively,
+          even when there should be none. This has been fixed."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
@@ -375,11 +375,9 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 					}
 
 					Integer resultSize = result.size();
-					int start;
+					int start = offsetI;
 					if (resultSize != null) {
-						start = Math.max(0, Math.min(offsetI, resultSize - 1));
-					} else {
-						start = offsetI;
+						start = Math.max(0, Math.min(offsetI, resultSize));
 					}
 
 					ResponseEncoding responseEncoding = RestfulServerUtils.determineResponseEncodingNoDefault(theRequest, theServer.getDefaultResponseEncoding());

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
@@ -369,15 +369,15 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 						count = result.preferredPageSize();
 					}
 
-					Integer offsetI = RestfulServerUtils.tryToExtractNamedParameter(theRequest, Constants.PARAM_PAGINGOFFSET);
-					if (offsetI == null || offsetI < 0) {
-						offsetI = 0;
+					Integer offset = RestfulServerUtils.tryToExtractNamedParameter(theRequest, Constants.PARAM_PAGINGOFFSET);
+					if (offset == null || offset < 0) {
+						offset = 0;
 					}
 
 					Integer resultSize = result.size();
-					int start = offsetI;
+					int start = offset;
 					if (resultSize != null) {
-						start = Math.max(0, Math.min(offsetI, resultSize));
+						start = Math.max(0, Math.min(offset, resultSize));
 					}
 
 					ResponseEncoding responseEncoding = RestfulServerUtils.determineResponseEncodingNoDefault(theRequest, theServer.getDefaultResponseEncoding());

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/PagingTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/PagingTest.java
@@ -7,7 +7,6 @@ import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.client.impl.GenericClient;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/PagingTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/PagingTest.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.client.impl.GenericClient;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
@@ -146,6 +147,37 @@ public class PagingTest {
 		}
 	}
 
+	@Test()
+	public void testSendingSameRequestConsecutivelyResultsInSameResponse() throws Exception {
+		initBundleProvider(10);
+		myServerExtension.getRestfulServer().registerProvider(new DummyPatientResourceProvider());
+		myServerExtension.getRestfulServer().setPagingProvider(pagingProvider);
+
+		when(pagingProvider.canStoreSearchResults()).thenReturn(true);
+		when(pagingProvider.getDefaultPageSize()).thenReturn(10);
+		when(pagingProvider.getMaximumPageSize()).thenReturn(50);
+		when(pagingProvider.storeResultList(any(RequestDetails.class), any(IBundleProvider.class))).thenReturn("ABCD");
+		when(pagingProvider.retrieveResultList(any(RequestDetails.class), anyString())).thenReturn(ourBundleProvider);
+
+		String nextLink;
+		String base = "http://localhost:" + myServerExtension.getPort();
+		HttpGet get = new HttpGet(base + "/Patient?_getpagesoffset=10");
+		String responseContent;
+		try (CloseableHttpResponse resp = ourClient.execute(get)) {
+			assertEquals(200, resp.getStatusLine().getStatusCode());
+			responseContent = IOUtils.toString(resp.getEntity().getContent(), Charsets.UTF_8);
+
+			Bundle bundle = ourContext.newJsonParser().parseResource(Bundle.class, responseContent);
+			assertEquals(0, bundle.getEntry().size());
+		}
+		try (CloseableHttpResponse resp = ourClient.execute(get)) {
+			assertEquals(200, resp.getStatusLine().getStatusCode());
+			responseContent = IOUtils.toString(resp.getEntity().getContent(), Charsets.UTF_8);
+
+			Bundle bundle = ourContext.newJsonParser().parseResource(Bundle.class, responseContent);
+			assertEquals(0, bundle.getEntry().size());
+		}
+	}
 	private void checkParam(String theUri, String theCheckedParam, String theExpectedValue) {
 		Optional<String> paramValue = URLEncodedUtils.parse(theUri, CHARSET_UTF8).stream()
 			.filter(nameValuePair -> nameValuePair.getName().equals(theCheckedParam))


### PR DESCRIPTION
Fixed the way the offset is calculated when offset is more than or equal to the total number of resources available

Closes #4207 