### PR TITLE
Fix UrlUtil.unescape() by not escaping "+" to " " if this is an "application/..." _outputFormat.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -489,11 +489,11 @@ public class UrlUtil {
 			return null;
 		}
 		// If the user passes "_outputFormat" as a GET request parameter directly in the URL:
-		final boolean hasOutputFormat = theString.startsWith("application/");
+		final boolean shouldEscapePlus = !theString.startsWith("application/");
 
 		for (int i = 0; i < theString.length(); i++) {
 			char nextChar = theString.charAt(i);
-			if (nextChar == '%' || (nextChar == '+') && !hasOutputFormat) {
+			if (nextChar == '%' || (nextChar == '+' && shouldEscapePlus)) {
 				try {
 					// Yes it would be nice to not use a string "UTF-8" but the equivalent
 					// method that takes Charset is JDK10+ only... sigh....

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -488,9 +488,12 @@ public class UrlUtil {
 		if (theString == null) {
 			return null;
 		}
+		// If the user passes "_outputFormat" as a GET request parameter directly in the URL:
+		final boolean hasOutputFormat = theString.startsWith("application/");
+
 		for (int i = 0; i < theString.length(); i++) {
 			char nextChar = theString.charAt(i);
-			if (nextChar == '%' || nextChar == '+') {
+			if (nextChar == '%' || (nextChar == '+') && !hasOutputFormat) {
 				try {
 					// Yes it would be nice to not use a string "UTF-8" but the equivalent
 					// method that takes Charset is JDK10+ only... sigh....

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
@@ -1,10 +1,12 @@
 package ca.uhn.fhir.util;
 
+import ca.uhn.fhir.rest.api.Constants;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +45,20 @@ public class UrlUtilTest {
 	public void testEscape() {
 		assertEquals("A%20B", UrlUtil.escapeUrlParam("A B"));
 		assertEquals("A%2BB", UrlUtil.escapeUrlParam("A+B"));
+	}
+
+	@Test
+	public void testUnescape() {
+		assertAll(
+			() -> assertEquals(Constants.CT_JSON, UrlUtil.unescape(Constants.CT_JSON)),
+			() -> assertEquals(Constants.CT_NDJSON, UrlUtil.unescape(Constants.CT_NDJSON)),
+			() -> assertEquals(Constants.CT_XML, UrlUtil.unescape(Constants.CT_XML)),
+			() -> assertEquals(Constants.CT_XML_PATCH, UrlUtil.unescape(Constants.CT_XML_PATCH)),
+			() -> assertEquals(Constants.CT_APPLICATION_GZIP, UrlUtil.unescape(Constants.CT_APPLICATION_GZIP)),
+			() -> assertEquals(Constants.CT_RDF_TURTLE, UrlUtil.unescape(Constants.CT_RDF_TURTLE)),
+			() -> assertEquals(Constants.CT_FHIR_JSON, UrlUtil.unescape(Constants.CT_FHIR_JSON)),
+			() -> assertEquals(Constants.CT_FHIR_NDJSON, UrlUtil.unescape(Constants.CT_FHIR_NDJSON))
+		);
 	}
 
 	@Test

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4218-bulk-export-get-output-format-param-string-escape-issue.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4218-bulk-export-get-output-format-param-string-escape-issue.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4218
+title: "Performing a bulk export with an _outputParam value encoded in a GET request URL that contains a '+' (ex: 'application/fhir+ndjson') will result in a 400 because the '+' is replaced with a ' '.  After this fix the '+' will remain in the parameter value."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
@@ -863,6 +863,46 @@ public class BulkDataExportProviderTest {
 		}
 	}
 
+	@Test
+	public void testGetBulkExport_outputFormat_FhirNdJson() throws IOException {
+//		http://localhost:8000/$export?_outputFormat=application/fhir+ndjson&_type=Patient&_typeFilter=Patient?gender=female&_since=2022-10-30T11:14:00Z
+
+		// setup
+		final Batch2JobInfo info = new Batch2JobInfo();
+		info.setJobId(A_JOB_ID);
+		info.setStatus(BulkExportJobStatusEnum.COMPLETE);
+		info.setEndTime(InstantType.now().getValue());
+
+		// when
+		when(myJobRunner.startNewJob(any()))
+			.thenReturn(createJobStartResponse());
+//		when(myJobRunner.getJobInfo(eq(A_JOB_ID)))
+//			.thenReturn(info);
+
+		// call
+//		final String url = String.format("http://localhost:%s/%s?_outputFormat=application/fhir+ndjson&_type=Patient&_typeFilter=Patient?gender=female&_since=2022-10-30T11:14:00Z");
+
+
+		// TODO:  the bug only happens if you encode it in the URL
+		final HttpGet httpGet = new HttpGet("http://localhost:" + myPort + "/" + JpaConstants.OPERATION_EXPORT + "?_outputFormat=application/fhir+ndjson&_type=Patient&_typeFilter=Patient?gender=female&_since=2022-10-30T11:14:00Z");
+//		final HttpGet httpGet = new HttpGet("http://localhost:" + myPort + "/" + JpaConstants.OPERATION_EXPORT);
+//		httpGet.addHeader("_outputFormat", "application/fhir+ndjson");
+//		httpGet.addHeader("_type", "Patient");
+//		httpGet.addHeader("_typeFilter", "Patient?gender=female");
+//		httpGet.addHeader("since", "2022-10-30T11:14:00Z");
+		httpGet.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RESPOND_ASYNC);
+
+		try (CloseableHttpResponse response = myClient.execute(httpGet)) {
+			ourLog.info("Response: {}", response.toString());
+			// TODO:  assert equals
+		}
+
+		final BulkExportParameters params = verifyJobStart();
+
+		final String outputFormat = params.getOutputFormat();
+		assertEquals(Constants.CT_FHIR_NDJSON, params.getOutputFormat());
+	}
+
 	private void callExportAndAssertJobId(Parameters input, String theExpectedJobId) throws IOException {
 		HttpPost post;
 		post = new HttpPost("http://localhost:" + myPort + "/" + JpaConstants.OPERATION_EXPORT);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
@@ -101,7 +101,6 @@ public abstract class BaseMethodBinding {
 	}
 
 	protected Object[] createMethodParams(RequestDetails theRequest) {
-		// TODO:  the bug with NdJson is somewhere in here
 		Object[] params = new Object[getParameters().size()];
 		for (int i = 0; i < getParameters().size(); i++) {
 			IParameter param = getParameters().get(i);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
@@ -101,6 +101,7 @@ public abstract class BaseMethodBinding {
 	}
 
 	protected Object[] createMethodParams(RequestDetails theRequest) {
+		// TODO:  the bug with NdJson is somewhere in here
 		Object[] params = new Object[getParameters().size()];
 		for (int i = 0; i < getParameters().size(); i++) {
 			IParameter param = getParameters().get(i);


### PR DESCRIPTION
Closes [4218](https://github.com/hapifhir/hapi-fhir/issues/4218)