### PR TITLE
Fix circular dependency in SnapshotGeneratingValidationSupport

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/SnapshotGeneratingValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/SnapshotGeneratingValidationSupport.java
@@ -50,7 +50,6 @@ public class SnapshotGeneratingValidationSupport implements IValidationSupport {
 	@Override
 	public IBaseResource generateSnapshot(ValidationSupportContext theValidationSupportContext, IBaseResource theInput, String theUrl, String theWebUrl, String theProfileName) {
 
-		String inputUrl = null;
 		try {
 			FhirVersionEnum version = theInput.getStructureFhirVersionEnum();
 			assert version == myCtx.getVersion().getVersion();
@@ -60,70 +59,69 @@ public class SnapshotGeneratingValidationSupport implements IValidationSupport {
 
 			org.hl7.fhir.r5.model.StructureDefinition inputCanonical = (org.hl7.fhir.r5.model.StructureDefinition) converter.toCanonical(theInput);
 
-			inputUrl = inputCanonical.getUrl();
+			final String inputUrl = inputCanonical.getUrl();
 			if (theValidationSupportContext.getCurrentlyGeneratingSnapshots().contains(inputUrl)) {
 				ourLog.warn("Detected circular dependency, already generating snapshot for: {}", inputUrl);
 				return theInput;
 			}
 			theValidationSupportContext.getCurrentlyGeneratingSnapshots().add(inputUrl);
 
-			String baseDefinition = inputCanonical.getBaseDefinition();
-			if (isBlank(baseDefinition)) {
-				throw new PreconditionFailedException(Msg.code(704) + "StructureDefinition[id=" + inputCanonical.getIdElement().getId() + ", url=" + inputCanonical.getUrl() + "] has no base");
+			try {
+				String baseDefinition = inputCanonical.getBaseDefinition();
+				if (isBlank(baseDefinition)) {
+					throw new PreconditionFailedException(Msg.code(704) + "StructureDefinition[id=" + inputCanonical.getIdElement().getId() + ", url=" + inputCanonical.getUrl() + "] has no base");
+				}
+
+				IBaseResource base = theValidationSupportContext.getRootValidationSupport().fetchStructureDefinition(baseDefinition);
+				if (base == null) {
+					throw new PreconditionFailedException(Msg.code(705) + "Unknown base definition: " + baseDefinition);
+				}
+
+				org.hl7.fhir.r5.model.StructureDefinition baseCanonical = (org.hl7.fhir.r5.model.StructureDefinition) converter.toCanonical(base);
+
+				if (baseCanonical.getSnapshot().getElement().isEmpty()) {
+					// If the base definition also doesn't have a snapshot, generate that first
+					theValidationSupportContext.getRootValidationSupport().generateSnapshot(theValidationSupportContext, base, null, null, null);
+					baseCanonical = (org.hl7.fhir.r5.model.StructureDefinition) converter.toCanonical(base);
+				}
+
+				ArrayList<ValidationMessage> messages = new ArrayList<>();
+				org.hl7.fhir.r5.conformance.ProfileUtilities.ProfileKnowledgeProvider profileKnowledgeProvider = new ProfileKnowledgeWorkerR5(myCtx);
+				IWorkerContext context = new VersionSpecificWorkerContextWrapper(theValidationSupportContext, converter);
+				ProfileUtilities profileUtilities = new ProfileUtilities(context, messages, profileKnowledgeProvider);
+				profileUtilities.generateSnapshot(baseCanonical, inputCanonical, theUrl, theWebUrl, theProfileName);
+
+				switch (version) {
+					case DSTU3:
+						org.hl7.fhir.dstu3.model.StructureDefinition generatedDstu3 = (org.hl7.fhir.dstu3.model.StructureDefinition) converter.fromCanonical(inputCanonical);
+						((org.hl7.fhir.dstu3.model.StructureDefinition) theInput).getSnapshot().getElement().clear();
+						((org.hl7.fhir.dstu3.model.StructureDefinition) theInput).getSnapshot().getElement().addAll(generatedDstu3.getSnapshot().getElement());
+						break;
+					case R4:
+						org.hl7.fhir.r4.model.StructureDefinition generatedR4 = (org.hl7.fhir.r4.model.StructureDefinition) converter.fromCanonical(inputCanonical);
+						((org.hl7.fhir.r4.model.StructureDefinition) theInput).getSnapshot().getElement().clear();
+						((org.hl7.fhir.r4.model.StructureDefinition) theInput).getSnapshot().getElement().addAll(generatedR4.getSnapshot().getElement());
+						break;
+					case R5:
+						org.hl7.fhir.r5.model.StructureDefinition generatedR5 = (org.hl7.fhir.r5.model.StructureDefinition) converter.fromCanonical(inputCanonical);
+						((org.hl7.fhir.r5.model.StructureDefinition) theInput).getSnapshot().getElement().clear();
+						((org.hl7.fhir.r5.model.StructureDefinition) theInput).getSnapshot().getElement().addAll(generatedR5.getSnapshot().getElement());
+						break;
+					case DSTU2:
+					case DSTU2_HL7ORG:
+					case DSTU2_1:
+					default:
+						throw new IllegalStateException(Msg.code(706) + "Can not generate snapshot for version: " + version);
+				}
+			} finally {
+				theValidationSupportContext.getCurrentlyGeneratingSnapshots().remove(inputUrl);
 			}
-
-			IBaseResource base = theValidationSupportContext.getRootValidationSupport().fetchStructureDefinition(baseDefinition);
-			if (base == null) {
-				throw new PreconditionFailedException(Msg.code(705) + "Unknown base definition: " + baseDefinition);
-			}
-
-			org.hl7.fhir.r5.model.StructureDefinition baseCanonical = (org.hl7.fhir.r5.model.StructureDefinition) converter.toCanonical(base);
-
-			if (baseCanonical.getSnapshot().getElement().isEmpty()) {
-				// If the base definition also doesn't have a snapshot, generate that first
-				theValidationSupportContext.getRootValidationSupport().generateSnapshot(theValidationSupportContext, base, null, null, null);
-				baseCanonical = (org.hl7.fhir.r5.model.StructureDefinition) converter.toCanonical(base);
-			}
-
-			ArrayList<ValidationMessage> messages = new ArrayList<>();
-			org.hl7.fhir.r5.conformance.ProfileUtilities.ProfileKnowledgeProvider profileKnowledgeProvider = new ProfileKnowledgeWorkerR5(myCtx);
-			IWorkerContext context = new VersionSpecificWorkerContextWrapper(theValidationSupportContext, converter);
-			ProfileUtilities profileUtilities = new ProfileUtilities(context, messages, profileKnowledgeProvider);
-			profileUtilities.generateSnapshot(baseCanonical, inputCanonical, theUrl, theWebUrl, theProfileName);
-
-			switch (version) {
-				case DSTU3:
-					org.hl7.fhir.dstu3.model.StructureDefinition generatedDstu3 = (org.hl7.fhir.dstu3.model.StructureDefinition) converter.fromCanonical(inputCanonical);
-					((org.hl7.fhir.dstu3.model.StructureDefinition) theInput).getSnapshot().getElement().clear();
-					((org.hl7.fhir.dstu3.model.StructureDefinition) theInput).getSnapshot().getElement().addAll(generatedDstu3.getSnapshot().getElement());
-					break;
-				case R4:
-					org.hl7.fhir.r4.model.StructureDefinition generatedR4 = (org.hl7.fhir.r4.model.StructureDefinition) converter.fromCanonical(inputCanonical);
-					((org.hl7.fhir.r4.model.StructureDefinition) theInput).getSnapshot().getElement().clear();
-					((org.hl7.fhir.r4.model.StructureDefinition) theInput).getSnapshot().getElement().addAll(generatedR4.getSnapshot().getElement());
-					break;
-				case R5:
-					org.hl7.fhir.r5.model.StructureDefinition generatedR5 = (org.hl7.fhir.r5.model.StructureDefinition) converter.fromCanonical(inputCanonical);
-					((org.hl7.fhir.r5.model.StructureDefinition) theInput).getSnapshot().getElement().clear();
-					((org.hl7.fhir.r5.model.StructureDefinition) theInput).getSnapshot().getElement().addAll(generatedR5.getSnapshot().getElement());
-					break;
-				case DSTU2:
-				case DSTU2_HL7ORG:
-				case DSTU2_1:
-				default:
-					throw new IllegalStateException(Msg.code(706) + "Can not generate snapshot for version: " + version);
-			}
-
 			return theInput;
 
 		} catch (BaseServerResponseException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new InternalErrorException(Msg.code(707) + "Failed to generate snapshot", e);
-		} finally {
-			if (inputUrl != null) {
-				theValidationSupportContext.getCurrentlyGeneratingSnapshots().remove(inputUrl);
-			}
 		}
 	}
 


### PR DESCRIPTION
Correct scoping for the finally frame that undoes the addition of the input URL to the 'currently generating snapshots' hash set.