### PR TITLE
Smile 4892 DocumentReference Attachment url

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4240-document-reference-with-long-attachment-url.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4240-document-reference-with-long-attachment-url.yaml
@@ -3,4 +3,4 @@ type: fix
 issue: 4240
 jira: SMILE-4892
 title:  "Previously, when creating a `DocumentReference` with an `Attachment` containing a URL over 254 characters
-an error was thrown. This has been corrected and now an `Attachment` URL can be up to 2000 characters."
+an error was thrown. This has been corrected and now an `Attachment` URL can be up to 500 characters."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4240-document-reference-with-long-attachment-url.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4240-document-reference-with-long-attachment-url.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4240
+jira: SMILE-4892
+title:  "Previously, when creating a `DocumentReference` with an `Attachment` containing a URL over 254 characters
+an error was thrown. This has been corrected and now an `Attachment` URL can be up to 2000 characters."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -107,7 +107,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable("HFJ_SPIDX_URI")
 			.modifyColumn("20221103.1", "SP_URI")
 			.nullable()
-			.withType(ColumnTypeEnum.STRING, 2000);
+			.withType(ColumnTypeEnum.STRING, 500);
 	}
 
 	private void init610() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -103,6 +103,11 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.modifyColumn("20221017.1", "BLOB_SIZE")
 			.nullable()
 			.withType(ColumnTypeEnum.LONG);
+
+		version.onTable("HFJ_SPIDX_URI")
+			.modifyColumn("20221103.1", "SP_URI")
+			.nullable()
+			.withType(ColumnTypeEnum.STRING, 2000);
 	}
 
 	private void init610() {

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamUri.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamUri.java
@@ -59,9 +59,10 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 public class ResourceIndexedSearchParamUri extends BaseResourceIndexedSearchParam {
 
 	/*
-	 * Note that MYSQL chokes on unique indexes for lengths > 255 so be careful here
+	 * Do not use the SP_URI column in a unique index because MySQL will not be able to
+	 * support this column length (https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html)
 	 */
-	public static final int MAX_LENGTH = 254;
+	public static final int MAX_LENGTH = 2000;
 
 	private static final long serialVersionUID = 1L;
 	@Column(name = "SP_URI", nullable = true, length = MAX_LENGTH)

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamUri.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamUri.java
@@ -59,10 +59,11 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 public class ResourceIndexedSearchParamUri extends BaseResourceIndexedSearchParam {
 
 	/*
-	 * Do not use the SP_URI column in a unique index because MySQL will not be able to
-	 * support this column length (https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html)
+	 * Be careful when modifying this value
+	 * MySQL chokes on indexes with combined column length greater than 3052 bytes (768 chars)
+	 * https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html
 	 */
-	public static final int MAX_LENGTH = 2000;
+	public static final int MAX_LENGTH = 500;
 
 	private static final long serialVersionUID = 1L;
 	@Column(name = "SP_URI", nullable = true, length = MAX_LENGTH)

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
@@ -4825,9 +4825,9 @@ public class ResourceProviderDstu3Test extends BaseResourceProviderDstu3Test {
 	}
 
 	@Test
-	public void testDocumentReferenceWith2000CharAttachmentUrl() throws IOException {
+	public void testDocumentReferenceWith500CharAttachmentUrl() throws IOException {
 		final DocumentReference.ReferredDocumentStatus docStatus = DocumentReference.ReferredDocumentStatus.FINAL;
-		final String longUrl = StringUtils.repeat("a", 2000);
+		final String longUrl = StringUtils.repeat("a", 500);
 
 		DocumentReference submittedDocumentReference = new DocumentReference();
 		submittedDocumentReference.setDocStatus(docStatus);

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
@@ -4825,9 +4825,9 @@ public class ResourceProviderDstu3Test extends BaseResourceProviderDstu3Test {
 	}
 
 	@Test
-	public void testDocumentReferenceWith256CharAttachmentUrl() throws IOException {
+	public void testDocumentReferenceWith2000CharAttachmentUrl() throws IOException {
 		final DocumentReference.ReferredDocumentStatus docStatus = DocumentReference.ReferredDocumentStatus.FINAL;
-		final String longUrl = StringUtils.repeat("a", 255);
+		final String longUrl = StringUtils.repeat("a", 2000);
 
 		DocumentReference submittedDocumentReference = new DocumentReference();
 		submittedDocumentReference.setDocStatus(docStatus);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
@@ -39,7 +39,6 @@ import ca.uhn.fhir.jpa.subscription.channel.api.IChannelReceiver;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.apache.commons.lang3.Validate;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.messaging.MessageHandler;


### PR DESCRIPTION
Previously, when creating a `DocumentReference` with an `Attachment` containing a URL over 254 characters an error was thrown. This has been corrected and now an `Attachment` URL can be up to 500 characters.