### PR TITLE
bulk export permanently reusing cached results

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4247-bulk-export-job-reuse.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_2_0/4247-bulk-export-job-reuse.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4247
+title: "Previously, Bulk Export jobs were always reused, even if completed. Now, jobs are only reused if an identical job is already running, and has not yet completed or failed."

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
@@ -101,8 +101,7 @@ public class JobCoordinatorImpl implements IJobCoordinator {
 		if (theStartRequest.isUseCache()) {
 			FetchJobInstancesRequest request = new FetchJobInstancesRequest(theStartRequest.getJobDefinitionId(), theStartRequest.getParameters(),
 				StatusEnum.QUEUED,
-				StatusEnum.IN_PROGRESS,
-				StatusEnum.COMPLETED
+				StatusEnum.IN_PROGRESS
 			);
 
 			List<JobInstance> existing = myJobPersistence.fetchInstances(request, 0, 1000);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
@@ -39,6 +39,7 @@ import ca.uhn.fhir.jpa.subscription.channel.api.IChannelReceiver;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.apache.commons.lang3.Validate;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.messaging.MessageHandler;
@@ -96,13 +97,9 @@ public class JobCoordinatorImpl implements IJobCoordinator {
 		if (isBlank(paramsString)) {
 			throw new InvalidRequestException(Msg.code(2065) + "No parameters supplied");
 		}
-
 		// if cache - use that first
 		if (theStartRequest.isUseCache()) {
-			FetchJobInstancesRequest request = new FetchJobInstancesRequest(theStartRequest.getJobDefinitionId(), theStartRequest.getParameters(),
-				StatusEnum.QUEUED,
-				StatusEnum.IN_PROGRESS
-			);
+			FetchJobInstancesRequest request = new FetchJobInstancesRequest(theStartRequest.getJobDefinitionId(), theStartRequest.getParameters(), getStatesThatTriggerCache());
 
 			List<JobInstance> existing = myJobPersistence.fetchInstances(request, 0, 1000);
 			if (!existing.isEmpty()) {
@@ -139,6 +136,13 @@ public class JobCoordinatorImpl implements IJobCoordinator {
 		Batch2JobStartResponse response = new Batch2JobStartResponse();
 		response.setJobId(instanceId);
 		return response;
+	}
+
+	/**
+	 * Cache will be used if an identical job is QUEUED or IN_PROGRESS. Otherwise a new one will kickoff.
+	 */
+	private StatusEnum[] getStatesThatTriggerCache() {
+		return new StatusEnum[]{StatusEnum.QUEUED, StatusEnum.IN_PROGRESS};
 	}
 
 	@Override


### PR DESCRIPTION
* Fix bug where we were checking completed jobs as cache candidates 
* Add changelog
* Add test. 

Closes #4247 