### PR TITLE
Update swagger-ui link to https

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_plain/openapi.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_plain/openapi.md
@@ -36,4 +36,4 @@ You then simply have to register the interceptor against your RestfulServer inst
 
 # Demonstration
 
-See the HAPI FHIR Test Server for a demonstration of HAPI FHIR OpenAPI functionality: http://hapi.fhir.org/baseR4/swagger-ui/
+See the HAPI FHIR Test Server for a demonstration of HAPI FHIR OpenAPI functionality: https://hapi.fhir.org/baseR4/swagger-ui/


### PR DESCRIPTION
The link to the swagger-ui in https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html leads to an http page: http://hapi.fhir.org/baseR4/swagger-ui/

When the link is followed, the UI shows CORS error because the http page is trying to request https data.

```
Failed to load API definition.
 
Fetch error
Failed to fetch https://hapi.fhir.org/baseR4/api-docs?page=System Level Operations
Fetch error
Possible cross-origin (CORS) issue? The URL origin (https://hapi.fhir.org) does not match the page (http://hapi.fhir.org). Check the server returns the correct 'Access-Control-Allow-*' headers.
```

The correct link in the docs should be https://hapi.fhir.org/baseR4/swagger-ui/, which displays without error.

