### PR TITLE
fix(sec): upgrade org.mortbay.jetty:jetty to 7.0.0pre4

### DIFF
--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.mortbay.jetty</groupId>
 			<artifactId>jetty</artifactId>
-			<version>6.1.26</version> <!-- Use an old version -->
+			<version>7.0.0pre4</version> <!-- Use an old version -->
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.mortbay.jetty:jetty 6.1.26
- [CVE-2011-4461](https://www.oscs1024.com/hd/CVE-2011-4461)


### What did I do？
Upgrade org.mortbay.jetty:jetty from 6.1.26 to 7.0.0pre4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS