### PR TITLE
4269 implement a toString for OkHttpRestfulRequest to have better log…

### DIFF
--- a/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulRequest.java
+++ b/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulRequest.java
@@ -105,4 +105,8 @@ public class OkHttpRestfulRequest extends BaseHttpRequest implements IHttpReques
     	myRequestBuilder.removeHeader(theHeaderName);
 	}
 
+	@Override
+	public String toString() {
+		return getHttpVerbName() + " " + getUri();
+	}
 }

--- a/hapi-fhir-client-okhttp/src/test/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulRequestTest.java
+++ b/hapi-fhir-client-okhttp/src/test/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulRequestTest.java
@@ -1,0 +1,27 @@
+package ca.uhn.fhir.okhttp.client;
+
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OkHttpRestfulRequestTest {
+
+	@Test
+	void toString_afterCreation_GetUsefulDataForLogging() {
+		String theUrl = "https://example.com/fhir/meta";
+		OkHttpRestfulClientFactory clientFactory = new OkHttpRestfulClientFactory();
+
+		OkHttpRestfulRequest okHttpRestfulRequest = new OkHttpRestfulRequest(clientFactory.getNativeClient(), theUrl, RequestTypeEnum.GET, null);
+		assertEquals("GET https://example.com/fhir/meta", okHttpRestfulRequest.toString());
+	}
+
+	@Test
+	void toString_afterCreationPostUsefulDataForLogging() {
+		String theUrl = "https://another.example.com/fhir/Task";
+		OkHttpRestfulClientFactory clientFactory = new OkHttpRestfulClientFactory();
+
+		OkHttpRestfulRequest okHttpRestfulRequest = new OkHttpRestfulRequest(clientFactory.getNativeClient(), theUrl, RequestTypeEnum.POST, null);
+		assertEquals("POST https://another.example.com/fhir/Task", okHttpRestfulRequest.toString());
+	}
+}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_3_0/4270-fix-logging-interceptor-with-okhttp.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_3_0/4270-fix-logging-interceptor-with-okhttp.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4270
+title: "When using the client LoggingInterceptor with OkHttp clients, the request URL was not
+   correctly logged. Thanks to Roel Scholten for the pull request!"

--- a/pom.xml
+++ b/pom.xml
@@ -830,6 +830,10 @@
 			<name>Vitor Pamplona</name>
 			<organization>PathCheck Foundation / EyeNetra Inc</organization>
 		</developer>
+		<developer>
+			<id>Roel-Scholten</id>
+			<name>Roel Scholten</name>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
…gin…

Implement a toString for OkHttpRestfulRequest logging to have better logging. Currently this still differs from the ApacheHttpRequest.java as we do not have the used protocol (http/1.1/alpn) on request creation. This is added to the Response object.