### PR TITLE
bundle not throwing an error when multiple matches were found

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_3_0/4281-bundle-does-not-throw-an-error-when-multiple-matches-are-found-for-a-conditional-url.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_3_0/4281-bundle-does-not-throw-an-error-when-multiple-matches-are-found-for-a-conditional-url.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4281
+title: "Previously, when creating a bundle, if multiple resources matched the conditional URL provided 
+         in the request, it would process the request using the last resource found as a match. 
+         An error is now thrown when multiple resources are found"

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/storage/TransactionDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/storage/TransactionDetails.java
@@ -20,9 +20,11 @@ package ca.uhn.fhir.rest.api.server.storage;
  * #L%
  */
 
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.api.InterceptorInvocationTimingEnum;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import org.apache.commons.lang3.Validate;
@@ -162,8 +164,20 @@ public class TransactionDetails {
 
 		if (myResolvedMatchUrls.isEmpty()) {
 			myResolvedMatchUrls = new HashMap<>();
+		} else if (matchUrlWitDiffIdExists(theConditionalUrl, thePersistentId)) {
+			String msg = "Invalid match URL " + theConditionalUrl + " - Multiple resources match this search";
+			throw new PreconditionFailedException(Msg.code(2207) + msg);
 		}
 		myResolvedMatchUrls.put(theConditionalUrl, thePersistentId);
+	}
+
+	private boolean matchUrlWitDiffIdExists(String theConditionalUrl, @Nonnull ResourcePersistentId thePersistentId) {
+		if (myResolvedMatchUrls.containsKey(theConditionalUrl) && myResolvedMatchUrls.get(theConditionalUrl) != NOT_FOUND) {
+			if (myResolvedMatchUrls.get(theConditionalUrl).getId() != thePersistentId.getId()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/storage/TransactionDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/storage/TransactionDetails.java
@@ -164,18 +164,16 @@ public class TransactionDetails {
 
 		if (myResolvedMatchUrls.isEmpty()) {
 			myResolvedMatchUrls = new HashMap<>();
-		} else if (matchUrlWitDiffIdExists(theConditionalUrl, thePersistentId)) {
+		} else if (matchUrlWithDiffIdExists(theConditionalUrl, thePersistentId)) {
 			String msg = "Invalid match URL " + theConditionalUrl + " - Multiple resources match this search";
 			throw new PreconditionFailedException(Msg.code(2207) + msg);
 		}
 		myResolvedMatchUrls.put(theConditionalUrl, thePersistentId);
 	}
 
-	private boolean matchUrlWitDiffIdExists(String theConditionalUrl, @Nonnull ResourcePersistentId thePersistentId) {
+	private boolean matchUrlWithDiffIdExists(String theConditionalUrl, @Nonnull ResourcePersistentId thePersistentId) {
 		if (myResolvedMatchUrls.containsKey(theConditionalUrl) && myResolvedMatchUrls.get(theConditionalUrl) != NOT_FOUND) {
-			if (myResolvedMatchUrls.get(theConditionalUrl).getId() != thePersistentId.getId()) {
-				return true;
-			}
+			return myResolvedMatchUrls.get(theConditionalUrl).getId() != thePersistentId.getId();
 		}
 		return false;
 	}


### PR DESCRIPTION
Adding a resolved match url now checks if multiple persistent ids are found for a conditional URL