### PR TITLE
Issue 4310 Fix.  Add "distinct" and "sorted" to "Server knows how to handle" error message:

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4311-improve-search-params-in-error-message.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4311-improve-search-params-in-error-message.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 4311
+title: "When a REST client performs a search with an unknown search parameter, the
+   resulting error message will now sort and deduplicate the list of allowable
+   search parameters. Thanks to GitHub user @granadacoder for the pull request!"

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -1919,6 +1919,8 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	}
 
 	protected void throwUnknownResourceTypeException(String theResourceName) {
+		/* perform a 'distinct' in case there are multiple concrete IResourceProviders declared for the same FHIR-Resource. (A concrete IResourceProvider for Patient@Read and a separate concrete for Patient@Search for example */
+		/* perform a 'sort' to provide an easier to read alphabetized list (vs how the different FHIR-resource IResourceProviders happened to be registered */
 		List<String> knownDistinctAndSortedResourceTypes = myResourceProviders.stream()
 			.map(t -> t.getResourceType().getSimpleName())
 			.distinct()

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -1919,10 +1919,12 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	}
 
 	protected void throwUnknownResourceTypeException(String theResourceName) {
-		List<String> knownResourceTypes = myResourceProviders.stream()
+		List<String> knownDistinctAndSortedResourceTypes = myResourceProviders.stream()
 			.map(t -> t.getResourceType().getSimpleName())
+			.distinct()
+			.sorted()
 			.collect(toList());
-		throw new ResourceNotFoundException(Msg.code(302) + "Unknown resource type '" + theResourceName + "' - Server knows how to handle: " + knownResourceTypes);
+		throw new ResourceNotFoundException(Msg.code(302) + "Unknown resource type '" + theResourceName + "' - Server knows how to handle: " + knownDistinctAndSortedResourceTypes);
 	}
 
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -834,6 +834,9 @@
 			<id>Roel-Scholten</id>
 			<name>Roel Scholten</name>
 		</developer>
+		<developer>
+			<id>granadacoder</id>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
See:

https://github.com/hapifhir/hapi-fhir/issues/4310

In a nutshell.

Add "distinct" and "sorted" to the string-list of FHIR-resources used for the error message:

    Server knows how to handle

