### PR TITLE
allow mongo implementation of IDeleteExpungeSvc

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSvcImpl.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Transactional(propagation = Propagation.MANDATORY)
-public class DeleteExpungeSvcImpl implements IDeleteExpungeSvc {
+public class DeleteExpungeSvcImpl implements IDeleteExpungeSvc<JpaPid> {
 	private static final Logger ourLog = LoggerFactory.getLogger(DeleteExpungeSvcImpl.class);
 
 	private final EntityManager myEntityManager;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IDeleteExpungeSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IDeleteExpungeSvc.java
@@ -21,13 +21,14 @@ package ca.uhn.fhir.jpa.api.svc;
  */
 
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Transactional(propagation = Propagation.MANDATORY)
-public interface IDeleteExpungeSvc {
+public interface IDeleteExpungeSvc<T extends IResourcePersistentId<?>> {
 
-	void deleteExpunge(List<JpaPid> thePersistentIds);
+	void deleteExpunge(List<T> thePersistentIds);
 }


### PR DESCRIPTION
A follow-up to yesterday's refactoring, so that the IDeleteExpungeSvc interface is not tied to JPA.