### PR TITLE
$member-match operation returns success even the query contains non-existing patient id and coverage id

### DIFF
--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -203,3 +203,4 @@ operation.member.match.error.missing.parameter=Parameter "{0}" is required.
 operation.member.match.error.beneficiary.without.identifier=Coverage beneficiary does not have an identifier.
 operation.member.match.error.patient.not.found=Could not find matching patient for coverage.
 operation.member.match.error.consent.release.data.mismatch=Consent policy does not match the data release segmentation capabilities.
+operation.member.match.error.nonexisting.patient.id=Could not find matching patient for coverage based on given resource id.

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4351-member-match-operation-returns-success-for-non-existing-ids.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4351-member-match-operation-returns-success-for-non-existing-ids.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4351
+title: "Previously, member match operation returns success even the query contains non-existing patient id and coverage id. 
+Now, this issue has been fixed and post query with non-existing ids will get an unmatched code of 422."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatchR4ResourceProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatchR4ResourceProvider.java
@@ -86,7 +86,7 @@ public class MemberMatchR4ResourceProvider {
 		validateParams(theMemberPatient, theCoverageToMatch, theCoverageToLink, theConsent);
 
 		Optional<Coverage> coverageOpt = myMemberMatcherR4Helper.findMatchingCoverage(theCoverageToMatch);
-		if ( ! coverageOpt.isPresent()) {
+		if (! coverageOpt.isPresent()) {
 			String i18nMessage = myFhirContext.getLocalizer().getMessage(
 				"operation.member.match.error.coverage.not.found");
 			throw new UnprocessableEntityException(Msg.code(1155) + i18nMessage);
@@ -101,7 +101,7 @@ public class MemberMatchR4ResourceProvider {
 		}
 
 		Patient patient = patientOpt.get();
-		if (!myMemberMatcherR4Helper.validPatientMember(patient, theMemberPatient)) {
+		if (! myMemberMatcherR4Helper.validPatientMember(patient, theMemberPatient)) {
 			String i18nMessage = myFhirContext.getLocalizer().getMessage(
 				"operation.member.match.error.patient.not.found");
 			throw new UnprocessableEntityException(Msg.code(2146) + i18nMessage);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4Helper.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4Helper.java
@@ -257,7 +257,9 @@ public class MemberMatcherR4Helper {
 			return false;
 		}
 
-		validPatientMemberId(thePatientFromContract, thePatientToMatch);
+		if (thePatientToMatch.hasId()) {
+			validPatientMemberId(thePatientFromContract, thePatientToMatch);
+		}
 
 		StringOrListParam familyName = new StringOrListParam();
 		for (HumanName name : thePatientToMatch.getName()) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
@@ -162,6 +162,17 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		validateNewCoverage(parametersResponse, newCoverage);
 	}
 
+	@Test
+	public void testMemberMatch_NonExistingPatientIdAndCoverageId() throws Exception {
+		createCoverageWithBeneficiary(true, true);
+		myPatient.setId("Patient/nonexistingId");
+		oldCoverage.setId("Coverage/nonexistingId");
+
+		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
+			"Could not find matching patient for coverage based on given resource id.");
+	}
+
 
 	@Test
 	public void testCoverageNoBeneficiaryReturns422() throws Exception {


### PR DESCRIPTION
#4351

- Added a validation method to check if the Id exists and matches 