### PR TITLE
Fix MDM update link on resources with an old version.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4364-mdm-update-link-fails-for-resources-previous-mdm-version.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4364-mdm-update-link-fails-for-resources-previous-mdm-version.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4364
+jira: HAPI-0738
+title: "Running MDM update link will fail if resources were created with a previous MDM rules version.  This is now fixed with a query that retrieves and updates MDM links regardless of the MDM version of the resource links."

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -151,7 +151,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 	 * @return a list of {@link IMdmLink} entities matching these criteria.
 	 */
 	public List<M> getMdmLinksBySourcePidAndMatchResult(P theSourcePid, MdmMatchResultEnum theMatchResult) {
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setSourcePersistenceId(theSourcePid);
 		exampleLink.setMatchResult(theMatchResult);
 		Example<M> example = Example.of(exampleLink);
@@ -193,7 +193,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 			return Optional.empty();
 		}
 
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setSourcePersistenceId(pid);
 		exampleLink.setMatchResult(theMatchResult);
 		Example<M> example = Example.of(exampleLink);
@@ -215,7 +215,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 
 	public Optional<M> getMdmLinksByGoldenResourcePidSourcePidAndMatchResult(P theGoldenResourcePid,
 																															P theSourcePid, MdmMatchResultEnum theMatchResult) {
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setGoldenResourcePersistenceId(theGoldenResourcePid);
 		exampleLink.setSourcePersistenceId(theSourcePid);
 		exampleLink.setMatchResult(theMatchResult);
@@ -229,7 +229,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 	 * @return A list of {@link IMdmLink} that hold potential duplicate golden resources.
 	 */
 	public List<M> getPossibleDuplicates() {
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setMatchResult(MdmMatchResultEnum.POSSIBLE_DUPLICATE);
 		Example<M> example = Example.of(exampleLink);
 		return myMdmLinkDao.findAll(example);
@@ -241,7 +241,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 		if (pid == null) {
 			return Optional.empty();
 		}
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setSourcePersistenceId(pid);
 		Example<M> example = Example.of(exampleLink);
 		return myMdmLinkDao.findOne(example);
@@ -321,7 +321,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 		if (pid == null) {
 			return Collections.emptyList();
 		}
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setSourcePersistenceId(pid);
 		Example<M> example = Example.of(exampleLink);
 		return myMdmLinkDao.findAll(example);
@@ -339,7 +339,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 		if (pid == null) {
 			return Collections.emptyList();
 		}
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setGoldenResourcePersistenceId(pid);
 		exampleLink.setMatchResult(MdmMatchResultEnum.MATCH);
 		Example<M> example = Example.of(exampleLink);

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -138,6 +138,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 		link.setGoldenResourcePersistenceId(theGoldenResourcePid);
 
 		//TODO - replace the use of example search
+		// TODO:  This is our last chance to fix the bug in 3868
 		Example<M> example = Example.of(link);
 
 		return myMdmLinkDao.findOne(example);

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvc.java
@@ -133,12 +133,11 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 		if (theSourceResourcePid == null || theGoldenResourcePid == null) {
 			return Optional.empty();
 		}
-		M link = myMdmLinkFactory.newMdmLink();
+		M link = myMdmLinkFactory.newMdmLinkVersionless();
 		link.setSourcePersistenceId(theSourceResourcePid);
 		link.setGoldenResourcePersistenceId(theGoldenResourcePid);
 
 		//TODO - replace the use of example search
-		// TODO:  This is our last chance to fix the bug in 3868
 		Example<M> example = Example.of(link);
 
 		return myMdmLinkDao.findOne(example);
@@ -272,7 +271,7 @@ public class MdmLinkDaoSvc<P extends IResourcePersistentId, M extends IMdmLink<P
 		if (pid == null) {
 			return Collections.emptyList();
 		}
-		M exampleLink = myMdmLinkFactory.newMdmLink();
+		M exampleLink = myMdmLinkFactory.newMdmLinkVersionless();
 		exampleLink.setGoldenResourcePersistenceId(pid);
 		Example<M> example = Example.of(exampleLink);
 		return myMdmLinkDao.findAll(example);

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/BaseMdmR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/BaseMdmR4Test.java
@@ -27,12 +27,12 @@ import ca.uhn.fhir.jpa.searchparam.registry.SearchParamRegistryImpl;
 import ca.uhn.fhir.jpa.subscription.match.config.SubscriptionProcessorConfig;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.mdm.api.IMdmLink;
-import ca.uhn.fhir.mdm.api.IMdmSettings;
 import ca.uhn.fhir.mdm.api.MdmConstants;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.mdm.dao.IMdmLinkDao;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
+import ca.uhn.fhir.mdm.rules.config.MdmSettings;
 import ca.uhn.fhir.mdm.rules.svc.MdmResourceMatcherSvc;
 import ca.uhn.fhir.mdm.util.EIDHelper;
 import ca.uhn.fhir.mdm.util.MdmResourceUtil;
@@ -119,7 +119,7 @@ abstract public class BaseMdmR4Test extends BaseJpaR4Test {
 	@Autowired
 	protected IIdHelperService<JpaPid> myIdHelperService;
 	@Autowired
-	protected IMdmSettings myMdmSettings;
+	protected MdmSettings myMdmSettings;
 	@Autowired
 	protected MdmMatchLinkSvc myMdmMatchLinkSvc;
 	@Autowired

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplTest.java
@@ -44,7 +44,7 @@ class MdmLinkUpdaterSvcImplTest extends BaseMdmR4Test {
 	}
 
 	@Test
-	public void testUpdateLinkMatchAfterVersion1Change() {
+	public void testUpdateLinkMatchAfterVersionChange() {
 		myMdmSettings.getMdmRules().setVersion("1");
 
 		final Patient goldenPatient = createGoldenPatient(buildJanePatient());

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/dao/MdmLinkFactory.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/dao/MdmLinkFactory.java
@@ -24,6 +24,15 @@ import ca.uhn.fhir.mdm.api.IMdmLink;
 import ca.uhn.fhir.mdm.api.IMdmSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Creates a new {@link IMdmLink} either with the current {@link IMdmSettings#getRuleVersion()} or with a null version.
+ * <br>
+ * **Use extreme caution**.  The recommended practice is to only use (@link #newMdmLink()} when WRITING an MDM record.
+ * <br>
+ * Otherwise, there is the risk that code that searches for an MDM record fill fail to locate it due to a version mismatch.
+ * <br>
+ * Database code makes use of SpringData {@link org.springframework.data.domain.Example} queries.
+ */
 public class MdmLinkFactory<M extends IMdmLink<?>> {
 	private final IMdmSettings myMdmSettings;
 	private final IMdmLinkImplFactory<M> myMdmLinkImplFactory;
@@ -37,6 +46,8 @@ public class MdmLinkFactory<M extends IMdmLink<?>> {
 	/**
 	 * Create a new {@link IMdmLink}, populating it with the version of the ruleset used to create it.
 	 *
+	 * Use this method **only** when writing a new MDM record.
+	 *
 	 * @return the new {@link IMdmLink}
 	 */
 	public M newMdmLink() {
@@ -45,8 +56,11 @@ public class MdmLinkFactory<M extends IMdmLink<?>> {
 		return retval;
 	}
 
-	// TODO: javadoc
-	// TODO: think about other methods that need to be versionless
+	/**
+	 * Creating a new {@link IMdmLink} with the version deliberately omitted.  It will return as null.
+	 *
+	 * This is the recommended use when querying for any MDM records
+	 */
 	public M newMdmLinkVersionless() {
 		return myMdmLinkImplFactory.newMdmLinkImpl();
 	}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/dao/MdmLinkFactory.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/dao/MdmLinkFactory.java
@@ -24,12 +24,12 @@ import ca.uhn.fhir.mdm.api.IMdmLink;
 import ca.uhn.fhir.mdm.api.IMdmSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class MdmLinkFactory<M extends IMdmLink> {
+public class MdmLinkFactory<M extends IMdmLink<?>> {
 	private final IMdmSettings myMdmSettings;
 	private final IMdmLinkImplFactory<M> myMdmLinkImplFactory;
 
 	@Autowired
-	public MdmLinkFactory(IMdmSettings theMdmSettings, IMdmLinkImplFactory theMdmLinkImplFactory) {
+	public MdmLinkFactory(IMdmSettings theMdmSettings, IMdmLinkImplFactory<M> theMdmLinkImplFactory) {
 		myMdmSettings = theMdmSettings;
 		myMdmLinkImplFactory = theMdmLinkImplFactory;
 	}
@@ -43,5 +43,11 @@ public class MdmLinkFactory<M extends IMdmLink> {
 		M retval = myMdmLinkImplFactory.newMdmLinkImpl();
 		retval.setVersion(myMdmSettings.getRuleVersion());
 		return retval;
+	}
+
+	// TODO: javadoc
+	// TODO: think about other methods that need to be versionless
+	public M newMdmLinkVersionless() {
+		return myMdmLinkImplFactory.newMdmLinkImpl();
 	}
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/dao/MdmLinkFactory.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/dao/MdmLinkFactory.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * <br>
  * Database code makes use of SpringData {@link org.springframework.data.domain.Example} queries.
  */
-public class MdmLinkFactory<M extends IMdmLink<?>> {
+public class MdmLinkFactory<M extends IMdmLink> {
 	private final IMdmSettings myMdmSettings;
 	private final IMdmLinkImplFactory<M> myMdmLinkImplFactory;
 


### PR DESCRIPTION
* Currently, the MdmLinkFactory always creates an MdmLink with the most current version
* Due to the use of SpringData Example queries, that version gets passed into any query that retrieves MdmLinks
* Enhance the MdmLinkFactory with a versionless variant that buids an MdmLink with a null version
* Replace calls to the factory to the versionless method from all MdmDao methods that *read* an MdmLink as opposed to creating or updating it
* This fixes the bug where updating or retrieving an MdmLink was not found due to the SpringData Example usage above

Closes [4364](https://github.com/hapifhir/hapi-fhir/issues/4364)