### PR TITLE
Fix Schematron issue when running in OSGi container

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/schematron/SchematronBaseValidator.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/schematron/SchematronBaseValidator.java
@@ -34,6 +34,8 @@ import ca.uhn.fhir.validation.SingleValidationMessage;
 import ca.uhn.fhir.validation.ValidationContext;
 import com.helger.commons.error.IError;
 import com.helger.commons.error.list.IErrorList;
+import com.helger.commons.io.resource.ClassPathResource;
+import com.helger.commons.io.resource.IReadableResource;
 import com.helger.schematron.ISchematronResource;
 import com.helger.schematron.SchematronHelper;
 import com.helger.schematron.svrl.jaxb.SchematronOutputType;
@@ -150,7 +152,11 @@ public class SchematronBaseValidator implements IValidatorModule {
 				ourLog.error("Failed to close stream", e);
 			}
 
-			retVal = SchematronResourceSCH.fromClassPath(pathToBase);
+			// Allow Schematron to load SCH files from the 'validation-resources' 
+			// bundles when running in an OSGi container. This is because the 
+			// Schematron bundle does not have DynamicImport-Package in its manifest.
+            IReadableResource schResource = new ClassPathResource(pathToBase, this.getClass().getClassLoader());
+            retVal = new SchematronResourceSCH(schResource);
 			myClassToSchematron.put(theClass, retVal);
 			return retVal;
 		}


### PR DESCRIPTION
This fix allows Schematron validation to work in an OSGi container. Currently, Schematron is not able to load the .sch files from the "validation-resources" bundles. This was caused by the fact that, in OSGi, the "validation-resource" bundles are not visible to the classloader for the 'ph-schematron*' bundle.

The fix is to crate the SCH Resource using the classloader for hapi-fhir-base which *does* have visibility to the 'validation-resource' bundles
