### PR TITLE
Add Device to the list of resource types considered for group bulk export async

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4385-group-bulk-export-async-device-resource-missing-from-results.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4385-group-bulk-export-async-device-resource-missing-from-results.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 4385
+title: "Group bulk export async will not retrieve Device resources even if they're linked to a Patient and Group.  This has been fixed by adding Device to the list of qualifying resources."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
@@ -623,7 +623,13 @@ public class BulkDataExportProviderTest {
 
 		// verify
 		assertThat(execute.getStatusLine().getStatusCode(), is(equalTo(202)));
-		verifyJobStart();
+		final BulkExportParameters bulkExportParameters = verifyJobStart();
+
+		assertAll(
+			() -> assertTrue(bulkExportParameters.getResourceTypes().contains("Patient")),
+			() -> assertTrue(bulkExportParameters.getResourceTypes().contains("Group")),
+			() -> assertTrue(bulkExportParameters.getResourceTypes().contains("Device"))
+		);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
@@ -34,6 +34,8 @@ import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +47,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.awaitility.Awaitility.await;
@@ -571,6 +574,49 @@ public class BulkDataExportTest extends BaseResourceProviderR4Test {
 		options.setExportStyle(BulkDataExportOptions.ExportStyle.PATIENT);
 		options.setOutputFormat(Constants.CT_FHIR_NDJSON);
 		verifyBulkExportResults(options, List.of("Patient/P1", deviceId), Collections.emptyList());
+	}
+
+	@ParameterizedTest
+	@MethodSource("bulkExportOptionsResourceTypes")
+	public void testDeviceBulkExportWithPatientPartOfGroup(Set<String> resourceTypesForExport) {
+		final Patient patient = new Patient();
+		patient.setId("A");
+		patient.setActive(true);
+		final IIdType patientIdType = myClient.update().resource(patient).execute().getId().toUnqualifiedVersionless();
+
+		final Group group = new Group();
+		group.setId("B");
+		final Group.GroupMemberComponent groupMemberComponent = new Group.GroupMemberComponent();
+		final Reference patientReference = new Reference(patientIdType.getValue());
+		groupMemberComponent.setEntity(patientReference);
+		group.getMember().add(groupMemberComponent);
+		final IIdType groupIdType = myClient.update().resource(group).execute().getId().toUnqualifiedVersionless();
+
+		final Device device = new Device();
+		device.setId("C");
+		device.setStatus(Device.FHIRDeviceStatus.ACTIVE);
+		device.setPatient(patientReference);
+		final IIdType deviceIdType = myClient.create().resource(device).execute().getId().toUnqualifiedVersionless();
+
+		final BulkDataExportOptions options = new BulkDataExportOptions();
+		options.setResourceTypes(resourceTypesForExport);
+		options.setGroupId(new IdType("Group", "B"));
+		options.setFilters(new HashSet<>());
+		options.setExportStyle(BulkDataExportOptions.ExportStyle.GROUP);
+		options.setOutputFormat(Constants.CT_FHIR_NDJSON);
+
+		final List<String> expectedContainedIds;
+		if (resourceTypesForExport.contains("Device")) {
+			expectedContainedIds = List.of(patientIdType.getValue(), groupIdType.getValue(), deviceIdType.getValue());
+		} else {
+			expectedContainedIds = List.of(patientIdType.getValue(), groupIdType.getValue());
+		}
+
+		verifyBulkExportResults(options, expectedContainedIds, Collections.emptyList());
+	}
+
+	private static Stream<Set<String>> bulkExportOptionsResourceTypes() {
+		return Stream.of(Set.of("Patient", "Group"), Set.of("Patient", "Group", "Device"));
 	}
 
 	private void verifyBulkExportResults(BulkDataExportOptions theOptions, List<String> theContainedList, List<String> theExcludedList) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/bulk/export/provider/BulkDataExportProvider.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/bulk/export/provider/BulkDataExportProvider.java
@@ -237,7 +237,8 @@ public class BulkDataExportProvider {
 
 	private Set<String> getPatientCompartmentResources() {
 		if (myCompartmentResources == null) {
-			myCompartmentResources = SearchParameterUtil.getAllResourceTypesThatAreInPatientCompartment(myFhirContext);
+			myCompartmentResources = new HashSet<>(SearchParameterUtil.getAllResourceTypesThatAreInPatientCompartment(myFhirContext));
+			myCompartmentResources.add("Device");
 		}
 		return myCompartmentResources;
 	}


### PR DESCRIPTION
- In the case of a group export async with no provided resource types, add Device to the implicitly built list of the resource types.

Closes [4385](https://github.com/hapifhir/hapi-fhir/issues/4385)