### PR TITLE
4420 tags are not included in search results after using $meta delete on one tag

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4420-tags-are-not-included-in-search-results-after-using-meta-delete-on-one-tag.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4420-tags-are-not-included-in-search-results-after-using-meta-delete-on-one-tag.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4420
+jira: SMILE-5734
+title: "Fixed a bug with $meta-delete which will cause the resource, when included as part of a search result,
+to have all its tags be missing."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
@@ -451,6 +451,28 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 	}
 
 	@Test
+	public void testMetaDelete_TagStorageModeVersioned_ShouldShowRemainingTagsInGetAllResources() {
+		Patient pt = new Patient();
+		Meta pMeta = new Meta();
+		pMeta.addTag().setSystem("urn:system1").setCode("urn:code1");
+		pMeta.addTag().setSystem("urn:system2").setCode("urn:code2");
+		pt.setMeta(pMeta);
+		IIdType id = myClient.create().resource(pt).execute().getId().toUnqualifiedVersionless();
+
+		Meta meta = myClient.meta().get(Meta.class).fromResource(id).execute();
+		assertEquals(2, meta.getTag().size());
+
+		Meta inMeta = new Meta();
+		inMeta.addTag().setSystem("urn:system2").setCode("urn:code2");
+		meta = myClient.meta().delete().onResource(id).meta(inMeta).execute();
+		assertEquals(1, meta.getTag().size());
+
+		Bundle patientBundle = myClient.search().forResource("Patient").returnBundle(Bundle.class).execute();
+		Patient patient = (Patient) patientBundle.getEntry().get(0).getResource();
+		assertEquals(1, patient.getMeta().getTag().size());
+	}
+
+	@Test
 	public void testInlineTags_Search_Profile() {
 		myDaoConfig.setTagStorageMode(DaoConfig.TagStorageModeEnum.INLINE);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
@@ -428,6 +428,29 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 	}
 
 	@Test
+	public void testMetaDelete_TagStorageModeNonVersioned_ShouldShowRemainingTagsInGetAllResources() {
+		myDaoConfig.setTagStorageMode(DaoConfig.TagStorageModeEnum.NON_VERSIONED);
+		Patient pt = new Patient();
+		Meta pMeta = new Meta();
+		pMeta.addTag().setSystem("urn:system1").setCode("urn:code1");
+		pMeta.addTag().setSystem("urn:system2").setCode("urn:code2");
+		pt.setMeta(pMeta);
+		IIdType id = myClient.create().resource(pt).execute().getId().toUnqualifiedVersionless();
+
+		Meta meta = myClient.meta().get(Meta.class).fromResource(id).execute();
+		assertEquals(2, meta.getTag().size());
+
+		Meta inMeta = new Meta();
+		inMeta.addTag().setSystem("urn:system2").setCode("urn:code2");
+		meta = myClient.meta().delete().onResource(id).meta(inMeta).execute();
+		assertEquals(1, meta.getTag().size());
+
+		Bundle patientBundle = myClient.search().forResource("Patient").returnBundle(Bundle.class).execute();
+		Patient patient = (Patient) patientBundle.getEntry().get(0).getResource();
+		assertEquals(1, patient.getMeta().getTag().size());
+	}
+
+	@Test
 	public void testInlineTags_Search_Profile() {
 		myDaoConfig.setTagStorageMode(DaoConfig.TagStorageModeEnum.INLINE);
 


### PR DESCRIPTION
- added a check on tag storage mode to only delete tags from the latest version of the resource if it's non-versioned