### PR TITLE
Fix case in *n*arrativeLink URL

### DIFF
--- a/hapi-fhir-jpaserver-ips/src/main/java/ca/uhn/fhir/jpa/ips/generator/IpsGeneratorSvcImpl.java
+++ b/hapi-fhir-jpaserver-ips/src/main/java/ca/uhn/fhir/jpa/ips/generator/IpsGeneratorSvcImpl.java
@@ -253,7 +253,7 @@ public class IpsGeneratorSvcImpl implements IIpsGeneratorSvc {
 		for (IBaseResource next : theResourcesToInclude) {
 
 			IBaseExtension<?, ?> narrativeLink = ((IBaseHasExtensions) next).addExtension();
-			narrativeLink.setUrl("http://hl7.org/fhir/StructureDefinition/NarrativeLink");
+			narrativeLink.setUrl("http://hl7.org/fhir/StructureDefinition/narrativeLink");
 			String narrativeLinkValue = theCompositionBuilder.getComposition().getIdElement().getValue()
 				+ "#"
 				+ myFhirContext.getResourceType(next)


### PR DESCRIPTION
I think it's only set in this file (but if you know elsewhere, please do as well) 