### PR TITLE
GenericClient can't build non-fhir requests.

### DIFF
--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/client/GenericClientNonFhirTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/client/GenericClientNonFhirTest.java
@@ -1,0 +1,22 @@
+package ca.uhn.fhir.rest.client;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GenericClientNonFhirTest {
+	FhirContext myFhirContext = FhirContext.forR4Cached();
+	@Test
+	void genericClientHttpClient_canBuildGetRequest() {
+	    // given
+		IGenericClient genericClient = myFhirContext.newRestfulGenericClient("http://example.com");
+
+		IHttpRequest getRequest = genericClient.getHttpClient().createGetRequest(myFhirContext, EncodingEnum.JSON);
+		assertEquals("GET", getRequest.getHttpVerbName());
+	}
+
+}


### PR DESCRIPTION
reproduction of genericClient.getHttpClient().createGetRequest(myFhirContext, EncodingEnum.JSON)  failure.
