### PR TITLE
Removes unneeded logging in MdmStorageInterceptor

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/3979-mdm-storage-interceptor-unnecessary-logging.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/3979-mdm-storage-interceptor-unnecessary-logging.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 3979
+title: "Previously, the MdmStorageInterceptor was needlessly logging a warning if theOldResource of an update was null.
+This is now fixed."

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -129,6 +129,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-test-utilities</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
     </dependencies>
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/interceptor/MdmStorageInterceptor.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/interceptor/MdmStorageInterceptor.java
@@ -116,8 +116,6 @@ public class MdmStorageInterceptor implements IMdmStorageInterceptor {
 		if (theOldResource != null) {
 			forbidIfMdmManagedTagIsPresent(theOldResource);
 			forbidModifyingMdmTag(theUpdatedResource, theOldResource);
-		} else {
-			ourLog.warn("Null theOldResource for {} {}", theUpdatedResource == null ? "null updated resource" : theUpdatedResource.getIdElement(), theRequestDetails);
 		}
 
 		if (myMdmSettings.isPreventEidUpdates()) {

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/Interceptor/MdmStorageInterceptorTest.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/Interceptor/MdmStorageInterceptorTest.java
@@ -1,0 +1,64 @@
+package ca.uhn.fhir.mdm.Interceptor;
+
+import ca.uhn.fhir.mdm.api.IMdmSettings;
+import ca.uhn.fhir.mdm.interceptor.MdmStorageInterceptor;
+import ca.uhn.fhir.model.dstu2.resource.Patient;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class MdmStorageInterceptorTest {
+
+	private static final Logger ourLog = (Logger) LoggerFactory.getLogger(MdmStorageInterceptor.class);
+	private ListAppender<ILoggingEvent> myListAppender;
+
+	@InjectMocks
+	private MdmStorageInterceptor myMdmStorageInterceptor;
+	@Mock
+	private IMdmSettings myMdmSettings;
+
+	@BeforeEach
+	public void beforeEach(){
+		myListAppender = new ListAppender<>();
+		myListAppender.start();
+		ourLog.addAppender(myListAppender);
+	}
+
+	@AfterEach
+	public void afterEach(){
+		myListAppender.stop();
+	}
+
+	@Test
+	public void testBlockManualGoldenResourceManipulationOnUpdate_nullOldResource_noLogs() {
+		Patient updatedResource = new Patient();
+		RequestDetails requestDetails = new ServletRequestDetails();
+
+		myMdmStorageInterceptor.blockManualGoldenResourceManipulationOnUpdate(null, updatedResource, requestDetails, null);
+
+		List<ILoggingEvent> warningLogs = myListAppender
+			.list
+			.stream()
+			.filter(event -> Level.WARN.equals(event.getLevel()))
+			.toList();
+		assertEquals(0, warningLogs.size());
+
+	}
+
+}


### PR DESCRIPTION
Fixes `MdmStorageInterceptor Is Unnecessarily Processing Data That Is Not MDM-Related` #4450 