### PR TITLE
Enabling massIngestionMode causes incomplete resource deletion

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4475-fix-incomplete-resource-deletion-with-massinjectionmode-enabled.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4475-fix-incomplete-resource-deletion-with-massinjectionmode-enabled.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4475
+jira: SMILE-4961
+title: "Enabling mass ingestion mode alters the resource deletion process leaving resources partially deleted. The problem has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -143,7 +143,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
-import static ca.uhn.fhir.jpa.model.util.JpaConstants.ALL_PARTITIONS_NAME;
+import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -601,7 +601,11 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 
 		} else {
 
-			theEntity.setHashSha256(null);
+			if(nonNull(theEntity.getHashSha256())){
+				theEntity.setHashSha256(null);
+				changed = true;
+			}
+
 			resourceBinary = null;
 			resourceText = null;
 			encoding = ResourceEncodingEnum.DEL;
@@ -939,7 +943,6 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			entity.setUpdated(theDeletedTimestampOrNull);
 			entity.setNarrativeText(null);
 			entity.setContentText(null);
-			entity.setHashSha256(null);
 			entity.setIndexStatus(INDEX_STATUS_INDEXED);
 			changed = populateResourceIntoEntity(theTransactionDetails, theRequest, theResource, entity, true);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
@@ -2895,9 +2895,28 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 
 	}
 
-	private void printQueryCount(String theMessage){
-		
-		ourLog.info("QueryCount {} is: ", theMessage);
+	@Test
+	public void testDeleteResource_WithMassIngestionMode_enabled(){
+		myDaoConfig.setMassIngestionMode(true);
+
+		// given
+		Observation observation = new Observation()
+			.setStatus(Observation.ObservationStatus.FINAL)
+			.addCategory(new CodeableConcept().addCoding(new Coding("http://category-type", "12345", null)))
+			.setCode(new CodeableConcept().addCoding(new Coding("http://coverage-type", "12345", null)));
+
+		IIdType idDt = myObservationDao.create(observation, mySrd).getEntity().getIdDt();
+
+		// when
+		myCaptureQueriesListener.clear();
+		myObservationDao.delete(idDt, mySrd);
+
+		// then
+		assertQueryCount(3,1,1, 1);
+	}
+
+	private void printQueryCount(){
+
 		ourLog.info("\tselect: {}", myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		ourLog.info("\tupdate: {}", myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
 		ourLog.info("\tinsert: {}", myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
@@ -2905,16 +2924,15 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 
 	}
 
-	private void assertQueryCount(int theExpectedSelect, int theExpectedUpdate, int theExpectedInsert, int theExpectedDelete){
-		myCaptureQueriesListener.logSelectQueriesForCurrentThread();
+	private void assertQueryCount(int theExpectedSelectCount, int theExpectedUpdateCount, int theExpectedInsertCount, int theExpectedDeleteCount){
 
-		assertEquals(theExpectedSelect, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+		assertEquals(theExpectedSelectCount, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		myCaptureQueriesListener.logUpdateQueriesForCurrentThread();
-		assertEquals(theExpectedUpdate, myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
+		assertEquals(theExpectedUpdateCount, myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
 		myCaptureQueriesListener.logInsertQueriesForCurrentThread();
-		assertEquals(theExpectedInsert, myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
+		assertEquals(theExpectedInsertCount, myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
 		myCaptureQueriesListener.logDeleteQueriesForCurrentThread();
-		assertEquals(theExpectedDelete, myCaptureQueriesListener.getDeleteQueriesForCurrentThread().size());
+		assertEquals(theExpectedDeleteCount, myCaptureQueriesListener.getDeleteQueriesForCurrentThread().size());
 	}
 
 	private Group createGroup(List<IIdType> theIIdTypeList) {


### PR DESCRIPTION
#### Background:
Enabling MassIngestionMode will have negative effects on the resource deletion process. When a resource is deleted with the mode enabled:

- entries related to the deleted resource in the various index tables are not removed;
-  the entry marking the resource deletion is not added to the HFJ_RES_VER table;

#### what was done:
- modification of the deletion process to keep on marking the resource being deleted has  'changed' to trigger updates of the index tables and adding an entry to the version table;
- adding tests;
- adding changelog;