### PR TITLE
Reindex batch job fails when processing deleted resources.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4481-reindex-batch-job-fails-when-processing-deleted-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4481-reindex-batch-job-fails-when-processing-deleted-resources.yaml
@@ -2,4 +2,4 @@
 type: fix
 issue: 4481
 jira: SMILE-4961
-title: ""
+title: "Previously, a reindex batch job would fail when executing on deleted resources.  This issue has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4481-reindex-batch-job-fails-when-processing-deleted-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4481-reindex-batch-job-fails-when-processing-deleted-resources.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4481
+jira: SMILE-4961
+title: ""

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -51,6 +51,7 @@ import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 
@@ -99,8 +100,9 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 		List<IResourcePersistentId> ids = dao.searchForIds(searchParamMap, request);
 
 		Date lastDate = null;
-		if (ids.size() > 0) {
-			lastDate = dao.readByPid(ids.get(ids.size() - 1)).getMeta().getLastUpdated();
+		if (isNotEmpty(ids)) {
+			IResourcePersistentId lastResourcePersistentId = ids.get(ids.size() - 1);
+			lastDate = dao.readByPid(lastResourcePersistentId, true).getMeta().getLastUpdated();
 		}
 
 		return new HomogeneousResourcePidList(resourceType, ids, lastDate);


### PR DESCRIPTION
**Background:**
Due to issue [4475](https://github.com/hapifhir/hapi-fhir/issues/4475) which has been [fixed](https://github.com/hapifhir/hapi-fhir/pull/4476), it is possible that a reindex batch job processe resource that have been deleted.  

The current implementation of batch processing does not allow reindexing on a deleted resource.  The LoadIdsStep fails preventing entries related to the deleted resource from being removed from the various index tables.

**What Was Done:**
- Allowing the LoadIdsStep to process deleted resources;
- Adding test;
- Adding changelog;
