### PR TITLE
Fix subscription validation not to validate partition ID when invoked from an update pointcut

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4485-subscription-cross-partition-custom-interceptor-put-update-error-hapi-2010.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4485-subscription-cross-partition-custom-interceptor-put-update-error-hapi-2010.yaml
@@ -1,0 +1,5 @@
+type: fix
+issue: 4485
+jira:  SMILE-5561
+title: "Cross-partition subscription PUT with a custom interceptor will fail on validation because the read partition ID is used.
+        This has been fixed by skipping validation if the validator invoked for an update pointcut."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4485-subscription-cross-partition-custom-interceptor-put-update-error-hapi-2010.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4485-subscription-cross-partition-custom-interceptor-put-update-error-hapi-2010.yaml
@@ -2,4 +2,4 @@ type: fix
 issue: 4485
 jira:  SMILE-5561
 title: "Cross-partition subscription PUT with a custom interceptor will fail on validation because the read partition ID is used.
-        This has been fixed by skipping validation if the validator invoked for an update pointcut."
+        This has been fixed by skipping validation if the validator invoked during an update operation"

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -83,23 +83,29 @@ public class SubscriptionValidatingInterceptor {
 		myFhirContext = theFhirContext;
 	}
 
-//	/**
-//		@deprecated Please call either {@link #resourcePreCreate(IBaseResource, RequestDetails, RequestPartitionId)} or
-//		{@link #resourceUpdated(IBaseResource, IBaseResource, RequestDetails, RequestPartitionId)} based on whether this is for a create or update.
-//	 */
-//	@Deprecated
-//	// TODO:  what do we do with this?  change the signature?  default to CREATED?
-//	public void validateSubmittedSubscription(IBaseResource theSubscription) {
-//		validateSubmittedSubscription(theSubscription, null, null, thePointcut);
-//	}
+	// This will be deleted once the next snapshot (6.3.15) is published
+	@Deprecated
+	public void validateSubmittedSubscription(IBaseResource theSubscription) {
+		validateSubmittedSubscription(theSubscription, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED);
+	}
 
+	// This will be deleted once the next snapshot (6.3.15) is published
+	@Deprecated(since="6.3.14")
 	public void validateSubmittedSubscription(IBaseResource theSubscription,
 															RequestDetails theRequestDetails,
-															RequestPartitionId theRequestPartitionId,
-															Pointcut thePointcut) {
+															RequestPartitionId theRequestPartitionId) {
+
+		validateSubmittedSubscription(theSubscription, theRequestDetails, theRequestPartitionId, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED);
+	}
+
+	@VisibleForTesting
+	void validateSubmittedSubscription(IBaseResource theSubscription,
+												  RequestDetails theRequestDetails,
+												  RequestPartitionId theRequestPartitionId,
+												  Pointcut thePointcut) {
 		if (Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED != thePointcut && Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED != thePointcut) {
 			// TODO: Do we need a custom Msg code here or does this work?
-			throw new IllegalArgumentException("Expected Pointcut to be either STORAGE_PRESTORAGE_RESOURCE_CREATED or STORAGE_PRESTORAGE_RESOURCE_UPDATED but was: " + thePointcut);
+			throw new UnprocessableEntityException(Msg.code(2267) + "Expected Pointcut to be either STORAGE_PRESTORAGE_RESOURCE_CREATED or STORAGE_PRESTORAGE_RESOURCE_UPDATED but was: " + thePointcut);
 		}
 
 		if (!"Subscription".equals(myFhirContext.getResourceType(theSubscription))) {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -104,7 +104,6 @@ public class SubscriptionValidatingInterceptor {
 												  RequestPartitionId theRequestPartitionId,
 												  Pointcut thePointcut) {
 		if (Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED != thePointcut && Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED != thePointcut) {
-			// TODO: Do we need a custom Msg code here or does this work?
 			throw new UnprocessableEntityException(Msg.code(2267) + "Expected Pointcut to be either STORAGE_PRESTORAGE_RESOURCE_CREATED or STORAGE_PRESTORAGE_RESOURCE_UPDATED but was: " + thePointcut);
 		}
 
@@ -176,8 +175,7 @@ public class SubscriptionValidatingInterceptor {
 				throw new UnprocessableEntityException(Msg.code(2009) + "Cross partition subscription is not enabled on this server");
 			}
 
-			// TODO:  what if theRequestPartitionId  is non-null?
-			if (Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED == thePointcut) {
+			if (theRequestPartitionId == null && Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED == thePointcut) {
 				return;
 			}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.SubscriptionStrategyEvaluator;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionCanonicalizer;
+import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.BeforeEach;
@@ -155,6 +156,7 @@ public class SubscriptionValidatingInterceptorTest {
 	public void testSubscriptionUpdate() {
 		final Subscription subscription = createSubscription();
 
+		// Assert there is no Exception thrown here.
 		mySubscriptionValidatingInterceptor.resourceUpdated(subscription, subscription, null, null);
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -50,7 +50,7 @@ public class SubscriptionValidatingInterceptorTest {
 	public void testEmptySub() {
 		try {
 			Subscription badSub = new Subscription();
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(8) + "Can not process submitted Subscription - Subscription.status must be populated on this server"));
@@ -63,7 +63,7 @@ public class SubscriptionValidatingInterceptorTest {
 		try {
 			Subscription badSub = new Subscription();
 			badSub.setStatus(Subscription.SubscriptionStatus.ACTIVE);
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(11) + "Subscription.criteria must be populated"));
@@ -76,7 +76,7 @@ public class SubscriptionValidatingInterceptorTest {
 			Subscription badSub = new Subscription();
 			badSub.setStatus(Subscription.SubscriptionStatus.ACTIVE);
 			badSub.setCriteria("Patient");
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(14) + "Subscription.criteria must be in the form \"{Resource Type}?[params]\""));
@@ -89,7 +89,7 @@ public class SubscriptionValidatingInterceptorTest {
 			Subscription badSub = new Subscription();
 			badSub.setStatus(Subscription.SubscriptionStatus.ACTIVE);
 			badSub.setCriteria("Patient?");
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(20) + "Subscription.channel.type must be populated"));
@@ -104,7 +104,7 @@ public class SubscriptionValidatingInterceptorTest {
 			badSub.setCriteria("Patient?");
 			Subscription.SubscriptionChannelComponent channel = badSub.getChannel();
 			channel.setType(Subscription.SubscriptionChannelType.MESSAGE);
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(16) + "No endpoint defined for message subscription"));
@@ -121,7 +121,7 @@ public class SubscriptionValidatingInterceptorTest {
 
 		channel.setEndpoint("foo");
 		try {
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(17) + "Only 'channel' protocol is supported for Subscriptions with channel type 'message'"));
@@ -129,7 +129,7 @@ public class SubscriptionValidatingInterceptorTest {
 
 		channel.setEndpoint("channel");
 		try {
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(17) + "Only 'channel' protocol is supported for Subscriptions with channel type 'message'"));
@@ -137,7 +137,7 @@ public class SubscriptionValidatingInterceptorTest {
 
 		channel.setEndpoint("channel:");
 		try {
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+			mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 			fail();
 		} catch (UnprocessableEntityException e) {
 			assertThat(e.getMessage(), is(Msg.code(19) + "Invalid subscription endpoint uri channel:"));
@@ -145,7 +145,7 @@ public class SubscriptionValidatingInterceptorTest {
 
 		// Happy path
 		channel.setEndpoint("channel:my-queue-name");
-		mySubscriptionValidatingInterceptor.validateSubmittedSubscription(badSub);
+		mySubscriptionValidatingInterceptor.resourcePreCreate(badSub, null, null);
 	}
 
 	@Configuration


### PR DESCRIPTION
- Ensure subscription validation knows whether it's processing a CREATE or UPDATE pointcut
- Skip the partition ID validation if this is for an UPDATE
- Rename the `resourcePreCreate` method that does updates
- Adjust unit test code to call proper create or update methods
- Ensure all other public methods in the validate are deprecated, to be removed after the next snapshot version is published.

Closes https://github.com/hapifhir/hapi-fhir/issues/4485