### PR TITLE
Having narrative_generation documentation reference an html snippet

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/narrative_generation.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/narrative_generation.md
@@ -54,8 +54,8 @@ Note that these templates expect a few specific CSS definitions to be present in
 
 To use your own templates for narrative generation, simply create one or more templates, using the Thymeleaf HTML based syntax.
 
-```java
-{{snippet:classpath:/ca/uhn/fhir/narrative/OperationOutcome.html}}
+```html
+{{snippet:classpath:/ca/uhn/hapi/fhir/docs/snippet/OperationOutcome.html}}
 ```
 
 Then create a properties file which describes your templates. In this properties file, each resource to be defined has a pair or properties.

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/snippet/OperationOutcome.html
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/snippet/OperationOutcome.html
@@ -1,0 +1,23 @@
+
+<html>
+<head>
+   <link rel="stylesheet" type="text/css" href="narrative.css"/>
+</head>
+<body>
+<!--*/-->
+<div>
+   <h1>Operation Outcome</h1>
+   <table border="0">
+      <tr th:each="issue : ${resource.issue}">
+         <td th:text="${issue.severityElement.value}" style="font-weight: bold;"></td>
+         <td th:text="${issue.location}"></td>
+         <td th:narrative="${issue.diagnostics}"></td>
+      </tr>
+   </table>
+</div>
+
+<!--*/-->
+</body>
+</html>
+
+


### PR DESCRIPTION
Background:
In an effort to enhance documentation, PR #4521 updated file OperationOutcome.html to use tag th:narrative.  The tag was added because the html file was referenced in the narrative generator documentation as having an example of usage of tag th:narrative but did.

Adding the tag broke the implementation as file OperationOutcome.html is not just referenced in documentation.

What was done:
- created a separate file OperationOutcome.html in the documentation structure with the narrative tag so it can be safely referenced by the narrative documentation.  
- no changeLog required since this PR is a fix to an issue introduced by #4521.