### PR TITLE
fixed channel import null pointer exception from null header

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4533-channel-import-null-header-null-pointer-exception.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4533-channel-import-null-header-null-pointer-exception.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 4533
+jira: SMILE-5554
+title: "Previously, if a message with a null header was sent to a Channel Import module and failed,
+a NullPointerException would occur and the consumer would become unable to receive any further messages.
+This has now been fixed."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessage.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessage.java
@@ -53,6 +53,9 @@ public abstract class BaseJsonMessage<T> implements Message<T>, IModelJson {
 	}
 
 	public HapiMessageHeaders getHapiHeaders() {
+		if (myHeaders == null) {
+			setDefaultRetryHeaders();
+		}
 		return myHeaders;
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessage.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessage.java
@@ -28,6 +28,8 @@ import org.springframework.messaging.MessageHeaders;
 
 import javax.annotation.Nullable;
 
+import static java.util.Objects.isNull;
+
 public abstract class BaseJsonMessage<T> implements Message<T>, IModelJson {
 
 	private static final long serialVersionUID = 1L;
@@ -53,7 +55,7 @@ public abstract class BaseJsonMessage<T> implements Message<T>, IModelJson {
 	}
 
 	public HapiMessageHeaders getHapiHeaders() {
-		if (myHeaders == null) {
+		if (isNull(myHeaders)) {
 			setDefaultRetryHeaders();
 		}
 		return myHeaders;

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/HapiMessageHeaders.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/HapiMessageHeaders.java
@@ -27,6 +27,8 @@ import org.springframework.messaging.MessageHeaders;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Objects.isNull;
+
 /**
  * This class is for holding headers for BaseJsonMessages. Any serializable data can be thrown into
  * the header map. There are also three special headers, defined by the constants in this class, which are for use
@@ -57,6 +59,9 @@ public class HapiMessageHeaders implements IModelJson {
 	}
 
 	public Integer getRetryCount() {
+		if (isNull(this.myRetryCount)) {
+			return 0;
+		}
 		return this.myRetryCount;
 	}
 

--- a/hapi-fhir-storage-test-utilities/src/test/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessageTest.java
+++ b/hapi-fhir-storage-test-utilities/src/test/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessageTest.java
@@ -70,9 +70,12 @@ class BaseJsonMessageTest {
 
 	@Test
 	void test_resourceModifiedJsonMessage_getRetryCountOnNullHeaders_willReturnZero() {
+		// Given
 		ResourceModifiedJsonMessage message = new ResourceModifiedJsonMessage();
 		message.setHeaders(null);
+		// When
 		HapiMessageHeaders headers = message.getHapiHeaders();
+		// Then
 		assertEquals(0, headers.getRetryCount());
 	}
 }

--- a/hapi-fhir-storage-test-utilities/src/test/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessageTest.java
+++ b/hapi-fhir-storage-test-utilities/src/test/java/ca/uhn/fhir/rest/server/messaging/json/BaseJsonMessageTest.java
@@ -67,4 +67,12 @@ class BaseJsonMessageTest {
 		message.setPayload(payload);
 		assertEquals(RESOURCE_ID, message.getMessageKeyOrNull());
 	}
+
+	@Test
+	void test_resourceModifiedJsonMessage_getRetryCountOnNullHeaders_willReturnZero() {
+		ResourceModifiedJsonMessage message = new ResourceModifiedJsonMessage();
+		message.setHeaders(null);
+		HapiMessageHeaders headers = message.getHapiHeaders();
+		assertEquals(0, headers.getRetryCount());
+	}
 }


### PR DESCRIPTION
Fixes `Message Channel Stops Processing Messages When a Processing Exception Making the Channel Unusable` #4533 