### PR TITLE
Avoid logging message payloads that contain sensitive data

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4537-message-to-string-redaction.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4537-message-to-string-redaction.yaml
@@ -1,0 +1,5 @@
+---
+type: change
+issue: 4537
+title: "ResourceDeliveryMessage no longer includes the payload in toString().
+   This avoids leaking sensitive data to logs and other channels."

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceDeliveryMessage.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceDeliveryMessage.java
@@ -128,7 +128,8 @@ public class ResourceDeliveryMessage extends BaseResourceMessage implements IRes
 	public String toString() {
 		return new ToStringBuilder(this)
 			.append("mySubscription", mySubscription)
-			.append("myPayloadString", myPayloadString)
+			// it isn't safe to log payloads
+			.append("myPayloadString", "[Not Logged]")
 			.append("myPayload", myPayloadDecoded)
 			.append("myPayloadId", myPayloadId)
 			.append("myPartitionId", myPartitionId)


### PR DESCRIPTION
Message payloads may contain PHI, and shouldn't be logged.
