### PR TITLE
4523 meta source field in subscription messages is inconsistently populated

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/MetaUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/MetaUtil.java
@@ -36,12 +36,25 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 
 public class MetaUtil {
 	private static final Logger ourLog = LoggerFactory.getLogger(MetaUtil.class);
 
 	private MetaUtil() {
 		// non-instantiable
+	}
+
+	public static String cleanProvenanceSourceUri(String theProvenanceSourceUri) {
+		if (isNotBlank(theProvenanceSourceUri)) {
+			int hashIndex = theProvenanceSourceUri.indexOf('#');
+			if (hashIndex != -1) {
+				theProvenanceSourceUri = theProvenanceSourceUri.substring(0, hashIndex);
+			}
+		}
+		return defaultString(theProvenanceSourceUri);
 	}
 
 	public static String getSource(FhirContext theContext, IBaseMetaType theMeta) {
@@ -78,6 +91,16 @@ public class MetaUtil {
 			retVal = ((IPrimitiveType<?>) sourceValues.get(0)).getValueAsString();
 		}
 		return retVal;
+	}
+
+	public static <R extends IBaseResource> void populateResourceSource(FhirContext theFhirContext, String provenanceSourceUri, String provenanceRequestId, R retVal) {
+		if (isNotBlank(provenanceRequestId) || isNotBlank(provenanceSourceUri)) {
+			String sourceString = cleanProvenanceSourceUri(provenanceSourceUri)
+				+ (isNotBlank(provenanceRequestId) ? "#" : "")
+				+ defaultString(provenanceRequestId);
+
+			setSource(theFhirContext, retVal, sourceString);
+		}
 	}
 
 	/**
@@ -118,5 +141,6 @@ public class MetaUtil {
 		}
 		sourceElement.setValueAsString(theValue);
 	}
+
 
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4523-meta-source-field-in-subscription-messages-is-inconsistently-populated.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_4_0/4523-meta-source-field-in-subscription-messages-is-inconsistently-populated.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4523
+title: "Previously, meta source field in subscription messages was inconsistently populated regarding different requests.
+Now, this has been fixed and meta source will be included in all subscription messages."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -1291,10 +1291,12 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 		}
 
 		String requestId = getRequestId(theRequest, source);
-		source = cleanProvenanceSourceUri(source);
+		source = MetaUtil.cleanProvenanceSourceUri(source);
 
-		boolean haveSource = isNotBlank(source) && myConfig.getStoreMetaSourceInformation().isStoreSourceUri();
-		boolean haveRequestId = isNotBlank(requestId) && myConfig.getStoreMetaSourceInformation().isStoreRequestId();
+		boolean shouldStoreSource = myConfig.getStoreMetaSourceInformation().isStoreSourceUri();
+		boolean shouldStoreRequestId = myConfig.getStoreMetaSourceInformation().isStoreRequestId();
+		boolean haveSource = isNotBlank(source) && shouldStoreSource;
+		boolean haveRequestId = isNotBlank(requestId) && shouldStoreRequestId;
 		if (haveSource || haveRequestId) {
 			ResourceHistoryProvenanceEntity provenance = new ResourceHistoryProvenanceEntity();
 			provenance.setResourceHistoryTable(historyEntry);
@@ -1306,6 +1308,12 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			if (haveSource) {
 				provenance.setSourceUri(source);
 			}
+
+			if (theResource != null) {
+				MetaUtil.populateResourceSource(myFhirContext,  shouldStoreSource ? source : null, shouldStoreRequestId ? requestId : null , theResource);
+			}
+
+
 			myEntityManager.persist(provenance);
 		}
 	}
@@ -1586,16 +1594,6 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 	@Nonnull
 	public static MemoryCacheService.TagDefinitionCacheKey toTagDefinitionMemoryCacheKey(TagTypeEnum theTagType, String theScheme, String theTerm) {
 		return new MemoryCacheService.TagDefinitionCacheKey(theTagType, theScheme, theTerm);
-	}
-
-	static String cleanProvenanceSourceUri(String theProvenanceSourceUri) {
-		if (isNotBlank(theProvenanceSourceUri)) {
-			int hashIndex = theProvenanceSourceUri.indexOf('#');
-			if (hashIndex != -1) {
-				theProvenanceSourceUri = theProvenanceSourceUri.substring(0, hashIndex);
-			}
-		}
-		return defaultString(theProvenanceSourceUri);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
@@ -59,7 +59,6 @@ import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseMetaType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
-import org.hl7.fhir.r4.model.Bundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +70,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.cleanProvenanceSourceUri;
 import static ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.decodeResource;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -80,7 +78,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 	public static final LenientErrorHandler LENIENT_ERROR_HANDLER = new LenientErrorHandler(false).setErrorOnInvalidValue(false);
 	private static final Logger ourLog = LoggerFactory.getLogger(JpaStorageResourceParser.class);
 	@Autowired
-	private FhirContext myContext;
+	private FhirContext myFhirContext;
 	@Autowired
 	private DaoConfig myDaoConfig;
 	@Autowired
@@ -92,7 +90,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 
 	@Override
 	public IBaseResource toResource(IBasePersistedResource theEntity, boolean theForHistoryOperation) {
-		RuntimeResourceDefinition type = myContext.getResourceDefinition(theEntity.getResourceType());
+		RuntimeResourceDefinition type = myFhirContext.getResourceDefinition(theEntity.getResourceType());
 		Class<? extends IBaseResource> resourceType = type.getImplementingClass();
 		return toResource(resourceType, (IBaseResourceEntity) theEntity, null, theForHistoryOperation);
 	}
@@ -212,7 +210,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 		retVal = populateResourceMetadata(theEntity, theForHistoryOperation, tagList, version, retVal);
 
 		// 6. Handle source (provenance)
-		populateResourceSource(provenanceSourceUri, provenanceRequestId, retVal);
+		MetaUtil.populateResourceSource(myFhirContext, provenanceSourceUri, provenanceRequestId, retVal);
 
 		// 7. Add partition information
 		populateResourcePartitionInformation(theEntity, retVal);
@@ -232,16 +230,6 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 		}
 	}
 
-	private <R extends IBaseResource> void populateResourceSource(String provenanceSourceUri, String provenanceRequestId, R retVal) {
-		if (isNotBlank(provenanceRequestId) || isNotBlank(provenanceSourceUri)) {
-			String sourceString = cleanProvenanceSourceUri(provenanceSourceUri)
-				+ (isNotBlank(provenanceRequestId) ? "#" : "")
-				+ defaultString(provenanceRequestId);
-
-			MetaUtil.setSource(myContext, retVal, sourceString);
-		}
-	}
-
 	@SuppressWarnings("unchecked")
 	private <R extends IBaseResource> R parseResource(IBaseResourceEntity theEntity, ResourceEncodingEnum resourceEncoding, String decodedResourceText, Class<R> resourceType) {
 		R retVal;
@@ -254,7 +242,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 			} catch (Exception e) {
 				StringBuilder b = new StringBuilder();
 				b.append("Failed to parse database resource[");
-				b.append(myContext.getResourceType(resourceType));
+				b.append(myFhirContext.getResourceType(resourceType));
 				b.append("/");
 				b.append(theEntity.getIdDt().getIdPart());
 				b.append(" (pid ");
@@ -270,7 +258,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 
 		} else {
 
-			retVal = (R) myContext.getResourceDefinition(theEntity.getResourceType()).newInstance();
+			retVal = (R) myFhirContext.getResourceDefinition(theEntity.getResourceType()).newInstance();
 
 		}
 		return retVal;
@@ -280,12 +268,12 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 	private <R extends IBaseResource> Class<R> determineTypeToParse(Class<R> theResourceType, @Nullable Collection<? extends BaseTag> tagList) {
 		Class<R> resourceType = theResourceType;
 		if (tagList != null) {
-			if (myContext.hasDefaultTypeForProfile()) {
+			if (myFhirContext.hasDefaultTypeForProfile()) {
 				for (BaseTag nextTag : tagList) {
 					if (nextTag.getTag().getTagType() == TagTypeEnum.PROFILE) {
 						String profile = nextTag.getTag().getCode();
 						if (isNotBlank(profile)) {
-							Class<? extends IBaseResource> newType = myContext.getDefaultTypeForProfile(profile);
+							Class<? extends IBaseResource> newType = myFhirContext.getDefaultTypeForProfile(profile);
 							if (newType != null && theResourceType.isAssignableFrom(newType)) {
 								ourLog.debug("Using custom type {} for profile: {}", newType.getName(), profile);
 								resourceType = (Class<R>) newType;
@@ -316,7 +304,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 	private <R extends IResource> R populateResourceMetadataHapi(IBaseResourceEntity theEntity, @Nullable Collection<? extends BaseTag> theTagList, boolean theForHistoryOperation, R res, Long theVersion) {
 		R retVal = res;
 		if (theEntity.getDeleted() != null) {
-			res = (R) myContext.getResourceDefinition(res).newInstance();
+			res = (R) myFhirContext.getResourceDefinition(res).newInstance();
 			retVal = res;
 			ResourceMetadataKeyEnum.DELETED_AT.put(res, new InstantDt(theEntity.getDeleted()));
 			if (theForHistoryOperation) {
@@ -353,7 +341,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 							profiles.add(new IdDt(next.getTag().getCode()));
 							break;
 						case SECURITY_LABEL:
-							IBaseCoding secLabel = (IBaseCoding) myContext.getVersion().newCodingDt();
+							IBaseCoding secLabel = (IBaseCoding) myFhirContext.getVersion().newCodingDt();
 							secLabel.setSystem(next.getTag().getSystem());
 							secLabel.setCode(next.getTag().getCode());
 							secLabel.setDisplay(next.getTag().getDisplay());
@@ -383,7 +371,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 	private <R extends IBaseResource> R populateResourceMetadataRi(IBaseResourceEntity theEntity, @Nullable Collection<? extends BaseTag> theTagList, boolean theForHistoryOperation, IAnyResource res, Long theVersion) {
 		R retVal = (R) res;
 		if (theEntity.getDeleted() != null) {
-			res = (IAnyResource) myContext.getResourceDefinition(res).newInstance();
+			res = (IAnyResource) myFhirContext.getResourceDefinition(res).newInstance();
 			retVal = (R) res;
 			ResourceMetadataKeyEnum.DELETED_AT.put(res, new InstantDt(theEntity.getDeleted()));
 			if (theForHistoryOperation) {
@@ -442,8 +430,8 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 	@Override
 	public void updateResourceMetadata(IBaseResourceEntity theEntitySource, IBaseResource theResourceTarget) {
 		IIdType id = theEntitySource.getIdDt();
-		if (myContext.getVersion().getVersion().isRi()) {
-			id = myContext.getVersion().newIdType().setValue(id.getValue());
+		if (myFhirContext.getVersion().getVersion().isRi()) {
+			id = myFhirContext.getVersion().newIdType().setValue(id.getValue());
 		}
 
 		if (id.hasResourceType() == false) {
@@ -463,8 +451,8 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 
 	private FhirContext getContext(FhirVersionEnum theVersion) {
 		Validate.notNull(theVersion, "theVersion must not be null");
-		if (theVersion == myContext.getVersion().getVersion()) {
-			return myContext;
+		if (theVersion == myFhirContext.getVersion().getVersion()) {
+			return myFhirContext;
 		}
 		return FhirContext.forCached(theVersion);
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.util.HapiExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,8 +60,14 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 
 	protected void doDelivery(ResourceDeliveryMessage theSourceMessage, CanonicalSubscription theSubscription, IChannelProducer theChannelProducer, ResourceModifiedJsonMessage theWrappedMessageToSend) {
 		String payloadId = theSourceMessage.getPayloadId();
+		IBaseResource payloadResource = null;
 		if (isNotBlank(theSubscription.getPayloadSearchCriteria())) {
-			IBaseResource payloadResource = createDeliveryBundleForPayloadSearchCriteria(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
+			payloadResource = createDeliveryBundleForPayloadSearchCriteria(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
+		} else if (! theWrappedMessageToSend.getPayload().getPayloadString().contains(HapiExtensions.EXT_META_SOURCE)){
+			payloadResource = updateDeliveryResourceWithMetaSource(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
+		}
+
+		if (payloadResource != null) {
 			ResourceModifiedJsonMessage newWrappedMessageToSend = convertDeliveryMessageToResourceModifiedMessage(theSourceMessage, payloadResource);
 			theWrappedMessageToSend.setPayload(newWrappedMessageToSend.getPayload());
 			payloadId = payloadResource.getIdElement().toUnqualifiedVersionless().getValue();

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -64,7 +64,7 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 		if (isNotBlank(theSubscription.getPayloadSearchCriteria())) {
 			payloadResource = createDeliveryBundleForPayloadSearchCriteria(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
 		} else if (! theWrappedMessageToSend.getPayload().getPayloadString().contains(HapiExtensions.EXT_META_SOURCE)){
-			payloadResource = updateDeliveryResourceWithMetaSource(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
+			payloadResource = updateDeliveryResourceWithMetaSource(theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
 		}
 
 		if (payloadResource != null) {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -60,18 +60,14 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 
 	protected void doDelivery(ResourceDeliveryMessage theSourceMessage, CanonicalSubscription theSubscription, IChannelProducer theChannelProducer, ResourceModifiedJsonMessage theWrappedMessageToSend) {
 		String payloadId = theSourceMessage.getPayloadId();
-		IBaseResource payloadResource = null;
-		if (isNotBlank(theSubscription.getPayloadSearchCriteria())) {
-			payloadResource = createDeliveryBundleForPayloadSearchCriteria(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
-		} else if (! theWrappedMessageToSend.getPayload().getPayloadString().contains(HapiExtensions.EXT_META_SOURCE)){
-			payloadResource = updateDeliveryResourceWithMetaSource(theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
-		}
 
-		if (payloadResource != null) {
+		if (isNotBlank(theSubscription.getPayloadSearchCriteria())) {
+			IBaseResource payloadResource = createDeliveryBundleForPayloadSearchCriteria(theSubscription, theWrappedMessageToSend.getPayload().getPayload(myFhirContext));
 			ResourceModifiedJsonMessage newWrappedMessageToSend = convertDeliveryMessageToResourceModifiedMessage(theSourceMessage, payloadResource);
 			theWrappedMessageToSend.setPayload(newWrappedMessageToSend.getPayload());
 			payloadId = payloadResource.getIdElement().toUnqualifiedVersionless().getValue();
 		}
+
 		theChannelProducer.send(theWrappedMessageToSend);
 		ourLog.debug("Delivering {} message payload {} for {}", theSourceMessage.getOperationType(), payloadId, theSubscription.getIdElement(myFhirContext).toUnqualifiedVersionless().getValue());
 	}

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
@@ -406,16 +406,6 @@ public class BaseSubscriptionDeliverySubscriberTest {
 		//Given: we have a subscription message that contains a patient resource
 		Patient p1 = generatePatient();
 		p1.addName().setFamily("p1-family");
-		p1.getMeta().setSource("#example-source");
-		IBundleProvider bundleProvider = new SimpleBundleProvider(List.of(p1));
-
-		//When
-		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_BEFORE_MESSAGE_DELIVERY), ArgumentMatchers.any(HookParams.class))).thenReturn(true);
-		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_AFTER_MESSAGE_DELIVERY), any())).thenReturn(false);
-		when(myChannelFactory.getOrCreateProducer(any(), any(), any())).thenReturn(myChannelProducer);
-		when(myDaoRegistry.getResourceDao(anyString())).thenReturn(myResourceDao);
-		when(myMatchUrlService.translateMatchUrl(any(), any(), any())).thenReturn(new SearchParameterMap());
-		when(myResourceDao.search(any(), any())).thenReturn(bundleProvider);
 
 		CanonicalSubscription subscription = generateSubscription();
 		subscription.setCriteriaString("[*]");
@@ -424,6 +414,15 @@ public class BaseSubscriptionDeliverySubscriberTest {
 		payload.setSubscription(subscription);
 		payload.setPayload(myCtx, p1, EncodingEnum.JSON);
 		payload.setOperationType(ResourceModifiedMessage.OperationTypeEnum.CREATE);
+
+		//When
+		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_BEFORE_MESSAGE_DELIVERY), ArgumentMatchers.any(HookParams.class))).thenReturn(true);
+		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_AFTER_MESSAGE_DELIVERY), any())).thenReturn(false);
+		when(myChannelFactory.getOrCreateProducer(any(), any(), any())).thenReturn(myChannelProducer);
+		when(myDaoRegistry.getResourceDao(anyString())).thenReturn(myResourceDao);
+
+		p1.getMeta().setSource("#example-source");
+		when(myResourceDao.read(any(), any())).thenReturn(p1);
 
 		//Then: meta.source field will be included in the message
 		myMessageSubscriber.handleMessage(payload);

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
@@ -268,9 +268,6 @@ public class BaseSubscriptionDeliverySubscriberTest {
 		assertEquals(p1.getIdElement().getValue(), receivedBundle.getEntry().get(0).getResource().getIdElement().getValue());
 		assertEquals(p2.getIdElement().getValue(), receivedBundle.getEntry().get(1).getResource().getIdElement().getValue());
 
-
-		System.out.println("CREATE message: " + myCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(receivedBundle));
-
 	}
 
 	@Test
@@ -405,7 +402,7 @@ public class BaseSubscriptionDeliverySubscriberTest {
 	}
 
 	@Test
-	public void testSubscriptionMessageContainsMetaSourceField_CREATE() throws URISyntaxException {
+	public void testSubscriptionMessageContainsMetaSourceField() throws URISyntaxException {
 		//Given: we have a subscription message that contains a patient resource
 		Patient p1 = generatePatient();
 		p1.addName().setFamily("p1-family");

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
@@ -208,6 +208,7 @@ public class BaseSubscriptionDeliverySubscriberTest {
 		});
 		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_AFTER_MESSAGE_DELIVERY), any())).thenReturn(false);
 		when(myChannelFactory.getOrCreateProducer(any(), any(), any())).thenReturn(myChannelProducer);
+		when(myDaoRegistry.getResourceDao(anyString())).thenReturn(myResourceDao);
 
 		CanonicalSubscription subscription = generateSubscription();
 		Patient patient = generatePatient();
@@ -345,6 +346,7 @@ public class BaseSubscriptionDeliverySubscriberTest {
 		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_BEFORE_MESSAGE_DELIVERY), any())).thenReturn(true);
 		when(myInterceptorBroadcaster.callHooks(eq(Pointcut.SUBSCRIPTION_AFTER_MESSAGE_DELIVERY), any())).thenReturn(false);
 		when(myChannelFactory.getOrCreateProducer(any(), any(), any())).thenReturn(myChannelProducer);
+		when(myDaoRegistry.getResourceDao(anyString())).thenReturn(myResourceDao);
 
 		CanonicalSubscription subscription = generateSubscription();
 		Patient patient = generatePatient();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDaoTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDaoTest.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.jpa.model.entity.TagTypeEnum;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
 import ca.uhn.fhir.util.AsyncUtil;
+import ca.uhn.fhir.util.MetaUtil;
 import ca.uhn.fhir.util.ThreadPoolUtil;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -387,9 +388,9 @@ public class BaseHapiFhirDaoTest {
 
 	@Test
 	public void cleanProvenanceSourceUri() {
-		assertEquals("", BaseHapiFhirDao.cleanProvenanceSourceUri(null));
-		assertEquals("abc", BaseHapiFhirDao.cleanProvenanceSourceUri("abc"));
-		assertEquals("abc", BaseHapiFhirDao.cleanProvenanceSourceUri("abc#def"));
-		assertEquals("abc", BaseHapiFhirDao.cleanProvenanceSourceUri("abc#def#ghi"));
+		assertEquals("", MetaUtil.cleanProvenanceSourceUri(null));
+		assertEquals("abc", MetaUtil.cleanProvenanceSourceUri("abc"));
+		assertEquals("abc", MetaUtil.cleanProvenanceSourceUri("abc#def"));
+		assertEquals("abc", MetaUtil.cleanProvenanceSourceUri("abc#def#ghi"));
 	}
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR4Test.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.jpa.subscription.channel.impl.LinkedBlockingChannel;
 import ca.uhn.fhir.jpa.subscription.submit.interceptor.SubscriptionMatcherInterceptor;
 import ca.uhn.fhir.jpa.test.util.SubscriptionTestUtil;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.test.utilities.server.HashMapResourceProviderExtension;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
 import ca.uhn.fhir.test.utilities.server.TransactionCapturingProviderExtension;
@@ -175,15 +176,20 @@ public abstract class BaseSubscriptionsR4Test extends BaseResourceProviderR4Test
 
 
 	protected Observation sendObservation(String theCode, String theSystem) {
-		return sendObservation(theCode, theSystem, null);
+		return sendObservation(theCode, theSystem, null, null);
 	}
 
-	protected Observation sendObservation(String theCode, String theSystem, String theSource) {
+	protected Observation sendObservation(String theCode, String theSystem, String theSource, String theRequestId) {
 		Observation observation = createBaseObservation(theCode, theSystem);
 		if (!StringUtils.isBlank(theSource)) {
 			observation.getMeta().setSource(theSource);
 		}
-		IIdType id = myObservationDao.create(observation).getId();
+
+		SystemRequestDetails systemRequestDetails = new SystemRequestDetails();
+		if (!StringUtils.isBlank(theRequestId)) {
+			systemRequestDetails.setRequestId(theRequestId);
+		}
+		IIdType id = myObservationDao.create(observation, systemRequestDetails).getId();
 		observation.setId(id);
 		return observation;
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
@@ -1,0 +1,124 @@
+package ca.uhn.fhir.jpa.subscription.message;
+
+import ca.uhn.fhir.jpa.api.config.DaoConfig;
+import ca.uhn.fhir.jpa.subscription.BaseSubscriptionsR4Test;
+import ca.uhn.fhir.jpa.subscription.channel.api.ChannelConsumerSettings;
+import ca.uhn.fhir.jpa.subscription.channel.api.IChannelReceiver;
+import ca.uhn.fhir.jpa.subscription.channel.subscription.SubscriptionChannelFactory;
+import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedJsonMessage;
+import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
+import ca.uhn.fhir.jpa.test.util.StoppableSubscriptionDeliveringRestHookSubscriber;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Subscription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test the rest-hook subscriptions
+ */
+public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
+	@Autowired
+	private SubscriptionChannelFactory myChannelFactory ;
+	private static final Logger ourLog = LoggerFactory.getLogger(MessageSubscriptionR4Test.class);
+	private TestQueueConsumerHandler<ResourceModifiedJsonMessage> handler;
+
+	@Autowired
+	StoppableSubscriptionDeliveringRestHookSubscriber myStoppableSubscriptionDeliveringRestHookSubscriber;
+
+	@AfterEach
+	public void cleanupStoppableSubscriptionDeliveringRestHookSubscriber() {
+		myStoppableSubscriptionDeliveringRestHookSubscriber.setCountDownLatch(null);
+		myStoppableSubscriptionDeliveringRestHookSubscriber.unPause();
+		myDaoConfig.setTriggerSubscriptionsForNonVersioningChanges(new DaoConfig().isTriggerSubscriptionsForNonVersioningChanges());
+	}
+	@BeforeEach
+	public void beforeRegisterRestHookListener() {
+		mySubscriptionTestUtil.registerMessageInterceptor();
+
+		IChannelReceiver receiver = myChannelFactory.newMatchingReceivingChannel("my-queue-name", new ChannelConsumerSettings());
+		handler = new TestQueueConsumerHandler();
+		receiver.subscribe(handler);
+	}
+
+	private Subscription createObservationSubscription() {
+		Subscription subscription = new Subscription();
+		subscription.setReason("Monitor new neonatal function (note, age will be determined by the monitor)");
+		subscription.setStatus(Subscription.SubscriptionStatus.REQUESTED);
+		subscription.setCriteria("[Observation]");
+
+		Subscription.SubscriptionChannelComponent channel = subscription.getChannel();
+		channel.setType(Subscription.SubscriptionChannelType.MESSAGE);
+		channel.setPayload("application/fhir+json");
+		channel.setEndpoint("channel:my-queue-name");
+
+		subscription.setChannel(channel);
+		postOrPutSubscription(subscription);
+		return subscription;
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"[*]", "Observation?code=zoop", "[Observation]"})
+	public void testCreateUpdateAndPatchRetainCorrectSourceThroughDelivery() throws Exception {
+		createObservationSubscription();
+
+		waitForActivatedSubscriptionCount(1);
+
+		String source = "http://some-random-system.com";
+		Observation obs = sendObservation("zoop", "SNOMED-CT", source);
+
+		//Quick validation source stored.
+		Observation readObs = myObservationDao.read(obs.getIdElement().toUnqualifiedVersionless());
+		assertThat(readObs.getMeta().getSource(), is(equalTo(source)));
+
+		// Should see 1 subscription notification
+		waitForQueueToDrain();
+
+		//Should receive at our queue receiver
+		Observation receivedObs = fetchSingleObservationFromSubscriptionTerminalEndpoint();
+		assertThat(receivedObs.getMeta().getSource(), is(equalTo(source)));
+
+		//Then when we update the resource with a new source
+		String newSource = "http://some-new-source";
+		receivedObs.getMeta().setSource(newSource);
+		Coding coding = new CodeableConcept().addCoding().setSystem("system").setCode("zoop");
+		receivedObs.setCode(new CodeableConcept().addCoding(coding));
+		myObservationDao.update(receivedObs, new SystemRequestDetails());
+
+
+		//We should see that source reflected in our subscription.
+		waitForQueueToDrain();
+		await().until(() -> handler.getMessages().size() == 1);
+
+		receivedObs = fetchSingleObservationFromSubscriptionTerminalEndpoint();
+		assertThat(receivedObs.getMeta().getSource(), is(equalTo(newSource)));
+	}
+
+	private Observation fetchSingleObservationFromSubscriptionTerminalEndpoint() {
+		assertThat(handler.getMessages().size(), is(equalTo(1)));
+		ResourceModifiedJsonMessage resourceModifiedJsonMessage = handler.getMessages().get(0);
+		ResourceModifiedMessage payload = resourceModifiedJsonMessage.getPayload();
+		String payloadString = payload.getPayloadString();
+		IBaseResource resource = myFhirContext.newJsonParser().parseResource(payloadString);
+		Observation receivedObs = (Observation) resource;
+		handler.clearMessages();
+		return receivedObs;
+	}
+
+
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/TestQueueConsumerHandler.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/TestQueueConsumerHandler.java
@@ -1,0 +1,31 @@
+package ca.uhn.fhir.jpa.subscription.message;
+
+import org.slf4j.Logger;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class TestQueueConsumerHandler<T> implements MessageHandler {
+	private static final Logger ourLog = getLogger(TestQueueConsumerHandler.class);
+	List<T> myMessages;
+	@Override
+	public void handleMessage(Message<?> message) throws MessagingException {
+		getMessages().add((T)message);
+		ourLog.info("Received message: {}", message);
+	}
+	public void clearMessages() {
+		myMessages.clear();;
+	}
+
+	public List<T> getMessages() {
+		if (myMessages == null) {
+			myMessages = new ArrayList<>();
+		}
+		return myMessages;
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
@@ -135,7 +135,7 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 		 * Send version 1
 		 */
 
-		Observation obs = sendObservation(code, "SNOMED-CT", "http://source-system.com");
+		Observation obs = sendObservation(code, "SNOMED-CT", "http://source-system.com", null);
 		obs = myObservationDao.read(obs.getIdElement().toUnqualifiedVersionless());
 
 		// Should see 1 subscription notification

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
@@ -135,7 +135,7 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 		 * Send version 1
 		 */
 
-		Observation obs = sendObservation(code, "SNOMED-CT");
+		Observation obs = sendObservation(code, "SNOMED-CT", "http://source-system.com");
 		obs = myObservationDao.read(obs.getIdElement().toUnqualifiedVersionless());
 
 		// Should see 1 subscription notification
@@ -145,6 +145,7 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 		assertEquals(Constants.CT_FHIR_JSON_NEW, ourRestfulServer.getRequestContentTypes().get(0));
 		assertEquals("1", ourObservationProvider.getStoredResources().get(0).getIdElement().getVersionIdPart());
 		assertEquals("1", ourObservationProvider.getStoredResources().get(0).getMeta().getVersionId());
+		assertEquals("http://source-system.com", ourObservationProvider.getStoredResources().get(0).getMeta().getSource());
 		assertEquals(obs.getMeta().getLastUpdatedElement().getValueAsString(), ourObservationProvider.getStoredResources().get(0).getMeta().getLastUpdatedElement().getValueAsString());
 		assertEquals(obs.getMeta().getLastUpdatedElement().getValueAsString(), ourObservationProvider.getStoredResources().get(0).getMeta().getLastUpdatedElement().getValueAsString());
 		assertEquals("1", ourObservationProvider.getStoredResources().get(0).getIdentifierFirstRep().getValue());
@@ -154,6 +155,7 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 		 */
 
 		obs.getIdentifierFirstRep().setSystem("foo").setValue("2");
+		obs.getMeta().setSource("http://other-source");
 		myObservationDao.update(obs);
 		obs = myObservationDao.read(obs.getIdElement().toUnqualifiedVersionless());
 
@@ -164,6 +166,7 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 		assertEquals(Constants.CT_FHIR_JSON_NEW, ourRestfulServer.getRequestContentTypes().get(0));
 		assertEquals("2", ourObservationProvider.getStoredResources().get(0).getIdElement().getVersionIdPart());
 		assertEquals("2", ourObservationProvider.getStoredResources().get(0).getMeta().getVersionId());
+		assertEquals("http://other-source", ourObservationProvider.getStoredResources().get(0).getMeta().getSource());
 		assertEquals(obs.getMeta().getLastUpdatedElement().getValueAsString(), ourObservationProvider.getStoredResources().get(0).getMeta().getLastUpdatedElement().getValueAsString());
 		assertEquals(obs.getMeta().getLastUpdatedElement().getValueAsString(), ourObservationProvider.getStoredResources().get(0).getMeta().getLastUpdatedElement().getValueAsString());
 		assertEquals("2", ourObservationProvider.getStoredResources().get(0).getIdentifierFirstRep().getValue());

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/util/SubscriptionTestUtil.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/util/SubscriptionTestUtil.java
@@ -81,6 +81,11 @@ public class SubscriptionTestUtil {
 		mySubscriptionSubmitInterceptorLoader.start();
 	}
 
+	public void registerMessageInterceptor() {
+		myDaoConfig.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.MESSAGE);
+		mySubscriptionSubmitInterceptorLoader.start();
+	}
+
 	public void registerWebSocketInterceptor() {
 		myDaoConfig.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		mySubscriptionSubmitInterceptorLoader.start();


### PR DESCRIPTION
* Populate resource with correct source information before it gets published to subscriptions
* Parameterized test 
* Changelog
* rename myContext to myFhirContext

