### PR TITLE
Simultaneous $reindex and DELETE can orphan index rows

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4584-reindex-orphan-index-rows.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4584-reindex-orphan-index-rows.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4548
+title: "Simultaneous DELETE and $reindex operations could corrupt the search index.  This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -1352,7 +1352,6 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 
 		ResourceTable entity = myEntityManager.find(ResourceTable.class, persistentId.getId());
-		//ResourceTable entity = myEntityManager.find(ResourceTable.class, persistentId.getId(), LockModeType.PESSIMISTIC_WRITE);
 		if (entity == null) {
 			throw new ResourceNotFoundException(Msg.code(1998) + theId);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -133,6 +133,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
+import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import javax.servlet.http.HttpServletResponse;
@@ -1222,10 +1223,10 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	@Override
 	public void reindex(IResourcePersistentId thePid, RequestDetails theRequest, TransactionDetails theTransactionDetails) {
 		JpaPid jpaPid = (JpaPid) thePid;
-		Optional<ResourceTable> entityOpt = myResourceTableDao.findById(jpaPid.getId());
 		// wipmb possible fix
 		// wipmb where to retry?  In HapiTxMgr, or in job step?
-		//Optional<ResourceTable> entityOpt = Optional.ofNullable(myEntityManager.find(ResourceTable.class, jpaPid.getId(), LockModeType.OPTIMISTIC));
+		Optional<ResourceTable> entityOpt = Optional.ofNullable(myEntityManager.find(ResourceTable.class, jpaPid.getId(), LockModeType.OPTIMISTIC));
+		//Optional<ResourceTable> entityOpt = myResourceTableDao.findById(jpaPid.getId());
 		if (!entityOpt.isPresent()) {
 			ourLog.warn("Unable to find entity with PID: {}", jpaPid.getId());
 			return;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -1223,6 +1223,9 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	public void reindex(IResourcePersistentId thePid, RequestDetails theRequest, TransactionDetails theTransactionDetails) {
 		JpaPid jpaPid = (JpaPid) thePid;
 		Optional<ResourceTable> entityOpt = myResourceTableDao.findById(jpaPid.getId());
+		// wipmb possible fix
+		// wipmb where to retry?  In HapiTxMgr, or in job step?
+		//Optional<ResourceTable> entityOpt = Optional.ofNullable(myEntityManager.find(ResourceTable.class, jpaPid.getId(), LockModeType.OPTIMISTIC));
 		if (!entityOpt.isPresent()) {
 			ourLog.warn("Unable to find entity with PID: {}", jpaPid.getId());
 			return;
@@ -1345,6 +1348,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 
 		ResourceTable entity = myEntityManager.find(ResourceTable.class, persistentId.getId());
+		//ResourceTable entity = myEntityManager.find(ResourceTable.class, persistentId.getId(), LockModeType.PESSIMISTIC_WRITE);
 		if (entity == null) {
 			throw new ResourceNotFoundException(Msg.code(1998) + theId);
 		}

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -1945,6 +1945,7 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 			IPrimitiveType<Date> nextBaseDateTime = (IPrimitiveType<Date>) theValue;
 			if (nextBaseDateTime.getValue() != null) {
 				myIndexedSearchParamDate = new ResourceIndexedSearchParamDate(myPartitionSettings, theResourceType, theSearchParam.getName(), nextBaseDateTime.getValue(), nextBaseDateTime.getValueAsString(), nextBaseDateTime.getValue(), nextBaseDateTime.getValueAsString(), nextBaseDateTime.getValueAsString());
+				ourLog.trace("DateExtractor - extracted {} for {}", nextBaseDateTime, theSearchParam.getName());
 				theParams.add(myIndexedSearchParamDate);
 			}
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/ReindexStepTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/ReindexStepTest.java
@@ -61,7 +61,7 @@ public class ReindexStepTest extends BaseJpaR4Test {
 
 		// Verify
 		assertEquals(2, outcome.getRecordsProcessed());
-		assertEquals(4, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(6, myCaptureQueriesListener.logSelectQueries().size());
 		assertEquals(0, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(0, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());
@@ -91,7 +91,7 @@ public class ReindexStepTest extends BaseJpaR4Test {
 
 		// Verify
 		assertEquals(2, outcome.getRecordsProcessed());
-		assertEquals(6, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(8, myCaptureQueriesListener.logSelectQueries().size());
 		assertEquals(0, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(0, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());
@@ -124,7 +124,7 @@ public class ReindexStepTest extends BaseJpaR4Test {
 
 		// Verify
 		assertEquals(2, outcome.getRecordsProcessed());
-		assertEquals(4, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(6, myCaptureQueriesListener.logSelectQueries().size());
 		// name, family, phonetic, deceased, active
 		assertEquals(5, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(0, myCaptureQueriesListener.countUpdateQueries());
@@ -192,7 +192,7 @@ public class ReindexStepTest extends BaseJpaR4Test {
 
 		// Verify
 		assertEquals(2, outcome.getRecordsProcessed());
-		assertEquals(8, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(10, myCaptureQueriesListener.logSelectQueries().size());
 		assertEquals(0, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(4, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());
@@ -237,7 +237,7 @@ public class ReindexStepTest extends BaseJpaR4Test {
 
 		// Verify
 		assertEquals(4, outcome.getRecordsProcessed());
-		assertEquals(5, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(9, myCaptureQueriesListener.logSelectQueries().size());
 		assertEquals(5, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(2, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
@@ -123,12 +123,14 @@ public class ReindexRaceBugTest extends BaseJpaR4Test {
 
 						ourLog.info("Run $reindex");
 						myObservationDao.reindex(JpaPid.fromIdAndResourceType(observationPid, "Observation"), rd, new TransactionDetails());
+
 						ourLog.info("$reindex done release main thread to delete");
 						latchReindexStart.countDown();
 
-						ourLog.info("Wait for latch");
+						ourLog.info("Wait for delete to finish");
 						latchDeleteFinished.await();
-						ourLog.info("Commit now that delete is finished");
+
+						ourLog.info("Commit $reindex now that delete is finished");
 
 					} catch (Exception e) {
 						ourLog.error("$reindex failed", e);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
@@ -5,14 +5,17 @@ import ca.uhn.fhir.jpa.dao.BaseHapiFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.JpaResourceDaoObservation;
 import ca.uhn.fhir.jpa.dao.TestDaoSearch;
 import ca.uhn.fhir.jpa.dao.ThreadPoolFactory;
+import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamDate;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.jpa.test.config.TestR4Config;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
+import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.storage.test.DaoTestDataBuilder;
 import ca.uhn.fhir.test.utilities.ITestDataBuilder;
@@ -20,12 +23,18 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.SearchParameter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import javax.annotation.Nullable;
@@ -37,8 +46,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ContextConfiguration(classes = {
@@ -56,23 +67,30 @@ public class ReindexRaceBugTest extends BaseJpaR4Test {
 	TestDaoSearch myDaoSearch;
 //	@Autowired
 //	JpaResourceDaoObservation myRawDao;
+	@Autowired
+	HapiTransactionService myHapiTransactionService;
+
+	@BeforeEach
+	void setUp() {
+		myTransactionTemplate = new TransactionTemplate(getTxManager(), new DefaultTransactionAttribute(TransactionDefinition.PROPAGATION_REQUIRES_NEW));
+	}
 
 	// wipmb try overlapping job step reindex with resource deletion. if job step has 100 resources, then the delete could finish
 	@Test
 	void deleteOverlapsWithReindex_leavesIndexRowsP() throws InterruptedException {
-		myTransactionTemplate = new TransactionTemplate(getTxManager());
+
 		CountDownLatch latchReindexStart = new CountDownLatch(1);
 		CountDownLatch latchDeleteFinished = new CountDownLatch(1);
 		CountDownLatch latchReindexFinished = new CountDownLatch(1);
 
 		ourLog.info("An observation is created");
 
-		var observationId = myTransactionTemplate.execute((tx) -> {
+		var observationCreateOutcome = callInFreshTx((rd, tx) -> {
 			Observation o = (Observation) myTDB.buildResource("Observation", myTDB.withEffectiveDate("2021-01-01T00:00:00"));
-			return myObservationDao.create(o, mySrd);
+			return myObservationDao.create(o, rd);
 		});
-		long observationPid = Long.parseLong(observationId.getId().getIdPart());
-		IBundleProvider bundleProvider = myDaoSearch.searchForBundleProvider("/SearchParameter?base=Observation");
+		IIdType observationId = observationCreateOutcome.getId().toVersionless();
+		long observationPid = Long.parseLong(observationCreateOutcome.getId().getIdPart());
 
 		ourLog.info("Then a SP is created after that matches data in the Observation");
 		SearchParameter sp = myFhirContext.newJsonParser().parseResource(SearchParameter.class, """
@@ -88,16 +106,17 @@ public class ReindexRaceBugTest extends BaseJpaR4Test {
 			}
 			""");
 		this.myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(false);
-		DaoMethodOutcome spId = myTransactionTemplate.execute((tx) ->
-			mySearchParameterDao.update(sp, mySrd));
-		mySearchParamRegistry.forceRefresh();
+		DaoMethodOutcome spId = callInFreshTx((rd, tx) -> {
+			DaoMethodOutcome result = mySearchParameterDao.update(sp, rd);
+			mySearchParamRegistry.forceRefresh();
+			return result;
+		});
 
 		int beforeRowCount = getSPIDXDateCount(observationPid);
 		assertEquals(1, beforeRowCount, "date index row for date");
 
 
 		// suppose reindex job step starts here and loads the resource and ResourceTable entity
-		Observation observation = myObservationDao.read(observationId.getId(), mySrd);
 		ExecutorService backgroundReindexThread = Executors.newSingleThreadExecutor(new ThreadFactory() {
 			@Override
 			public Thread newThread(@NotNull Runnable r) {
@@ -106,11 +125,12 @@ public class ReindexRaceBugTest extends BaseJpaR4Test {
 		});
 		backgroundReindexThread.submit(()->{
 
-			myTransactionTemplate.execute((tx) -> {
+			callInFreshTx((rd, tx) -> {
 				try {
 
 					ourLog.info("Starting background $reindex");
 					ResourceTable observationRow = myEntityManager.find(ResourceTable.class, observationPid);
+					Observation observation = myObservationDao.read(observationId, rd);
 
 					// load the params now.
 //			ourLog.info("Fetching date info");
@@ -138,8 +158,20 @@ public class ReindexRaceBugTest extends BaseJpaR4Test {
 
 		// then the resource is deleted
 		ourLog.info("Deleting observation");
-		myTransactionTemplate.execute(tx->
-			myObservationDao.delete(observationId.getId()));
+		DaoMethodOutcome deleteResult = callInFreshTx((rd, tx) ->
+			myObservationDao.delete(observationId, rd));
+
+		assertEquals(0, getSPIDXDateCount(observationPid), "A deleted resource should have 0 index rows");
+
+		try {
+			// confirm deleted
+			Observation readBack = callInFreshTx((rd, tx)->
+				myObservationDao.read(observationId, rd, false));
+			ourLog.debug("Observation readBack {}", myFhirContext.newJsonParser().encodeResourceToString(readBack));
+			fail("Read deleted resource");
+		} catch (ResourceGoneException e) {
+			// expected
+		}
 
 		// then the reindex call finishes
 		ourLog.info("Release $reindex");
@@ -149,16 +181,49 @@ public class ReindexRaceBugTest extends BaseJpaR4Test {
 		ourLog.info("Await $reindex finish");
 		latchReindexFinished.await();
 
-		int afterRowCount = getSPIDXDateCount(observationPid);
-
-		assertEquals(0, afterRowCount, "no rows after indexing");
-
+		assertEquals(0, getSPIDXDateCount(observationPid), "A deleted resource should still have 0 index rows, after $reindex completes");
 
 	}
 
+
+	@Test
+	void testDeleteThenRead_throwsException() {
+	    // given
+		var observationCreate = callInFreshTx((rd, tx) -> {
+			Observation o = (Observation) myTDB.buildResource("Observation", myTDB.withEffectiveDate("2021-01-01T00:00:00"));
+			return myObservationDao.create(o, rd);
+		});
+		IIdType observationId = observationCreate.getId().toVersionless();
+
+		// when
+		ourLog.info("Deleting observation");
+		DaoMethodOutcome deleteResult = callInFreshTx((rd, tx) ->
+			myObservationDao.delete(observationId, rd));
+		assertTrue(deleteResult.getEntity().isDeleted(), "row is deleted");
+		assertEquals(2, deleteResult.getEntity().getVersion(), "version changed");
+
+		try {
+			// confirm deleted
+			Observation readBack = callInFreshTx((rd, tx) ->
+				myObservationDao.read(observationId, rd, false));
+			fail("Read deleted resource");
+		} catch (ResourceGoneException e) {
+			// expected
+		}
+	}
+
+	private <T> T callInFreshTx(BiFunction<RequestDetails, TransactionStatus, T> theCallback) {
+		SystemRequestDetails requestDetails = new SystemRequestDetails();
+		return myHapiTransactionService.withRequest(requestDetails)
+			.withTransactionDetails(new TransactionDetails())
+			.withPropagation(Propagation.REQUIRES_NEW)
+			.execute(tx-> theCallback.apply(requestDetails, tx));
+	}
+
+
 	@Nullable
 	private Integer getSPIDXDateCount(long observationPid) {
-		return myTransactionTemplate.execute((tx) ->
+		return callInFreshTx((rd, tx) ->
 			myResourceIndexedSearchParamDateDao.findAllForResourceId(observationPid).size());
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
@@ -106,7 +106,7 @@ class ReindexRaceBugTest extends BaseJpaR4Test {
 						myObservationDao.reindex(JpaPid.fromIdAndResourceType(observationPid, "Observation"), rd, new TransactionDetails());
 
 						ourLog.info("$reindex done release main thread to delete");
-						phaser.arriveAtMyEndOf(Steps.RUN_REINDEX);
+						phaser.arriveAndAwaitSharedEndOf(Steps.RUN_REINDEX);
 
 						ourLog.info("Wait for delete to finish");
 						phaser.arriveAndAwaitSharedEndOf(Steps.RUN_DELETE);
@@ -139,7 +139,7 @@ class ReindexRaceBugTest extends BaseJpaR4Test {
 		assertEquals(0, getSPIDXDateCount(observationPid), "A deleted resource should have 0 index rows");
 
 		ourLog.info("Let $reindex commit");
-		phaser.arriveAtMyEndOf(Steps.RUN_DELETE);
+		phaser.arriveAndAwaitSharedEndOf(Steps.RUN_DELETE);
 
 		// then the reindex call finishes
 		ourLog.info("Await $reindex commit");

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/search/reindex/ReindexRaceBugTest.java
@@ -1,0 +1,165 @@
+package ca.uhn.fhir.jpa.search.reindex;
+
+import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
+import ca.uhn.fhir.jpa.dao.BaseHapiFhirResourceDao;
+import ca.uhn.fhir.jpa.dao.JpaResourceDaoObservation;
+import ca.uhn.fhir.jpa.dao.TestDaoSearch;
+import ca.uhn.fhir.jpa.dao.ThreadPoolFactory;
+import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamDate;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.jpa.test.config.TestR4Config;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
+import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
+import ca.uhn.fhir.storage.test.DaoTestDataBuilder;
+import ca.uhn.fhir.test.utilities.ITestDataBuilder;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.SearchParameter;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.annotation.Nullable;
+import javax.persistence.EntityManager;
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ContextConfiguration(classes = {
+	DaoTestDataBuilder.Config.class,
+	TestDaoSearch.Config.class
+})
+public class ReindexRaceBugTest extends BaseJpaR4Test {
+	private static final Logger ourLog = LoggerFactory.getLogger(ReindexRaceBugTest.class);
+	@Autowired
+	EntityManager myEntityManager;
+	TransactionTemplate myTransactionTemplate;
+	@Autowired
+	DaoTestDataBuilder myTDB;
+	@Autowired
+	TestDaoSearch myDaoSearch;
+//	@Autowired
+//	JpaResourceDaoObservation myRawDao;
+
+	// wipmb try overlapping job step reindex with resource deletion. if job step has 100 resources, then the delete could finish
+	@Test
+	void deleteOverlapsWithReindex_leavesIndexRowsP() throws InterruptedException {
+		myTransactionTemplate = new TransactionTemplate(getTxManager());
+		CountDownLatch latchReindexStart = new CountDownLatch(1);
+		CountDownLatch latchDeleteFinished = new CountDownLatch(1);
+		CountDownLatch latchReindexFinished = new CountDownLatch(1);
+
+		ourLog.info("An observation is created");
+
+		var observationId = myTransactionTemplate.execute((tx) -> {
+			Observation o = (Observation) myTDB.buildResource("Observation", myTDB.withEffectiveDate("2021-01-01T00:00:00"));
+			return myObservationDao.create(o, mySrd);
+		});
+		long observationPid = Long.parseLong(observationId.getId().getIdPart());
+		IBundleProvider bundleProvider = myDaoSearch.searchForBundleProvider("/SearchParameter?base=Observation");
+
+		ourLog.info("Then a SP is created after that matches data in the Observation");
+		SearchParameter sp = myFhirContext.newJsonParser().parseResource(SearchParameter.class, """
+			{
+			  "resourceType": "SearchParameter",
+			  "id": "observation-date2",
+			  "status": "active",
+			  "code": "date2",
+			  "name": "date2",
+			  "base": [ "Observation" ],
+			  "type": "date",
+			  "expression": "Observation.effective"
+			}
+			""");
+		this.myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(false);
+		DaoMethodOutcome spId = myTransactionTemplate.execute((tx) ->
+			mySearchParameterDao.update(sp, mySrd));
+		mySearchParamRegistry.forceRefresh();
+
+		int beforeRowCount = getSPIDXDateCount(observationPid);
+		assertEquals(1, beforeRowCount, "date index row for date");
+
+
+		// suppose reindex job step starts here and loads the resource and ResourceTable entity
+		Observation observation = myObservationDao.read(observationId.getId(), mySrd);
+		ExecutorService backgroundReindexThread = Executors.newSingleThreadExecutor(new ThreadFactory() {
+			@Override
+			public Thread newThread(@NotNull Runnable r) {
+				return new Thread(r, "Reindex-thread");
+			}
+		});
+		backgroundReindexThread.submit(()->{
+
+			myTransactionTemplate.execute((tx) -> {
+				try {
+
+					ourLog.info("Starting background $reindex");
+					ResourceTable observationRow = myEntityManager.find(ResourceTable.class, observationPid);
+
+					// load the params now.
+//			ourLog.info("Fetching date info");
+//			observationRow.getParamsDate();
+
+					// then finishes the reindex after the deletion.
+					ourLog.info("Run $reindex and release main thread");
+					myObservationDao.reindex(observation, observationRow);
+					latchReindexStart.countDown();
+					// but is paused here
+					ourLog.info("Wait for latch");
+					latchDeleteFinished.await();
+					ourLog.info("Commit");
+
+				} catch (Exception e) {
+					ourLog.error("$reindex failed", e);
+				}
+				return 0;
+			});
+			latchReindexFinished.countDown();
+		});
+
+		ourLog.info("Wait for $reindex to start");
+		latchReindexStart.await();
+
+		// then the resource is deleted
+		ourLog.info("Deleting observation");
+		myTransactionTemplate.execute(tx->
+			myObservationDao.delete(observationId.getId()));
+
+		// then the reindex call finishes
+		ourLog.info("Release $reindex");
+		latchDeleteFinished.countDown();
+
+
+		ourLog.info("Await $reindex finish");
+		latchReindexFinished.await();
+
+		int afterRowCount = getSPIDXDateCount(observationPid);
+
+		assertEquals(0, afterRowCount, "no rows after indexing");
+
+
+	}
+
+	@Nullable
+	private Integer getSPIDXDateCount(long observationPid) {
+		return myTransactionTemplate.execute((tx) ->
+			myResourceIndexedSearchParamDateDao.findAllForResourceId(observationPid).size());
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
@@ -111,6 +111,7 @@ import ca.uhn.fhir.validation.ValidationResult;
 import org.hl7.fhir.common.hapi.validation.support.CachingValidationSupport;
 import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.Appointment;
 import org.hl7.fhir.r4.model.AuditEvent;
@@ -211,11 +212,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {
-	TestR4Config.class,
-	DaoTestDataBuilder.Config.class
-})
-public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuilder.WithSupport {
+@ContextConfiguration(classes = {TestR4Config.class})
+public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuilder {
 	public static final String MY_VALUE_SET = "my-value-set";
 	public static final String URL_MY_VALUE_SET = "http://example.com/my_value_set";
 	public static final String URL_MY_CODE_SYSTEM = "http://example.com/my_code_system";
@@ -519,8 +517,6 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 	private PerformanceTracingLoggingInterceptor myPerformanceTracingLoggingInterceptor;
 	@Autowired
 	private IBulkDataExportJobSchedulingHelper myBulkDataScheduleHelper;
-	@Autowired
-	private DaoTestDataBuilder myTestDataBuilder;
 
 	@RegisterExtension
 	private final PreventDanglingInterceptorsExtension myPreventDanglingInterceptorsExtension = new PreventDanglingInterceptorsExtension(()-> myInterceptorRegistry);
@@ -590,6 +586,18 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 	public void beforeResetConfig() {
 		myFhirContext.setParserErrorHandler(new StrictErrorHandler());
 		myValidationSettings.setLocalReferenceValidationDefaultPolicy(new ValidationSettings().getLocalReferenceValidationDefaultPolicy());
+	}
+
+	@Override
+	public IIdType doCreateResource(IBaseResource theResource) {
+		IFhirResourceDao dao = myDaoRegistry.getResourceDao(theResource.getClass());
+		return dao.create(theResource, mySrd).getId().toUnqualifiedVersionless();
+	}
+
+	@Override
+	public IIdType doUpdateResource(IBaseResource theResource) {
+		IFhirResourceDao dao = myDaoRegistry.getResourceDao(theResource.getClass());
+		return dao.update(theResource, mySrd).getId().toUnqualifiedVersionless();
 	}
 
 	protected String encode(IBaseResource theResource) {
@@ -885,10 +893,5 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 		public ContainedReferenceValidationPolicy policyForContained(IResourceValidator validator, Object appContext, String containerType, String containerId, Element.SpecialElement containingResourceType, String path, String url) {
 			return ContainedReferenceValidationPolicy.CHECK_VALID;
 		}
-	}
-
-	@Override
-	public Support getTestDataBuilderSupport() {
-		return myTestDataBuilder;
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/resources/logback-test.xml
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/resources/logback-test.xml
@@ -17,9 +17,7 @@
 	<logger name="org.hibernate.event.internal.DefaultPersistEventListener" level="info"/>
 	<logger name="org.eclipse" level="error"/>
 	<logger name="ca.uhn.fhir.rest.client" level="info"/>
-	<logger name="ca.uhn.fhir.jpa.dao" level="trace"/>
-	<logger name="ca.uhn.fhir.jpa.searchparam.extractor" level="trace"/>
-	<logger name="ca.uhn.fhir.jpa.searchparam.registry.JpaSearchParamCache" level="trace"/>
+	<logger name="ca.uhn.fhir.jpa.dao" level="info"/>
 
 	<!-- set to debug to enable term expansion logs -->
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/resources/logback-test.xml
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/resources/logback-test.xml
@@ -17,13 +17,15 @@
 	<logger name="org.hibernate.event.internal.DefaultPersistEventListener" level="info"/>
 	<logger name="org.eclipse" level="error"/>
 	<logger name="ca.uhn.fhir.rest.client" level="info"/>
-	<logger name="ca.uhn.fhir.jpa.dao" level="info"/>
+	<logger name="ca.uhn.fhir.jpa.dao" level="trace"/>
+	<logger name="ca.uhn.fhir.jpa.searchparam.extractor" level="trace"/>
+	<logger name="ca.uhn.fhir.jpa.searchparam.registry.JpaSearchParamCache" level="trace"/>
 
 	<!-- set to debug to enable term expansion logs -->
 
 	<logger name="ca.uhn.fhir.jpa.term" level="info"/>
 	<!-- Set to 'trace' to enable SQL logging -->
-	<logger name="org.hibernate.SQL" level="info"/>
+	<logger name="org.hibernate.SQL" level="trace"/>
 	<!-- Set to 'trace' to enable SQL Value logging -->
 	<logger name="org.hibernate.type" level="info"/>
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/resources/logback-test.xml
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/resources/logback-test.xml
@@ -23,7 +23,7 @@
 
 	<logger name="ca.uhn.fhir.jpa.term" level="info"/>
 	<!-- Set to 'trace' to enable SQL logging -->
-	<logger name="org.hibernate.SQL" level="trace"/>
+	<logger name="org.hibernate.SQL" level="info"/>
 	<!-- Set to 'trace' to enable SQL Value logging -->
 	<logger name="org.hibernate.type" level="info"/>
 

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -182,10 +182,16 @@
                 </exclusion>
 			</exclusions>
 		</dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.seregamorph</groupId>
+			<artifactId>hamcrest-more-matchers</artifactId>
+			<version>0.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/test/concurrency/LockstepEnumPhaser.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/test/concurrency/LockstepEnumPhaser.java
@@ -1,0 +1,95 @@
+package ca.uhn.test.concurrency;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Phaser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Test helper to force a particular sequence on 2 or more threads.
+ * Wraps Phaser with an Enum for better messages, and some test support.
+ *
+ * @param <E> an enum used to name the phases.
+ */
+public class LockstepEnumPhaser<E extends Enum<E>> {
+	private static final Logger ourLog = LoggerFactory.getLogger(LockstepEnumPhaser.class);
+	final Phaser myPhaser;
+	final Class<E> myEnumClass;
+	final E[] myEnumConstants;
+
+	public LockstepEnumPhaser(int theParticipantCount, Class<E> theEnumClass) {
+		myPhaser = new Phaser(theParticipantCount);
+		myEnumClass = theEnumClass;
+		myEnumConstants = myEnumClass.getEnumConstants();
+	}
+
+	public E arrive() {
+		E result = phaseToEnum(myPhaser.arrive());
+		ourLog.info("Arrive in phase {}", result);
+		return result;
+	}
+
+	public void assertInPhase(E theStageEnum) {
+		assertEquals(theStageEnum, getPhase(), "In stage " + theStageEnum);
+	}
+
+	public E getPhase() {
+		return phaseToEnum(myPhaser.getPhase());
+	}
+
+	public E awaitAdvance(E thePhase) {
+		checkAwait(thePhase);
+		return doAwait(thePhase);
+	}
+
+	/**
+	 * Like arrive(), but verify stage first
+	 */
+	public E arriveAtMyEndOf(E thePhase) {
+		assertInPhase(thePhase);
+		return arrive();
+	}
+
+	public E arriveAndAwaitSharedEndOf(E thePhase) {
+		checkAwait(thePhase);
+		arrive();
+		return doAwait(thePhase);
+	}
+
+	public E arriveAndDeregister() {
+		return phaseToEnum(myPhaser.arriveAndDeregister());
+	}
+
+	public E register() {
+		return phaseToEnum(myPhaser.register());
+	}
+
+	private E doAwait(E thePhase) {
+		ourLog.debug("Start doAwait - {}", thePhase);
+		E phase = phaseToEnum(myPhaser.awaitAdvance(thePhase.ordinal()));
+		ourLog.info("Finish doAwait - {}", thePhase);
+		return phase;
+	}
+
+	private void checkAwait(E thePhase) {
+		E currentPhase = getPhase();
+		if (currentPhase.ordinal() < thePhase.ordinal()) {
+			fail("Can't wait for end of phase " + thePhase + ", still in phase " + currentPhase);
+		} else if (currentPhase.ordinal() > thePhase.ordinal()) {
+			ourLog.warn("Skip waiting for phase {}, already in phase {}", thePhase, currentPhase);
+		}
+	}
+
+
+	private E phaseToEnum(int resultOrdinal) {
+		if (resultOrdinal >= myEnumConstants.length) {
+			throw new IllegalStateException("Enum " + myEnumClass.getName() + " should declare one more stage for post-completion reporting in phase " + resultOrdinal);
+		}
+		return myEnumConstants[resultOrdinal];
+	}
+
+
+}

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/test/concurrency/LockstepEnumPhaser.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/test/concurrency/LockstepEnumPhaser.java
@@ -11,6 +11,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test helper to force a particular sequence on 2 or more threads.
  * Wraps Phaser with an Enum for better messages, and some test support.
+ * The only use is to impose a particular execution sequence over multiple threads when reproducing bugs.
+ *
+ * The simplest usage is to declare the number of collaborators as theParticipantCount
+ * in the constructor, and then have each participant thread call {@link #arriveAndAwaitSharedEndOf}
+ * as they finish the work of every phase.
+ * Every thread needs to confirm, even if they do no work in that phase.
+ * <p>
+ * Note: this is just a half-baked wrapper around Phaser.
+ * The behaviour is not especially precise, or tested. Comments welcome: MB.
  *
  * @param <E> an enum used to name the phases.
  */
@@ -86,7 +95,7 @@ public class LockstepEnumPhaser<E extends Enum<E>> {
 
 	private E phaseToEnum(int resultOrdinal) {
 		if (resultOrdinal >= myEnumConstants.length) {
-			throw new IllegalStateException("Enum " + myEnumClass.getName() + " should declare one more stage for post-completion reporting in phase " + resultOrdinal);
+			throw new IllegalStateException("Enum " + myEnumClass.getName() + " should declare one more enum value for post-completion reporting of phase " + resultOrdinal);
 		}
 		return myEnumConstants[resultOrdinal];
 	}

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/test/concurrency/LockstepEnumPhaserTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/test/concurrency/LockstepEnumPhaserTest.java
@@ -1,10 +1,16 @@
 package ca.uhn.test.concurrency;
 
+import com.github.seregamorph.hamcrest.OrderMatchers;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -12,11 +18,19 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static ca.uhn.test.concurrency.LockstepEnumPhaserTest.Stages.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static ca.uhn.test.concurrency.LockstepEnumPhaserTest.Stages.FINISHED;
+import static ca.uhn.test.concurrency.LockstepEnumPhaserTest.Stages.ONE;
+import static ca.uhn.test.concurrency.LockstepEnumPhaserTest.Stages.THREE;
+import static ca.uhn.test.concurrency.LockstepEnumPhaserTest.Stages.TWO;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LockstepEnumPhaserTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(LockstepEnumPhaserTest.class);
+	final ExecutorService myExecutorService = Executors.newFixedThreadPool(10);
+	final List<Pair<Integer, Stages>> myProgressEvents = new ArrayList<>();
+	/** Compare progress records by stage */
+	final Comparator<Pair<Integer, Stages>> myProgressStageComparator = Comparator.comparing(Pair::getRight);
 
 	enum Stages {
 		ONE, TWO, THREE, FINISHED
@@ -46,35 +60,131 @@ class LockstepEnumPhaserTest {
 	void phaserWithTwoThreads_runsInLockStep() throws InterruptedException, ExecutionException {
 		// given
 		myPhaser = new LockstepEnumPhaser<>(2, Stages.class);
-		ExecutorService executorService = Executors.newFixedThreadPool(2);
 
 		// run two copies of the same schedule
+		AtomicInteger i = new AtomicInteger(0);
 		Callable<Integer> schedule = ()->{
+			// get unique ids for each thread.
+			int threadId = i.getAndIncrement();
+
 			myPhaser.assertInPhase(ONE);
 			ourLog.info("Starting");
+			recordProgress(threadId);
 
 			myPhaser.arriveAndAwaitSharedEndOf(ONE);
 
 			myPhaser.assertInPhase(TWO);
+			recordProgress(threadId);
 
 			myPhaser.arriveAndAwaitSharedEndOf(TWO);
 
 			myPhaser.assertInPhase(THREE);
+			recordProgress(threadId);
 
 			Stages nextStage = myPhaser.awaitAdvance(TWO);
 			assertEquals(THREE, nextStage);
 
 			myPhaser.arriveAtMyEndOf(THREE);
 
+			recordProgress(threadId);
 			ourLog.info("Finished");
 
 			return 1;
 		};
-		Future<Integer> result1 = executorService.submit(schedule);
-		Future<Integer> result2 = executorService.submit(schedule);
+		Future<Integer> result1 = myExecutorService.submit(schedule);
+		Future<Integer> result2 = myExecutorService.submit(schedule);
 
 		assertEquals(1, result1.get());
 		assertEquals(1, result2.get());
+		assertThat("progress is ordered", myProgressEvents, OrderMatchers.softOrdered(myProgressStageComparator));
+		assertThat("all progress logged", myProgressEvents, Matchers.hasSize(8));
+	}
+
+	private void recordProgress(int threadId) {
+		myProgressEvents.add(Pair.of(threadId, myPhaser.getPhase()));
+	}
+
+	@Timeout(5)
+	@Test
+	void phaserWithTwoThreads_canAddThird_sequencContinues() throws InterruptedException, ExecutionException {
+		// given
+		myPhaser = new LockstepEnumPhaser<>(2, Stages.class);
+
+		// run one simple schedule
+		Callable<Integer> schedule1 = ()->{
+			int threadId = 1;
+			ourLog.info("Starting schedule1");
+			myPhaser.assertInPhase(ONE);
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(ONE);
+
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(TWO);
+
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(THREE);
+
+			recordProgress(threadId);
+
+			ourLog.info("Finished schedule1");
+
+			return 1;
+		};
+		// this schedule will start half-way in
+		Callable<Integer> schedule2 = ()->{
+			int threadId = 2;
+			ourLog.info("Starting schedule2");
+			myPhaser.assertInPhase(THREE);
+
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(THREE);
+
+			recordProgress(threadId);
+
+			ourLog.info("Finished schedule2");
+
+			return 1;
+		};
+		// this schedule will start schedule 2 half-way
+		Callable<Integer> schedule3 = ()->{
+			int threadId = 3;
+			myPhaser.assertInPhase(ONE);
+			ourLog.info("Starting schedule3");
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(ONE);
+
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(TWO);
+
+			// add a new thread to the mix
+			myPhaser.register(); // tell the phaser to expect one more
+			myExecutorService.submit(schedule2);
+
+			recordProgress(threadId);
+
+			myPhaser.arriveAndAwaitSharedEndOf(THREE);
+
+			recordProgress(threadId);
+
+			ourLog.info("Finished schedule3");
+
+			return 1;
+		};
+		Future<Integer> result1 = myExecutorService.submit(schedule1);
+		Future<Integer> result2 = myExecutorService.submit(schedule3);
+
+		assertEquals(1, result1.get());
+		assertEquals(1, result2.get());
+
+		assertThat("progress is ordered", myProgressEvents, OrderMatchers.softOrdered(myProgressStageComparator));
+		assertThat("all progress logged", myProgressEvents, Matchers.hasSize(10));
+
 	}
 
 }

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/test/concurrency/LockstepEnumPhaserTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/test/concurrency/LockstepEnumPhaserTest.java
@@ -1,0 +1,80 @@
+package ca.uhn.test.concurrency;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static ca.uhn.test.concurrency.LockstepEnumPhaserTest.Stages.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LockstepEnumPhaserTest {
+	private static final Logger ourLog = LoggerFactory.getLogger(LockstepEnumPhaserTest.class);
+
+	enum Stages {
+		ONE, TWO, THREE, FINISHED
+	}
+
+	LockstepEnumPhaser<Stages> myPhaser;
+
+	@Timeout(1)
+	@Test
+	void phaserWithOnePariticpant_worksFine() {
+	    // given
+		myPhaser = new LockstepEnumPhaser<>(1, Stages.class);
+
+		myPhaser.assertInPhase(ONE);
+
+		myPhaser.arriveAtMyEndOf(ONE);
+
+		myPhaser.arriveAndAwaitSharedEndOf(TWO);
+
+		myPhaser.arriveAndAwaitSharedEndOf(THREE);
+
+		myPhaser.assertInPhase(FINISHED);
+	}
+
+	@Timeout(5)
+	@Test
+	void phaserWithTwoThreads_runsInLockStep() throws InterruptedException, ExecutionException {
+		// given
+		myPhaser = new LockstepEnumPhaser<>(2, Stages.class);
+		ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+		// run two copies of the same schedule
+		Callable<Integer> schedule = ()->{
+			myPhaser.assertInPhase(ONE);
+			ourLog.info("Starting");
+
+			myPhaser.arriveAndAwaitSharedEndOf(ONE);
+
+			myPhaser.assertInPhase(TWO);
+
+			myPhaser.arriveAndAwaitSharedEndOf(TWO);
+
+			myPhaser.assertInPhase(THREE);
+
+			Stages nextStage = myPhaser.awaitAdvance(TWO);
+			assertEquals(THREE, nextStage);
+
+			myPhaser.arriveAtMyEndOf(THREE);
+
+			ourLog.info("Finished");
+
+			return 1;
+		};
+		Future<Integer> result1 = executorService.submit(schedule);
+		Future<Integer> result2 = executorService.submit(schedule);
+
+		assertEquals(1, result1.get());
+		assertEquals(1, result2.get());
+	}
+
+}


### PR DESCRIPTION
DELETEs during $reindex is leaving rows in the hfj_spidx_* tables.  This is a big problem because:
1. a query will find resource_ids, but then the bundle builder will throw an exception trying to build the resource
2. A $reindex won't fix it since $reindex will usually skip deleted resources (unless you use the same query as 1).

This change tickles Hibernate so it ensures that $reindex maintains an optimistic lock on resource version even though no writes happen to the resource table.
