### PR TITLE
Ensure querying $mdm-link-history on only golden resource or resource only does not result in an error

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4680-mdm-link-history-only-one-of-each-param-no-error.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4680-mdm-link-history-only-one-of-each-param-no-error.yaml
@@ -1,4 +1,4 @@
 ---
 type: fix
 issue: 4680
-title: "Previously, invoking $mdm-link-history on only the golden resource ID or source ID would fail due to faulty validation.  This has been fixed."
+title: "Previously, invoking $mdm-link-history on only the golden resource ID or source ID would fail due to faulty validation.  This has been corrected."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4680-mdm-link-history-only-one-of-each-param-no-error.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4680-mdm-link-history-only-one-of-each-param-no-error.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4680
+title: "Previously, invoking $mdm-link-history on only the golden resource ID or source ID would fail due to faulty validation.  This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HibernatePropertiesProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HibernatePropertiesProvider.java
@@ -57,13 +57,6 @@ public class HibernatePropertiesProvider {
 			myDialect = dialect;
 		}
 
-		if (myEntityManagerFactory != null) {
-			final Map<String, Object> jpaPropertyMap = myEntityManagerFactory.getJpaPropertyMap();
-			if (! jpaPropertyMap.containsKey(Constants.HIBERNATE_INTEGRATION_ENVERS_ENABLED)) {
-				jpaPropertyMap.put(Constants.HIBERNATE_INTEGRATION_ENVERS_ENABLED, myStorageSettings.isNonResourceDbHistoryEnabled());
-			}
-		}
-
 		return dialect;
 	}
 

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvcTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/dao/MdmLinkDaoSvcTest.java
@@ -113,8 +113,8 @@ public class MdmLinkDaoSvcTest extends BaseMdmR4Test {
 
 		final MdmHistorySearchParameters mdmHistorySearchParameters =
 			new MdmHistorySearchParameters()
-				.addGoldenResourceIds(getIdsFromMdmLinks(MdmLink::getGoldenResourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients3.get(0)))
-				.addSourceIds(getIdsFromMdmLinks(MdmLink::getSourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients2.get(0)));
+				.setGoldenResourceIds(getIdsFromMdmLinks(MdmLink::getGoldenResourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients3.get(0)))
+				.setSourceIds(getIdsFromMdmLinks(MdmLink::getSourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients2.get(0)));
 
 		final List<MdmLinkWithRevision<MdmLink>> actualMdmLinkRevisions = myMdmLinkDaoSvc.findMdmLinkHistory(mdmHistorySearchParameters);
 
@@ -154,7 +154,7 @@ public class MdmLinkDaoSvcTest extends BaseMdmR4Test {
 
 		final MdmHistorySearchParameters mdmHistorySearchParameters =
 			new MdmHistorySearchParameters()
-				.addGoldenResourceIds(getIdsFromMdmLinks(MdmLink::getGoldenResourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients3.get(0)));
+				.setGoldenResourceIds(getIdsFromMdmLinks(MdmLink::getGoldenResourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients3.get(0)));
 
 		final List<MdmLinkWithRevision<MdmLink>> actualMdmLinkRevisions = myMdmLinkDaoSvc.findMdmLinkHistory(mdmHistorySearchParameters);
 
@@ -190,7 +190,7 @@ public class MdmLinkDaoSvcTest extends BaseMdmR4Test {
 
 		final MdmHistorySearchParameters mdmHistorySearchParameters =
 			new MdmHistorySearchParameters()
-				.addSourceIds(getIdsFromMdmLinks(MdmLink::getSourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients2.get(0)));
+				.setSourceIds(getIdsFromMdmLinks(MdmLink::getSourcePersistenceId, mdmLinksWithLinkedPatients1.get(0), mdmLinksWithLinkedPatients2.get(0)));
 
 		final List<MdmLinkWithRevision<MdmLink>> actualMdmLinkRevisions = myMdmLinkDaoSvc.findMdmLinkHistory(mdmHistorySearchParameters);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/MdmHistorySearchParameters.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/MdmHistorySearchParameters.java
@@ -33,8 +33,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class MdmHistorySearchParameters {
-	private final List<IIdType> myGoldenResourceIds = new ArrayList<>();
-	private final List<IIdType> mySourceIds = new ArrayList<>();
+	private List<IIdType> myGoldenResourceIds = new ArrayList<>();
+	private List<IIdType> mySourceIds = new ArrayList<>();
 
 	public MdmHistorySearchParameters() {}
 
@@ -46,13 +46,13 @@ public class MdmHistorySearchParameters {
 		return mySourceIds;
 	}
 
-	public MdmHistorySearchParameters addGoldenResourceIds(List<String> theGoldenResourceIds) {
-		myGoldenResourceIds.addAll(extractId(theGoldenResourceIds));
+	public MdmHistorySearchParameters setGoldenResourceIds(List<String> theGoldenResourceIds) {
+		myGoldenResourceIds = extractId(theGoldenResourceIds);
 		return this;
 	}
 
-	public MdmHistorySearchParameters addSourceIds(List<String> theSourceIds) {
-		mySourceIds.addAll(extractId(theSourceIds));
+	public MdmHistorySearchParameters setSourceIds(List<String> theSourceIds) {
+		mySourceIds = extractId(theSourceIds);
 		return this;
 	}
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/MdmHistorySearchParameters.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/MdmHistorySearchParameters.java
@@ -27,13 +27,14 @@ import org.hl7.fhir.instance.model.api.IIdType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class MdmHistorySearchParameters {
-	private List<IIdType> myGoldenResourceIds;
-	private List<IIdType> mySourceIds;
+	private final List<IIdType> myGoldenResourceIds = new ArrayList<>();
+	private final List<IIdType> mySourceIds = new ArrayList<>();
 
 	public MdmHistorySearchParameters() {}
 
@@ -45,13 +46,13 @@ public class MdmHistorySearchParameters {
 		return mySourceIds;
 	}
 
-	public MdmHistorySearchParameters setGoldenResourceIds(List<String> theGoldenResourceIds) {
-		myGoldenResourceIds = extractId(theGoldenResourceIds);
+	public MdmHistorySearchParameters addGoldenResourceIds(List<String> theGoldenResourceIds) {
+		myGoldenResourceIds.addAll(extractId(theGoldenResourceIds));
 		return this;
 	}
 
-	public MdmHistorySearchParameters setSourceIds(List<String> theSourceIds) {
-		mySourceIds = extractId(theSourceIds);
+	public MdmHistorySearchParameters addSourceIds(List<String> theSourceIds) {
+		mySourceIds.addAll(extractId(theSourceIds));
 		return this;
 	}
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/BaseMdmProvider.java
@@ -73,7 +73,7 @@ public abstract class BaseMdmProvider {
 	}
 
 	private void validateBothCannotBeNullOrEmpty(String theFirstName, List<IPrimitiveType<String>> theFirstList, String theSecondName, List<IPrimitiveType<String>> theSecondList) {
-		if ((theFirstList == null || theFirstList.isEmpty()) || (theSecondList == null || theSecondList.isEmpty())) {
+		if ((theFirstList == null || theFirstList.isEmpty()) && (theSecondList == null || theSecondList.isEmpty())) {
 			throw new InvalidRequestException(Msg.code(2292) + "both ["+theFirstName+"] and ["+theSecondName+"] cannot be null or empty");
 		}
 	}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
@@ -59,8 +59,8 @@ public class MdmLinkHistoryProviderDstu3Plus extends BaseMdmProvider {
 		final IBaseParameters retVal = ParametersUtil.newInstance(myFhirContext);
 
 		final MdmHistorySearchParameters mdmHistorySearchParameters = new MdmHistorySearchParameters()
-			.addGoldenResourceIds(goldenResourceIdsToUse)
-			.addSourceIds(resourceIdsToUse);
+			.setGoldenResourceIds(goldenResourceIdsToUse)
+			.setSourceIds(resourceIdsToUse);
 
 		final List<MdmLinkWithRevisionJson> mdmLinkRevisionsFromSvc = myMdmControllerSvc.queryLinkHistory(mdmHistorySearchParameters, theRequestDetails);
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
@@ -59,8 +59,8 @@ public class MdmLinkHistoryProviderDstu3Plus extends BaseMdmProvider {
 		final IBaseParameters retVal = ParametersUtil.newInstance(myFhirContext);
 
 		final MdmHistorySearchParameters mdmHistorySearchParameters = new MdmHistorySearchParameters()
-			.setGoldenResourceIds(goldenResourceIdsToUse)
-			.setSourceIds(resourceIdsToUse);
+			.addGoldenResourceIds(goldenResourceIdsToUse)
+			.addSourceIds(resourceIdsToUse);
 
 		final List<MdmLinkWithRevisionJson> mdmLinkRevisionsFromSvc = myMdmControllerSvc.queryLinkHistory(mdmHistorySearchParameters, theRequestDetails);
 


### PR DESCRIPTION
- Fix bug in validation in MDM link history provider to allow either golden resource or source ID to be passed only, but not both empty
- Fix JPA Doa logic to handle either golden resource or source IDs to be passed alone with proper conditional logic

Closes https://github.com/hapifhir/hapi-fhir/issues/4680