### PR TITLE
Update BaseResourceReturningMethodBinding.java

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
@@ -271,7 +271,7 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 				}
 			}
 			if (offset != null && offset > 0) {
-				int start = Math.max(0, theOffset - pageSize);
+				int start = Math.max(0, offset - pageSize);
 				links.setPrev(RestfulServerUtils.createOffsetPagingLink(links, theRequest.getRequestPath(), theRequest.getTenantId(), start, pageSize, theRequest.getParameters()));
 			}
 		} else if (isNotBlank(theResult.getCurrentPageId())) {


### PR DESCRIPTION
This fixes the previous links for the plain server. This was reported in https://github.com/hapifhir/hapi-fhir/issues/4705. 