### PR TITLE
Remove IntelliJ workaround now that IDEA-85478 is fixed.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4710-remove-intellij-maven-version-hack.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4710-remove-intellij-maven-version-hack.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 4710
+title: "Removed maven configuration hack for IntelliJ now that Jetbrains supports different java versions in test and main (IDEA-85478)."

--- a/pom.xml
+++ b/pom.xml
@@ -2989,36 +2989,6 @@
 				</plugins>
 			</build>
 		</profile>
-
-		<!--
-		This profile is basically here to work around an IJ bug where the
-		<testSource> tag is ignored in IJ's compiler. See:
-		https://youtrack.jetbrains.com/issue/IDEA-85478
-		-->
-		<profile>
-			<id>ide</id>
-			<activation>
-				<activeByDefault>false</activeByDefault>
-				<property>
-					<name>idea.maven.embedder.version</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<source>17</source>
-							<target>17</target>
-							<release>17</release>
-							<testSource>17</testSource>
-							<testTarget>17</testTarget>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 		<profile>
 			<id>ossrh-repo</id>
 			<activation>


### PR DESCRIPTION
2023.1 fixes this nicely.  We no longer need this hack.
