### PR TITLE
Tune postgres settings for Hapi indexing.

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -262,6 +262,43 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.unique(false)
 			.online(true)
 			.withColumns("HASH_IDENTITY", "SP_LATITUDE", "SP_LONGITUDE", "RES_ID", "PARTITION_ID");
+
+
+		// Postgres tuning.
+		version.executeRawSqls("20230402.1", Map.of(DriverTypeEnum.POSTGRES_9_4, List.of(
+			// we can't use convering index until the autovacuum runs, which kills index performance
+			"ALTER TABLE hfj_resource SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_forced_id SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_res_link SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_coords SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_date SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_number SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_quantity SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_string SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_token SET autovacuum_vacuum_scale_factor = 0.01",
+			"ALTER TABLE hfj_spidx_uri SET autovacuum_vacuum_scale_factor = 0.01",
+
+			// PG by default tracks the most common 100 values.  But our hashes cover 100s of SPs and need greater depth.
+			// Set stats depth to the max.
+			"alter table hfj_spidx_token alter column hash_identity set statistics 10000",
+			"alter table hfj_spidx_token alter column hash_sys set statistics 10000",
+			"alter table hfj_spidx_token alter column hash_sys_and_value set statistics 10000",
+			"alter table hfj_spidx_token alter column hash_value set statistics 10000",
+			"alter table hfj_spidx_uri alter column hash_identity set statistics 10000",
+			"alter table hfj_spidx_uri alter column hash_uri set statistics 10000",
+			"alter table hfj_spidx_string alter column hash_identity set statistics 10000",
+			"alter table hfj_spidx_string alter column hash_exact set statistics 10000",
+			"alter table hfj_spidx_string alter column hash_norm_prefix set statistics 10000",
+			"alter table hfj_spidx_date alter column hash_identity set statistics 10000",
+			"alter table hfj_spidx_coords alter column hash_identity set statistics 10000",
+			"alter table hfj_res_link alter column src_path set statistics 10000",
+			"alter table hfj_res_link alter column target_resource_id set statistics 10000",
+			"alter table hfj_res_link alter column src_resource_id set statistics 10000",
+			"alter table hfj_spidx_number alter column hash_identity set statistics 10000",
+			"alter table hfj_spidx_quantity alter column hash_identity set statistics 10000",
+			"alter table hfj_spidx_quantity alter column hash_identity_and_units set statistics 10000",
+			"alter table hfj_spidx_quantity alter column hash_identity_sys_units set statistics 10000"
+			)));
 	}
 
 	protected void init640() {


### PR DESCRIPTION
Two tuning changes for PG:

1. Lower the autovacuum threshold for all index tables.  Postgres can't use a covering index to skip row-reads until the visibility map is updated.  This happens during vacuum.
2. Deepen the most-frequent stats collection for all hash columns.  The PG default is only 100, and our hash columns index unique values for 100s of SPs.  We need this so the planner has better cardinality estimates.