### PR TITLE
Improve performance of ResourceSearchView (use hfj_resource res_id instead of hfj_res_ver res_id when querying by resource pids)

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4716-search-view-performance.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4716-search-view-performance.yaml
@@ -1,0 +1,6 @@
+---
+type: perf
+issue: 4716
+title: "The SQL query used to fetch pages of search results resulted in an inefficient use
+   of the database in cases where resources have many different versions stored. Thanks to
+   Primož Delopst for the pull request!"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/ResourceSearchView.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/ResourceSearchView.java
@@ -46,7 +46,7 @@ import java.util.Date;
 @Entity
 @Immutable
 @Subselect("SELECT h.pid               as pid,            " +
-	"               h.res_id            as res_id,         " +
+	"               r.res_id            as res_id,         " +
 	"               h.res_type          as res_type,       " +
 	"               h.res_version       as res_version,    " + // FHIR version
 	"               h.res_ver           as res_ver,        " + // resource version

--- a/pom.xml
+++ b/pom.xml
@@ -859,6 +859,10 @@
 		<developer>
 			<id>JorisHeadease</id>
 		</developer>
+		<developer>
+			<id>delopst</id>
+			<name>Primož Delopst</name>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Hi.

We had a lot of issues when using HAPI FHiR which had a lot of resources with a lot of versions. 
This was tested on a database with 1 million resources and 9 million versions and after changing this, query times when using IResourceSearchViewDao.findByResourceIds went down from a few seconds to 100ms.

Regards, Primoz
