### PR TITLE
Absent score/vector fields for MATCH MDM links

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4729-absent-score-vector-fields-mdm-match.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4729-absent-score-vector-fields-mdm-match.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 4729
+title: "When there is an EID MDM MATCH, the MATCH link has no score. This issue has been fixed."

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/BaseMdmR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/BaseMdmR4Test.java
@@ -573,6 +573,10 @@ abstract public class BaseMdmR4Test extends BaseJpaR4Test {
 		assertFields(MdmLink::getScore, theExpectedValues);
 	}
 
+	protected void assertLinksMatchVector(Long... theExpectedValues) {
+		assertFields(MdmLink::getVector, theExpectedValues);
+	}
+
 	public SearchParameterMap buildGoldenResourceSearchParameterMap() {
 		SearchParameterMap spMap = new SearchParameterMap();
 		spMap.setLoadSynchronous(true);

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvcMultipleEidModeTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvcMultipleEidModeTest.java
@@ -46,6 +46,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH);
 		assertLinksCreatedNewResource(true);
 		assertLinksMatchedByEid(false);
+		assertLinksMatchScore(1.0);
+		assertLinksMatchVector((Long) null);
 
 		IAnyResource janeGoldenResource = getGoldenResourceFromTargetResource(patient);
 		List<CanonicalEID> hapiEid = myEidHelper.getHapiEid(janeGoldenResource);
@@ -58,6 +60,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, MATCH);
 		assertLinksCreatedNewResource(true, false);
 		assertLinksMatchedByEid(false, false);
+		assertLinksMatchScore(1.0, 2.0/3.0);
+		assertLinksMatchVector(null, 6L);
 
 		//We want to make sure the patients were linked to the same GoldenResource.
 		assertThat(patient, is(sameGoldenResourceAs(janePatient)));
@@ -94,6 +98,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH);
 		assertLinksCreatedNewResource(true);
 		assertLinksMatchedByEid(false);
+		assertLinksMatchScore(1.0);
+		assertLinksMatchVector((Long) null);
 
 		Patient patient2 = buildPaulPatient();
 		addExternalEID(patient2, "id_5");
@@ -102,6 +108,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, MATCH);
 		assertLinksCreatedNewResource(true, false);
 		assertLinksMatchedByEid(false, true);
+		assertLinksMatchScore(1.0, 1.0);
+		assertLinksMatchVector(null, null);
 
 		assertThat(patient1, is(sameGoldenResourceAs(patient2)));
 
@@ -117,6 +125,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, MATCH);
 		assertLinksCreatedNewResource(true, false);
 		assertLinksMatchedByEid(false, true);
+		assertLinksMatchScore(1.0, 1.0);
+		assertLinksMatchVector(null, null);
 
 		assertThat(patient1, is(sameGoldenResourceAs(patient2)));
 
@@ -133,6 +143,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH);
 		assertLinksCreatedNewResource(true);
 		assertLinksMatchedByEid(false);
+		assertLinksMatchScore(1.0);
+		assertLinksMatchVector((Long) null);
 
 		Patient patient2 = buildJanePatient();
 		addExternalEID(patient2, "eid-2");
@@ -141,6 +153,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, MATCH, POSSIBLE_DUPLICATE);
 		assertLinksCreatedNewResource(true, true, false);
 		assertLinksMatchedByEid(false, false, true);
+		assertLinksMatchScore(1.0, 1.0, null);
+		assertLinksMatchVector(null, null, null);
 
 		List<MdmLink> possibleDuplicates = (List<MdmLink>) myMdmLinkDaoSvc.getPossibleDuplicates();
 		assertThat(possibleDuplicates, hasSize(1));
@@ -167,6 +181,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH);
 		assertLinksCreatedNewResource(true);
 		assertLinksMatchedByEid(false);
+		assertLinksMatchScore(1.0);
+		assertLinksMatchVector((Long) null);
 
 		Patient patient2 = buildPaulPatient();
 		addExternalEID(patient2, "eid-2");
@@ -175,6 +191,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, MATCH);
 		assertLinksCreatedNewResource(true, true);
 		assertLinksMatchedByEid(false, false);
+		assertLinksMatchScore(1.0, 1.0);
+		assertLinksMatchVector(null, null);
 
 		Patient patient3 = buildPaulPatient();
 		addExternalEID(patient3, "eid-22");
@@ -182,6 +200,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, MATCH, MATCH);
 		assertLinksCreatedNewResource(true, true, false);
 		assertLinksMatchedByEid(false, false, true);
+		assertLinksMatchScore(1.0, 1.0, 1.0);
+		assertLinksMatchVector(null, null, null);
 
 		//Now, Patient 2 and 3 are linked, and the GoldenResource has 2 eids.
 		assertThat(patient2, is(sameGoldenResourceAs(patient3)));
@@ -197,6 +217,8 @@ public class MdmMatchLinkSvcMultipleEidModeTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, POSSIBLE_MATCH, MATCH, POSSIBLE_MATCH, POSSIBLE_DUPLICATE);
 		assertLinksCreatedNewResource(true, true, false, false, false);
 		assertLinksMatchedByEid(false, true, true, true, true);
+		assertLinksMatchScore(1.0, 1.0, 1.0, 1.0, null);
+		assertLinksMatchVector(null, null, null, null, null);
 
 		assertThat(patient2, is(not(matchedToAGoldenResource())));
 		assertThat(patient2, is(possibleMatchWith(patient1)));

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvcTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmMatchLinkSvcTest.java
@@ -69,6 +69,7 @@ public class MdmMatchLinkSvcTest extends BaseMdmR4Test {
 		assertLinksCreatedNewResource(true);
 		assertLinksMatchedByEid(false);
 		assertLinksMatchScore(1.0);
+		assertLinksMatchVector((Long) null);
 	}
 
 	@Test
@@ -81,6 +82,7 @@ public class MdmMatchLinkSvcTest extends BaseMdmR4Test {
 		assertLinksCreatedNewResource(true);
 		assertLinksMatchedByEid(false);
 		assertLinksMatchScore(1.0);
+		assertLinksMatchVector((Long) null);
 	}
 
 	@Test
@@ -96,6 +98,7 @@ public class MdmMatchLinkSvcTest extends BaseMdmR4Test {
 		assertLinksCreatedNewResource(true, true);
 		assertLinksMatchedByEid(false, false);
 		assertLinksMatchScore(1.0, 1.0);
+		assertLinksMatchVector(null, null);
 	}
 
 	@Test
@@ -111,6 +114,7 @@ public class MdmMatchLinkSvcTest extends BaseMdmR4Test {
 		assertLinksCreatedNewResource(true, false);
 		assertLinksMatchedByEid(false, false);
 		assertLinksMatchScore(1.0, 2.0/3.0);
+		assertLinksMatchVector(null, 6L);
 	}
 
 	@Test
@@ -131,6 +135,8 @@ public class MdmMatchLinkSvcTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, NO_MATCH, MATCH);
 		assertLinksCreatedNewResource(true, false, true);
 		assertLinksMatchedByEid(false, false, false);
+		assertLinksMatchScore(1.0, null, 1.0);
+		assertLinksMatchVector(null, null, null);
 	}
 
 	@Test
@@ -156,6 +162,8 @@ public class MdmMatchLinkSvcTest extends BaseMdmR4Test {
 		assertLinksMatchResult(MATCH, NO_MATCH, MATCH);
 		assertLinksCreatedNewResource(true, false, true);
 		assertLinksMatchedByEid(false, false, false);
+		assertLinksMatchScore(1.0, null, 1.0);
+		assertLinksMatchVector(null, null, null);
 	}
 
 	@Test

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/MdmMatchOutcome.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/MdmMatchOutcome.java
@@ -29,7 +29,7 @@ public final class MdmMatchOutcome {
 	public static final MdmMatchOutcome POSSIBLE_DUPLICATE = new MdmMatchOutcome(null, null).setMatchResultEnum(MdmMatchResultEnum.POSSIBLE_DUPLICATE);
 	public static final MdmMatchOutcome NO_MATCH = new MdmMatchOutcome(null, null).setMatchResultEnum(MdmMatchResultEnum.NO_MATCH);
 	public static final MdmMatchOutcome NEW_GOLDEN_RESOURCE_MATCH = new MdmMatchOutcome(null, 1.0).setMatchResultEnum(MdmMatchResultEnum.MATCH).setCreatedNewResource(true);
-	public static final MdmMatchOutcome EID_MATCH = new MdmMatchOutcome(null, null).setMatchResultEnum(MdmMatchResultEnum.MATCH).setEidMatch(true);
+	public static final MdmMatchOutcome EID_MATCH = new MdmMatchOutcome(null, 1.0).setMatchResultEnum(MdmMatchResultEnum.MATCH).setEidMatch(true);
 	public static final MdmMatchOutcome POSSIBLE_MATCH = new MdmMatchOutcome(null, null).setMatchResultEnum(MdmMatchResultEnum.POSSIBLE_MATCH);
 
 	/**
@@ -44,7 +44,7 @@ public final class MdmMatchOutcome {
 	private final Double score;
 
 	/**
-	 * Did the MDM match operation result in creating a new golden resource resource?
+	 * Did the MDM match operation result in creating a new golden resource?
 	 */
 	private boolean myCreatedNewResource;
 
@@ -75,7 +75,6 @@ public final class MdmMatchOutcome {
 	public boolean isPossibleMatch() {
 		 return myMatchResultEnum == MdmMatchResultEnum.POSSIBLE_MATCH;
 	}
-
 
 	public boolean isPossibleDuplicate() {
 		return myMatchResultEnum == MdmMatchResultEnum.POSSIBLE_DUPLICATE;
@@ -144,11 +143,8 @@ public final class MdmMatchOutcome {
 	 * 	Returns the normalized score
 	 */
 	public Double getNormalizedScore() {
-		if (myCreatedNewResource) {
-			// If we created a new golden resource from this match, the match score must be 1.00
-			return 1.0;
-		} else if (myMdmRuleCount == 0) {
-			return 0.0;
+		if (myMdmRuleCount == 0) {
+			return score;
 		}
 		return score / myMdmRuleCount;
 	}


### PR DESCRIPTION
Fixes `Absent score/vector fields for MATCH MDM links` #4729 
Sets score for EID Match links to 1.0 without a vector, similar to score/vector for a new golden resource.