### PR TITLE
Add `old-intellij` profile to support the old way.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3001,6 +3001,35 @@
 				</plugins>
 			</build>
 		</profile>
+
+		<!--
+		This profile is basically here to work around an IJ bug where the
+		<testSource> tag is ignored in IJ's compiler. See:
+		https://youtrack.jetbrains.com/issue/IDEA-85478
+		IntelliJ 2023.1 now supports this, so we removed the activation.
+		But if you want to run an older IntelliJ, activate the old-intellij profile in the Maven tab.
+		-->
+		<profile>
+			<id>old-intellij</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>17</source>
+							<target>17</target>
+							<release>17</release>
+							<testSource>17</testSource>
+							<testTarget>17</testTarget>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>ossrh-repo</id>
 			<activation>


### PR DESCRIPTION
Activate the `old-intellij` profile to get the old behaviour where everything is Java 17.