### PR TITLE
4745 one source record should create no match link with no errors when two golden records are possible matches

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4745-one-source-record-should-create-no-match-link-with-no-errors-when-two-golden-records-are-possible-matches.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4745-one-source-record-should-create-no-match-link-with-no-errors-when-two-golden-records-are-possible-matches.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4745
+title: "Fixed an issue where a golden resource could not be chosen as no-match when another golden resource
+   was already chosen as a match."

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImpl.java
@@ -118,8 +118,11 @@ public class MdmLinkUpdaterSvcImpl implements IMdmLinkUpdaterSvc {
 
 		myMdmResourceDaoSvc.upsertGoldenResource(theGoldenResource, theMdmContext.getResourceType());
 		if (theMatchResult == MdmMatchResultEnum.NO_MATCH) {
-			// Need to find a new Golden Resource to link this target to
-			myMdmMatchLinkSvc.updateMdmLinksForMdmSource(theSourceResource, theMdmContext);
+			// We need to return no match for when a Golden Resource has already been found elsewhere
+			if (myMdmLinkDaoSvc.getMdmLinksBySourcePidAndMatchResult(sourceResourceId, MdmMatchResultEnum.MATCH).isEmpty()) {
+				// Need to find a new Golden Resource to link this target to
+				myMdmMatchLinkSvc.updateMdmLinksForMdmSource(theSourceResource, theMdmContext);
+			}
 		}
 		return theGoldenResource;
 	}

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplIT.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplIT.java
@@ -82,10 +82,10 @@ class MdmLinkUpdaterSvcImplIT extends BaseMdmR4Test {
 		Patient goldenA = getGoldenFor(patientA);
 		Patient goldenB = getGoldenFor(patientB);
 
-		// create Patient C -> no MATCH link. Only POSSIBLE_MATCH GR A and POSSIBLE_MATCH GR B and
+		// create Patient C -> no MATCH link. Only POSSIBLE_MATCH GR A and POSSIBLE_MATCH GR B
 		Patient patientC = createPatientFromJsonInputFileWithPossibleMatches( List.of(goldenA, goldenB) );
-
 		MdmTransactionContext mdmTransactionContext = getPatientUpdateLinkContext();
+
 		// update POSSIBLE_MATCH Patient C -> GR A to MATCH (should work OK)
 		myMdmLinkUpdaterSvc.updateLink(goldenA, patientC, MdmMatchResultEnum.MATCH, mdmTransactionContext);
 

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplIT.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplIT.java
@@ -3,7 +3,6 @@ package ca.uhn.fhir.jpa.mdm.svc;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
 import ca.uhn.fhir.jpa.mdm.BaseMdmR4Test;
-import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.mdm.api.IMdmLink;
 import ca.uhn.fhir.mdm.api.IMdmLinkUpdaterSvc;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
@@ -11,6 +10,7 @@ import ca.uhn.fhir.mdm.api.MdmMatchOutcome;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.mdm.model.MdmTransactionContext;
 import ca.uhn.fhir.mdm.util.MessageHelper;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
@@ -35,10 +35,6 @@ class MdmLinkUpdaterSvcImplIT extends BaseMdmR4Test {
 	public static final String Patient_A_JSON_PATH = TEST_RSC_PATH + "patient-A.json/";
 	public static final String Patient_B_JSON_PATH = TEST_RSC_PATH + "patient-B.json/";
 	public static final String Patient_C_JSON_PATH = TEST_RSC_PATH + "patient-C.json/";
-
-	public static final String Patient_SR1_JSON_PATH = TEST_RSC_PATH + "patient-SR1.json/";
-	public static final String Patient_SR2_JSON_PATH = TEST_RSC_PATH + "patient-SR2.json/";
-	public static final String Patient_SR3_JSON_PATH = TEST_RSC_PATH + "patient-SR3.json/";
 
 	@Autowired
 	private IMdmLinkUpdaterSvc myMdmLinkUpdaterSvc;

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplIT.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImplIT.java
@@ -36,6 +36,10 @@ class MdmLinkUpdaterSvcImplIT extends BaseMdmR4Test {
 	public static final String Patient_B_JSON_PATH = TEST_RSC_PATH + "patient-B.json/";
 	public static final String Patient_C_JSON_PATH = TEST_RSC_PATH + "patient-C.json/";
 
+	public static final String Patient_SR1_JSON_PATH = TEST_RSC_PATH + "patient-SR1.json/";
+	public static final String Patient_SR2_JSON_PATH = TEST_RSC_PATH + "patient-SR2.json/";
+	public static final String Patient_SR3_JSON_PATH = TEST_RSC_PATH + "patient-SR3.json/";
+
 	@Autowired
 	private IMdmLinkUpdaterSvc myMdmLinkUpdaterSvc;
 
@@ -72,7 +76,26 @@ class MdmLinkUpdaterSvcImplIT extends BaseMdmR4Test {
 		assertEquals(expectedExceptionMessage, thrown.getMessage());
 	}
 
+	@Test
+	void testUpdateLinkToNoMatchWhenAnotherLinkToDifferentGoldenExistsShouldNotFail() throws Exception {
+		// create Patient A -> MATCH GR A
+		Patient patientA = createPatientFromJsonInputFile(Patient_A_JSON_PATH);
+		// create Patient B -> MATCH GR B
+		Patient patientB = createPatientFromJsonInputFile(Patient_B_JSON_PATH);
 
+		Patient goldenA = getGoldenFor(patientA);
+		Patient goldenB = getGoldenFor(patientB);
+
+		// create Patient C -> no MATCH link. Only POSSIBLE_MATCH GR A and POSSIBLE_MATCH GR B and
+		Patient patientC = createPatientFromJsonInputFileWithPossibleMatches( List.of(goldenA, goldenB) );
+
+		MdmTransactionContext mdmTransactionContext = getPatientUpdateLinkContext();
+		// update POSSIBLE_MATCH Patient C -> GR A to MATCH (should work OK)
+		myMdmLinkUpdaterSvc.updateLink(goldenA, patientC, MdmMatchResultEnum.MATCH, mdmTransactionContext);
+
+		// update POSSIBLE_MATCH Patient C -> GR B to NO_MATCH (should work OK)
+		myMdmLinkUpdaterSvc.updateLink(goldenB, patientC, MdmMatchResultEnum.NO_MATCH, mdmTransactionContext);
+	}
 
 	private Patient createPatientFromJsonInputFileWithPossibleMatches(List<Patient> theGoldens) throws Exception {
 		Patient patient = createPatientFromJsonInputFile(Patient_C_JSON_PATH, false);


### PR DESCRIPTION
Fixed an issue where a golden resource could not be chosen as no-match when another golden resource was already chosen as a match.

Closes #4745