### PR TITLE
Add covering data to res_link index for all tgt->src queries.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4769-link-index.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4769-link-index.yaml
@@ -1,0 +1,5 @@
+---
+type: perf
+issue: 4769
+title: "Chained and reverse-chained searches will be faster in some scenarios.
+  All required columns are now included in the IDX_RL_TGT_v2 index."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/upgrade.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/upgrade.md
@@ -2,7 +2,7 @@
 This release has breaking changes.
 * The Resource $validate operation no longer returns Precondition Failed 412 when a resource fails validation.  It now returns 200 irrespective of the validation outcome as required by the [FHIR Specification for the Resource $validate operation](https://www.hl7.org/fhir/R4/resource-operation-validate.html).
   
-* This release changes database indexing for string and uri SearchParameters. The database migration may take several minutes.  These changes will be applied automatically on first startup. To avoid this delay on first startup, run the migration manually.
+* This release changes database indexing for string, uri, reference SearchParameters. The database migration may take several minutes.  These changes will be applied automatically on first startup. To avoid this delay on first startup, run the migration manually.
 
 Bulk export behaviour is changing in this release such that Binary resources created as part of the response will now be created in the partition that the bulk export was requested rather than in the DEFAULT partition as was being done previously.
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/upgrade.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/upgrade.md
@@ -2,7 +2,7 @@
 This release has breaking changes.
 * The Resource $validate operation no longer returns Precondition Failed 412 when a resource fails validation.  It now returns 200 irrespective of the validation outcome as required by the [FHIR Specification for the Resource $validate operation](https://www.hl7.org/fhir/R4/resource-operation-validate.html).
   
-* This release changes database indexing for string, uri, reference SearchParameters. The database migration may take several minutes.  These changes will be applied automatically on first startup. To avoid this delay on first startup, run the migration manually.
+* This release changes database indexing for string, uri, and reference SearchParameters. The database migration may take several minutes.  These changes will be applied automatically on first startup. To avoid this delay on first startup, run the migration manually.
 
 Bulk export behaviour is changing in this release such that Binary resources created as part of the response will now be created in the partition that the bulk export was requested rather than in the DEFAULT partition as was being done previously.
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
@@ -45,9 +45,11 @@ import java.util.Date;
 
 @Entity
 @Table(name = "HFJ_RES_LINK", indexes = {
-	@Index(name = "IDX_RL_TPATHRES", columnList = "SRC_PATH,TARGET_RESOURCE_ID"),
+	// We need to join both ways, so index from src->tgt and from tgt->src.
+	// From src->tgt, rows are usually written all together as part of ingestion - keep the index small, and read blocks as needed.
 	@Index(name = "IDX_RL_SRC", columnList = "SRC_RESOURCE_ID"),
-	@Index(name = "IDX_RL_DEST", columnList = "TARGET_RESOURCE_ID")
+	// But from tgt->src, include all the match columns. Targets will usually be randomly distributed - each row in separate block.
+	@Index(name = "IDX_RL_TGT_v2", columnList = "TARGET_RESOURCE_ID, SRC_PATH, SRC_RESOURCE_ID, TARGET_RESOURCE_TYPE,PARTITION_ID")
 })
 public class ResourceLink extends BaseResourceIndex {
 
@@ -211,7 +213,7 @@ public class ResourceLink extends BaseResourceIndex {
 		// Must have set an url like http://example.org/something
 		// We treat 'something' as the resource type because of fix for #659. Prior to #659 fix, 'something' was
 		// treated as the id and 'example.org' was treated as the resource type
-		// TODO: log a warning?
+		// Maybe log a warning?
 //		}
 
 		myTargetResourceType = theTargetResourceUrl.getResourceType();


### PR DESCRIPTION
Closes #3511

Add all columns required to satisfy our chained/revchain queries when joining on target_resource_id.
