### PR TITLE
delete operation removes element from list

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4782-fhir-patch-delete.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4782-fhir-patch-delete.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4782
+title: "Previously, a FHIRPath patch delete operation where the path resolved to an element in a collection, the element
+was not always being removed from the collection. This has been fixed."


### PR DESCRIPTION
When executing a FHIRPatch delete operation on an element in a list, we were not actually removing the element from the list. We were just nulling out all its fields, which would then cause it to be skipped when rendering as JSON, making it look like it was gone. I followed the patterns used by the move operation to actually update the contents of the list.