### PR TITLE
Don't generate empty JSON element for comment

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -553,7 +553,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 			}
 
 
-			if (!extensions.isEmpty() || !modifierExtensions.isEmpty() || !comments.isEmpty()) {
+			if (!extensions.isEmpty() || !modifierExtensions.isEmpty() || (!comments.isEmpty() && isSupportsFhirComment())) {
 				if (inArray) {
 					// If this is a repeatable field, the extensions go in an array too
 					beginArray(theEventWriter, '_' + currentChildName);

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/4832-json-serialization-produced-empty-object-for-comment.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/4832-json-serialization-produced-empty-object-for-comment.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4832
+title: "When serializing resources in JSON, if resource came from an XML-parsed resource that
+   contained comments, the JSON serializer incorrectly created an empty object. This has
+   been corrected."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
@@ -42,6 +42,7 @@ import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Type;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
@@ -173,6 +174,36 @@ public class JsonParserR4Test extends BaseTest {
 		String encoded = ourCtx.newXmlParser().encodeResourceToString(parsed);
 		assertEquals("<Patient xmlns=\"http://hl7.org/fhir\"><text><div xmlns=\"http://www.w3.org/1999/xhtml\"><img src=\"foo\"/>@fhirabend</div></text></Patient>", encoded);
 	}
+
+
+	@Test
+	public void testDontEncodeEmptyExtensionList() {
+		String asXml = """
+			<Bundle xmlns="http://hl7.org/fhir">
+			     <entry>
+			        <resource>
+			            <Composition>
+			                <section>
+			                    <entry>
+			                        <!--  Referenz auf PractitionerRole  -->
+			                        <reference value="PractitionerRole/8f1ba38d-c4c1-4c49-ac2a-7ff0e56bc150" />
+			                    </entry>
+			                </section>
+			            </Composition>
+			        </resource>
+			    </entry>
+			</Bundle>
+			""";
+
+		ourLog.info(asXml);
+
+		Bundle bundle = ourCtx.newXmlParser().parseResource(Bundle.class, asXml);
+
+		String asString = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(bundle);
+		ourLog.info(asString);
+		assertThat(asString, not(containsString("{ }")));
+	}
+
 
 
 	@Test


### PR DESCRIPTION
We should not generate an empty JSON element for comments parsed from XML