### PR TITLE
Fix: Replace basic field with empty value in TerserUtil

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -441,7 +441,10 @@ public final class TerserUtil {
 	private static void replaceField(FhirTerser theTerser, IBaseResource theFrom, IBaseResource theTo, BaseRuntimeChildDefinition childDefinition) {
 		List<IBase> fromValues = childDefinition.getAccessor().getValues(theFrom);
 		List<IBase> toValues = childDefinition.getAccessor().getValues(theTo);
-		if (fromValues != toValues) {
+
+		if (fromValues.isEmpty() && !toValues.isEmpty()) {
+			childDefinition.getMutator().setValue(theTo, null);
+		} else if (fromValues != toValues) {
 			clear(toValues);
 
 			mergeFields(theTerser, theTo, childDefinition, fromValues, toValues);
@@ -528,7 +531,6 @@ public final class TerserUtil {
 	/**
 	 * Creates a new element taking into consideration elements with choice that are not directly retrievable by element
 	 * name
-	 *
 	 *
 	 * @param theFhirTerser
 	 * @param theChildDefinition  Child to create a new instance for

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
@@ -468,6 +468,16 @@ class TerserUtilTest {
 		assertEquals(1, p2.getName().size());
 		assertEquals("Doe", p2.getName().get(0).getFamily());
 	}
+		@Test
+	public void testReplaceFieldByEmptyValue() {
+		Patient p1 = new Patient();
+		Patient p2 = new Patient();
+		p2.setActive(true);
+
+		TerserUtil.replaceField(ourFhirContext, "active", p1, p2);
+
+		assertFalse(p2.hasActive());
+	}
 
 	@Test
 	public void testReplaceFieldsByPredicate() {

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
@@ -476,6 +476,7 @@ class TerserUtilTest {
 
 		TerserUtil.replaceField(ourFhirContext, "active", p1, p2);
 
+		// expect p2 to have 'active removed'
 		assertFalse(p2.hasActive());
 	}
 


### PR DESCRIPTION
I came across this bug when doing some resource merging logic.

Before the fix, `TerserUtil` would fail silently and log the error at debug level.