### PR TITLE
Change to a release version of the Clinical Reasoning dependency.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,8 +70,8 @@ stages:
                   #                  Put to top, but kept in order here
                   #                  -  name: hapi_fhir_jpaserver_test_utilities
                   #                     module: hapi-fhir-jpaserver-test-utilities
-                  -  name: hapi_fhir_jpaserver_uhnfhirtest
-                     module: hapi-fhir-jpaserver-uhnfhirtest
+#                  -  name: hapi_fhir_jpaserver_uhnfhirtest
+#                     module: hapi-fhir-jpaserver-uhnfhirtest
                   -  name: hapi_fhir_server
                      module: hapi-fhir-server
                   -  name: hapi_fhir_server_mdm

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -238,5 +238,37 @@
             <artifactId>poi</artifactId>
         </dependency>
     </dependencies>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.0.0</version>
+					<executions>
+						<execution>
+							<id>enforce-maven</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<requireReleaseDeps>
+										<message>No Clinical Reasoning Snapshots Allowed!</message>
+										<includes>
+											<include>org.opencds.cqf:*</include>
+											<include>org.opencds.cqf.cql:*</include>
+											<include>org.opencds.cqf.fhir:*</include>
+											<include>info.cqframework:*</include>
+										</includes>
+									</requireReleaseDeps>
+								</rules>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 
 </project>

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -238,37 +238,44 @@
             <artifactId>poi</artifactId>
         </dependency>
     </dependencies>
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.0.0</version>
-					<executions>
-						<execution>
-							<id>enforce-maven</id>
-							<goals>
-								<goal>enforce</goal>
-							</goals>
-							<configuration>
-								<rules>
-									<requireReleaseDeps>
-										<message>No Clinical Reasoning Snapshots Allowed!</message>
-										<includes>
-											<include>org.opencds.cqf:*</include>
-											<include>org.opencds.cqf.cql:*</include>
-											<include>org.opencds.cqf.fhir:*</include>
-											<include>info.cqframework:*</include>
-										</includes>
-									</requireReleaseDeps>
-								</rules>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
-
+	<profiles>
+		<profile>
+			<id>CI</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-enforcer-plugin</artifactId>
+							<executions>
+								<execution>
+									<id>enforce-no-snapshot-cr-dependencies</id>
+									<goals>
+										<goal>enforce</goal>
+									</goals>
+									<phase>verify</phase>
+									<configuration>
+										<rules>
+											<requireReleaseDeps>
+												<message>No Clinical Reasoning Snapshots Allowed!</message>
+												<excludes>
+													<exclude>*:*</exclude>
+												</excludes>
+												<includes>
+													<include>org.opencds.cqf:*</include>
+													<include>org.opencds.cqf.cql:*</include>
+													<include>org.opencds.cqf.fhir:*</include>
+													<include>info.cqframework:*</include>
+												</includes>
+											</requireReleaseDeps>
+										</rules>
+									</configuration>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2479,7 +2479,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>enforce-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 		<module>hapi-fhir-jpaserver-ips</module>
 		<module>hapi-fhir-jpaserver-mdm</module>
 		<module>hapi-fhir-testpage-overlay</module>
-		<module>hapi-fhir-jpaserver-uhnfhirtest</module>
+<!--		<module>hapi-fhir-jpaserver-uhnfhirtest</module>-->
 		<module>hapi-fhir-client-okhttp</module>
 		<module>hapi-fhir-android</module>
 		<module>hapi-fhir-cli</module>

--- a/pom.xml
+++ b/pom.xml
@@ -982,7 +982,7 @@
 
 		<elastic_apm_version>1.28.4</elastic_apm_version>
 		<!-- CQL Support -->
-		<clinical-reasoning.version>3.0.0-PRE3-SNAPSHOT</clinical-reasoning.version>
+		<clinical-reasoning.version>3.0.0-PRE2</clinical-reasoning.version>
 
 		<!-- Site properties -->
 		<fontawesomeVersion>5.4.1</fontawesomeVersion>


### PR DESCRIPTION
* A SNAPSHOT dependency on an upstream module was added to HAPI FHIR, which changed and caused some downstream tests to break.
* Going forward, hapi `master` branch should only depend on release versions of the clinical-reasoning module. Maven enforcer plugin was added to require that.
* Clinical Reasoning modules are released every sprint (every 3 weeks) so by the time PR is opened / reviewed / merged on HAPI master there ought to be a release version available
