### PR TITLE
When new push occurs, delete old remote pipeline

### DIFF
--- a/.github/workflows/cdr_check/trigger_and_poll_gitlab.py
+++ b/.github/workflows/cdr_check/trigger_and_poll_gitlab.py
@@ -9,10 +9,16 @@ trigger_token = os.getenv("TRIGGER_TOKEN")
 project_api_read_token = os.getenv("READ_API_TOKEN")
 current_hapi_branch = os.getenv("HAPI_BRANCH")
 target_cdr_branch = os.getenv("CDR_BRANCH")
+comment = os.getenv("TRIGGERING_COMMENT")
+
+def fprint(message):
+    print(message, flush=True)
+fprint(f"comment is {comment}")
 
 if not target_cdr_branch:
-    print("Defaulting CDR branch to master as this is an automatic build.")
+    fprint("Defaulting CDR branch to master as this is an automatic build.")
     target_cdr_branch = "master"
+
 
 form_data = {
     "token": trigger_token,
@@ -20,13 +26,15 @@ form_data = {
     "variables[HAPI_BRANCH]": current_hapi_branch
 }
 
-print(f"About to start job. [target_cdr_branch={target_cdr_branch}, current_hapi_branch={current_hapi_branch}]")
-print("Triggering Remote CI process on gitlab.com.")
+fprint(f"About to start job. [target_cdr_branch={target_cdr_branch}, current_hapi_branch={current_hapi_branch}]")
+fprint("Triggering Remote CI process on gitlab.com.")
 result = requests.post("https://gitlab.com/api/v4/projects/1927185/trigger/pipeline", data=form_data)
 if result.status_code > 399:
-    print(result.json())
+    fprint(result.json())
 trigger_json = result.json()
+fprint(trigger_json)
 pipeline_id = trigger_json["id"]
+
 
 
 def poll_for_pipeline_status(pipeline_id):
@@ -38,21 +46,31 @@ def poll_for_pipeline_status(pipeline_id):
     return pipeline_status_json
 
 
-print(f"Generated pipeline. [pipeline_id={pipeline_id}]")
+fprint(f"Generated pipeline. [pipeline_id={pipeline_id}]")
+
+#Set as output of job
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    fprint(f'pipeline_id={pipeline_id}', file=fh)
+
+
 status = None
 status_json = poll_for_pipeline_status(pipeline_id)
+fprint(f"Status_json is {status_json}")
 start_time = datetime.datetime.now()
 
 while status not in complete_statuses:
     status = status_json["status"]
     now = datetime.datetime.now()
-    print(f"Job not yet complete. [status={status}, duration={(now - start_time).total_seconds()}s]")
+    fprint(f"Job not yet complete. [status={status}, duration={(now - start_time).total_seconds()}s]")
     sleep(10)
     status_json = poll_for_pipeline_status(pipeline_id)
 
 if status == "success":
-    print(f"CDR compiled against this branch! Please visit: {status_json['web_url']}")
+    fprint(f"CDR compiled against this branch! Please visit: {status_json['web_url']}")
     sys.exit(0)
 else:
-    print(f"CDR failed against this branch! Please visit: {status_json['web_url']}")
+    fprint(f"CDR failed against this branch! Please visit: {status_json['web_url']}")
     sys.exit(1)
+
+
+

--- a/.github/workflows/compile_against_cdr.yml
+++ b/.github/workflows/compile_against_cdr.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   compile-against-cdr:
     runs-on: ubuntu-latest
+    concurrency:
+       group: ${{ github.workflow }}-${{ github.ref }}
+       cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3
       name: Checkout
@@ -34,3 +37,10 @@ jobs:
         HAPI_BRANCH: ${{ github.head_ref || github.ref_name }}
         # When run via the manual run, this will be set. When run in a PR, it will be blank.
         CDR_BRANCH: ${{ inputs.cdr_branch }}
+    -  run: poetry run python cancel_remote_pipeline.py
+       if: ${{ cancelled() }}
+       name: Cancel Remote Pipeline
+       working-directory: ./.github/workflows/cdr_check
+       env:
+          READ_API_TOKEN: ${{ secrets.GITLAB_READ_API_TOKEN }}
+          PIPELINE_ID: ${{ steps.execute-pipeline.outputs.pipeline_id }}

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/ResourceModifiedTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/ResourceModifiedTest.java
@@ -65,5 +65,4 @@ public class ResourceModifiedTest {
 		assertEquals(msg.getPartitionId().getPartitionIds().size(), 1);
 		assertEquals(msg.getPartitionId().getPartitionIds().get(0), 123);
 	}
-
 }


### PR DESCRIPTION
- adds  cancel handling logic to the compile-against-cdr job. 
- ensures only one copy running per PR. 

