### PR TITLE
Resolve 4863 from release branch searchparametercanonicalizer does not account for search parameters for custom resources types when converting dstu23 into runtimesearchparam

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4863-resolve-searchparametercanonicalizer-does-not-account-for-search-parameters-for-custom-resources-types-when-converting-dstu23-into-runtimesearchparam.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4863-resolve-searchparametercanonicalizer-does-not-account-for-search-parameters-for-custom-resources-types-when-converting-dstu23-into-runtimesearchparam.yaml
@@ -1,5 +1,5 @@
 ---
 type: fix
 issue: 4863
-title: "The SearchParameterCanonicalizer does not correctly convert DSTU2 and DSTU3 custom resources search parameters 
+title: "The SearchParameterCanonicalizer does not correctly convert DSTU2 and DSTU3 custom resources SearchParameters 
 into RuntimeSearchParam. This is now fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4863-resolve-searchparametercanonicalizer-does-not-account-for-search-parameters-for-custom-resources-types-when-converting-dstu23-into-runtimesearchparam.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4863-resolve-searchparametercanonicalizer-does-not-account-for-search-parameters-for-custom-resources-types-when-converting-dstu23-into-runtimesearchparam.yaml
@@ -1,5 +1,5 @@
 ---
 type: fix
 issue: 4863
-title: "The SearchParameterCanonicalizer does not correctly convert DSTU2 and DSTU3 custom resources SearchParameters 
+title: "Previously the SearchParameterCanonicalizer did not correctly convert DSTU2 and DSTU3 custom resources SearchParameters 
 into RuntimeSearchParam. This is now fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4863-resolve-searchparametercanonicalizer-does-not-account-for-search-parameters-for-custom-resources-types-when-converting-dstu23-into-runtimesearchparam.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_6_0/4863-resolve-searchparametercanonicalizer-does-not-account-for-search-parameters-for-custom-resources-types-when-converting-dstu23-into-runtimesearchparam.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4863
+title: "The SearchParameterCanonicalizer does not correctly convert DSTU2 and DSTU3 custom resources search parameters 
+into RuntimeSearchParam. This is now fixed."

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -154,15 +154,19 @@ public class SearchParameterCanonicalizer {
 					break;
 			}
 		}
-		Set<String> providesMembershipInCompartments = Collections.emptySet();
 		Set<String> targets = DatatypeUtil.toStringSet(theNextSp.getTarget());
 		// add extensions as target if the SP is for a custom resource type
+		Set<String> targetsFromExtensions = new HashSet<>();
 		List<ExtensionDt> customSPTargets = theNextSp.getUndeclaredExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
 		for (ExtensionDt e : customSPTargets) {
 			String eStr = e.getValueAsPrimitive().getValueAsString();
 			if (StringUtils.isNotBlank(eStr)) {
-				targets.add(eStr);
+				targetsFromExtensions.add(eStr);
 			}
+		}
+		if (!targetsFromExtensions.isEmpty()){
+			targets.remove("String");
+			targets.addAll(targetsFromExtensions);
 		}
 
 		if (isBlank(name) || isBlank(path)) {
@@ -188,7 +192,7 @@ public class SearchParameterCanonicalizer {
 		}
 
 		List<RuntimeSearchParam.Component> components = Collections.emptyList();
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, base);
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targets, status, unique, components, base);
 	}
 
 	private RuntimeSearchParam canonicalizeSearchParameterDstu3(org.hl7.fhir.dstu3.model.SearchParameter theNextSp) {
@@ -262,15 +266,19 @@ public class SearchParameterCanonicalizer {
 			}
 		}
 
-		Set<String> providesMembershipInCompartments = Collections.emptySet();
 		Set<String> targets = DatatypeUtil.toStringSet(theNextSp.getTarget());
 		// add extensions as target if the SP is for a custom resource type
+		Set<String> targetsFromExtensions = new HashSet<>();
 		List<Extension> customSPTargets = theNextSp.getExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
 		for (Extension e : customSPTargets) {
 			String eStr = e.getValueAsPrimitive().getValueAsString();
 			if (StringUtils.isNotBlank(eStr)) {
-				targets.add(eStr);
+				targetsFromExtensions.add(eStr);
 			}
+		}
+		if (!targetsFromExtensions.isEmpty()){
+			targets.remove("Resource");
+			targets.addAll(targetsFromExtensions);
 		}
 
 		if (isBlank(name) || isBlank(path) || paramType == null) {
@@ -300,7 +308,7 @@ public class SearchParameterCanonicalizer {
 			components.add(new RuntimeSearchParam.Component(next.getExpression(), next.getDefinition().getReferenceElement().toUnqualifiedVersionless().getValue()));
 		}
 
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, base);
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targets, status, unique, components, base);
 	}
 
 	private RuntimeSearchParam canonicalizeSearchParameterR4Plus(IBaseResource theNextSp) {
@@ -379,13 +387,13 @@ public class SearchParameterCanonicalizer {
 				status = RuntimeSearchParam.RuntimeSearchParamStatusEnum.UNKNOWN;
 				break;
 		}
-		Set<String> providesMembershipInCompartments = Collections.emptySet();
 
 		Set<String> targets = terser
 			.getValues(theNextSp, "target", IPrimitiveType.class)
 			.stream()
 			.map(IPrimitiveType::getValueAsString)
 			.collect(Collectors.toSet());
+		Set<String> targetsFromExtensions = new HashSet<>();
 		if (theNextSp instanceof IBaseHasExtensions) {
 			((IBaseHasExtensions) theNextSp)
 				.getExtension()
@@ -395,7 +403,11 @@ public class SearchParameterCanonicalizer {
 				.map(t -> ((IPrimitiveType<?>) t.getValue()))
 				.map(IPrimitiveType::getValueAsString)
 				.filter(StringUtils::isNotBlank)
-				.forEach(targets::add);
+				.forEach(targetsFromExtensions::add);
+		}
+		if(!targetsFromExtensions.isEmpty()){
+			targets.remove("Resource");
+			targets.addAll(targetsFromExtensions);
 		}
 
 		if (isBlank(name) || isBlank(path) || paramType == null) {
@@ -435,7 +447,7 @@ public class SearchParameterCanonicalizer {
 			components.add(new RuntimeSearchParam.Component(expression, definition));
 		}
 
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, base);
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targets, status, unique, components, base);
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -27,30 +27,48 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.model.api.ExtensionDt;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
-import ca.uhn.fhir.util.*;
+import ca.uhn.fhir.util.DatatypeUtil;
+import ca.uhn.fhir.util.ExtensionUtil;
+import ca.uhn.fhir.util.FhirTerser;
+import ca.uhn.fhir.util.HapiExtensions;
+import ca.uhn.fhir.util.PhoneticEncoderUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.SearchParameter;
-import org.hl7.fhir.instance.model.api.*;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.startsWith;
 
 @Service
 public class SearchParameterCanonicalizer {
 	private static final Logger ourLog = LoggerFactory.getLogger(SearchParameterCanonicalizer.class);
 
 	private final FhirContext myFhirContext;
-
+	private final FhirTerser myTerser;
 	@Autowired
 	public SearchParameterCanonicalizer(FhirContext theFhirContext) {
 		myFhirContext = theFhirContext;
+		myTerser = myFhirContext.newTerser();
 	}
 
 	private static Collection<String> toStrings(Collection<? extends IPrimitiveType<String>> theBase) {
@@ -96,21 +114,11 @@ public class SearchParameterCanonicalizer {
 		String description = theNextSp.getDescription();
 		String path = theNextSp.getXpath();
 
-		Collection<String> base = toStrings(Collections.singletonList(theNextSp.getBaseElement()));
-		// add extensions as base if the SP is for a custom resource type
-		List<ExtensionDt> customSPBase = theNextSp.getUndeclaredExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
-		ArrayList<String> baseFromExtensions = new ArrayList<>();
-		for (ExtensionDt e : customSPBase) {
-			String eStr = e.getValueAsPrimitive().getValueAsString();
-			if (StringUtils.isNotBlank(eStr)) {
-				baseFromExtensions.add(eStr);
-			}
-		}
-		// when base contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
-		// removed it for RuntimeSearchParam
-		if (!baseFromExtensions.isEmpty()){
-			base.remove("Resource");
-			base.addAll(baseFromExtensions);
+		Collection<String> baseResource = toStrings(Collections.singletonList(theNextSp.getBaseElement()));
+		List<String> baseCustomResources = extractDstu2CustomResourcesFromExtensions(theNextSp, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
+
+		if(!baseCustomResources.isEmpty()){
+			baseResource = Collections.singleton(baseCustomResources.get(0));
 		}
 
 		RestSearchParameterTypeEnum paramType = null;
@@ -156,22 +164,11 @@ public class SearchParameterCanonicalizer {
 					break;
 			}
 		}
-		Set<String> targets = DatatypeUtil.toStringSet(theNextSp.getTarget());
-		// add extensions as target if the SP is for a custom resource type
-		Set<String> targetsFromExtensions = new HashSet<>();
-		List<ExtensionDt> customSPTargets = theNextSp.getUndeclaredExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
-		for (ExtensionDt e : customSPTargets) {
-			String eStr = e.getValueAsPrimitive().getValueAsString();
-			if (StringUtils.isNotBlank(eStr)) {
-				targetsFromExtensions.add(eStr);
-			}
-		}
-		// when targets contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
-		// removed it for RuntimeSearchParam
-		if (!targetsFromExtensions.isEmpty()){
-			targets.remove("Resource");
-			targets.addAll(targetsFromExtensions);
-		}
+
+		Set<String> targetResources = DatatypeUtil.toStringSet(theNextSp.getTarget());
+		List<String> targetCustomResources = extractDstu2CustomResourcesFromExtensions(theNextSp, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
+
+		maybeAddCustomResourcesToResources(targetResources, targetCustomResources);
 
 		if (isBlank(name) || isBlank(path)) {
 			if (paramType != RestSearchParameterTypeEnum.COMPOSITE) {
@@ -196,7 +193,7 @@ public class SearchParameterCanonicalizer {
 		}
 
 		List<RuntimeSearchParam.Component> components = Collections.emptyList();
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targets, status, unique, components, base);
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targetResources, status, unique, components, baseResource);
 	}
 
 	private RuntimeSearchParam canonicalizeSearchParameterDstu3(org.hl7.fhir.dstu3.model.SearchParameter theNextSp) {
@@ -204,22 +201,10 @@ public class SearchParameterCanonicalizer {
 		String description = theNextSp.getDescription();
 		String path = theNextSp.getExpression();
 
-		List<String> base = new ArrayList<>(toStrings(theNextSp.getBase()));
-		// add extensions as base if the SP is for a custom resource type
-		List<Extension> customSPBase = theNextSp.getExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
-		ArrayList<String> baseFromExtensions = new ArrayList<>();
-		for (Extension e : customSPBase){
-			String eStr = e.getValueAsPrimitive().getValueAsString();
-			if (StringUtils.isNotBlank(eStr)) {
-				baseFromExtensions.add(eStr);
-			}
-		}
-		// when base contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
-		// removed it for RuntimeSearchParam
-		if (!baseFromExtensions.isEmpty()){
-			base.remove("Resource");
-			base.addAll(baseFromExtensions);
-		}
+		List<String> baseResources = new ArrayList<>(toStrings(theNextSp.getBase()));
+		List<String> baseCustomResources = extractDstu3CustomResourcesFromExtensions(theNextSp, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
+
+		maybeAddCustomResourcesToResources(baseResources, baseCustomResources);
 
 		RestSearchParameterTypeEnum paramType = null;
 		RuntimeSearchParam.RuntimeSearchParamStatusEnum status = null;
@@ -272,22 +257,10 @@ public class SearchParameterCanonicalizer {
 			}
 		}
 
-		Set<String> targets = DatatypeUtil.toStringSet(theNextSp.getTarget());
-		// add extensions as target if the SP is for a custom resource type
-		Set<String> targetsFromExtensions = new HashSet<>();
-		List<Extension> customSPTargets = theNextSp.getExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
-		for (Extension e : customSPTargets) {
-			String eStr = e.getValueAsPrimitive().getValueAsString();
-			if (StringUtils.isNotBlank(eStr)) {
-				targetsFromExtensions.add(eStr);
-			}
-		}
-		// when targets contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
-		// removed it for RuntimeSearchParam
-		if (!targetsFromExtensions.isEmpty()){
-			targets.remove("Resource");
-			targets.addAll(targetsFromExtensions);
-		}
+		Set<String> targetResources = DatatypeUtil.toStringSet(theNextSp.getTarget());
+		List<String> targetCustomResources = extractDstu3CustomResourcesFromExtensions(theNextSp, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
+
+		maybeAddCustomResourcesToResources(targetResources, targetCustomResources);
 
 		if (isBlank(name) || isBlank(path) || paramType == null) {
 			if (paramType != RestSearchParameterTypeEnum.COMPOSITE) {
@@ -316,44 +289,23 @@ public class SearchParameterCanonicalizer {
 			components.add(new RuntimeSearchParam.Component(next.getExpression(), next.getDefinition().getReferenceElement().toUnqualifiedVersionless().getValue()));
 		}
 
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targets, status, unique, components, base);
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targetResources, status, unique, components, baseResources);
 	}
 
 	private RuntimeSearchParam canonicalizeSearchParameterR4Plus(IBaseResource theNextSp) {
-		FhirTerser terser = myFhirContext.newTerser();
-		String name = terser.getSinglePrimitiveValueOrNull(theNextSp, "code");
-		String description = terser.getSinglePrimitiveValueOrNull(theNextSp, "description");
-		String path = terser.getSinglePrimitiveValueOrNull(theNextSp, "expression");
 
+		String name = myTerser.getSinglePrimitiveValueOrNull(theNextSp, "code");
+		String description = myTerser.getSinglePrimitiveValueOrNull(theNextSp, "description");
+		String path = myTerser.getSinglePrimitiveValueOrNull(theNextSp, "expression");
 
-		List<String> base = terser
-			.getValues(theNextSp, "base", IPrimitiveType.class)
-			.stream()
-			.map(IPrimitiveType::getValueAsString)
-			.collect(Collectors.toList());
+		Set<String> baseResources = extractR4PlusResources("base", theNextSp);
+		List<String> baseCustomResources = extractR4PlusCustomResourcesFromExtensions(theNextSp, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
 
-		ArrayList<String> baseFromExtension = new ArrayList<>();
-		if (theNextSp instanceof IBaseHasExtensions) {
-			((IBaseHasExtensions) theNextSp)
-				.getExtension()
-				.stream()
-				.filter(t -> HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE.equals(t.getUrl()))
-				.filter(t -> t.getValue() instanceof IPrimitiveType)
-				.map(t -> ((IPrimitiveType<?>) t.getValue()))
-				.map(IPrimitiveType::getValueAsString)
-				.filter(StringUtils::isNotBlank)
-				.forEach(baseFromExtension::add);
-		}
-		// when base contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
-		// removed it for RuntimeSearchParam
-		if (!baseFromExtension.isEmpty()){
-			base.remove("Resource");
-			base.addAll(baseFromExtension);
-		}
+		maybeAddCustomResourcesToResources(baseResources, baseCustomResources);
 
 		RestSearchParameterTypeEnum paramType = null;
 		RuntimeSearchParam.RuntimeSearchParamStatusEnum status = null;
-		switch (terser.getSinglePrimitiveValue(theNextSp, "type").orElse("")) {
+		switch (myTerser.getSinglePrimitiveValue(theNextSp, "type").orElse("")) {
 			case "composite":
 				paramType = RestSearchParameterTypeEnum.COMPOSITE;
 				break;
@@ -382,7 +334,7 @@ public class SearchParameterCanonicalizer {
 				paramType = RestSearchParameterTypeEnum.SPECIAL;
 				break;
 		}
-		switch (terser.getSinglePrimitiveValue(theNextSp, "status").orElse("")) {
+		switch (myTerser.getSinglePrimitiveValue(theNextSp, "status").orElse("")) {
 			case "active":
 				status = RuntimeSearchParam.RuntimeSearchParamStatusEnum.ACTIVE;
 				break;
@@ -397,29 +349,10 @@ public class SearchParameterCanonicalizer {
 				break;
 		}
 
-		Set<String> targets = terser
-			.getValues(theNextSp, "target", IPrimitiveType.class)
-			.stream()
-			.map(IPrimitiveType::getValueAsString)
-			.collect(Collectors.toSet());
-		Set<String> targetsFromExtensions = new HashSet<>();
-		if (theNextSp instanceof IBaseHasExtensions) {
-			((IBaseHasExtensions) theNextSp)
-				.getExtension()
-				.stream()
-				.filter(t -> HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE.equals(t.getUrl()))
-				.filter(t -> t.getValue() instanceof IPrimitiveType)
-				.map(t -> ((IPrimitiveType<?>) t.getValue()))
-				.map(IPrimitiveType::getValueAsString)
-				.filter(StringUtils::isNotBlank)
-				.forEach(targetsFromExtensions::add);
-		}
-		// when targets contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
-		// removed it for RuntimeSearchParam
-		if(!targetsFromExtensions.isEmpty()){
-			targets.remove("Resource");
-			targets.addAll(targetsFromExtensions);
-		}
+		Set<String> targetResources = extractR4PlusResources("target", theNextSp);
+		List<String> targetCustomResources = extractR4PlusCustomResourcesFromExtensions(theNextSp, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
+
+		maybeAddCustomResourcesToResources(targetResources, targetCustomResources);
 
 		if (isBlank(name) || isBlank(path) || paramType == null) {
 			if ("_text".equals(name) || "_content".equals(name)) {
@@ -430,7 +363,7 @@ public class SearchParameterCanonicalizer {
 		}
 
 		IIdType id = theNextSp.getIdElement();
-		String uri = terser.getSinglePrimitiveValueOrNull(theNextSp, "url");
+		String uri = myTerser.getSinglePrimitiveValueOrNull(theNextSp, "url");
 		ComboSearchParamType unique = null;
 
 		String value = ((IBaseHasExtensions) theNextSp).getExtension()
@@ -448,9 +381,9 @@ public class SearchParameterCanonicalizer {
 		}
 
 		List<RuntimeSearchParam.Component> components = new ArrayList<>();
-		for (IBase next : terser.getValues(theNextSp, "component")) {
-			String expression = terser.getSinglePrimitiveValueOrNull(next, "expression");
-			String definition = terser.getSinglePrimitiveValueOrNull(next, "definition");
+		for (IBase next : myTerser.getValues(theNextSp, "component")) {
+			String expression = myTerser.getSinglePrimitiveValueOrNull(next, "expression");
+			String definition = myTerser.getSinglePrimitiveValueOrNull(next, "definition");
 			if (startsWith(definition, "/SearchParameter/")) {
 				definition = definition.substring(1);
 			}
@@ -458,7 +391,15 @@ public class SearchParameterCanonicalizer {
 			components.add(new RuntimeSearchParam.Component(expression, definition));
 		}
 
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targets, status, unique, components, base);
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, Collections.emptySet(), targetResources, status, unique, components, baseResources);
+	}
+
+	private Set<String> extractR4PlusResources(String thePath, IBaseResource theNextSp) {
+		return myTerser
+			.getValues(theNextSp, thePath, IPrimitiveType.class)
+			.stream()
+			.map(IPrimitiveType::getValueAsString)
+			.collect(Collectors.toSet());
 	}
 
 	/**
@@ -506,5 +447,62 @@ public class SearchParameterCanonicalizer {
 		}
 	}
 
+	private List<String> extractDstu2CustomResourcesFromExtensions(ca.uhn.fhir.model.dstu2.resource.SearchParameter theSearchParameter, String theExtensionUrl) {
+
+		List<ExtensionDt> customSpExtensionDt = theSearchParameter.getUndeclaredExtensionsByUrl(theExtensionUrl);
+
+		return customSpExtensionDt.stream()
+			.map(theExtensionDt -> theExtensionDt.getValueAsPrimitive().getValueAsString())
+			.filter(StringUtils::isNotBlank)
+			.collect(Collectors.toList());
+	}
+
+	private List<String> extractDstu3CustomResourcesFromExtensions(org.hl7.fhir.dstu3.model.SearchParameter theSearchParameter, String theExtensionUrl) {
+
+		List<Extension> customSpExtensions = theSearchParameter.getExtensionsByUrl(theExtensionUrl);
+
+		return customSpExtensions.stream()
+			.map(theExtension -> theExtension.getValueAsPrimitive().getValueAsString())
+			.filter(StringUtils::isNotBlank)
+			.collect(Collectors.toList());
+
+	}
+
+	private List<String> extractR4PlusCustomResourcesFromExtensions(IBaseResource theSearchParameter, String theExtensionUrl) {
+
+		List<String> retVal = new ArrayList<>();
+
+		if (theSearchParameter instanceof IBaseHasExtensions) {
+			((IBaseHasExtensions) theSearchParameter)
+				.getExtension()
+				.stream()
+				.filter(t -> theExtensionUrl.equals(t.getUrl()))
+				.filter(t -> t.getValue() instanceof IPrimitiveType)
+				.map(t -> ((IPrimitiveType<?>) t.getValue()))
+				.map(IPrimitiveType::getValueAsString)
+				.filter(StringUtils::isNotBlank)
+				.forEach(retVal::add);
+		}
+
+		return retVal;
+	}
+
+	private <T extends Collection<String>> void maybeAddCustomResourcesToResources(T theResources, List<String> theCustomResources) {
+		// SearchParameter base and target components require strict binding to ResourceType for dstu[2|3], R4, R4B
+		// and to Version Independent Resource Types for R5.
+		//
+		// To handle custom resources, we set a placeholder of type 'Resource' in the base or target component and define
+		// the custom resource by adding a corresponding extension with url HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE
+		// or HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE with the name of the custom resource.
+		//
+		// To provide a base/target list that contains both the resources and customResources, we need to remove the placeholders
+		// from the theResources and add theCustomResources.
+
+		if (!theCustomResources.isEmpty()){
+			theResources.removeAll(Collections.singleton("Resource"));
+			theResources.addAll(theCustomResources);
+		}
+
+	}
 
 }

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -95,6 +95,17 @@ public class SearchParameterCanonicalizer {
 		String name = theNextSp.getCode();
 		String description = theNextSp.getDescription();
 		String path = theNextSp.getXpath();
+
+		Collection<String> base = toStrings(Collections.singletonList(theNextSp.getBaseElement()));
+		// add extensions as base if the SP is for a custom resource type
+		List<ExtensionDt> customSPBase = theNextSp.getUndeclaredExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
+		for (ExtensionDt e : customSPBase) {
+			String eStr = e.getValueAsPrimitive().getValueAsString();
+			if (StringUtils.isNotBlank(eStr)) {
+				base.add(eStr);
+			}
+		}
+
 		RestSearchParameterTypeEnum paramType = null;
 		RuntimeSearchParam.RuntimeSearchParamStatusEnum status = null;
 		if (theNextSp.getTypeElement().getValueAsEnum() != null) {
@@ -140,6 +151,14 @@ public class SearchParameterCanonicalizer {
 		}
 		Set<String> providesMembershipInCompartments = Collections.emptySet();
 		Set<String> targets = DatatypeUtil.toStringSet(theNextSp.getTarget());
+		// add extensions as target if the SP is for a custom resource type
+		List<ExtensionDt> customSPTargets = theNextSp.getUndeclaredExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
+		for (ExtensionDt e : customSPTargets) {
+			String eStr = e.getValueAsPrimitive().getValueAsString();
+			if (StringUtils.isNotBlank(eStr)) {
+				targets.add(eStr);
+			}
+		}
 
 		if (isBlank(name) || isBlank(path)) {
 			if (paramType != RestSearchParameterTypeEnum.COMPOSITE) {
@@ -164,14 +183,24 @@ public class SearchParameterCanonicalizer {
 		}
 
 		List<RuntimeSearchParam.Component> components = Collections.emptyList();
-		Collection<? extends IPrimitiveType<String>> base = Collections.singletonList(theNextSp.getBaseElement());
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, toStrings(base));
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, base);
 	}
 
 	private RuntimeSearchParam canonicalizeSearchParameterDstu3(org.hl7.fhir.dstu3.model.SearchParameter theNextSp) {
 		String name = theNextSp.getCode();
 		String description = theNextSp.getDescription();
 		String path = theNextSp.getExpression();
+
+		List<String> base = new ArrayList<>(toStrings(theNextSp.getBase()));
+		// add extensions as base if the SP is for a custom resource type
+		List<Extension> customSPBase = theNextSp.getExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
+		for (Extension e : customSPBase){
+			String eStr = e.getValueAsPrimitive().getValueAsString();
+			if (StringUtils.isNotBlank(eStr)) {
+				base.add(eStr);
+			}
+		}
+
 		RestSearchParameterTypeEnum paramType = null;
 		RuntimeSearchParam.RuntimeSearchParamStatusEnum status = null;
 		if (theNextSp.getType() != null) {
@@ -222,8 +251,17 @@ public class SearchParameterCanonicalizer {
 					break;
 			}
 		}
+
 		Set<String> providesMembershipInCompartments = Collections.emptySet();
 		Set<String> targets = DatatypeUtil.toStringSet(theNextSp.getTarget());
+		// add extensions as target if the SP is for a custom resource type
+		List<Extension> customSPTargets = theNextSp.getExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE);
+		for (Extension e : customSPTargets) {
+			String eStr = e.getValueAsPrimitive().getValueAsString();
+			if (StringUtils.isNotBlank(eStr)) {
+				targets.add(eStr);
+			}
+		}
 
 		if (isBlank(name) || isBlank(path) || paramType == null) {
 			if (paramType != RestSearchParameterTypeEnum.COMPOSITE) {
@@ -252,7 +290,7 @@ public class SearchParameterCanonicalizer {
 			components.add(new RuntimeSearchParam.Component(next.getExpression(), next.getDefinition().getReferenceElement().toUnqualifiedVersionless().getValue()));
 		}
 
-		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, toStrings(theNextSp.getBase()));
+		return new RuntimeSearchParam(id, uri, name, description, path, paramType, providesMembershipInCompartments, targets, status, unique, components, base);
 	}
 
 	private RuntimeSearchParam canonicalizeSearchParameterR4Plus(IBaseResource theNextSp) {

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -99,11 +99,16 @@ public class SearchParameterCanonicalizer {
 		Collection<String> base = toStrings(Collections.singletonList(theNextSp.getBaseElement()));
 		// add extensions as base if the SP is for a custom resource type
 		List<ExtensionDt> customSPBase = theNextSp.getUndeclaredExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
+		ArrayList<String> baseFromExtensions = new ArrayList<>();
 		for (ExtensionDt e : customSPBase) {
 			String eStr = e.getValueAsPrimitive().getValueAsString();
 			if (StringUtils.isNotBlank(eStr)) {
-				base.add(eStr);
+				baseFromExtensions.add(eStr);
 			}
+		}
+		if (!baseFromExtensions.isEmpty()){
+			base.remove("Resource");
+			base.addAll(baseFromExtensions);
 		}
 
 		RestSearchParameterTypeEnum paramType = null;
@@ -194,11 +199,16 @@ public class SearchParameterCanonicalizer {
 		List<String> base = new ArrayList<>(toStrings(theNextSp.getBase()));
 		// add extensions as base if the SP is for a custom resource type
 		List<Extension> customSPBase = theNextSp.getExtensionsByUrl(HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE);
+		ArrayList<String> baseFromExtensions = new ArrayList<>();
 		for (Extension e : customSPBase){
 			String eStr = e.getValueAsPrimitive().getValueAsString();
 			if (StringUtils.isNotBlank(eStr)) {
-				base.add(eStr);
+				baseFromExtensions.add(eStr);
 			}
+		}
+		if (!baseFromExtensions.isEmpty()){
+			base.remove("Resource");
+			base.addAll(baseFromExtensions);
 		}
 
 		RestSearchParameterTypeEnum paramType = null;
@@ -299,11 +309,14 @@ public class SearchParameterCanonicalizer {
 		String description = terser.getSinglePrimitiveValueOrNull(theNextSp, "description");
 		String path = terser.getSinglePrimitiveValueOrNull(theNextSp, "expression");
 
+
 		List<String> base = terser
 			.getValues(theNextSp, "base", IPrimitiveType.class)
 			.stream()
 			.map(IPrimitiveType::getValueAsString)
 			.collect(Collectors.toList());
+
+		ArrayList<String> baseFromExtension = new ArrayList<>();
 		if (theNextSp instanceof IBaseHasExtensions) {
 			((IBaseHasExtensions) theNextSp)
 				.getExtension()
@@ -313,7 +326,12 @@ public class SearchParameterCanonicalizer {
 				.map(t -> ((IPrimitiveType<?>) t.getValue()))
 				.map(IPrimitiveType::getValueAsString)
 				.filter(StringUtils::isNotBlank)
-				.forEach(base::add);
+				.forEach(baseFromExtension::add);
+		}
+
+		if (!baseFromExtension.isEmpty()){
+			base.remove("Resource");
+			base.addAll(baseFromExtension);
 		}
 
 		RestSearchParameterTypeEnum paramType = null;

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizer.java
@@ -106,6 +106,8 @@ public class SearchParameterCanonicalizer {
 				baseFromExtensions.add(eStr);
 			}
 		}
+		// when base contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
+		// removed it for RuntimeSearchParam
 		if (!baseFromExtensions.isEmpty()){
 			base.remove("Resource");
 			base.addAll(baseFromExtensions);
@@ -164,8 +166,10 @@ public class SearchParameterCanonicalizer {
 				targetsFromExtensions.add(eStr);
 			}
 		}
+		// when targets contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
+		// removed it for RuntimeSearchParam
 		if (!targetsFromExtensions.isEmpty()){
-			targets.remove("String");
+			targets.remove("Resource");
 			targets.addAll(targetsFromExtensions);
 		}
 
@@ -210,6 +214,8 @@ public class SearchParameterCanonicalizer {
 				baseFromExtensions.add(eStr);
 			}
 		}
+		// when base contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
+		// removed it for RuntimeSearchParam
 		if (!baseFromExtensions.isEmpty()){
 			base.remove("Resource");
 			base.addAll(baseFromExtensions);
@@ -276,6 +282,8 @@ public class SearchParameterCanonicalizer {
 				targetsFromExtensions.add(eStr);
 			}
 		}
+		// when targets contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
+		// removed it for RuntimeSearchParam
 		if (!targetsFromExtensions.isEmpty()){
 			targets.remove("Resource");
 			targets.addAll(targetsFromExtensions);
@@ -336,7 +344,8 @@ public class SearchParameterCanonicalizer {
 				.filter(StringUtils::isNotBlank)
 				.forEach(baseFromExtension::add);
 		}
-
+		// when base contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
+		// removed it for RuntimeSearchParam
 		if (!baseFromExtension.isEmpty()){
 			base.remove("Resource");
 			base.addAll(baseFromExtension);
@@ -405,6 +414,8 @@ public class SearchParameterCanonicalizer {
 				.filter(StringUtils::isNotBlank)
 				.forEach(targetsFromExtensions::add);
 		}
+		// when targets contains custom resources, "Resource" is present to satisfy 1...* cardinality requirement of FHIR
+		// removed it for RuntimeSearchParam
 		if(!targetsFromExtensions.isEmpty()){
 			targets.remove("Resource");
 			targets.addAll(targetsFromExtensions);

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizerTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizerTest.java
@@ -35,33 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SearchParameterCanonicalizerTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(SearchParameterCanonicalizerTest.class);
 
-//	SearchParameter initSearchParam(String version){
-//		switch (version){
-//			case "Dstu2":
-//				ca.uhn.fhir.model.dstu2.resource.SearchParameter sp = new ca.uhn.fhir.model.dstu2.resource.SearchParameter();
-//				sp.setBase(ResourceTypeEnum.RESOURCE);
-//				sp.setType(SearchParamTypeEnum.REFERENCE);
-//				sp.setStatus(ConformanceResourceStatusEnum.ACTIVE);
-//				sp.setXpath("Meal.chef | Observation.subject");
-//				break;
-//			case "Dstu3":
-//				org.hl7.fhir.dstu3.model.SearchParameter sp = new org.hl7.fhir.dstu3.model.SearchParameter();
-//				sp.addBase("Resource");
-//				sp.addBase("Patient");
-//				sp.setType(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
-//				sp.setStatus(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
-//				sp.setExpression("Meal.chef | Observation.subject");
-//				break;
-//			case "R4":
-//				SearchParameter sp = new SearchParameter();
-//				sp.addBase("Resource");
-//				sp.addBase("Patient");
-//				sp.setType(Enumerations.SearchParamType.REFERENCE);
-//				sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
-//				sp.setExpression("Meal.chef | Observation.subject");
-//		}
-//	}
-
 	IBaseResource initSearchParamR4(){
 		SearchParameter sp = new SearchParameter();
 		sp.setId("SearchParameter/meal-chef");
@@ -215,7 +188,7 @@ public class SearchParameterCanonicalizerTest {
 		assertEquals(RestSearchParameterTypeEnum.REFERENCE, output.getParamType());
 		assertEquals(RuntimeSearchParam.RuntimeSearchParamStatusEnum.ACTIVE, output.getStatus());
 		assertThat(output.getPathsSplit(), containsInAnyOrder("Meal.chef", "Observation.subject"));
-		// DSTU2 Resources must only has 1 base
+		// DSTU2 Resources must only have 1 base
 		if ("Dstu2".equals(version)){
 			assertThat(output.getBase(), containsInAnyOrder("Meal"));
 		} else {

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizerTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizerTest.java
@@ -35,6 +35,39 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SearchParameterCanonicalizerTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(SearchParameterCanonicalizerTest.class);
 
+	ca.uhn.fhir.model.dstu2.resource.SearchParameter initSearchParamDstu2(){
+		ca.uhn.fhir.model.dstu2.resource.SearchParameter sp = new ca.uhn.fhir.model.dstu2.resource.SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.setBase(ResourceTypeEnum.RESOURCE);
+		sp.setCode("chef");
+		sp.setType(SearchParamTypeEnum.REFERENCE);
+		sp.setStatus(ConformanceResourceStatusEnum.ACTIVE);
+		sp.setXpath("Meal.chef | Observation.subject");
+		sp.addTarget(ResourceTypeEnum.RESOURCE);
+		sp.addTarget(ResourceTypeEnum.OBSERVATION);
+		sp.addUndeclaredExtension(new ExtensionDt(false, EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new StringDt("Meal")));
+		sp.addUndeclaredExtension(new ExtensionDt(false, EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new StringDt("Chef")));
+		return sp;
+	}
+
+	org.hl7.fhir.dstu3.model.SearchParameter initSearchParamDstu3(){
+		org.hl7.fhir.dstu3.model.SearchParameter sp = new org.hl7.fhir.dstu3.model.SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.addBase("Resource");
+		sp.addBase("Patient");
+		sp.setCode("chef");
+		sp.setType(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
+		sp.setStatus(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+		sp.setExpression("Meal.chef | Observation.subject");
+		sp.addTarget("Resource");
+		sp.addTarget("Observation");
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new org.hl7.fhir.dstu3.model.StringType("Meal"));
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new org.hl7.fhir.dstu3.model.StringType("Chef"));
+		return sp;
+	}
+
 	IBaseResource initSearchParamR4(){
 		SearchParameter sp = new SearchParameter();
 		sp.setId("SearchParameter/meal-chef");
@@ -86,38 +119,6 @@ public class SearchParameterCanonicalizerTest {
 		return sp;
 	}
 
-	org.hl7.fhir.dstu3.model.SearchParameter initSearchParamDstu3(){
-		org.hl7.fhir.dstu3.model.SearchParameter sp = new org.hl7.fhir.dstu3.model.SearchParameter();
-		sp.setId("SearchParameter/meal-chef");
-		sp.setUrl("http://example.org/SearchParameter/meal-chef");
-		sp.addBase("Resource");
-		sp.addBase("Patient");
-		sp.setCode("chef");
-		sp.setType(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
-		sp.setStatus(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
-		sp.setExpression("Meal.chef | Observation.subject");
-		sp.addTarget("Resource");
-		sp.addTarget("Observation");
-		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new org.hl7.fhir.dstu3.model.StringType("Meal"));
-		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new org.hl7.fhir.dstu3.model.StringType("Chef"));
-		return sp;
-	}
-
-	ca.uhn.fhir.model.dstu2.resource.SearchParameter initSearchParamDstu2(){
-		ca.uhn.fhir.model.dstu2.resource.SearchParameter sp = new ca.uhn.fhir.model.dstu2.resource.SearchParameter();
-		sp.setId("SearchParameter/meal-chef");
-		sp.setUrl("http://example.org/SearchParameter/meal-chef");
-		sp.setBase(ResourceTypeEnum.RESOURCE);
-		sp.setCode("chef");
-		sp.setType(SearchParamTypeEnum.REFERENCE);
-		sp.setStatus(ConformanceResourceStatusEnum.ACTIVE);
-		sp.setXpath("Meal.chef | Observation.subject");
-		sp.addTarget(ResourceTypeEnum.RESOURCE);
-		sp.addTarget(ResourceTypeEnum.OBSERVATION);
-		sp.addUndeclaredExtension(new ExtensionDt(false, EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new StringDt("Meal")));
-		sp.addUndeclaredExtension(new ExtensionDt(false, EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new StringDt("Chef")));
-		return sp;
-	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = {false, true})
@@ -194,7 +195,7 @@ public class SearchParameterCanonicalizerTest {
 		} else {
 			assertThat(output.getBase(), containsInAnyOrder("Meal", "Patient"));
 		}
-		assertThat(output.getTargets(), contains("Chef", "Observation"));
+		assertThat(output.getTargets(), containsInAnyOrder("Chef", "Observation"));
 		assertThat(output.getBase(), not(contains("Resource")));
 		assertThat(output.getTargets(), not(contains("Resource")));
 	}

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizerTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParameterCanonicalizerTest.java
@@ -2,11 +2,19 @@ package ca.uhn.fhir.jpa.searchparam.registry;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.model.api.ExtensionDt;
+import ca.uhn.fhir.model.dstu2.valueset.ConformanceResourceStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ResourceTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SearchParamTypeEnum;
+import ca.uhn.fhir.model.primitive.StringDt;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BaseResource;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.SearchParameter;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -14,14 +22,129 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static ca.uhn.fhir.util.HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE;
+import static ca.uhn.fhir.util.HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 public class SearchParameterCanonicalizerTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(SearchParameterCanonicalizerTest.class);
+
+//	SearchParameter initSearchParam(String version){
+//		switch (version){
+//			case "Dstu2":
+//				ca.uhn.fhir.model.dstu2.resource.SearchParameter sp = new ca.uhn.fhir.model.dstu2.resource.SearchParameter();
+//				sp.setBase(ResourceTypeEnum.RESOURCE);
+//				sp.setType(SearchParamTypeEnum.REFERENCE);
+//				sp.setStatus(ConformanceResourceStatusEnum.ACTIVE);
+//				sp.setXpath("Meal.chef | Observation.subject");
+//				break;
+//			case "Dstu3":
+//				org.hl7.fhir.dstu3.model.SearchParameter sp = new org.hl7.fhir.dstu3.model.SearchParameter();
+//				sp.addBase("Resource");
+//				sp.addBase("Patient");
+//				sp.setType(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
+//				sp.setStatus(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+//				sp.setExpression("Meal.chef | Observation.subject");
+//				break;
+//			case "R4":
+//				SearchParameter sp = new SearchParameter();
+//				sp.addBase("Resource");
+//				sp.addBase("Patient");
+//				sp.setType(Enumerations.SearchParamType.REFERENCE);
+//				sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+//				sp.setExpression("Meal.chef | Observation.subject");
+//		}
+//	}
+
+	IBaseResource initSearchParamR4(){
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.addBase("Resource");
+		sp.addBase("Patient");
+		sp.setCode("chef");
+		sp.setType(Enumerations.SearchParamType.REFERENCE);
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.setExpression("Meal.chef | Observation.subject");
+		sp.addTarget("Resource");
+		sp.addTarget("Observation");
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new StringType("Meal"));
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new StringType("Chef"));
+		return sp;
+	}
+
+	IBaseResource initSearchParamR4B(){
+		org.hl7.fhir.r4b.model.SearchParameter sp = new org.hl7.fhir.r4b.model.SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.addBase("Resource");
+		sp.addBase("Patient");
+		sp.setCode("chef");
+		sp.setType(org.hl7.fhir.r4b.model.Enumerations.SearchParamType.REFERENCE);
+		sp.setStatus(org.hl7.fhir.r4b.model.Enumerations.PublicationStatus.ACTIVE);
+		sp.setExpression("Meal.chef | Observation.subject");
+		sp.addTarget("Resource");
+		sp.addTarget("Observation");
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new org.hl7.fhir.r4b.model.StringType("Meal"));
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new org.hl7.fhir.r4b.model.StringType("Chef"));
+		return sp;
+	}
+
+	IBaseResource initSearchParamR5(){
+		org.hl7.fhir.r5.model.SearchParameter sp = new org.hl7.fhir.r5.model.SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.addBase(org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.RESOURCE);
+		sp.addBase(org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.PATIENT);
+		sp.setCode("chef");
+		sp.setType(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
+		sp.setStatus(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
+		sp.setExpression("Meal.chef | Observation.subject");
+		sp.addTarget(org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.RESOURCE);
+		sp.addTarget(org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.OBSERVATION);
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new org.hl7.fhir.r5.model.StringType("Meal"));
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new org.hl7.fhir.r5.model.StringType("Chef"));
+		return sp;
+	}
+
+	org.hl7.fhir.dstu3.model.SearchParameter initSearchParamDstu3(){
+		org.hl7.fhir.dstu3.model.SearchParameter sp = new org.hl7.fhir.dstu3.model.SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.addBase("Resource");
+		sp.addBase("Patient");
+		sp.setCode("chef");
+		sp.setType(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
+		sp.setStatus(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+		sp.setExpression("Meal.chef | Observation.subject");
+		sp.addTarget("Resource");
+		sp.addTarget("Observation");
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new org.hl7.fhir.dstu3.model.StringType("Meal"));
+		sp.addExtension(EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new org.hl7.fhir.dstu3.model.StringType("Chef"));
+		return sp;
+	}
+
+	ca.uhn.fhir.model.dstu2.resource.SearchParameter initSearchParamDstu2(){
+		ca.uhn.fhir.model.dstu2.resource.SearchParameter sp = new ca.uhn.fhir.model.dstu2.resource.SearchParameter();
+		sp.setId("SearchParameter/meal-chef");
+		sp.setUrl("http://example.org/SearchParameter/meal-chef");
+		sp.setBase(ResourceTypeEnum.RESOURCE);
+		sp.setCode("chef");
+		sp.setType(SearchParamTypeEnum.REFERENCE);
+		sp.setStatus(ConformanceResourceStatusEnum.ACTIVE);
+		sp.setXpath("Meal.chef | Observation.subject");
+		sp.addTarget(ResourceTypeEnum.RESOURCE);
+		sp.addTarget(ResourceTypeEnum.OBSERVATION);
+		sp.addUndeclaredExtension(new ExtensionDt(false, EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE, new StringDt("Meal")));
+		sp.addUndeclaredExtension(new ExtensionDt(false, EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE, new StringDt("Chef")));
+		return sp;
+	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = {false, true})
@@ -37,7 +160,6 @@ public class SearchParameterCanonicalizerTest {
 		sp.setExpression("Meal.chef | Observation.subject");
 		sp.addTarget("Chef");
 		sp.addTarget("Observation");
-
 		IBaseResource searchParamToCanonicalize = sp;
 		SearchParameterCanonicalizer svc;
 		if (theConvertToR5) {
@@ -57,7 +179,51 @@ public class SearchParameterCanonicalizerTest {
 		assertThat(output.getPathsSplit(), containsInAnyOrder("Meal.chef", "Observation.subject"));
 		assertThat(output.getBase(), containsInAnyOrder("Meal", "Patient"));
 		assertThat(output.getTargets(), contains("Chef", "Observation"));
+	}
 
+	@ParameterizedTest
+	@ValueSource(strings = {"Dstu2", "Dstu3", "R4", "R4B", "R5"})
+	public void testCanonicalizeSearchParameterWithCustomTypeAllVersion(String version) {
+		SearchParameterCanonicalizer svc;
+		IBaseResource searchParamToCanonicalize;
+
+		switch (version){
+			case "Dstu2":
+				searchParamToCanonicalize = initSearchParamDstu2();
+				svc = new SearchParameterCanonicalizer(FhirContext.forDstu2Cached());
+				break;
+			case "Dstu3":
+				searchParamToCanonicalize = initSearchParamDstu3();
+				svc = new SearchParameterCanonicalizer(FhirContext.forDstu3Cached());
+				break;
+			case "R4":
+				searchParamToCanonicalize = initSearchParamR4();
+				svc = new SearchParameterCanonicalizer(FhirContext.forR4Cached());
+				break;
+			case "R4B":
+				searchParamToCanonicalize = initSearchParamR4B();
+				svc = new SearchParameterCanonicalizer(FhirContext.forR4BCached());
+				break;
+			default:
+				searchParamToCanonicalize = initSearchParamR5();
+				svc = new SearchParameterCanonicalizer(FhirContext.forR5Cached());
+				break;
+		}
+
+		RuntimeSearchParam output = svc.canonicalizeSearchParameter(searchParamToCanonicalize);
+		assertEquals("chef", output.getName());
+		assertEquals(RestSearchParameterTypeEnum.REFERENCE, output.getParamType());
+		assertEquals(RuntimeSearchParam.RuntimeSearchParamStatusEnum.ACTIVE, output.getStatus());
+		assertThat(output.getPathsSplit(), containsInAnyOrder("Meal.chef", "Observation.subject"));
+		// DSTU2 Resources must only has 1 base
+		if ("Dstu2".equals(version)){
+			assertThat(output.getBase(), containsInAnyOrder("Meal"));
+		} else {
+			assertThat(output.getBase(), containsInAnyOrder("Meal", "Patient"));
+		}
+		assertThat(output.getTargets(), contains("Chef", "Observation"));
+		assertThat(output.getBase(), not(contains("Resource")));
+		assertThat(output.getTargets(), not(contains("Resource")));
 	}
 
 }


### PR DESCRIPTION
What was done:
- Modified `SearchParameterCanonicalizer` for R4+ resources so that when it processes search parameters for custom resources, the "Resource" in base and targets fields is ignored.
- Applied the same logic for custom resource search parameters to DSTU2&3 canonicalizers.
- Implemented tests to test the above functionality