### PR TITLE
lowers log level to remove bootup noise

### DIFF
--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StatusEnum.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StatusEnum.java
@@ -211,7 +211,7 @@ public enum StatusEnum {
 
 		if (!canTransition) {
 			// we have a bug?
-			ourLog.warn("Tried to execute an illegal state transition. [origStatus={}, newStatus={}]", theOrigStatus, theNewStatus);
+			ourLog.debug("Tried to execute an illegal state transition. [origStatus={}, newStatus={}]", theOrigStatus, theNewStatus);
 		}
 		return canTransition;
 	}


### PR DESCRIPTION
Removes these logs from bootup: 
![image](https://github.com/hapifhir/hapi-fhir/assets/1720433/b5388b40-3d3a-45d1-b046-469224653825)
