### PR TITLE
Fixed R5 Subscription deserialization

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -1003,7 +1003,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 		for (Iterator<String> keyIter = theObject.keyIterator(); keyIter.hasNext(); ) {
 			String nextName = keyIter.next();
 			if ("resourceType".equals(nextName)) {
-				if (theState.isToplevelElement()) {
+				if (theState.isToplevelResourceElement()) {
 					continue;
 				}
 			} else if ("extension".equals(nextName)) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -1003,7 +1003,9 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 		for (Iterator<String> keyIter = theObject.keyIterator(); keyIter.hasNext(); ) {
 			String nextName = keyIter.next();
 			if ("resourceType".equals(nextName)) {
-				continue;
+				if (theState.isToplevelElement()) {
+					continue;
+				}
 			} else if ("extension".equals(nextName)) {
 				BaseJsonLikeArray array = grabJsonArray(theObject, nextName, "extension");
 				parseExtension(theState, array, false);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
@@ -148,6 +148,10 @@ class ParserState<T> {
 		return myState.isPreResource();
 	}
 
+	boolean isToplevelElement() {
+		return myState.myStack == null;
+	}
+
 	private Object newContainedDt(IResource theTarget) {
 		return ReflectionUtil.newInstance(theTarget.getStructureFhirVersionEnum().getVersionImplementation().getContainedType());
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
@@ -149,7 +149,7 @@ class ParserState<T> {
 	}
 
 	boolean isToplevelResourceElement() {
-		return myState instanceof ParserState.ResourceStateHl7Org;
+		return myState instanceof ParserState.ResourceStateHl7Org || myState instanceof ParserState.ResourceStateHapi;
 	}
 
 	private Object newContainedDt(IResource theTarget) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
@@ -148,8 +148,8 @@ class ParserState<T> {
 		return myState.isPreResource();
 	}
 
-	boolean isToplevelElement() {
-		return myState.myStack == null;
+	boolean isToplevelResourceElement() {
+		return myState instanceof ParserState.ResourceStateHl7Org;
 	}
 
 	private Object newContainedDt(IResource theTarget) {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/4922-subscriptiontopic-deser.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/4922-subscriptiontopic-deser.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 4922
+title: "R5 Subscription.filterBy.resourceType failed to deserialize because the deserializer skipped all elements named
+'resourceType'. This has been changed so that only toplevel resourceType elements are skipped in the deserialization process."

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionTopicSerializationTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionTopicSerializationTest.java
@@ -1,6 +1,7 @@
 package ca.uhn.fhir.jpa.subscription;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r5.model.Bundle;
 import org.hl7.fhir.r5.model.Subscription;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
@@ -36,10 +37,58 @@ public class SubscriptionTopicSerializationTest {
 			""";
 
 		Subscription subscription = ourFhirContext.newJsonParser().parseResource(Subscription.class, input);
+		assertEquals("Subscription", subscription.getResourceType().name());
 		assertEquals("Encounter", subscription.getFilterByFirstRep().getResourceType());
 
 		// Also test the other direction
 		String serialized = ourFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(subscription);
+		assertEquals(input.trim(), serialized);
+	}
+
+	@Test
+	void testSubscriptionDerializationInBundle() {
+		@Language("json")
+		String input = """
+{
+  "resourceType": "Bundle",
+  "id": "bundle-transaction",
+  "type": "transaction",
+  "entry": [ {
+    "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a",
+    "resource": {
+      "resourceType": "Subscription",
+      "id": "2",
+      "status": "active",
+      "topic": "http://example.com/topic/test",
+      "reason": "Monitor new neonatal function (note, age will be determined by the monitor)",
+      "filterBy": [ {
+        "resourceType": "Encounter",
+        "filterParameter": "participation-type",
+        "comparator": "eq",
+        "value": "PRPF"
+      } ],
+      "channelType": {
+        "system": "http://terminology.hl7.org/CodeSystem/subscription-channel-type",
+        "code": "rest-hook"
+      },
+      "endpoint": "http://localhost:57333/fhir/context",
+      "contentType": "application/fhir+json"
+    },
+    "request": {
+      "method": "POST",
+      "url": "Subscription"
+    }
+  } ]
+}
+			""";
+
+		Bundle bundle = ourFhirContext.newJsonParser().parseResource(Bundle.class, input);
+		Subscription subscription = (Subscription) bundle.getEntry().get(0).getResource();
+		assertEquals("Subscription", subscription.getResourceType().name());
+		assertEquals("Encounter", subscription.getFilterByFirstRep().getResourceType());
+
+		// Also test the other direction
+		String serialized = ourFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(bundle);
 		assertEquals(input.trim(), serialized);
 	}
 }

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionTopicSerializationTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionTopicSerializationTest.java
@@ -1,0 +1,41 @@
+package ca.uhn.fhir.jpa.subscription;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r5.model.Subscription;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SubscriptionTopicSerializationTest {
+	FhirContext ourFhirContext = FhirContext.forR5Cached();
+
+	@Test
+	void testSubscriptionDerialization() {
+		@Language("json")
+		String input = """
+			{
+			  "resourceType": "Subscription",
+			  "id": "2",
+			  "status": "active",
+			  "topic": "http://example.com/topic/test",
+			  "reason": "Monitor new neonatal function (note, age will be determined by the monitor)",
+			  "filterBy": [ {
+			    "resourceType": "Encounter",
+			    "filterParameter": "participation-type",
+			    "comparator": "eq",
+			    "value": "PRPF"
+			  } ],
+			  "channelType": {
+			    "system": "http://terminology.hl7.org/CodeSystem/subscription-channel-type",
+			    "code": "rest-hook"
+			  },
+			  "endpoint": "http://localhost:57333/fhir/context",
+			  "contentType": "application/fhir+json"
+			}
+			""";
+
+		Subscription subscription = ourFhirContext.newJsonParser().parseResource(Subscription.class, input);
+		assertEquals("Encounter", subscription.getFilterByFirstRep().getResourceType());
+	}
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionTopicSerializationTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionTopicSerializationTest.java
@@ -37,5 +37,9 @@ public class SubscriptionTopicSerializationTest {
 
 		Subscription subscription = ourFhirContext.newJsonParser().parseResource(Subscription.class, input);
 		assertEquals("Encounter", subscription.getFilterByFirstRep().getResourceType());
+
+		// Also test the other direction
+		String serialized = ourFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(subscription);
+		assertEquals(input.trim(), serialized);
 	}
 }


### PR DESCRIPTION
R5 Subscription.filterBy.resourceType failed to deserialize because the deserializer skipped all elements named "resourceType".  This has been changed so that only toplevel resourceType elements are skipped in the deserialization process.