### PR TITLE
Ensure StepExecutor only logs a stack trace and error if the retries have been exhausted.  Otherwise, just log a debug.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/4960-delete-expunge-mssql-oracle-10000-resources-error.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/4960-delete-expunge-mssql-oracle-10000-resources-error.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 4960
+jira: SMILE-5740
+title: "Running a $delete-expunge MSSQL or Oracle with over 10,000 resources results in a error and a stack trace, even though the job ends in status COMPLETE.
+        This has been fixed."

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/StepExecutor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/StepExecutor.java
@@ -70,7 +70,7 @@ public class StepExecutor {
 			return false;
 		} catch (Exception e) {
 			if (theStepExecutionDetails.hasAssociatedWorkChunk()) {
-				ourLog.debug("Temporary failure executing job {} step {}, marking chunk {} as ERRORED", jobDefinitionId, targetStepId, chunkId);
+				ourLog.info("Temporary problem executing job {} step {}, marking chunk {} as retriable ERRORED", jobDefinitionId, targetStepId, chunkId);
 				WorkChunkErrorEvent parameters = new WorkChunkErrorEvent(chunkId, e.getMessage());
 				WorkChunkStatusEnum newStatus = myJobPersistence.onWorkChunkError(parameters);
 				if (newStatus == WorkChunkStatusEnum.FAILED) {

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/StepExecutor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/StepExecutor.java
@@ -70,10 +70,11 @@ public class StepExecutor {
 			return false;
 		} catch (Exception e) {
 			if (theStepExecutionDetails.hasAssociatedWorkChunk()) {
-				ourLog.error("Failure executing job {} step {}, marking chunk {} as ERRORED", jobDefinitionId, targetStepId, chunkId, e);
+				ourLog.debug("Temporary failure executing job {} step {}, marking chunk {} as ERRORED", jobDefinitionId, targetStepId, chunkId);
 				WorkChunkErrorEvent parameters = new WorkChunkErrorEvent(chunkId, e.getMessage());
 				WorkChunkStatusEnum newStatus = myJobPersistence.onWorkChunkError(parameters);
 				if (newStatus == WorkChunkStatusEnum.FAILED) {
+					ourLog.error("Exhausted retries:  Failure executing job {} step {}, marking chunk {} as ERRORED", jobDefinitionId, targetStepId, chunkId, e);
 					return false;
 				}
 			} else {


### PR DESCRIPTION
- Ensure that StepExecutor does not log errors and stack traces on retryable errors
- Only log an error and stack trace if the retries have expired

Closes https://github.com/hapifhir/hapi-fhir/issues/4960