### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -40,7 +40,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -54,4 +54,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL is now giving the following warnings:

`This version of the CodeQL Action was deprecated on January 18th, 2023, and is no longer updated or supported`

<img width="1214" alt="Screenshot 2023-06-09 at 11 31 16 AM" src="https://github.com/hapifhir/hapi-fhir/assets/22824488/b577e8ee-1cdd-4935-a77a-81358bef2454">


This PR updates it to version 2, which appears to run and report vulnerabilities without this warning:

<img width="1226" alt="Screenshot 2023-06-09 at 11 31 43 AM" src="https://github.com/hapifhir/hapi-fhir/assets/22824488/d1a976b6-8fb5-4b75-925e-2239d41dadd1">

This can be verified in detail by exploring the CodeQL check in this PR (see: https://github.com/hapifhir/hapi-fhir/actions/runs/5215904840) , as well as the Security tab (see: https://github.com/hapifhir/hapi-fhir/security/code-scanning?query=is%3Aopen+branch%3Ado-20230608-bump-codeql-version.

