### PR TITLE
Set header support for IHttpRequest

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/IHttpRequest.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/IHttpRequest.java
@@ -29,6 +29,21 @@ import java.util.Map;
 public interface IHttpRequest {
 
 	/**
+	 * Set headers of the request
+	 *
+	 * @param headers  Map of headers
+	 */
+	void setHeaders(Map<String, List<String>> headers);
+
+	/**
+	 * Set header of the request
+	 *
+	 * @param theName  the header name
+	 * @param theValue the header value
+	 */
+	void setHeader(String theName, String theValue);
+
+	/**
 	 * Add a header to the request
 	 *
 	 * @param theName  the header name

--- a/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulRequest.java
+++ b/hapi-fhir-client-okhttp/src/main/java/ca/uhn/fhir/okhttp/client/OkHttpRestfulRequest.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.rest.client.api.IHttpResponse;
 import ca.uhn.fhir.util.StopWatch;
 import okhttp3.Call;
 import okhttp3.Call.Factory;
+import okhttp3.Headers;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Adapter for building an OkHttp-specific request.
@@ -60,7 +62,22 @@ public class OkHttpRestfulRequest extends BaseHttpRequest implements IHttpReques
         return myRequestBuilder;
     }
 
-    @Override
+	@Override
+	public void setHeaders(Map<String, List<String>> headers) {
+		myRequestBuilder.headers(Headers.of(
+			headers.entrySet()
+				.stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, e -> String.join(",", e.getValue())))
+		));
+	}
+
+
+	@Override
+	public void setHeader(String theName, String theValue) {
+		myRequestBuilder.header(theName, theValue);
+	}
+
+	@Override
     public void addHeader(String theName, String theValue) {
         myRequestBuilder.addHeader(theName, theValue);
     }

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpRequest.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpRequest.java
@@ -32,6 +32,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
 
 import java.io.IOException;
 import java.net.URI;
@@ -41,6 +42,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * A Http Request based on Apache. This is an adapter around the class
@@ -56,6 +58,24 @@ public class ApacheHttpRequest extends BaseHttpRequest implements IHttpRequest {
 	public ApacheHttpRequest(HttpClient theClient, HttpRequestBase theApacheRequest) {
 		this.myClient = theClient;
 		this.myRequest = theApacheRequest;
+	}
+
+	@Override
+	public void setHeaders(Map<String, List<String>> headers) {
+		myRequest.setHeaders(headers.entrySet().stream()
+			.flatMap(
+				e -> e.getValue().stream()
+					.map(v -> new BasicHeader(e.getKey(), v))
+			)
+			.collect(Collectors.toList())
+			.toArray(Header[]::new)
+		);
+	}
+
+
+	@Override
+	public void setHeader(String theName, String theValue) {
+		myRequest.setHeader(new BasicHeader(theName, theValue));
 	}
 
 	@Override

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/client/JaxRsHttpRequest.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/client/JaxRsHttpRequest.java
@@ -28,7 +28,10 @@ import ca.uhn.fhir.util.StopWatch;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -53,6 +56,24 @@ public class JaxRsHttpRequest extends BaseHttpRequest implements IHttpRequest {
 		this.myRequestType = theRequestType;
 		this.myEntity = theEntity;
 	}
+
+	@Override
+	public void setHeaders(Map<String, List<String>> headers) {
+		myHeaders.clear();
+		myHeaders.putAll(headers);
+		MultivaluedMap<String, Object> headersMap = new MultivaluedHashMap<>();
+		headers.forEach((k,v) -> headersMap.put(k, new ArrayList<>(v)));
+		getRequest().headers(headersMap);
+	}
+
+
+	@Override
+	public void setHeader(String theName, String theValue) {
+		myHeaders.put(theName, new LinkedList<>());
+		myHeaders.get(theName).add(theValue);
+		getRequest().header(theName, theValue);
+	}
+
 
 	@Override
 	public void addHeader(String theName, String theValue) {


### PR DESCRIPTION
For interceptors that have to update values of existing headers of IHttpRequest, like AWS V4 signing requests for Amazon HealthLake. 