### PR TITLE
Partitioning: creating two partitions with the same ID overwrites the first

### DIFF
--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -188,6 +188,7 @@ ca.uhn.fhir.jpa.dao.index.IdHelperService.nonUniqueForcedId=Non-unique ID specif
 
 ca.uhn.fhir.jpa.partition.PartitionLookupSvcImpl.noIdSupplied=No Partition ID supplied
 ca.uhn.fhir.jpa.partition.PartitionLookupSvcImpl.missingPartitionIdOrName=Partition must have an ID and a Name
+ca.uhn.fhir.jpa.partition.PartitionLookupSvcImpl.duplicatePartitionId=Partition ID already exists
 ca.uhn.fhir.jpa.partition.PartitionLookupSvcImpl.unknownPartitionId=No partition exists with ID {0}
 ca.uhn.fhir.jpa.partition.PartitionLookupSvcImpl.invalidName=Partition name "{0}" is not valid
 ca.uhn.fhir.jpa.partition.PartitionLookupSvcImpl.cantCreateDuplicatePartitionName=Partition name "{0}" is already defined

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5011-partitioning-can-create-more-than-one-partition-with-same-id.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5011-partitioning-can-create-more-than-one-partition-with-same-id.yaml
@@ -1,4 +1,5 @@
 ---
 type: fix
 issue: 5011
-title: "Fixed bug that allowed creation of two partitions with the same id"
+title: "Previously, if a partition was created with an ID that was alrady in use, it would overwite the partition that 
+ was using that ID. Now attempting to overwrite will return a 400"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5011-partitioning-can-create-more-than-one-partition-with-same-id.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5011-partitioning-can-create-more-than-one-partition-with-same-id.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5011
+title: "Fixed bug that allowed creation of two partitions with the same id"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5011-partitioning-can-create-more-than-one-partition-with-same-id.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5011-partitioning-can-create-more-than-one-partition-with-same-id.yaml
@@ -1,5 +1,5 @@
 ---
 type: fix
 issue: 5011
-title: "Previously, if a partition was created with an ID that was alrady in use, it would overwite the partition that 
+title: "Previously, if a partition was created with an ID that was already in use, it would overwrite the partition that 
  was using that ID. Now attempting to overwrite will return a 400"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -199,14 +199,9 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 	}
 
 	private void validIdUponCreation(PartitionEntity thePartition){
-		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
-		if(!allPartitions.isEmpty()) {
-			for (PartitionEntity i : allPartitions) {
-				if (i.getId().equals(thePartition.getId())) {
-					String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
-					throw new InvalidRequestException(Msg.code(2366) + msg);
-				}
-			}
+		if (myPartitionDao.findById(thePartition.getId())!=null) {
+			String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
+			throw new InvalidRequestException(Msg.code(2366) + msg);
 		}
 	}
 	private void validateHaveValidPartitionIdAndName(PartitionEntity thePartition) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -199,11 +199,13 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 	}
 
 	private void validIdUponCreation(PartitionEntity thePartition){
-		if (myPartitionDao.findById(thePartition.getId())!=null) {
+		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
+		if (myPartitionDao.findById(thePartition.getId())!=null&&!allPartitions.isEmpty()) {
 			String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
 			throw new InvalidRequestException(Msg.code(2366) + msg);
 		}
 	}
+
 	private void validateHaveValidPartitionIdAndName(PartitionEntity thePartition) {
 		if (thePartition.getId() == null || isBlank(thePartition.getName())) {
 			String msg = myFhirCtx.getLocalizer().getMessage(PartitionLookupSvcImpl.class, "missingPartitionIdOrName");

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -199,8 +199,7 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 	}
 
 	private void validIdUponCreation(PartitionEntity thePartition){
-		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
-		if (myPartitionDao.findById(thePartition.getId()).isPresent() && !allPartitions.isEmpty()) {
+		if (myPartitionDao.findById(thePartition.getId()).isPresent()) {
 			String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
 			throw new InvalidRequestException(Msg.code(2366) + msg);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -200,10 +200,12 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 
 	private void validIdUponCreation(PartitionEntity thePartition){
 		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
-		for(PartitionEntity i : allPartitions){
-			if(i.getId().equals(thePartition.getId())){
-				String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
-				throw new InvalidRequestException(Msg.code(2366) + msg);
+		if(!allPartitions.isEmpty()) {
+			for (PartitionEntity i : allPartitions) {
+				if (i.getId().equals(thePartition.getId())) {
+					String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
+					throw new InvalidRequestException(Msg.code(2366) + msg);
+				}
 			}
 		}
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -216,7 +216,7 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 
 		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
 		for(PartitionEntity i : allPartitions){
-			if(i.getId()==thePartition.getId()){
+			if(i.getId().equals(thePartition.getId())){
 				String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
 				throw new InvalidRequestException(Msg.code(2366) + msg);
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -51,6 +51,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -213,6 +214,13 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 			throw new InvalidRequestException(Msg.code(1312) + msg);
 		}
 
+		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
+		for(PartitionEntity i : allPartitions){
+			if(i.getId()==thePartition.getId()){
+				String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
+				throw new InvalidRequestException(Msg.code(2366) + msg);
+			}
+		}
 	}
 
 	private void validateNotInUnnamedPartitionMode() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -127,7 +127,7 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 		validateNotInUnnamedPartitionMode();
 		validateHaveValidPartitionIdAndName(thePartition);
 		validatePartitionNameDoesntAlreadyExist(thePartition.getName());
-
+		validIdUponCreation(thePartition);
 		ourLog.info("Creating new partition with ID {} and Name {}", thePartition.getId(), thePartition.getName());
 
 		PartitionEntity retVal = myPartitionDao.save(thePartition);
@@ -198,6 +198,15 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 		}
 	}
 
+	private void validIdUponCreation(PartitionEntity thePartition){
+		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
+		for(PartitionEntity i : allPartitions){
+			if(i.getId().equals(thePartition.getId())){
+				String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
+				throw new InvalidRequestException(Msg.code(2366) + msg);
+			}
+		}
+	}
 	private void validateHaveValidPartitionIdAndName(PartitionEntity thePartition) {
 		if (thePartition.getId() == null || isBlank(thePartition.getName())) {
 			String msg = myFhirCtx.getLocalizer().getMessage(PartitionLookupSvcImpl.class, "missingPartitionIdOrName");
@@ -212,14 +221,6 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 		if (!PARTITION_NAME_VALID_PATTERN.matcher(thePartition.getName()).matches()) {
 			String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "invalidName", thePartition.getName());
 			throw new InvalidRequestException(Msg.code(1312) + msg);
-		}
-
-		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
-		for(PartitionEntity i : allPartitions){
-			if(i.getId().equals(thePartition.getId())){
-				String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
-				throw new InvalidRequestException(Msg.code(2366) + msg);
-			}
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -200,7 +200,7 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 
 	private void validIdUponCreation(PartitionEntity thePartition){
 		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
-		if (myPartitionDao.findById(thePartition.getId())!=null&&!allPartitions.isEmpty()) {
+		if (myPartitionDao.findById(thePartition.getId()).isPresent() && !allPartitions.isEmpty()) {
 			String msg = myFhirCtx.getLocalizer().getMessageSanitized(PartitionLookupSvcImpl.class, "duplicatePartitionId");
 			throw new InvalidRequestException(Msg.code(2366) + msg);
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/PartitionManagementProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/PartitionManagementProviderTest.java
@@ -93,7 +93,6 @@ public class PartitionManagementProviderTest {
 		assertEquals("PARTITION-123", ((StringType) response.getParameterValue(ProviderConstants.PARTITION_MANAGEMENT_PARTITION_NAME)).getValue());
 		assertEquals("a description", ((StringType) response.getParameterValue(ProviderConstants.PARTITION_MANAGEMENT_PARTITION_DESC)).getValue());
 	}
-
 	@Nonnull
 	private Parameters createInputPartition() {
 		Parameters input = new Parameters();
@@ -101,6 +100,26 @@ public class PartitionManagementProviderTest {
 		input.addParameter(ProviderConstants.PARTITION_MANAGEMENT_PARTITION_NAME, new CodeType("PARTITION-123"));
 		input.addParameter(ProviderConstants.PARTITION_MANAGEMENT_PARTITION_DESC, new StringType("a description"));
 		return input;
+	}
+
+	@Test
+	public void testCreatePartition_whenPartitionAlreadyExists_operationNotAllowed() {
+		try {
+			Parameters inputPartition = createInputPartition();
+			for(int i = 0; i<2; i++) {
+				myClient
+					.operation()
+					.onServer()
+					.named(ProviderConstants.PARTITION_MANAGEMENT_CREATE_PARTITION)
+					.withParameters(inputPartition)
+					.encodedXml()
+					.execute();
+			}
+			fail();
+		} catch (InvalidRequestException e) {
+			assertEquals("HTTP 400 Bad Request: " + Msg.code(2366) + "Partition ID already exists", e.getMessage());
+		}
+		verify(myPartitionConfigSvc, times(0)).createPartition(any(), any());
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/PartitionManagementProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/PartitionManagementProviderTest.java
@@ -103,26 +103,6 @@ public class PartitionManagementProviderTest {
 	}
 
 	@Test
-	public void testCreatePartition_whenPartitionAlreadyExists_operationNotAllowed() {
-		try {
-			Parameters inputPartition = createInputPartition();
-			for(int i = 0; i<2; i++) {
-				myClient
-					.operation()
-					.onServer()
-					.named(ProviderConstants.PARTITION_MANAGEMENT_CREATE_PARTITION)
-					.withParameters(inputPartition)
-					.encodedXml()
-					.execute();
-			}
-			fail();
-		} catch (InvalidRequestException e) {
-			assertEquals("HTTP 400 Bad Request: " + Msg.code(2366) + "Partition ID already exists", e.getMessage());
-		}
-		verify(myPartitionConfigSvc, times(0)).createPartition(any(), any());
-	}
-
-	@Test
 	public void testCreatePartition_InvalidInput() {
 		try {
 			myClient

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/PartitionSettingsSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/PartitionSettingsSvcImplTest.java
@@ -104,6 +104,27 @@ public class PartitionSettingsSvcImplTest extends BaseJpaR4Test {
 	}
 
 	@Test
+	public void testCreatePartition_whenPartitionIdAlreadyExists_operationNotAllowed(){
+		try {
+			PartitionEntity partition = new PartitionEntity();
+			partition.setId(123);
+			partition.setName("NAME123");
+			partition.setDescription("A description");
+			myPartitionConfigSvc.createPartition(partition, null);
+
+			partition = new PartitionEntity();
+			partition.setId(123);
+			partition.setName("NAME111");
+			partition.setDescription("A description");
+			myPartitionConfigSvc.createPartition(partition, null);
+		}
+
+		catch (InvalidRequestException e) {
+			assertEquals( Msg.code(2366) + "Partition ID already exists", e.getMessage());
+		}
+	}
+
+	@Test
 	public void testUpdatePartition_TryToRenameDefault() {
 		PartitionEntity partition = new PartitionEntity();
 		partition.setId(null);


### PR DESCRIPTION
Added unit test and bug fix to ensure no two partitions with the same ID cannot be created.