### PR TITLE
Make Partition ID non-mandatory during partition creation. 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5014-auto-generate-partition-id.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5014-auto-generate-partition-id.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 5014
+title: "It is no longer mandatory to provide a partition ID when executing the `$partition-management-create-partition` operation. If you omit the partition ID, one will be randomly selected 
+from the available pool of values. Note that this may incur a small performance cost when creating partitions."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_partitioning/partitioning_management_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_partitioning/partitioning_management_operations.md
@@ -23,7 +23,7 @@ The `$partition-management-create-partition` operation can be used to create a n
             <td>Integer</td>
             <td>0..1</td>
             <td>
-                The numeric ID for the partition. This value can be any integer, positive or negative or zero. It must not be a value that has already been used. If omitted, a random integer will be selected.
+                The numeric ID for the partition. This value can be any integer, positive or negative or zero. It must not be a value that has already been used. If omitted, a random unused integer will be selected.
             </td>
         </tr>
         <tr>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_partitioning/partitioning_management_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_partitioning/partitioning_management_operations.md
@@ -21,9 +21,9 @@ The `$partition-management-create-partition` operation can be used to create a n
         <tr>
             <td>id</td>
             <td>Integer</td>
-            <td>1..1</td>
+            <td>0..1</td>
             <td>
-                The numeric ID for the partition. This value can be any integer, positive or negative or zero. It must not be a value that has already been used. 
+                The numeric ID for the partition. This value can be any integer, positive or negative or zero. It must not be a value that has already been used. If omitted, a random integer will be selected.
             </td>
         </tr>
         <tr>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/IPartitionLookupSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/IPartitionLookupSvc.java
@@ -46,6 +46,13 @@ public interface IPartitionLookupSvc {
 
 	void clearCaches();
 
+	/**
+	 * Will generate a random unused partition ID. Validates that no partition with that ID exists before returning.
+	 *
+	 * @return an integer, representing a random unused partition ID.
+	 */
+	int generateRandomUnusedPartitionId();
+
 	PartitionEntity createPartition(PartitionEntity thePartition, RequestDetails theRequestDetails);
 
 	PartitionEntity updatePartition(PartitionEntity thePartition);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -52,6 +52,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -120,9 +121,23 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 		myIdToPartitionCache.invalidateAll();
 	}
 
+	/**
+	 * Generate a random int which is guaranteed to  be unused by an existing partition.
+	 * @return an integer representing a partition ID that is not currently in use by the system.
+	 */
+	public int generateRandomUnusedPartitionId() {
+		int candidate = ThreadLocalRandom.current().nextInt();
+		Optional<PartitionEntity> partition = myPartitionDao.findById(candidate);
+		while (partition.isPresent()) {
+			candidate = ThreadLocalRandom.current().nextInt();
+			partition = myPartitionDao.findById(candidate);
+		}
+		return candidate;
+	}
 	@Override
 	@Transactional
 	public PartitionEntity createPartition(PartitionEntity thePartition, RequestDetails theRequestDetails) {
+
 		validateNotInUnnamedPartitionMode();
 		validateHaveValidPartitionIdAndName(thePartition);
 		validatePartitionNameDoesntAlreadyExist(thePartition.getName());

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionManagementProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionManagementProvider.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.partition;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.entity.PartitionEntity;
+import ca.uhn.fhir.model.primitive.IntegerDt;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -30,6 +31,9 @@ import ca.uhn.fhir.util.ParametersUtil;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.Nonnull;
@@ -51,6 +55,7 @@ import static org.hl7.fhir.instance.model.api.IPrimitiveType.toValueOrNull;
  * </ul>
  */
 public class PartitionManagementProvider {
+	private static final Logger ourLog = LoggerFactory.getLogger(PartitionLookupSvcImpl.class);
 
 	@Autowired
 	private FhirContext myCtx;
@@ -71,6 +76,11 @@ public class PartitionManagementProvider {
 		@OperationParam(name = ProviderConstants.PARTITION_MANAGEMENT_PARTITION_DESC, min = 0, max = 1, typeName = "string") IPrimitiveType<String> thePartitionDescription,
 		RequestDetails theRequestDetails
 	) {
+
+		if (thePartitionId == null && thePartitionName!= null && thePartitionName.hasValue()) {
+			thePartitionId = requestRandomPartitionId(thePartitionName);
+		}
+
 		validatePartitionIdSupplied(myCtx, toValueOrNull(thePartitionId));
 
 		PartitionEntity input = parseInput(thePartitionId, thePartitionName, thePartitionDescription);
@@ -81,6 +91,13 @@ public class PartitionManagementProvider {
 		IBaseParameters retVal = prepareOutput(output);
 
 		return retVal;
+	}
+
+	@NotNull
+	private IPrimitiveType<Integer> requestRandomPartitionId(IPrimitiveType<String> thePartitionName) {
+		int unusedPartitionId = myPartitionLookupSvc.generateRandomUnusedPartitionId();
+		ourLog.info("Request to create partition came in without a partition ID. Auto-assigning an available ID.[partition_id={}, partition_name={}]", unusedPartitionId, thePartitionName);
+		return new IntegerDt(unusedPartitionId);
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionManagementProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionManagementProvider.java
@@ -31,7 +31,6 @@ import ca.uhn.fhir.util.ParametersUtil;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,7 +92,7 @@ public class PartitionManagementProvider {
 		return retVal;
 	}
 
-	@NotNull
+	@Nonnull
 	private IPrimitiveType<Integer> requestRandomPartitionId(IPrimitiveType<String> thePartitionName) {
 		int unusedPartitionId = myPartitionLookupSvc.generateRandomUnusedPartitionId();
 		ourLog.info("Request to create partition came in without a partition ID. Auto-assigning an available ID.[partition_id={}, partition_name={}]", unusedPartitionId, thePartitionName);


### PR DESCRIPTION
closes #5014 

- Autogenerate a partition ID during create operation, if one is absent. 
- Changelogs
- Docs
- Test