### PR TITLE
fixed batch jobs on Postgres

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5021-unable-to-run-batch-jobs-on-postgres.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5021-unable-to-run-batch-jobs-on-postgres.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5021
+title: "Previously, running batch jobs with postgresql as the db will result in SQL error. This has now been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
@@ -42,6 +42,7 @@ import java.util.Date;
 
 import static ca.uhn.fhir.batch2.model.JobDefinition.ID_MAX_LENGTH;
 import static ca.uhn.fhir.jpa.entity.Batch2WorkChunkEntity.ERROR_MSG_MAX_LENGTH;
+import static ca.uhn.fhir.jpa.entity.Batch2WorkChunkEntity.WARNING_MSG_MAX_LENGTH;
 import static org.apache.commons.lang3.StringUtils.left;
 
 @Entity
@@ -113,8 +114,7 @@ public class Batch2JobInstanceEntity implements Serializable {
 	private String myEstimatedTimeRemaining;
 	@Column(name = "CUR_GATED_STEP_ID", length = ID_MAX_LENGTH, nullable = true)
 	private String myCurrentGatedStepId;
-	@Lob
-	@Column(name = "WARNING_MSG", nullable = true)
+	@Column(name = "WARNING_MSG", length = WARNING_MSG_MAX_LENGTH, nullable = true)
 	private String myWarningMessages;
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2WorkChunkEntity.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2WorkChunkEntity.java
@@ -53,6 +53,7 @@ import static org.apache.commons.lang3.StringUtils.left;
 public class Batch2WorkChunkEntity implements Serializable {
 
 	public static final int ERROR_MSG_MAX_LENGTH = 500;
+	public static final int WARNING_MSG_MAX_LENGTH = 4000;
 	private static final long serialVersionUID = -6202771941965780558L;
 	@Id
 	@Column(name = "ID", length = ID_MAX_LENGTH)
@@ -96,8 +97,7 @@ public class Batch2WorkChunkEntity implements Serializable {
 	private String myErrorMessage;
 	@Column(name = "ERROR_COUNT", nullable = false)
 	private int myErrorCount;
-	@Lob
-	@Column(name = "WARNING_MSG", nullable = true)
+	@Column(name = "WARNING_MSG", length = WARNING_MSG_MAX_LENGTH, nullable = true)
 	private String myWarningMessage;
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -277,6 +277,18 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.unique(false)
 			.withColumns("CONCEPT_MAP_GRP_ELM_PID")
 			.onlyAppliesToPlatforms(NON_AUTOMATIC_FK_INDEX_PLATFORMS);
+
+		version
+			.onTable("BT2_WORK_CHUNK")
+			.modifyColumn("20230622.1", "WARNING_MSG")
+			.nullable()
+			.withType(ColumnTypeEnum.STRING, 4000);
+
+		version
+			.onTable("BT2_JOB_INSTANCE")
+			.modifyColumn("20230622.2", "WARNING_MSG")
+			.nullable()
+			.withType(ColumnTypeEnum.STRING, 4000);
 	}
 
 	protected void init660() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -278,17 +278,26 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.withColumns("CONCEPT_MAP_GRP_ELM_PID")
 			.onlyAppliesToPlatforms(NON_AUTOMATIC_FK_INDEX_PLATFORMS);
 
+		// have to drop the column first, orcacle doesn't play well with converting clobs to varchar
 		version
 			.onTable("BT2_WORK_CHUNK")
-			.modifyColumn("20230622.1", "WARNING_MSG")
+			.dropColumn("20230622.1", "WARNING_MSG");
+
+		version
+			.onTable("BT2_WORK_CHUNK")
+			.addColumn("20230622.2", "WARNING_MSG")
 			.nullable()
-			.withType(ColumnTypeEnum.STRING, 4000);
+			.type(ColumnTypeEnum.STRING, 4000);
 
 		version
 			.onTable("BT2_JOB_INSTANCE")
-			.modifyColumn("20230622.2", "WARNING_MSG")
+			.dropColumn("20230622.3", "WARNING_MSG");
+
+		version
+			.onTable("BT2_JOB_INSTANCE")
+			.addColumn("20230622.4", "WARNING_MSG")
 			.nullable()
-			.withType(ColumnTypeEnum.STRING, 4000);
+			.type(ColumnTypeEnum.STRING, 4000);
 	}
 
 	protected void init660() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -162,13 +162,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.onTable("BT2_WORK_CHUNK")
 			.addColumn("20230524.1", "WARNING_MSG")
 			.nullable()
-			.type(ColumnTypeEnum.CLOB);
+			.type(ColumnTypeEnum.CLOB)
+			.doNothing(); // the migration below is the better implementation
 
 		version
 			.onTable("BT2_JOB_INSTANCE")
 			.addColumn("20230524.2", "WARNING_MSG")
 			.nullable()
-			.type(ColumnTypeEnum.CLOB);
+			.type(ColumnTypeEnum.CLOB)
+			.doNothing(); // the migration below is the better implementation
 
 		// adding indexes to foreign keys
 		// this makes our table scans more efficient,
@@ -278,10 +280,11 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.withColumns("CONCEPT_MAP_GRP_ELM_PID")
 			.onlyAppliesToPlatforms(NON_AUTOMATIC_FK_INDEX_PLATFORMS);
 
-		// have to drop the column first, orcacle doesn't play well with converting clobs to varchar
+		// add warning message to batch job instance using limited varchar column to store
 		version
 			.onTable("BT2_WORK_CHUNK")
-			.dropColumn("20230622.1", "WARNING_MSG");
+			.dropColumn("20230622.1", "WARNING_MSG")
+			.failureAllowed();
 
 		version
 			.onTable("BT2_WORK_CHUNK")
@@ -291,7 +294,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 		version
 			.onTable("BT2_JOB_INSTANCE")
-			.dropColumn("20230622.3", "WARNING_MSG");
+			.dropColumn("20230622.3", "WARNING_MSG")
+			.failureAllowed();
 
 		version
 			.onTable("BT2_JOB_INSTANCE")

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
 import ca.uhn.fhir.util.Logs;
 import ca.uhn.fhir.util.StopWatch;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 
@@ -125,7 +126,7 @@ public class InstanceProgress {
 	public void updateInstance(JobInstance theInstance) {
 		updateInstance(theInstance, false);
 
-		String newWarningMessage = String.join("\n", myWarningMessages);
+		String newWarningMessage = StringUtils.right(String.join("\n", myWarningMessages), 4000);
 		theInstance.setWarningMessages(newWarningMessage);
 	}
 


### PR DESCRIPTION
- changed warning message columns from LOB to varchar, and limit the size to 4000(max for varchar columns)
- changed how new warnings are append to the field, limiting the string to 4000 length, favouring new warnings 