### PR TITLE
#5023 Unexpected usage of awssdk StringUtils in hapi 6.6 jpa migration

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -43,7 +43,7 @@ import ca.uhn.fhir.jpa.model.entity.SearchParamPresentEntity;
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.util.VersionEnum;
-import software.amazon.awssdk.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -505,7 +505,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		String postgresTuningStatementsAll = ClasspathUtil.loadResource("ca/uhn/fhir/jpa/docs/database/hapifhirpostgres94-init01.sql");
 		List<String> postgresTuningStatements = Arrays
 			.stream(postgresTuningStatementsAll.split("\\n"))
-			.map(org.apache.commons.lang3.StringUtils::trim)
+			.map(StringUtils::trim)
 			.filter(StringUtils::isNotBlank)
 			.filter(t -> !t.startsWith("--"))
 			.collect(Collectors.toList());


### PR DESCRIPTION
Improvement / Fix for #5023 Unexpected usage of awssdk StringUtils in hapi 6.6 jpa migration task

(backport to 6.6 for one of a potential 6.6.2 would be welcome)