### PR TITLE
Reindex Batch Jobs stuck in QUEUED status after SearchParameter update

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5041-reindex-batch-jobs-stuck-in-queued-status.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5041-reindex-batch-jobs-stuck-in-queued-status.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5041
+jira: SMILE-6428
+title: "Previously, reindex batch jobs got stuck in QUEUED status after a SearchParameter update. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5041-reindex-batch-jobs-stuck-in-queued-status.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5041-reindex-batch-jobs-stuck-in-queued-status.yaml
@@ -2,4 +2,4 @@
 type: fix
 issue: 5041
 jira: SMILE-6428
-title: "Previously, reindex batch jobs got stuck in QUEUED status after a SearchParameter update. This has been fixed."
+title: "Fixed an issue where reindex batch jobs failed to start and were stuck in QUEUED status after a SearchParameter update."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/delete/job/ReindexJobTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/delete/job/ReindexJobTest.java
@@ -447,11 +447,11 @@ public class ReindexJobTest extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void testReindex_reindexingUponSearchParameterChangeEnabled_reindexJobCompleted() {
-		// make sure the resources auto-reindex after search parameter update is enabled
+	public void testReindex_withReindexingUponSearchParameterChangeEnabled_reindexJobCompleted() {
+		// make sure the resources auto-reindex after the search parameter update is enabled
 		myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(true);
 
-		// create Observation resource and SearchParameter for it to trigger re-index
+		// create an Observation resource and SearchParameter for it to trigger re-indexing
 		myReindexTestHelper.createObservationWithCode();
 		myReindexTestHelper.createCodeSearchParameter();
 
@@ -459,7 +459,7 @@ public class ReindexJobTest extends BaseJpaR4Test {
 		List<JobInstance> jobInstances = myJobPersistence.fetchInstancesByJobDefinitionId(ReindexAppCtx.JOB_REINDEX, 10, 0);
 		assertEquals(1, jobInstances.size());
 
-		// check that job is completed (not stuck in QUEUED status)
+		// check that the job is completed (not stuck in QUEUED status)
 		myBatch2JobHelper.awaitJobCompletion(jobInstances.get(0).getInstanceId());
 	}
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobCoordinatorImpl.java
@@ -43,7 +43,8 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -124,16 +125,39 @@ public class JobCoordinatorImpl implements IJobCoordinator {
 		myJobParameterJsonValidator.validateJobParameters(theRequestDetails, theStartRequest, jobDefinition);
 
 		IJobPersistence.CreateResult instanceAndFirstChunk =
-			myTransactionService.withSystemRequest()
-				.withPropagation(Propagation.REQUIRES_NEW)
-				.execute(() -> myJobPersistence.onCreateWithFirstChunk(jobDefinition, theStartRequest.getParameters()));
+			myTransactionService.withSystemRequest().execute(() ->
+				myJobPersistence.onCreateWithFirstChunk(jobDefinition, theStartRequest.getParameters()));
 
 		JobWorkNotification workNotification = JobWorkNotification.firstStepNotification(jobDefinition, instanceAndFirstChunk.jobInstanceId, instanceAndFirstChunk.workChunkId);
-		myBatchJobSender.sendWorkChannelMessage(workNotification);
+		sendBatchJobWorkNotificationAfterCommit(workNotification);
 
 		Batch2JobStartResponse response = new Batch2JobStartResponse();
 		response.setInstanceId(instanceAndFirstChunk.jobInstanceId);
 		return response;
+	}
+
+	/**
+	 * In order to make sure that the data is actually in the DB when JobWorkNotification is handled,
+	 * this method registers a transaction synchronization that sends JobWorkNotification to Job WorkChannel
+	 * if and when the current database transaction is successfully committed.
+	 * If the transaction is rolled back, the JobWorkNotification will not be sent to the job WorkChannel.
+	 */
+	private void sendBatchJobWorkNotificationAfterCommit(final JobWorkNotification theJobWorkNotification) {
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+				@Override
+				public int getOrder() {
+					return 0;
+				}
+
+				@Override
+				public void afterCommit() {
+					myBatchJobSender.sendWorkChannelMessage(theJobWorkNotification);
+				}
+			});
+		} else {
+			myBatchJobSender.sendWorkChannelMessage(theJobWorkNotification);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Previously, reindex batch jobs got stuck in QUEUED status after a SearchParameter update. This has been fixed.