### PR TITLE
Delete expunge fails with identical update timestamps

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5055-bulk-delete-on-2100-resources-fails.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5055-bulk-delete-on-2100-resources-fails.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 5055
+title: "
+      Delete expunge (and possibly other batch 2 jobs) will fail when given more than
+      2100 resources with identical timestamps when using an mssql database.
+"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5055-bulk-delete-on-2100-resources-fails.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5055-bulk-delete-on-2100-resources-fails.yaml
@@ -4,4 +4,5 @@ issue: 5055
 title: "
       Delete expunge (and possibly other batch 2 jobs) will fail when given more than
       2100 resources with identical timestamps when using an mssql database.
+      This has been fixed.
 "

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -48,7 +48,7 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
 	public static final int DEFAULT_PAGE_SIZE = 20000;
 
-	private static final int MAX_BATCH_OF_IDS = 500;
+	protected static final int MAX_BATCH_OF_IDS = 500;
 
 	private final IIdChunkProducer<IT> myIdChunkProducer;
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -91,6 +91,12 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 				break;
 			}
 
+			// If we get the same last time twice in a row, we've clearly reached the end
+			if (nextChunk.getLastDate().getTime() == previousLastTime) {
+				ourLog.info("Matching final timestamp of {}, loading is completed", new Date(previousLastTime));
+				break;
+			}
+
 			ourLog.info("Found {} IDs from {} to {}", nextChunk.size(), nextStart, nextChunk.getLastDate());
 			if (nextChunk.size() < 10 && HapiSystemProperties.isTestModeEnabled()) {
 				// TODO: I've added this in order to troubleshoot MultitenantBatchOperationR4Test
@@ -101,12 +107,6 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 			for (TypedResourcePid typedResourcePid : nextChunk.getTypedResourcePids()) {
 				TypedPidJson nextId = new TypedPidJson(typedResourcePid);
 				idBuffer.add(nextId);
-			}
-
-			// If we get the same last time twice in a row, we've clearly reached the end
-			if (nextChunk.getLastDate().getTime() == previousLastTime) {
-				ourLog.info("Matching final timestamp of {}, loading is completed", new Date(previousLastTime));
-				break;
 			}
 
 			previousLastTime = nextChunk.getLastDate().getTime();

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
@@ -11,7 +11,6 @@ import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -57,7 +56,7 @@ class ResourceIdListStepTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {1,100,500,501,2345})
+	@ValueSource(ints = {1, 100, 500, 501, 2345})
 	void testResourceIdListBatchSizeLimit(int theListSize) {
 		List<TypedResourcePid> idList = generateIdList(theListSize);
 		when(myStepExecutionDetails.getData()).thenReturn(myData);
@@ -73,7 +72,7 @@ class ResourceIdListStepTest {
 		doAnswer(i -> {
 			ResourceIdListWorkChunkJson list = i.getArgument(0);
 			Assertions.assertTrue(list.size() <= ResourceIdListStep.MAX_BATCH_OF_IDS,
-				"Id batch size should never exceed "+ResourceIdListStep.MAX_BATCH_OF_IDS);
+				"Id batch size should never exceed " + ResourceIdListStep.MAX_BATCH_OF_IDS);
 			return null;
 		}).when(myDataSink).accept(any(ResourceIdListWorkChunkJson.class));
 
@@ -81,20 +80,20 @@ class ResourceIdListStepTest {
 		assertNotEquals(null, run);
 
 		// The work should be divided into chunks of MAX_BATCH_OF_IDS in size (or less, but never more):
-		int expectedBatchCount = (int)Math.ceil((float)theListSize / ResourceIdListStep.MAX_BATCH_OF_IDS);
+		int expectedBatchCount = (int) Math.ceil((float) theListSize / ResourceIdListStep.MAX_BATCH_OF_IDS);
 		verify(myDataSink, times(expectedBatchCount)).accept(myDataCaptor.capture());
 		final List<ResourceIdListWorkChunkJson> allDataChunks = myDataCaptor.getAllValues();
 		assertEquals(expectedBatchCount, allDataChunks.size());
 
 		// Ensure that all chunks except the very last one are MAX_BATCH_OF_IDS in length
-		for (int i = 0; i < expectedBatchCount-1; i++) {
+		for (int i = 0; i < expectedBatchCount - 1; i++) {
 			assertEquals(ResourceIdListStep.MAX_BATCH_OF_IDS, allDataChunks.get(i).size());
 		}
 
 		// The very last chunk should be whatever is left over (if there is a remainder):
 		int expectedLastBatchSize = theListSize % ResourceIdListStep.MAX_BATCH_OF_IDS;
-		expectedLastBatchSize = (expectedLastBatchSize==0) ? ResourceIdListStep.MAX_BATCH_OF_IDS : expectedLastBatchSize;
-      assertEquals(expectedLastBatchSize, allDataChunks.get(allDataChunks.size() - 1).size());
+		expectedLastBatchSize = (expectedLastBatchSize == 0) ? ResourceIdListStep.MAX_BATCH_OF_IDS : expectedLastBatchSize;
+		assertEquals(expectedLastBatchSize, allDataChunks.get(allDataChunks.size() - 1).size());
 	}
 
 	private List<TypedResourcePid> generateIdList(int theListSize) {

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
@@ -1,0 +1,74 @@
+package ca.uhn.fhir.batch2.jobs.step;
+
+import ca.uhn.fhir.batch2.api.IJobDataSink;
+import ca.uhn.fhir.batch2.api.RunOutcome;
+import ca.uhn.fhir.batch2.api.StepExecutionDetails;
+import ca.uhn.fhir.batch2.jobs.chunk.PartitionedUrlChunkRangeJson;
+import ca.uhn.fhir.batch2.jobs.chunk.ResourceIdListWorkChunkJson;
+import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrlListJobParameters;
+import ca.uhn.fhir.jpa.api.pid.HomogeneousResourcePidList;
+import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
+import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceIdListStepTest {
+	private static final int LIST_SIZE = 1500;
+
+	@Mock
+	private IIdChunkProducer<PartitionedUrlChunkRangeJson> myIdChunkProducer;
+	@Mock
+	private StepExecutionDetails<PartitionedUrlListJobParameters, PartitionedUrlChunkRangeJson> myStepExecutionDetails;
+	@Mock
+	private IJobDataSink<ResourceIdListWorkChunkJson> myDataSink;
+	@Mock
+	private PartitionedUrlChunkRangeJson myData;
+	@Mock
+	private PartitionedUrlListJobParameters myParameters;
+
+	private ResourceIdListStep<PartitionedUrlListJobParameters, PartitionedUrlChunkRangeJson> myResourceIdListStep;
+
+	private List<TypedResourcePid> idList = new ArrayList<>();
+
+	@BeforeEach
+	void beforeEach() {
+		myResourceIdListStep = new ResourceIdListStep<>(myIdChunkProducer);
+		for (int id = 0; id <= LIST_SIZE; id++) {
+			IResourcePersistentId theId = mock(IResourcePersistentId.class);
+			when(theId.toString()).thenReturn(Integer.toString(id + 1));
+			TypedResourcePid typedId = new TypedResourcePid("Patient", theId);
+			idList.add(typedId);
+		}
+	}
+
+	@Test
+	void testMe() {
+		when(myStepExecutionDetails.getData()).thenReturn(myData);
+		when(myParameters.getBatchSize()).thenReturn(LIST_SIZE);
+		when(myStepExecutionDetails.getParameters()).thenReturn(myParameters);
+		Date someDate = new Date();
+		//final HomogeneousResourcePidList homogeneousResourcePidList = new HomogeneousResourcePidList(ResourceType.Patient.name(), ids, someDate, null);
+		HomogeneousResourcePidList homogeneousResourcePidList = mock(HomogeneousResourcePidList.class);
+		when(homogeneousResourcePidList.getTypedResourcePids()).thenReturn(idList);
+		when(homogeneousResourcePidList.getLastDate()).thenReturn(someDate);
+		when(myIdChunkProducer.fetchResourceIdsPage(any(), any(), any(), any(), any()))
+			.thenReturn(homogeneousResourcePidList);
+
+		final RunOutcome run = myResourceIdListStep.run(myStepExecutionDetails, myDataSink);
+		Assertions.assertNotEquals(null, run);
+	}
+}

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
@@ -8,31 +8,26 @@ import ca.uhn.fhir.batch2.jobs.chunk.ResourceIdListWorkChunkJson;
 import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrlListJobParameters;
 import ca.uhn.fhir.jpa.api.pid.HomogeneousResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
-import ca.uhn.fhir.model.api.IModelJson;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ResourceIdListStepTest {
-	private static final int LIST_SIZE = 1500;
+	private static final int LIST_SIZE = 2345;
 
 	@Mock
 	private IIdChunkProducer<PartitionedUrlChunkRangeJson> myIdChunkProducer;
@@ -61,7 +56,7 @@ class ResourceIdListStepTest {
 	}
 
 	@Test
-	void testMe() {
+	void testResourceIdListBatchSizeLimit() {
 		when(myStepExecutionDetails.getData()).thenReturn(myData);
 		when(myParameters.getBatchSize()).thenReturn(LIST_SIZE);
 		when(myStepExecutionDetails.getParameters()).thenReturn(myParameters);


### PR DESCRIPTION
Bulk delete of more than 2100 resources at a time could cause a failure with certain dialects (SQLServer2012Dialect) due to limitations in the number of elements allowed in an IN statement. ResourceIdListStep contained code that could exceed that limit in the case where all of the resources had the same res_updated value. This PR corrects the problem and adds a unit test to verify it (test fails without the fix and passes with the fix in place).

Closes [5055](https://github.com/hapifhir/hapi-fhir/issues/5055)