### PR TITLE
Fix _has parameter chained edge case

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceLinkPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceLinkPredicateBuilder.java
@@ -77,6 +77,7 @@ import com.healthmarketscience.sqlbuilder.NotCondition;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
 import com.healthmarketscience.sqlbuilder.UnaryCondition;
 import com.healthmarketscience.sqlbuilder.dbspec.basic.DbColumn;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.slf4j.Logger;
@@ -450,10 +451,21 @@ public class ResourceLinkPredicateBuilder
 		return QueryParameterUtils.toAndPredicate(pathPredicate, multiTypePredicate);
 	}
 
+	/**
+	 * Determines the resourceTypes a search parameter with a chain may refer to
+	 * @param theResourceName Resource that should have the search parameter
+	 * @param theParamName name of the search parameter (without the chain)
+	 * @param theReferenceParam the reference parameter, value may not be a reference if the parameter contains a chain
+	 * @return a list of possible resourceTypes that the parameter refers to
+	 */
 	@Nonnull
 	private List<String> determineCandidateResourceTypesForChain(String theResourceName, String theParamName, ReferenceParam theReferenceParam) {
 		final List<Class<? extends IBaseResource>> resourceTypes;
-		if (!theReferenceParam.hasResourceType()) {
+		// A token parameter with a system that has a URL would be interpreted as a reference with a resourceType.
+		boolean possiblyATokenParameter = StringUtils.isNotBlank(theReferenceParam.getChain())
+			&& StringUtils.isNotBlank(theReferenceParam.getValue()) && theReferenceParam.getValue().contains("|");
+
+		if (!theReferenceParam.hasResourceType() || possiblyATokenParameter) {
 
 			resourceTypes = determineResourceTypes(Collections.singleton(theResourceName), theParamName);
 

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoDstu3SearchNoFtTest.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/dao/dstu3/FhirResourceDaoDstu3SearchNoFtTest.java
@@ -435,6 +435,7 @@ public class FhirResourceDaoDstu3SearchNoFtTest extends BaseJpaDstu3Test {
 		{
 			Device device = new Device();
 			device.addIdentifier().setSystem("urn:system").setValue("DEVICEID");
+			device.addIdentifier().setSystem("http://hl7.org/fhir/NamingSystem/device-ids").setValue("DEVICEID");
 			IIdType devId = myDeviceDao.create(device, mySrd).getId().toUnqualifiedVersionless();
 
 			Patient patient = new Patient();
@@ -454,6 +455,11 @@ public class FhirResourceDaoDstu3SearchNoFtTest extends BaseJpaDstu3Test {
 		// Target exists and is linked
 		params.setLoadSynchronous(true);
 		params.add("_has", new HasParam("Observation", "subject", "device.identifier", "urn:system|DEVICEID"));
+		assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(params)), contains(pid0.getValue()));
+
+		params = new SearchParameterMap();
+		params.setLoadSynchronous(true);
+		params.add("_has", new HasParam("Observation", "subject", "device.identifier", "http://hl7.org/fhir/NamingSystem/device-ids|DEVICEID"));
 		assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(params)), contains(pid0.getValue()));
 
 		// No targets exist

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchNoFtTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchNoFtTest.java
@@ -1121,6 +1121,7 @@ public class FhirResourceDaoR4SearchNoFtTest extends BaseJpaR4Test {
 		{
 			Device device = new Device();
 			device.addIdentifier().setSystem("urn:system").setValue("DEVICEID");
+			device.addIdentifier().setSystem("http://hl7.org/fhir/NamingSystem/device-ids").setValue("DEVICEID");
 			IIdType devId = myDeviceDao.create(device, mySrd).getId().toUnqualifiedVersionless();
 
 			Patient patient = new Patient();
@@ -1136,12 +1137,17 @@ public class FhirResourceDaoR4SearchNoFtTest extends BaseJpaR4Test {
 
 		SearchParameterMap params;
 
-// KHS JA When we switched _has from two queries to a nested subquery, we broke support for chains within _has
-// We have decided for now to prefer the performance optimization of the subquery over the slower full capability
-//		params = new SearchParameterMap();
-//		params.setLoadSynchronous(true);
-//		params.add("_has", new HasParam("Observation", "subject", "device.identifier", "urn:system|DEVICEID"));
-//		assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(params)), contains(pid0.getValue()));
+		params = new SearchParameterMap();
+
+		// Target exists and is linked
+		params.setLoadSynchronous(true);
+		params.add("_has", new HasParam("Observation", "subject", "device.identifier", "urn:system|DEVICEID"));
+		assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(params)), contains(pid0.getValue()));
+
+		params = new SearchParameterMap();
+		params.setLoadSynchronous(true);
+		params.add("_has", new HasParam("Observation", "subject", "device.identifier", "http://hl7.org/fhir/NamingSystem/device-ids|DEVICEID"));
+		assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(params)), contains(pid0.getValue()));
 
 		// No targets exist
 		params = new SearchParameterMap();


### PR DESCRIPTION
Closes #5065, see the issue for more information

Added an extra check since `hasResourceType` may return a false positive. It happens in cases where the chained parameter value is a URL. It is then parsed as a reference that has a `resourceType` even though it is not a reference value.

Have not looked into the context regarding the case being commented out in `FhirResourceDaoR4SearchNoFtTest`, but it passed after enabling it.