### PR TITLE
Fix invalid resource HapiFhirStorageResponseCode.json to prevent  unnecessary warnings

### DIFF
--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/context/support/HapiFhirStorageResponseCode.json
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/context/support/HapiFhirStorageResponseCode.json
@@ -3,9 +3,7 @@
   "url": "https://hapifhir.io/fhir/CodeSystem/hapi-fhir-storage-response-code",
   "status": "active",
   "copyright": "Licensed under the terms of the Apache Software License 2.0.",
-  "author": [ {
-    "name": "HAPI FHIR"
-  } ],
+  "publisher": "HAPI FHIR",
   "caseSensitive": true,
   "content": "complete",
   "concept": [ {


### PR DESCRIPTION
The builtin resource `HapiFhirStorageResponseCode.json` causes unnecessary warnings because it is not valid. The JSON has an array property `author` which a [`CodeSystem`](http://hl7.org/fhir/R5/codesystem.html) resource does not have.

This fix replaces the `author` property with `publisher` (scalar because `publisher` is {0,1} instead of {0,*}).