### PR TITLE
Fix problem with _include=MedicationRequest:medication with R4

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
@@ -102,7 +102,9 @@ public class ResourceReferenceInfo {
 					final String completeName = myOwningResource + "." + myName;
 					boolean matched = false;
 					for (String s : searchParamDef.getPathsSplit()) {
-						if (s.equals(completeName) || s.startsWith(completeName + ".")) {
+						if (s.equals(completeName)
+								|| s.startsWith(completeName + ".")
+								|| s.startsWith("(" + completeName )) {
 							matched = true;
 							break;
 						}


### PR DESCRIPTION
A query for MedicationRequest that should include medication
did not work, because the SearchParamDefinition defined the
path as (MedicationRequest.medication as Reference)

Enhanced the matchesInclude method to allow extra parts after
the search path