### PR TITLE
5117 MDM Score for No Match Fields Should Not Be Included in Total Score 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5117-fix-no-match-mdm-score-included-in-total-score.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5117-fix-no-match-mdm-score-included-in-total-score.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5117
+title: "Previously, all MDM field scores, including `NO_MATCH`es, were included in the final total MDM score. This has 
+now been fixed so that only `MATCH`ed fields are included in the total MDM score."

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -151,13 +151,13 @@ public class MdmResourceMatcherSvc {
 						fieldComparator.getName(),
 						matchEvaluation.score,
 						vector);
+				score += matchEvaluation.score;
 			} else {
 				ourLog.trace(
 						"No match: Matcher {} did not match (score: {}).",
 						fieldComparator.getName(),
 						matchEvaluation.score);
 			}
-			score += matchEvaluation.score;
 			appliedRuleCount += 1;
 		}
 

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcR4Test.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcR4Test.java
@@ -57,4 +57,19 @@ public class MdmResourceMatcherSvcR4Test extends BaseMdmRulesR4Test {
 		patient3.addName().addGiven("Henry");
 		assertMatchResult(MdmMatchResultEnum.NO_MATCH, 0L, 0.0, false, false, myMdmResourceMatcherSvc.getMatchResult(myJohn, patient3));
 	}
+
+	@Test
+	public void testScoreOnlySummedWhenMatchFieldMatches() {
+		MdmMatchOutcome outcome = myMdmResourceMatcherSvc.getMatchResult(myJohn, myJohny);
+		assertMatchResult(MdmMatchResultEnum.POSSIBLE_MATCH, 1L, 0.816, false, false, outcome);
+
+		myJohn.addName().setFamily("Smith");
+		myJohny.addName().setFamily("htims");
+		outcome = myMdmResourceMatcherSvc.getMatchResult(myJohn, myJohny);
+		assertMatchResult(MdmMatchResultEnum.POSSIBLE_MATCH, 1L, 0.816, false, false, outcome);
+
+		myJohny.addName().setFamily("Smith");
+		outcome = myMdmResourceMatcherSvc.getMatchResult(myJohn, myJohny);
+		assertMatchResult(MdmMatchResultEnum.MATCH, 3L, 1.816, false, false, outcome);
+	}
 }


### PR DESCRIPTION
- Since not-matched fields should not be included, changed where score is added
- Added test and changelog

Closes #5117 