### PR TITLE
5123 - Use DEFAULT partition for server-based requests if none specified

### DIFF
--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsHooksContextBooterTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsHooksContextBooterTest.java
@@ -28,7 +28,7 @@ class CdsHooksContextBooterTest {
 	@Test
 	void validateJsonThrowsExceptionWhenInputIsInvalid() {
 		// setup
-		final String expected = "Invalid JSON: Unrecognized token 'abc': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
+		final String expected = "HAPI-2378: Invalid JSON: Unrecognized token 'abc': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
 			" at [Source: (String)\"abc\"; line: 1, column: 4]";
 		// execute
 		final UnprocessableEntityException actual = assertThrows(UnprocessableEntityException.class, () -> myFixture.validateJson("abc"));

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvcTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvcTest.java
@@ -93,7 +93,7 @@ class CdsPrefetchFhirClientSvcTest {
 			IBaseResource srq = myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "1234");
 			fail("should throw, no resource present");
 		} catch (InvalidRequestException e) {
-			assertEquals("Unable to translate url 1234 into a resource or a bundle.", e.getMessage());
+			assertEquals("HAPI-2384: Unable to translate url 1234 into a resource or a bundle.", e.getMessage());
 		}
 	}
 
@@ -106,7 +106,7 @@ class CdsPrefetchFhirClientSvcTest {
 			IBaseResource srq = myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "/1234");
 			fail("should throw, no resource present");
 		} catch (InvalidRequestException e) {
-			assertEquals("Failed to resolve /1234. Url does not start with a resource type.", e.getMessage());
+			assertEquals("HAPI-2383: Failed to resolve /1234. Url does not start with a resource type.", e.getMessage());
 		}
 	}
 }

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilTest.java
@@ -36,7 +36,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
+			assertEquals("HAPI-2375: Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
 		}
 	}
 
@@ -50,7 +50,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
+			assertEquals("HAPI-2375: Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
 		}
 	}
 
@@ -63,7 +63,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Request context did not provide a value for key <draftOrders>.  Available keys in context are: [patientId]", e.getMessage());
+			assertEquals("HAPI-2372: Request context did not provide a value for key <draftOrders>.  Available keys in context are: [patientId]", e.getMessage());
 		}
 	}
 
@@ -119,7 +119,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail("substituteTemplate call was successful with a null context field.");
 		} catch (InvalidRequestException e) {
-			assertEquals("Request context did not provide for resource(s) matching template. ResourceType missing is: ServiceRequest", e.getMessage());
+			assertEquals("HAPI-2373: Request context did not provide for resource(s) matching template. ResourceType missing is: ServiceRequest", e.getMessage());
 		}
 	}
 
@@ -134,7 +134,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Request context did not provide valid " + fhirContextR4.getVersion().getVersion() + " Bundle resource for template key <draftOrders>" , e.getMessage());
+			assertEquals("HAPI-2374: Request context did not provide valid " + fhirContextR4.getVersion().getVersion() + " Bundle resource for template key <draftOrders>", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -212,7 +212,7 @@
 		<dependency>
 			<groupId>io.specto</groupId>
 			<artifactId>hoverfly-java-junit5</artifactId>
-			<version>0.14.3</version>
+			<version>0.14.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlPathTokenizerTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlPathTokenizerTest.java
@@ -1,0 +1,78 @@
+package ca.uhn.fhir.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UrlPathTokenizerTest {
+
+	@Test
+	void urlPathTokenizer_withValidPath_tokenizesCorrectly() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("/root/subdir/subsubdir/file.html");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals(4, tokenizer.countTokens());
+		assertEquals("root", tokenizer.nextTokenUnescapedAndSanitized());
+		assertEquals("subdir", tokenizer.nextTokenUnescapedAndSanitized());
+		assertEquals("subsubdir", tokenizer.nextTokenUnescapedAndSanitized());
+		assertEquals("file.html", tokenizer.nextTokenUnescapedAndSanitized());
+		assertFalse(tokenizer.hasMoreTokens());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"",               // actually empty
+		"///////",        // effectively empty
+		"//  / / /  /   " // effectively empty with extraneous whitespace
+	})
+	void urlPathTokenizer_withEmptyPath_returnsEmpty(String thePath) {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer(thePath);
+		assertEquals(0, tokenizer.countTokens());
+	}
+
+	@Test
+	void urlPathTokenizer_withNullPath_returnsEmpty() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer(null);
+		assertEquals(0, tokenizer.countTokens());
+	}
+
+	@Test
+	void urlPathTokenizer_withSinglePathElement_returnsSingleToken() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("hello");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("hello", tokenizer.nextTokenUnescapedAndSanitized());
+	}
+
+	@Test
+	void urlPathTokenizer_withEscapedPath_shouldUnescape() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("Homer%20Simpson");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("Homer Simpson", tokenizer.nextTokenUnescapedAndSanitized());
+
+		tokenizer = new UrlPathTokenizer("hack%2Fslash");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("hack/slash", tokenizer.nextTokenUnescapedAndSanitized());
+	}
+
+	@Test
+	void urlPathTokenizer_peek_shouldNotConsumeTokens() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("this/that");
+		assertEquals(2, tokenizer.countTokens());
+		tokenizer.peek();
+		assertEquals(2, tokenizer.countTokens());
+	}
+
+	@Test
+	void urlPathTokenizer_withSuspiciousCharacters_sanitizesCorrectly() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("<DROP TABLE USERS>");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("&lt;DROP TABLE USERS&gt;", tokenizer.nextTokenUnescapedAndSanitized());
+
+		tokenizer = new UrlPathTokenizer("'\n\r\"");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("&apos;&#10;&#13;&quot;", tokenizer.nextTokenUnescapedAndSanitized());
+	}
+}

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
@@ -1,0 +1,173 @@
+package ca.uhn.fhir.rest.server.tenant;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.HapiLocalizer;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.util.UrlPathTokenizer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UrlBaseTenantIdentificationStrategyTest {
+
+	private final static String BASE_URL = "http://localhost:8888";
+
+	@Mock
+	private RequestDetails myRequestDetails;
+	private static SystemRequestDetails ourSystemRequestDetails;
+	@Mock
+	private IRestfulServerDefaults myRestfulServerDefaults;
+	@Mock
+	private FhirContext myFHIRContext;
+	@Mock
+	private HapiLocalizer myHapiLocalizer;
+
+	private static UrlBaseTenantIdentificationStrategy ourTenantStrategy;
+	private UrlPathTokenizer myUrlTokenizer;
+
+	@BeforeAll
+	static void setup() {
+		ourSystemRequestDetails = new SystemRequestDetails();
+		ourTenantStrategy = new UrlBaseTenantIdentificationStrategy();
+	}
+
+	@Test
+	void massageBaseUrl_givenBaseUrlAndTenant_shouldApplyTenant() {
+		//given a tenant id of TENANT1
+		when(myRequestDetails.getTenantId()).thenReturn("TENANT1");
+
+		//when we massage the server base url
+		String actual = ourTenantStrategy.massageServerBaseUrl(BASE_URL, myRequestDetails);
+
+		//then we should see /TENANT1 in the url
+		assertEquals(BASE_URL + "/TENANT1", actual);
+	}
+
+	@Test
+	void massageBaseUrl_givenBaseUrlAndNullTenant_shouldReturnBaseUrl() {
+		//given a null tenant id
+		when(myRequestDetails.getTenantId()).thenReturn(null);
+
+		//when we massage our base url
+		String actual = ourTenantStrategy.massageServerBaseUrl(BASE_URL, myRequestDetails);
+
+		//then nothing should happen
+		assertEquals(BASE_URL, actual);
+	}
+
+	@Test
+	void extractTenant_givenNormalRequestAndExplicitTenant_shouldUseTenant() {
+		//given a Patient request on MYTENANT
+		myUrlTokenizer = new UrlPathTokenizer("MYTENANT/Patient");
+
+		//when we extract the tenant identifier
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see MYTENANT
+		verify(myRequestDetails, times(1)).setTenantId("MYTENANT");
+	}
+
+	@Test
+	void extractTenant_givenSystemRequestWithNoTenant_shouldUseDefault() {
+		//given any request that starts with $ and no given partition name
+		myUrlTokenizer = new UrlPathTokenizer("$partition-management-create-partition");
+
+		//when we try to extract the tenant id
+		ourTenantStrategy.extractTenant(myUrlTokenizer, ourSystemRequestDetails);
+
+		//then we should see that it defaulted to the DEFAULT partition
+		assertEquals("DEFAULT", ourSystemRequestDetails.getTenantId());
+	}
+
+	@Test
+	void extractTenant_givenSystemRequestWithExplicitTenant_shouldUseTenant() {
+		//given a request that starts with $ on a named partition
+		myUrlTokenizer = new UrlPathTokenizer("MYTENANT/$partition-management-create-partition");
+
+		//when we extract the tenant from the request
+		ourTenantStrategy.extractTenant(myUrlTokenizer, ourSystemRequestDetails);
+
+		//then we should see MYTENANT
+		assertEquals("MYTENANT", ourSystemRequestDetails.getTenantId());
+	}
+
+	@Test
+	void extractTenant_givenMetadataRequestWithNoTenant_shouldUseDefault() {
+		//given a metadata request with no specified partition name
+		myUrlTokenizer = new UrlPathTokenizer("metadata");
+
+		//when we try to extract the tenant from the request
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see that it defaulted to the DEFAULT partition
+		verify(myRequestDetails, times(1)).setTenantId("DEFAULT");
+	}
+
+	@Test
+	void extractTenant_givenMetadataRequestWithExplicitTenant_shouldUseTenant() {
+		//given a metadata request on a named partition
+		myUrlTokenizer = new UrlPathTokenizer("MYTENANT/metadata");
+
+		//when we extract the tenant id
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see MYTENANT
+		verify(myRequestDetails, times(1)).setTenantId("MYTENANT");
+	}
+
+	@Test
+	void extractTenant_givenPatientRequestAndNoTenant_shouldInterpretPatientAsPartition() {
+		//given a Patient request with no partition name specified
+		myUrlTokenizer = new UrlPathTokenizer("Patient");
+
+		//when we try to extract the tenant from the request
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see that it interpreted Patient as the partition name
+		verify(myRequestDetails, times(1)).setTenantId("Patient");
+	}
+
+	@Test
+	void extractTenant_givenEmptyURLNoPartition_shouldThrowException() {
+		//given an empty URL with no partition name
+		when(myRequestDetails.getServer()).thenReturn(myRestfulServerDefaults);
+		when(myRestfulServerDefaults.getFhirContext()).thenReturn(myFHIRContext);
+		when(myFHIRContext.getLocalizer()).thenReturn(myHapiLocalizer);
+		myUrlTokenizer = new UrlPathTokenizer("");
+
+		//when we try to extract the tenant from the request
+		InvalidRequestException ire = assertThrows(InvalidRequestException.class, () -> {
+			ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+		});
+
+		//then we should see an exception thrown with HAPI-0307 in it
+		verify(myHapiLocalizer, times(1)).getMessage(RestfulServer.class, "rootRequest.multitenant");
+		assertTrue(ire.getMessage().contains("HAPI-0307"));
+	}
+
+	@Test
+	void extractTenant_givenSystemRequestWithEmptyUrl_shouldUseDefaultPartition() {
+		//given a system request with a blank url (is this even a valid test case?)
+		myUrlTokenizer = new UrlPathTokenizer("");
+
+		//when we try to extract the tenant id
+		ourTenantStrategy.extractTenant(myUrlTokenizer, ourSystemRequestDetails);
+
+		//then we should see that it defaulted to the DEFAULT partition
+		assertEquals("DEFAULT", ourSystemRequestDetails.getTenantId());
+	}
+}


### PR DESCRIPTION
Changes:

- `UrlPathTokenizer` uses StringTokenizer, which is old and inflexible. Replace this.
- Modify `UrlBaseTenantIdentificationStrategy` such that it uses the DEFAULT partition for server-based requests or metadata requests if no partition is explicitly given.
- Keep the existing behaviour of failing non server-based requests if they don't specify a partition, but change 500 Internal Server Error to a 400 Bad Request with a HAPI-0307 response body.
- Add tests... lots of tests

Closes [5123](https://github.com/hapifhir/hapi-fhir/issues/5123)