### PR TITLE
$delete-expunge over 10k resources will now delete all resources

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5150--delete-expunge-over-10k-resources-deletes-only-10k.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5150--delete-expunge-over-10k-resources-deletes-only-10k.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5150
+title: "When running a $delete-expunge with over 10,000 resources, only the first 10,000 resources were deleted.
+        This is now fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/9999-something.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/9999-something.yaml
@@ -1,4 +1,0 @@
----
-type: fix
-issue: 9999
-title: "Something something"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/9999-something.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/9999-something.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 9999
+title: "Something something"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
@@ -42,8 +42,20 @@ import javax.persistence.EntityManager;
 public class Batch2SupportConfig {
 
 	@Bean
-	public IBatch2DaoSvc batch2DaoSvc(IResourceTableDao theResourceTableDao, MatchUrlService theMatchUrlService, DaoRegistry theDaoRegistry, FhirContext theFhirContext, IHapiTransactionService theTransactionService, JpaStorageSettings theJpaStorageSettings) {
-		return new Batch2DaoSvcImpl(theResourceTableDao, theMatchUrlService, theDaoRegistry, theFhirContext, theTransactionService, theJpaStorageSettings);
+	public IBatch2DaoSvc batch2DaoSvc(
+			IResourceTableDao theResourceTableDao,
+			MatchUrlService theMatchUrlService,
+			DaoRegistry theDaoRegistry,
+			FhirContext theFhirContext,
+			IHapiTransactionService theTransactionService,
+			JpaStorageSettings theJpaStorageSettings) {
+		return new Batch2DaoSvcImpl(
+				theResourceTableDao,
+				theMatchUrlService,
+				theDaoRegistry,
+				theFhirContext,
+				theTransactionService,
+				theJpaStorageSettings);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
@@ -19,16 +19,21 @@
  */
 package ca.uhn.fhir.jpa.config;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
 import ca.uhn.fhir.jpa.api.svc.IDeleteExpungeSvc;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
 import ca.uhn.fhir.jpa.dao.data.IResourceLinkDao;
+import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
 import ca.uhn.fhir.jpa.dao.expunge.ResourceTableFKProvider;
+import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSqlBuilder;
 import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSvcImpl;
 import ca.uhn.fhir.jpa.reindex.Batch2DaoSvcImpl;
+import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 
@@ -37,8 +42,8 @@ import javax.persistence.EntityManager;
 public class Batch2SupportConfig {
 
 	@Bean
-	public IBatch2DaoSvc batch2DaoSvc() {
-		return new Batch2DaoSvcImpl();
+	public IBatch2DaoSvc batch2DaoSvc(IResourceTableDao theResourceTableDao, MatchUrlService theMatchUrlService, DaoRegistry theDaoRegistry, FhirContext theFhirContext, IHapiTransactionService theTransactionService, JpaStorageSettings theJpaStorageSettings) {
+		return new Batch2DaoSvcImpl(theResourceTableDao, theMatchUrlService, theDaoRegistry, theFhirContext, theTransactionService, theJpaStorageSettings);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -107,29 +107,27 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 	}
 
 	@Nonnull
-	private HomogeneousResourcePidList fetchResourceIdsPageWithUrl(Date theEnd, @Nonnull String theUrl, @Nullable RequestPartitionId theRequestPartitionId) {
+	private HomogeneousResourcePidList fetchResourceIdsPageWithUrl(
+			Date theEnd, @Nonnull String theUrl, @Nullable RequestPartitionId theRequestPartitionId) {
 		if (!theUrl.contains("?")) {
-			throw new InternalErrorException(
-					Msg.code(2422) + "this should never happen: URL is missing a '?'");
+			throw new InternalErrorException(Msg.code(2422) + "this should never happen: URL is missing a '?'");
 		}
 
-		final Integer internalSynchronousSearchSize =
-				myJpaStorageSettings.getInternalSynchronousSearchSize();
+		final Integer internalSynchronousSearchSize = myJpaStorageSettings.getInternalSynchronousSearchSize();
 
 		if (internalSynchronousSearchSize == null || internalSynchronousSearchSize <= 0) {
-			throw new InternalErrorException(
-					Msg.code(2423)
-							+ "this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
+			throw new InternalErrorException(Msg.code(2423)
+					+ "this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
 		}
 
-		List<IResourcePersistentId> currentIds =
-				fetchResourceIdsPageWithUrl(0, theUrl, theRequestPartitionId);
+		List<IResourcePersistentId> currentIds = fetchResourceIdsPageWithUrl(0, theUrl, theRequestPartitionId);
 		ourLog.debug("FIRST currentIds: {}", currentIds.size());
 
 		final List<IResourcePersistentId> allIds = new ArrayList<>(currentIds);
 
 		while (internalSynchronousSearchSize < currentIds.size()) {
-			// Ensure the offset is set to the last ID in the cumulative List, otherwise, we'll be stuck in an infinite loop here:
+			// Ensure the offset is set to the last ID in the cumulative List, otherwise, we'll be stuck in an infinite
+			// loop here:
 			currentIds = fetchResourceIdsPageWithUrl(allIds.size(), theUrl, theRequestPartitionId);
 			ourLog.debug("NEXT currentIds: {}", currentIds.size());
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.reindex;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
@@ -102,16 +103,16 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 					} else {
 						if (!theUrl.contains("?")) {
 							throw new InternalErrorException(
-									"HAPI-99999:  this should never happen: URL is missing a '?'");
+									Msg.code(2422) + ":  this should never happen: URL is missing a '?'");
 						}
 
 						final Integer internalSynchronousSearchSize =
 								myJpaStorageSettings.getInternalSynchronousSearchSize();
 
 						if (internalSynchronousSearchSize == null || internalSynchronousSearchSize <= 0) {
-							// TODO:  new HAPI code
 							throw new InternalErrorException(
-									"HAPI-99999:  this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
+									Msg.code(2423)
+											+ ":  this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
 						}
 
 						List<IResourcePersistentId> currentIds =

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -89,14 +89,7 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 
 	@Override
 	public IResourcePidList fetchResourceIdsPage(
-			Date theStart,
-			Date theEnd,
-			// TODO:  LD: We must keep thePageSize parameter here for the time being even if though it's no longer used
-			// in this class because
-			// otherwise we'll break other implementors of IBatch2DaoSvc
-			@Nonnull Integer thePageSize,
-			@Nullable RequestPartitionId theRequestPartitionId,
-			@Nullable String theUrl) {
+			Date theStart, Date theEnd, @Nullable RequestPartitionId theRequestPartitionId, @Nullable String theUrl) {
 		return myTransactionService
 				.withSystemRequest()
 				.withRequestPartitionId(theRequestPartitionId)

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -159,7 +159,9 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 	@Nonnull
 	private IResourcePidList fetchResourceIdsPageNoUrl(
 			Date theStart, Date theEnd, int thePagesize, RequestPartitionId theRequestPartitionId) {
-		Pageable page = Pageable.ofSize(thePagesize);
+//		Pageable page = Pageable.ofSize(thePagesize);
+		// TODO:  test this
+		Pageable page = Pageable.unpaged();
 		Slice<Object[]> slice;
 		if (theRequestPartitionId == null || theRequestPartitionId.isAllPartitions()) {
 			slice = myResourceTableDao.findIdsTypesAndUpdateTimesOfResourcesWithinUpdatedRangeOrderedFromOldest(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -51,8 +51,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-
 public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(Batch2DaoSvcImpl.class);
 
@@ -73,7 +71,13 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 		return true;
 	}
 
-	public Batch2DaoSvcImpl(IResourceTableDao theResourceTableDao, MatchUrlService theMatchUrlService, DaoRegistry theDaoRegistry, FhirContext theFhirContext, IHapiTransactionService theTransactionService, JpaStorageSettings theJpaStorageSettings) {
+	public Batch2DaoSvcImpl(
+			IResourceTableDao theResourceTableDao,
+			MatchUrlService theMatchUrlService,
+			DaoRegistry theDaoRegistry,
+			FhirContext theFhirContext,
+			IHapiTransactionService theTransactionService,
+			JpaStorageSettings theJpaStorageSettings) {
 		myResourceTableDao = theResourceTableDao;
 		myMatchUrlService = theMatchUrlService;
 		myDaoRegistry = theDaoRegistry;
@@ -97,20 +101,24 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 						return fetchResourceIdsPageNoUrl(theStart, theEnd, thePageSize, theRequestPartitionId);
 					} else {
 						if (!theUrl.contains("?")) {
-							throw new InternalErrorException("HAPI-99999:  this should never happen: URL is missing a '?'");
+							throw new InternalErrorException(
+									"HAPI-99999:  this should never happen: URL is missing a '?'");
 						}
 
-						final Integer internalSynchronousSearchSize = myJpaStorageSettings.getInternalSynchronousSearchSize();
+						final Integer internalSynchronousSearchSize =
+								myJpaStorageSettings.getInternalSynchronousSearchSize();
 
-						if (internalSynchronousSearchSize == null || internalSynchronousSearchSize <= 0)  {
+						if (internalSynchronousSearchSize == null || internalSynchronousSearchSize <= 0) {
 							// TODO:  new HAPI code
-							throw new InternalErrorException("HAPI-99999:  this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
+							throw new InternalErrorException(
+									"HAPI-99999:  this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
 						}
 
-						List<IResourcePersistentId> currentIds = fetchResourceIdsPageWithUrl(0, theUrl, theRequestPartitionId);
+						List<IResourcePersistentId> currentIds =
+								fetchResourceIdsPageWithUrl(0, theUrl, theRequestPartitionId);
 						ourLog.info("FIRST currentIds: {}", currentIds.size());
 						final List<IResourcePersistentId> allIds = new ArrayList<>(currentIds);
-						while (internalSynchronousSearchSize < currentIds.size() ) {
+						while (internalSynchronousSearchSize < currentIds.size()) {
 							currentIds = fetchResourceIdsPageWithUrl(allIds.size(), theUrl, theRequestPartitionId);
 							ourLog.info("NEXT currentIds: {}", currentIds.size());
 							allIds.addAll(currentIds);
@@ -123,7 +131,8 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 				});
 	}
 
-	private List<IResourcePersistentId> fetchResourceIdsPageWithUrl(int theOffset, String theUrl, RequestPartitionId theRequestPartitionId) {
+	private List<IResourcePersistentId> fetchResourceIdsPageWithUrl(
+			int theOffset, String theUrl, RequestPartitionId theRequestPartitionId) {
 		String resourceType = theUrl.substring(0, theUrl.indexOf('?'));
 		RuntimeResourceDefinition def = myFhirContext.getResourceDefinition(resourceType);
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -91,6 +91,9 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 	public IResourcePidList fetchResourceIdsPage(
 			Date theStart,
 			Date theEnd,
+			// TODO:  LD: We must keep thePageSize parameter here for the time being even if though it's no longer used
+			// in this class because
+			// otherwise we'll break other implementors of IBatch2DaoSvc
 			@Nonnull Integer thePageSize,
 			@Nullable RequestPartitionId theRequestPartitionId,
 			@Nullable String theUrl) {
@@ -99,7 +102,7 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 				.withRequestPartitionId(theRequestPartitionId)
 				.execute(() -> {
 					if (theUrl == null) {
-						return fetchResourceIdsPageNoUrl(theStart, theEnd, thePageSize, theRequestPartitionId);
+						return fetchResourceIdsPageNoUrl(theStart, theEnd, theRequestPartitionId);
 					} else {
 						return fetchResourceIdsPageWithUrl(theEnd, theUrl, theRequestPartitionId);
 					}
@@ -158,8 +161,8 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 
 	@Nonnull
 	private IResourcePidList fetchResourceIdsPageNoUrl(
-			Date theStart, Date theEnd, int thePagesize, RequestPartitionId theRequestPartitionId) {
-		Pageable page = Pageable.unpaged();
+			Date theStart, Date theEnd, RequestPartitionId theRequestPartitionId) {
+		final Pageable page = Pageable.unpaged();
 		Slice<Object[]> slice;
 		if (theRequestPartitionId == null || theRequestPartitionId.isAllPartitions()) {
 			slice = myResourceTableDao.findIdsTypesAndUpdateTimesOfResourcesWithinUpdatedRangeOrderedFromOldest(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -103,7 +103,7 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 					} else {
 						if (!theUrl.contains("?")) {
 							throw new InternalErrorException(
-									Msg.code(2422) + ":  this should never happen: URL is missing a '?'");
+									Msg.code(2422) + "this should never happen: URL is missing a '?'");
 						}
 
 						final Integer internalSynchronousSearchSize =

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -159,8 +159,6 @@ public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
 	@Nonnull
 	private IResourcePidList fetchResourceIdsPageNoUrl(
 			Date theStart, Date theEnd, int thePagesize, RequestPartitionId theRequestPartitionId) {
-//		Pageable page = Pageable.ofSize(thePagesize);
-		// TODO:  test this
 		Pageable page = Pageable.unpaged();
 		Slice<Object[]> slice;
 		if (theRequestPartitionId == null || theRequestPartitionId.isAllPartitions()) {

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/GoldenResourceSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/GoldenResourceSearchSvcImpl.java
@@ -82,8 +82,6 @@ public class GoldenResourceSearchSvcImpl implements IGoldenResourceSearchSvc {
 		DateRangeParam chunkDateRange =
 				DateRangeUtil.narrowDateRange(searchParamMap.getLastUpdated(), theStart, theEnd);
 		searchParamMap.setLastUpdated(chunkDateRange);
-		// TODO:  test this
-//		searchParamMap.setCount(thePageSize); // request this many pids
 		searchParamMap.add(
 				"_tag", new TokenParam(MdmConstants.SYSTEM_GOLDEN_RECORD_STATUS, MdmConstants.CODE_GOLDEN_RECORD));
 

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/GoldenResourceSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/GoldenResourceSearchSvcImpl.java
@@ -82,7 +82,8 @@ public class GoldenResourceSearchSvcImpl implements IGoldenResourceSearchSvc {
 		DateRangeParam chunkDateRange =
 				DateRangeUtil.narrowDateRange(searchParamMap.getLastUpdated(), theStart, theEnd);
 		searchParamMap.setLastUpdated(chunkDateRange);
-		searchParamMap.setCount(thePageSize); // request this many pids
+		// TODO:  test this
+//		searchParamMap.setCount(thePageSize); // request this many pids
 		searchParamMap.add(
 				"_tag", new TokenParam(MdmConstants.SYSTEM_GOLDEN_RECORD_STATUS, MdmConstants.CODE_GOLDEN_RECORD));
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantBatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantBatchOperationR4Test.java
@@ -32,10 +32,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.DEFAULT_PARTITION_NAME;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -108,7 +106,7 @@ public class MultitenantBatchOperationR4Test extends BaseMultitenantResourceProv
 		String jobId = BatchHelperR4.jobIdFromBatch2Parameters(response);
 		myBatch2JobHelper.awaitJobCompletion(jobId);
 
-		assertThat(interceptor.requestPartitionIds, hasSize(5));
+		assertThat(interceptor.requestPartitionIds, hasSize(4));
 		RequestPartitionId partitionId = interceptor.requestPartitionIds.get(0);
 		assertEquals(TENANT_B_ID, partitionId.getFirstPartitionIdOrNull());
 		assertEquals(TENANT_B, partitionId.getFirstPartitionNameOrNull());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
@@ -83,6 +83,17 @@ class Batch2DaoSvcImplTest extends BaseJpaR4Test {
 		}
 	}
 
+	@Test
+	void fetchResourcesByUrlNonsensicalResource() {
+		try {
+			mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "Banana?_expunge=true");
+		} catch (InternalErrorException exception) {
+			assertEquals("HAPI-2223: HAPI-1684: Unknown resource name \"Banana\" (this name is not known in FHIR version \"R4\")", exception.getMessage());
+		} catch (Exception exception) {
+			fail("caught wrong Exception");
+		}
+	}
+
 	@ParameterizedTest
 	@ValueSource(ints = {0, 9, 10, 11, 21, 22, 23, 45})
 	void fetchResourcesByUrl(int expectedNumResults) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
@@ -1,0 +1,117 @@
+package ca.uhn.fhir.jpa.reindex;
+
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
+import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
+import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
+import ca.uhn.fhir.jpa.dao.tx.NonTransactionalHapiTransactionService;
+import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.Nonnull;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Batch2DaoSvcImplTest extends BaseJpaR4Test {
+
+	private static final Date PREVIOUS_MILLENNIUM = toDate(LocalDate.of(1999, Month.DECEMBER, 31));
+	private static final Date TOMORROW = toDate(LocalDate.now().plusDays(1));
+	private static final String URL_PATIENT_EXPUNGE_TRUE = "Patient?_expunge=true";
+
+//	@Autowired
+	private IBatch2DaoSvc mySubject;
+
+	@Autowired
+	private JpaStorageSettings myJpaStorageSettings;
+	@Autowired
+	private MatchUrlService myMatchUrlService;
+	private final IHapiTransactionService myTransactionService = new NonTransactionalHapiTransactionService();
+
+	@BeforeEach
+	void beforeEach() {
+		myJpaStorageSettings.setInternalSynchronousSearchSize(10);
+		mySubject = new Batch2DaoSvcImpl(myResourceTableDao, myMatchUrlService, myDaoRegistry, myFhirContext, myTransactionService, myJpaStorageSettings);
+	}
+
+	@Test
+	void fetchResourcesByUrl_noResults() {
+		// TODO:  grab value from the functional test and use them here
+		// TODO:  try different variants of URLs and fail appropriately
+		final IResourcePidList resourcePidList = mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), URL_PATIENT_EXPUNGE_TRUE);
+
+		assertTrue(resourcePidList.isEmpty());
+	}
+
+	@Test
+	void fetchResourcesByUrl_oneResultLessThanThreshold() {
+		final int expectedNumResults = 9;
+
+		IntStream.range(0, expectedNumResults)
+			.forEach(num -> createPatient());
+
+		final IBundleProvider search = myPatientDao.search(SearchParameterMap.newSynchronous(), new SystemRequestDetails());
+		// TODO:  grab value from the functional test and use them here
+		// TODO:  try different variants of URLs and fail appropriately
+		// TODO:  today plus one day?
+		final IResourcePidList resourcePidList = mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), URL_PATIENT_EXPUNGE_TRUE);
+
+		// TODO:  figure out how to spy on results to figure out the number of dao calls
+		assertEquals(expectedNumResults, resourcePidList.size());
+	}
+
+	@Test
+	void fetchResourcesByUrl_resultsEqualToThreshold() {
+		final int expectedNumResults = 10;
+
+		IntStream.range(0, expectedNumResults)
+			.forEach(num -> createPatient(withId("patient"+num)));
+
+		final IBundleProvider search = myPatientDao.search(SearchParameterMap.newSynchronous(), new SystemRequestDetails());
+		// TODO:  grab value from the functional test and use them here
+		// TODO:  try different variants of URLs and fail appropriately
+		// TODO:  today plus one day?
+		final IResourcePidList resourcePidList = mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), URL_PATIENT_EXPUNGE_TRUE);
+
+		// TODO:  figure out how to spy on results to figure out the number of dao calls
+		assertEquals(expectedNumResults, resourcePidList.size());
+	}
+
+	// TODO:  parameterized
+	@Test
+	void fetchResourcesByUrl_resultsOverThreshold() {
+		final int expectedNumResults = 11;
+
+		IntStream.range(0, expectedNumResults)
+			.forEach(num -> createPatient());
+
+		final IBundleProvider search = myPatientDao.search(SearchParameterMap.newSynchronous(), new SystemRequestDetails());
+		// TODO:  grab value from the functional test and use them here
+		// TODO:  try different variants of URLs and fail appropriately
+		// TODO:  today plus one day?
+		final IResourcePidList resourcePidList = mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), URL_PATIENT_EXPUNGE_TRUE);
+
+		// TODO:  figure out how to spy on results to figure out the number of dao calls
+		assertEquals(expectedNumResults, resourcePidList.size());
+	}
+
+	@Nonnull
+	private static Date toDate(LocalDate theLocalDate) {
+		return Date.from(theLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
@@ -63,35 +63,23 @@ class Batch2DaoSvcImplTest extends BaseJpaR4Test {
 
 	@Test
 	void fetchResourcesByUrlEmptyUrl() {
-		try {
-			mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "");
-		} catch (InternalErrorException exception) {
-			assertEquals("HAPI-2422: this should never happen: URL is missing a '?'", exception.getMessage());
-		} catch (Exception exception) {
-			fail("caught wrong Exception");
-		}
+		final InternalErrorException exception = assertThrows(InternalErrorException.class, () -> mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), ""));
+
+		assertEquals("HAPI-2422: this should never happen: URL is missing a '?'", exception.getMessage());
 	}
 
 	@Test
 	void fetchResourcesByUrlSingleQuestionMark() {
-		try {
-			mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "?");
-		} catch (InternalErrorException exception) {
-			assertEquals("HAPI-2223: theResourceName must not be blank", exception.getMessage());
-		} catch (Exception exception) {
-			fail("caught wrong Exception");
-		}
+		final InternalErrorException exception = assertThrows(InternalErrorException.class, () -> mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "?"));
+
+		assertEquals("HAPI-2223: theResourceName must not be blank", exception.getMessage());
 	}
 
 	@Test
 	void fetchResourcesByUrlNonsensicalResource() {
-		try {
-			mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "Banana?_expunge=true");
-		} catch (InternalErrorException exception) {
-			assertEquals("HAPI-2223: HAPI-1684: Unknown resource name \"Banana\" (this name is not known in FHIR version \"R4\")", exception.getMessage());
-		} catch (Exception exception) {
-			fail("caught wrong Exception");
-		}
+		final InternalErrorException exception = assertThrows(InternalErrorException.class, () -> mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "Banana?_expunge=true"));
+
+		assertEquals("HAPI-2223: HAPI-1684: Unknown resource name \"Banana\" (this name is not known in FHIR version \"R4\")", exception.getMessage());
 	}
 
 	@ParameterizedTest

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
@@ -8,11 +8,8 @@ import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.dao.tx.NonTransactionalHapiTransactionService;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
-import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.model.primitive.IdDt;
-import ca.uhn.fhir.rest.api.server.IBundleProvider;
-import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +66,7 @@ class Batch2DaoSvcImplTest extends BaseJpaR4Test {
 		try {
 			mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "");
 		} catch (InternalErrorException exception) {
-			assertEquals("HAPI-99999:  this should never happen: URL is missing a '?'", exception.getMessage());
+			assertEquals("HAPI-2422: this should never happen: URL is missing a '?'", exception.getMessage());
 		} catch (Exception exception) {
 			fail("caught wrong Exception");
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/ResourceReindexSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/ResourceReindexSvcImplTest.java
@@ -3,16 +3,13 @@ package ca.uhn.fhir.jpa.reindex;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
-import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
-import org.hl7.fhir.r4.model.DateType;
-import org.hl7.fhir.r4.model.InstantType;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -111,26 +108,26 @@ public class ResourceReindexSvcImplTest extends BaseJpaR4Test {
 
 		// Setup
 
-		createPatient(withActiveFalse());
+		final Long patientId0 = createPatient(withActiveFalse()).getIdPartAsLong();
 		sleepUntilTimeChanges();
 
 		// Start of resources within range
 		Date start = new Date();
 		sleepUntilTimeChanges();
-		Long id0 = createPatient(withActiveFalse()).getIdPartAsLong();
+		Long patientId1 = createPatient(withActiveFalse()).getIdPartAsLong();
 		createObservation(withObservationCode("http://foo", "bar"));
 		createObservation(withObservationCode("http://foo", "bar"));
 		sleepUntilTimeChanges();
 		Date beforeLastInRange = new Date();
 		sleepUntilTimeChanges();
-		Long id1 = createPatient(withActiveFalse()).getIdPartAsLong();
+		Long patientId2 = createPatient(withActiveFalse()).getIdPartAsLong();
 		sleepUntilTimeChanges();
 		Date end = new Date();
 		sleepUntilTimeChanges();
 		// End of resources within range
 
 		createObservation(withObservationCode("http://foo", "bar"));
-		createPatient(withActiveFalse());
+		final Long patientId3 = createPatient(withActiveFalse()).getIdPartAsLong();
 		sleepUntilTimeChanges();
 
 		// Execute
@@ -140,13 +137,17 @@ public class ResourceReindexSvcImplTest extends BaseJpaR4Test {
 
 		// Verify
 
-		assertEquals(2, page.size());
+		assertEquals(4, page.size());
 		List<TypedResourcePid> typedResourcePids = page.getTypedResourcePids();
-		assertThat(page.getTypedResourcePids(), contains(new TypedResourcePid("Patient", id0), new TypedResourcePid("Patient", id1)));
+		assertThat(page.getTypedResourcePids(),
+			contains(new TypedResourcePid("Patient", patientId0),
+				new TypedResourcePid("Patient", patientId1),
+				new TypedResourcePid("Patient", patientId2),
+				new TypedResourcePid("Patient", patientId3)));
 		assertTrue(page.getLastDate().after(beforeLastInRange));
-		assertTrue(page.getLastDate().before(end));
+		assertTrue(page.getLastDate().before(end) || page.getLastDate().equals(end));
 
-		assertEquals(3, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(1, myCaptureQueriesListener.logSelectQueries().size());
 		assertEquals(0, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(0, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -75,8 +75,8 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 
 		ourLog.info("Beginning scan for reindex IDs in range {} to {}", start, end);
 
-	  RequestPartitionId requestPartitionId =
-				 theStepExecutionDetails.getParameters().getRequestPartitionId();
+		RequestPartitionId requestPartitionId =
+				theStepExecutionDetails.getParameters().getRequestPartitionId();
 		Set<TypedPidJson> idBuffer = new LinkedHashSet<>();
 		int totalIdsFound = 0;
 		int chunkCount = 0;
@@ -87,38 +87,39 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 			maxBatchId = Math.min(batchSize.intValue(), maxBatchId);
 		}
 
-		// TODO:  get rid of the page size semantics here and deal with one huge IResourcePidList, but break it up into multiple chunks
+		// TODO:  get rid of the page size semantics here and deal with one huge IResourcePidList, but break it up into
+		// multiple chunks
 		IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
-                start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
+				start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
 		if (nextChunk.isEmpty()) {
-			  ourLog.info("No data returned");
+			ourLog.info("No data returned");
 		}
 
 		ourLog.debug("Found {} IDs from {} to {}", nextChunk.size(), start, nextChunk.getLastDate());
 		if (nextChunk.size() < 10 && HapiSystemProperties.isTestModeEnabled()) {
-			  // which is failing intermittently. If that stops, makes sense to remove this
-			  ourLog.debug(" * PIDS: {}", nextChunk);
+			// which is failing intermittently. If that stops, makes sense to remove this
+			ourLog.debug(" * PIDS: {}", nextChunk);
 		}
 
 		for (TypedResourcePid typedResourcePid : nextChunk.getTypedResourcePids()) {
-			  TypedPidJson nextId = new TypedPidJson(typedResourcePid);
-			  idBuffer.add(nextId);
+			TypedPidJson nextId = new TypedPidJson(typedResourcePid);
+			idBuffer.add(nextId);
 		}
 
 		while (idBuffer.size() > maxBatchId) {
-			  List<TypedPidJson> submissionIds = new ArrayList<>();
-			  for (Iterator<TypedPidJson> iter = idBuffer.iterator(); iter.hasNext(); ) {
-					 submissionIds.add(iter.next());
-					 iter.remove();
-					 if (submissionIds.size() == maxBatchId) {
-							 break;
-					 }
-			  }
+			List<TypedPidJson> submissionIds = new ArrayList<>();
+			for (Iterator<TypedPidJson> iter = idBuffer.iterator(); iter.hasNext(); ) {
+				submissionIds.add(iter.next());
+				iter.remove();
+				if (submissionIds.size() == maxBatchId) {
+					break;
+				}
+			}
 
-			  totalIdsFound += submissionIds.size();
-			  chunkCount++;
-			  submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
+			totalIdsFound += submissionIds.size();
+			chunkCount++;
+			submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
 		}
 
 		totalIdsFound += idBuffer.size();

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -91,7 +91,7 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 				start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
 		if (nextChunk.isEmpty()) {
-			ourLog.info("No data returned");
+			ourLog.info("No data returned"); //x
 		}
 
 		ourLog.debug("Found {} IDs from {} to {}", nextChunk.size(), start, nextChunk.getLastDate());

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -95,10 +95,6 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 		}
 
 		ourLog.debug("Found {} IDs from {} to {}", nextChunk.size(), start, nextChunk.getLastDate());
-		if (nextChunk.size() < 10 && HapiSystemProperties.isTestModeEnabled()) {
-			// which is failing intermittently. If that stops, makes sense to remove this
-			ourLog.debug(" * PIDS: {}", nextChunk);
-		}
 
 		for (TypedResourcePid typedResourcePid : nextChunk.getTypedResourcePids()) {
 			TypedPidJson nextId = new TypedPidJson(typedResourcePid);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -87,8 +87,6 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 			maxBatchId = Math.min(batchSize.intValue(), maxBatchId);
 		}
 
-		// TODO:  get rid of the page size semantics here and deal with one huge IResourcePidList, but break it up into
-		// multiple chunks
 		IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
 				start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -88,19 +88,22 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 			// we won't go over MAX_BATCH_OF_IDS
 			maxBatchId = Math.min(batchSize.intValue(), maxBatchId);
 		}
-		while (true) {
+		// TODO: get rid of while(true)
+//		while (true) {
+			// TODO:  get rid of the page size semantics here and deal with one huge IResourcePidList, but break it up into multiple chunks
 			IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
 					nextStart, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
 			if (nextChunk.isEmpty()) {
 				ourLog.info("No data returned");
-				break;
+//				break;
 			}
 
+			// TODO:  do we need this anymore?
 			// If we get the same last time twice in a row, we've clearly reached the end
 			if (nextChunk.getLastDate().getTime() == previousLastTime) {
 				ourLog.info("Matching final timestamp of {}, loading is completed", new Date(previousLastTime));
-				break;
+//				break;
 			}
 
 			ourLog.info("Found {} IDs from {} to {}", nextChunk.size(), nextStart, nextChunk.getLastDate());
@@ -115,8 +118,8 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 				idBuffer.add(nextId);
 			}
 
-			previousLastTime = nextChunk.getLastDate().getTime();
-			nextStart = nextChunk.getLastDate();
+//			previousLastTime = nextChunk.getLastDate().getTime();
+//			nextStart = nextChunk.getLastDate();
 
 			while (idBuffer.size() > maxBatchId) {
 				List<TypedPidJson> submissionIds = new ArrayList<>();
@@ -132,7 +135,7 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 				chunkCount++;
 				submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
 			}
-		}
+//		}
 
 		totalIdsFound += idBuffer.size();
 		chunkCount++;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -75,11 +75,9 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 
 		ourLog.info("Beginning scan for reindex IDs in range {} to {}", start, end);
 
-		Date nextStart = start;
-		RequestPartitionId requestPartitionId =
-				theStepExecutionDetails.getParameters().getRequestPartitionId();
+	  RequestPartitionId requestPartitionId =
+				 theStepExecutionDetails.getParameters().getRequestPartitionId();
 		Set<TypedPidJson> idBuffer = new LinkedHashSet<>();
-		long previousLastTime = 0L;
 		int totalIdsFound = 0;
 		int chunkCount = 0;
 
@@ -88,54 +86,40 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 			// we won't go over MAX_BATCH_OF_IDS
 			maxBatchId = Math.min(batchSize.intValue(), maxBatchId);
 		}
-		// TODO: get rid of while(true)
-//		while (true) {
-			// TODO:  get rid of the page size semantics here and deal with one huge IResourcePidList, but break it up into multiple chunks
-			IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
-					nextStart, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
-			if (nextChunk.isEmpty()) {
-				ourLog.info("No data returned");
-//				break;
-			}
+		// TODO:  get rid of the page size semantics here and deal with one huge IResourcePidList, but break it up into multiple chunks
+		IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
+                start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
-			// TODO:  do we need this anymore?
-			// If we get the same last time twice in a row, we've clearly reached the end
-			if (nextChunk.getLastDate().getTime() == previousLastTime) {
-				ourLog.info("Matching final timestamp of {}, loading is completed", new Date(previousLastTime));
-//				break;
-			}
+		if (nextChunk.isEmpty()) {
+			  ourLog.info("No data returned");
+		}
 
-			ourLog.info("Found {} IDs from {} to {}", nextChunk.size(), nextStart, nextChunk.getLastDate());
-			if (nextChunk.size() < 10 && HapiSystemProperties.isTestModeEnabled()) {
-				// TODO: I've added this in order to troubleshoot MultitenantBatchOperationR4Test
-				// which is failing intermittently. If that stops, makes sense to remove this
-				ourLog.info(" * PIDS: {}", nextChunk);
-			}
+		ourLog.debug("Found {} IDs from {} to {}", nextChunk.size(), start, nextChunk.getLastDate());
+		if (nextChunk.size() < 10 && HapiSystemProperties.isTestModeEnabled()) {
+			  // which is failing intermittently. If that stops, makes sense to remove this
+			  ourLog.debug(" * PIDS: {}", nextChunk);
+		}
 
-			for (TypedResourcePid typedResourcePid : nextChunk.getTypedResourcePids()) {
-				TypedPidJson nextId = new TypedPidJson(typedResourcePid);
-				idBuffer.add(nextId);
-			}
+		for (TypedResourcePid typedResourcePid : nextChunk.getTypedResourcePids()) {
+			  TypedPidJson nextId = new TypedPidJson(typedResourcePid);
+			  idBuffer.add(nextId);
+		}
 
-//			previousLastTime = nextChunk.getLastDate().getTime();
-//			nextStart = nextChunk.getLastDate();
+		while (idBuffer.size() > maxBatchId) {
+			  List<TypedPidJson> submissionIds = new ArrayList<>();
+			  for (Iterator<TypedPidJson> iter = idBuffer.iterator(); iter.hasNext(); ) {
+					 submissionIds.add(iter.next());
+					 iter.remove();
+					 if (submissionIds.size() == maxBatchId) {
+							 break;
+					 }
+			  }
 
-			while (idBuffer.size() > maxBatchId) {
-				List<TypedPidJson> submissionIds = new ArrayList<>();
-				for (Iterator<TypedPidJson> iter = idBuffer.iterator(); iter.hasNext(); ) {
-					submissionIds.add(iter.next());
-					iter.remove();
-					if (submissionIds.size() == maxBatchId) {
-						break;
-					}
-				}
-
-				totalIdsFound += submissionIds.size();
-				chunkCount++;
-				submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
-			}
-//		}
+			  totalIdsFound += submissionIds.size();
+			  chunkCount++;
+			  submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
+		}
 
 		totalIdsFound += idBuffer.size();
 		chunkCount++;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -31,7 +31,6 @@ import ca.uhn.fhir.batch2.jobs.parameters.PartitionedJobParameters;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
-import ca.uhn.fhir.system.HapiSystemProperties;
 import ca.uhn.fhir.util.Logs;
 import org.slf4j.Logger;
 
@@ -91,7 +90,7 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 				start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
 		if (nextChunk.isEmpty()) {
-			ourLog.info("No data returned"); //x
+			ourLog.info("No data returned");
 		}
 
 		ourLog.debug("Found {} IDs from {} to {}", nextChunk.size(), start, nextChunk.getLastDate());

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/LoadIdsStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/LoadIdsStepTest.java
@@ -33,7 +33,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LoadIdsStepTest {
@@ -93,9 +92,8 @@ public class LoadIdsStepTest {
 			String actual = allCapturedValues.get(i).toString();
 			assertEquals(expected, actual);
 		}
-		// TODO:  figure out what this test is about
-		assertEquals(createIdChunk(40000, 40040).toString(),
-			allCapturedValues.get(expectedLoops -1).toString());
+		final ResourceIdListWorkChunkJson expectedIdChunk = createIdChunk(19500, 20000);
+		assertEquals(expectedIdChunk.toString(), allCapturedValues.get(expectedLoops -1).toString());
 	}
 
 	@Nonnull

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/LoadIdsStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/LoadIdsStepTest.java
@@ -6,7 +6,6 @@ import ca.uhn.fhir.batch2.jobs.chunk.PartitionedUrlChunkRangeJson;
 import ca.uhn.fhir.batch2.jobs.chunk.ResourceIdListWorkChunkJson;
 import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrlListJobParameters;
 import ca.uhn.fhir.batch2.model.JobInstance;
-import ca.uhn.fhir.jpa.api.pid.EmptyResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.HomogeneousResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
@@ -30,17 +29,15 @@ import static ca.uhn.fhir.batch2.jobs.step.ResourceIdListStep.DEFAULT_PAGE_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LoadIdsStepTest {
 
 	public static final Date DATE_1 = new InstantType("2022-01-01T00:00:00Z").getValue();
 	public static final Date DATE_2 = new InstantType("2022-01-02T00:00:00Z").getValue();
-	public static final Date DATE_3 = new InstantType("2022-01-03T00:00:00Z").getValue();
-	public static final Date DATE_4 = new InstantType("2022-01-04T00:00:00Z").getValue();
 	public static final Date DATE_END = new InstantType("2022-02-01T00:00:00Z").getValue();
 
 	@Mock
@@ -71,18 +68,11 @@ public class LoadIdsStepTest {
 
 		// First Execution
 
-		lenient().when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_1), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
+		when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_1), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
 			.thenReturn(createIdChunk(0L, 20000L, DATE_2));
-		lenient().when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_2), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
-			.thenReturn(createIdChunk(20000L, 40000L, DATE_3));
-		lenient().when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_3), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
-			.thenReturn(createIdChunk(40000L, 40040L, DATE_4));
-		lenient().when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_4), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
-			.thenReturn(new EmptyResourcePidList());
 
 		mySvc.run(details, mySink);
 
-		// TODO:  figure out the semantics of the new behaviour to make this pass:
 		final int expectedLoops = 40;
 		verify(mySink, times(40)).accept(myChunkIdsCaptor.capture());
 

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
@@ -56,7 +56,7 @@ class ResourceIdListStepTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {1, 100, 500, 501, 2345})
+	@ValueSource(ints = {1, 100, 500, 501, 2345, 10500})
 	void testResourceIdListBatchSizeLimit(int theListSize) {
 		List<TypedResourcePid> idList = generateIdList(theListSize);
 		when(myStepExecutionDetails.getData()).thenReturn(myData);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IBatch2DaoSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IBatch2DaoSvc.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.api.svc;
 
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 
@@ -43,7 +44,7 @@ public interface IBatch2DaoSvc {
 	 */
 	default IResourcePidList fetchResourceIdsPage(
 			Date theStart, Date theEnd, @Nullable RequestPartitionId theRequestPartitionId, @Nullable String theUrl) {
-		throw new UnsupportedOperationException("Not implemented unless explicitly overridden");
+		throw new UnsupportedOperationException(Msg.code(2425) + "Not implemented unless explicitly overridden");
 	}
 
 	// TODO: LD:  eliminate this call in all other implementors

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IBatch2DaoSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IBatch2DaoSvc.java
@@ -38,14 +38,33 @@ public interface IBatch2DaoSvc {
 	 *
 	 * @param theStart The start of the date range, must be inclusive.
 	 * @param theEnd   The end of the date range, should be exclusive.
-	 * @param thePageSize  The number of records to query in each pass.
-	 * @param theRequestPartitionId The request partition ID (may be <code>null</code> on nonpartitioned systems)
+	 * @param theRequestPartitionId The request partition ID (may be <code>null</code> on non-partitioned systems)
 	 * @param theUrl   The search URL, or <code>null</code> to return IDs for all resources across all resource types. Null will only be supplied if {@link #isAllResourceTypeSupported()} returns <code>true</code>.
 	 */
-	IResourcePidList fetchResourceIdsPage(
+	default IResourcePidList fetchResourceIdsPage(
+			Date theStart, Date theEnd, @Nullable RequestPartitionId theRequestPartitionId, @Nullable String theUrl) {
+		throw new UnsupportedOperationException("Not implemented unless explicitly overridden");
+	}
+
+	// TODO: LD:  eliminate this call in all other implementors
+	/**
+	 * @deprecated Please call (@link {@link #fetchResourceIdsPage(Date, Date, RequestPartitionId, String)} instead.
+	 * <p/>
+	 * Fetches a page of resource IDs for all resource types. The page size is up to the discretion of the implementation.
+	 *
+	 * @param theStart The start of the date range, must be inclusive.
+	 * @param theEnd   The end of the date range, should be exclusive.
+	 * @param thePageSize  The number of records to query in each pass.
+	 * @param theRequestPartitionId The request partition ID (may be <code>null</code> on non-partitioned systems)
+	 * @param theUrl   The search URL, or <code>null</code> to return IDs for all resources across all resource types. Null will only be supplied if {@link #isAllResourceTypeSupported()} returns <code>true</code>.
+	 */
+	@Deprecated
+	default IResourcePidList fetchResourceIdsPage(
 			Date theStart,
 			Date theEnd,
 			@Nonnull Integer thePageSize,
 			@Nullable RequestPartitionId theRequestPartitionId,
-			@Nullable String theUrl);
+			@Nullable String theUrl) {
+		return fetchResourceIdsPage(theStart, theEnd, theRequestPartitionId, theUrl);
+	}
 }


### PR DESCRIPTION
- Replace the logic in Batch2DaoSvcImpl.java for URL based searches that uses last update time sorting with _id sorting instead
- Instead of a single call to the resource DAO to fetch all IDs, do multiple calls each with a SearchParameterMap loadSynchronouslyUpTo of the JpaStorageSettings.getInternalSynchronousSearchSize() + 1.  Meaning, if that configuration is 10,000, then pass 10,001 to the SearchParameterMap
- Ensure on the first call, the SearchParamterMap offset is set to 0
- Compare the configuration above with the actual results.  So if, for example, 10,001 results are returned for a configured 10,000 results, continue to search on the IDs, which are sorted by _id
- Pass the total number of accumulated results as the offset for subsequent searches.   This means if we get back well over 30,000 results, we'll loop more than twice but will still accumulate results properly
- Remove the logic in ResourceIdListStep that loops over different update date sorted pages and replace it with a single call to IIdChunkProducer
- Edit unit tests that enforced the old behaviour to make them pass under the new

Closes https://github.com/hapifhir/hapi-fhir/issues/5150