### PR TITLE
Expunge operation on codesystem may throw 500 internal error with precondition fail message.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5155-expunge-operation-on-codesystem-may-return-500.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5155-expunge-operation-on-codesystem-may-return-500.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5155
+title: "Previously, requesting an $expunge operation on CodeSystem resource while CS batch deletion is underway would return HTTP 500.
+ This has been fixed to return HTTP 412 (precondition failed)."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5155-expunge-operation-on-codesystem-may-return-500.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5155-expunge-operation-on-codesystem-may-return-500.yaml
@@ -1,5 +1,5 @@
 ---
 type: fix
 issue: 5155
-title: "Previously, requesting an $expunge operation on CodeSystem resource while CS batch deletion is underway would return HTTP 500.
+title: "Previously, requesting an $expunge operation on CodeSystem resources while CS batch deletion is underway would return HTTP 500.
  This has been fixed to return HTTP 412 (precondition failed)."

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/MdmExpungeTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/MdmExpungeTest.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.mdm.interceptor.IMdmStorageInterceptor;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,7 @@ public class MdmExpungeTest extends BaseMdmR4Test {
 		try {
 			myPatientDao.expunge(myTargetId.toVersionless(), expungeOptions, null);
 			fail();
-		} catch (InternalErrorException e) {
+		} catch (PreconditionFailedException e) {
 			assertThat(e.getMessage(), containsString("ViolationException"));
 			assertThat(e.getMessage(), containsString("FK_EMPI_LINK_TARGET"));
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ExpungeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ExpungeR4Test.java
@@ -95,6 +95,8 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 	private ISearchResultDao mySearchResultDao;
 	@Autowired
 	private ThreadSafeResourceDeleterSvc myThreadSafeResourceDeleterSvc;
+	@Autowired
+	private ExpungeService myExpungeService;
 
 	@AfterEach
 	public void afterDisableExpunge() {
@@ -212,25 +214,27 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 
 	}
 
-	public void createStandardCodeSystems() {
+	public void createStandardCodeSystemWithOneVersion(){
 		CodeSystem codeSystem1 = new CodeSystem();
 		codeSystem1.setUrl(URL_MY_CODE_SYSTEM);
 		codeSystem1.setName("CS1-V1");
 		codeSystem1.setVersion("1");
 		codeSystem1.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
 		codeSystem1
-			.addConcept().setCode("C").setDisplay("Code C").addDesignation(
-				new CodeSystem.ConceptDefinitionDesignationComponent().setLanguage("en").setValue("CodeCDesignation")).addProperty(
-				new CodeSystem.ConceptPropertyComponent().setCode("CodeCProperty").setValue(new StringType("CodeCPropertyValue"))
-			)
-			.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CA").setDisplay("Code CA")
-				.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CAA").setDisplay("Code CAA"))
-			)
-			.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CB").setDisplay("Code CB"));
+				.addConcept().setCode("C").setDisplay("Code C").addDesignation(
+						new CodeSystem.ConceptDefinitionDesignationComponent().setLanguage("en").setValue("CodeCDesignation")).addProperty(
+						new CodeSystem.ConceptPropertyComponent().setCode("CodeCProperty").setValue(new StringType("CodeCPropertyValue"))
+				)
+				.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CA").setDisplay("Code CA")
+						.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CAA").setDisplay("Code CAA"))
+				)
+				.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CB").setDisplay("Code CB"));
 		codeSystem1
-			.addConcept().setCode("D").setDisplay("Code D");
+				.addConcept().setCode("D").setDisplay("Code D");
 		myOneVersionCodeSystemId = myCodeSystemDao.create(codeSystem1).getId();
+	}
 
+	public void createStandardCodeSystemWithTwoVersions(){
 		CodeSystem cs2v1 = new CodeSystem();
 		cs2v1.setUrl(URL_MY_CODE_SYSTEM_2);
 		cs2v1.setVersion("1");
@@ -244,6 +248,11 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 		cs2v2.setName("CS2-V2");
 		cs2v2.addConcept().setCode("F").setDisplay("Code F");
 		myTwoVersionCodeSystemIdV2 = myCodeSystemDao.create(cs2v2).getId();
+	}
+
+	public void createStandardCodeSystems() {
+		createStandardCodeSystemWithOneVersion();
+		createStandardCodeSystemWithTwoVersions();
 	}
 
 	private IFhirResourceDao<?> getDao(IIdType theId) {
@@ -670,10 +679,6 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 		assertExpunged(myDeletedPatientId.withVersion("2"));
 	}
 
-
-	@Autowired
-	private ExpungeService myExpungeService;
-
 	@Test
 	public void testExpungeDeletedWhereResourceInSearchResults() {
 		createStandardPatients();
@@ -900,25 +905,26 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 	}
 
 	@Test
-	public void testDeleteCodeSystemByUrlThenExpungeWithoutWaitingForBatch() {
+	public void testExpungeCodeSystem_whenCsIsBeingBatchDeleted_willGracefullyHandleConstraintViolationException(){
 		//set up
-		createStandardCodeSystems();
+		createStandardCodeSystemWithOneVersion();
 
 		myCodeSystemDao.deleteByUrl("CodeSystem?url=" + URL_MY_CODE_SYSTEM, null);
 		myTerminologyDeferredStorageSvc.saveDeferred();
+
 		try {
 			// execute
 			myCodeSystemDao.expunge(new ExpungeOptions()
 				.setExpungeDeletedResources(true)
 				.setExpungeOldVersions(true), null);
-			fail("expunge should not succeed since the delete batch job is not complete");
-		} catch (InternalErrorException e){
+			fail();
+		} catch (PreconditionFailedException preconditionFailedException){
 			// verify
-			assertNotExpunged(myOneVersionCodeSystemId.withVersion("2"));
-			assertThat(e.getMessage(), startsWith(
-				"HAPI-1084: ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException: HAPI-2415: The resource could not be ex" +
-					"punged. It is likely due to unfinished asynchronous deletions, please try again later:"));
+			assertThat(preconditionFailedException.getMessage(), startsWith(
+				"HAPI-2415: The resource could not be expunged. It is likely due to unfinished asynchronous deletions, please try again later"));
 		}
+
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
 	}
 
 	private List<Patient> createPatientsWithForcedIds(int theNumPatients) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.util.StopWatch;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
@@ -105,6 +106,8 @@ public class PartitionRunner {
 			try {
 				runnableTasks.get(0).call();
 				return;
+			} catch (PreconditionFailedException preconditionFailedException){
+				throw preconditionFailedException;
 			} catch (Exception e) {
 				ourLog.error("Error while " + myProcessName, e);
 				throw new InternalErrorException(Msg.code(1084) + e);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
@@ -106,7 +106,7 @@ public class PartitionRunner {
 			try {
 				runnableTasks.get(0).call();
 				return;
-			} catch (PreconditionFailedException preconditionFailedException){
+			} catch (PreconditionFailedException preconditionFailedException) {
 				throw preconditionFailedException;
 			} catch (Exception e) {
 				ourLog.error("Error while " + myProcessName, e);


### PR DESCRIPTION
**What was done:**
- Adding catch clause to the  PartitionRunner to avoid having the PreconditionFailedException being wrapped into an InternalError exception;
- Modifying test;
- Adding changelog.