### PR TITLE
bulkExportReuse with POST and GET

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5157-bulkexport-reuse-with-POSTandGET.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5157-bulkexport-reuse-with-POSTandGET.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5157
+title: "Previously, the reuse functionality did not operate correctly when dealing with POST and GET requests. This fix ensures that similar POST and GET export requests will be reused."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -226,13 +226,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 			if (index != -1) {
 				params = "";
 				arrOfParam[6] = arrOfParam[6].substring(0, index) + "\"";
-				for (int i = 0; i < arrOfParam.length; i++) {
-					if (i == arrOfParam.length - 1) {
-						params = params + arrOfParam[i];
-					} else {
-						params = params + arrOfParam[i] + ",";
-					}
-				}
+				params = String.join(",", arrOfParam);
 			}
 			instanceEntities = myJobInstanceRepository.findInstancesByJobIdParamsAndStatus(
 					definitionId, params, statuses, pageable);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -49,7 +49,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -225,13 +224,12 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 			Character displacer = '?';
 			int index = arrOfParam[6].indexOf(displacer);
 			if (index != -1) {
-				params="";
-				arrOfParam[6] = arrOfParam[6].substring(0, index)+"\"";
-				for(int i =0 ; i< arrOfParam.length;i++){
-					if(i==arrOfParam.length-1){
-						params=params+arrOfParam[i];
-					}
-					else {
+				params = "";
+				arrOfParam[6] = arrOfParam[6].substring(0, index) + "\"";
+				for (int i = 0; i < arrOfParam.length; i++) {
+					if (i == arrOfParam.length - 1) {
+						params = params + arrOfParam[i];
+					} else {
 						params = params + arrOfParam[i] + ",";
 					}
 				}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -220,13 +220,15 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		List<Batch2JobInstanceEntity> instanceEntities;
 
 		if (statuses != null && !statuses.isEmpty()) {
-			String[] arrOfParam = params.split(",");
-			Character displacer = '?';
-			int index = arrOfParam[6].indexOf(displacer);
-			if (index != -1) {
-				params = "";
-				arrOfParam[6] = arrOfParam[6].substring(0, index) + "\"";
-				params = String.join(",", arrOfParam);
+			if(definitionId.equals("BULK_EXPORT")) {
+				String[] arrOfParam = params.split(",");
+				Character displacer = '?';
+				int index = arrOfParam[6].indexOf(displacer);
+				if (index != -1) {
+					params = "";
+					arrOfParam[6] = arrOfParam[6].substring(0, index) + "\"";
+					params = String.join(",", arrOfParam);
+				}
 			}
 			instanceEntities = myJobInstanceRepository.findInstancesByJobIdParamsAndStatus(
 					definitionId, params, statuses, pageable);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -220,7 +220,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		List<Batch2JobInstanceEntity> instanceEntities;
 
 		if (statuses != null && !statuses.isEmpty()) {
-			if(definitionId.equals("BULK_EXPORT")) {
+			if (definitionId.equals("BULK_EXPORT")) {
 				String[] arrOfParam = params.split(",");
 				Character displacer = '?';
 				int index = arrOfParam[6].indexOf(displacer);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -238,7 +238,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		return toInstanceList(instanceEntities);
 	}
 
-	public String originalRequestUrlTruncation(String theParams) {
+	public String originalRequestUrlTruncation(String theParams) throws Exception {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
@@ -257,7 +257,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 				return mapper.writeValueAsString(objectNode);
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			throw new Exception("Error Truncating Original Request Url", e);
 		}
 		return null; // Return null in case of an error
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -238,20 +238,21 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		return toInstanceList(instanceEntities);
 	}
 
-	public String originalRequestUrlTruncation(String theParams) {
+	private String originalRequestUrlTruncation(String theParams) {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
 			mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
 			JsonNode rootNode = mapper.readTree(theParams);
+			String originalUrl = "originalRequestUrl";
 
 			if (rootNode instanceof ObjectNode) {
 				ObjectNode objectNode = (ObjectNode) rootNode;
 
-				if (objectNode.has("originalRequestUrl")) {
-					String url = objectNode.get("originalRequestUrl").asText();
+				if (objectNode.has(originalUrl)) {
+					String url = objectNode.get(originalUrl).asText();
 					if (url.contains("?")) {
-						objectNode.put("originalRequestUrl", url.split("\\?")[0]);
+						objectNode.put(originalUrl, url.split("\\?")[0]);
 					}
 				}
 				return mapper.writeValueAsString(objectNode);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -238,7 +238,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		return toInstanceList(instanceEntities);
 	}
 
-	public String originalRequestUrlTruncation(String theParams) throws Exception {
+	public String originalRequestUrlTruncation(String theParams) {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
@@ -257,7 +257,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 				return mapper.writeValueAsString(objectNode);
 			}
 		} catch (Exception e) {
-			throw new Exception("Error Truncating Original Request Url", e);
+			ourLog.info("Error Truncating Original Request Url",e);
 		}
 		return null; // Return null in case of an error
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -257,7 +257,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 				return mapper.writeValueAsString(objectNode);
 			}
 		} catch (Exception e) {
-			ourLog.info("Error Truncating Original Request Url",e);
+			ourLog.info("Error Truncating Original Request Url", e);
 		}
 		return null; // Return null in case of an error
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -259,7 +259,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		} catch (Exception e) {
 			ourLog.info("Error Truncating Original Request Url", e);
 		}
-		return null; // Return null in case of an error
+		return null;
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -220,6 +221,21 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		List<Batch2JobInstanceEntity> instanceEntities;
 
 		if (statuses != null && !statuses.isEmpty()) {
+			String[] arrOfParam = params.split(",");
+			Character displacer = '?';
+			int index = arrOfParam[6].indexOf(displacer);
+			if (index != -1) {
+				params="";
+				arrOfParam[6] = arrOfParam[6].substring(0, index)+"\"";
+				for(int i =0 ; i< arrOfParam.length;i++){
+					if(i==arrOfParam.length-1){
+						params=params+arrOfParam[i];
+					}
+					else {
+						params = params + arrOfParam[i] + ",";
+					}
+				}
+			}
 			instanceEntities = myJobInstanceRepository.findInstancesByJobIdParamsAndStatus(
 					definitionId, params, statuses, pageable);
 		} else {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -36,7 +36,12 @@ import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.entity.Batch2JobInstanceEntity;
 import ca.uhn.fhir.jpa.entity.Batch2WorkChunkEntity;
 import ca.uhn.fhir.model.api.PagingIterator;
+import ca.uhn.fhir.util.Batch2JobDefinitionConstants;
 import ca.uhn.fhir.util.Logs;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -220,14 +225,9 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		List<Batch2JobInstanceEntity> instanceEntities;
 
 		if (statuses != null && !statuses.isEmpty()) {
-			if (definitionId.equals("BULK_EXPORT")) {
-				String[] arrOfParam = params.split(",");
-				Character displacer = '?';
-				int index = arrOfParam[6].indexOf(displacer);
-				if (index != -1) {
-					params = "";
-					arrOfParam[6] = arrOfParam[6].substring(0, index) + "\"";
-					params = String.join(",", arrOfParam);
+			if (definitionId.equals(Batch2JobDefinitionConstants.BULK_EXPORT)) {
+				if (originalRequestUrlTruncation(params) != null) {
+					params = originalRequestUrlTruncation(params);
 				}
 			}
 			instanceEntities = myJobInstanceRepository.findInstancesByJobIdParamsAndStatus(
@@ -236,6 +236,30 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 			instanceEntities = myJobInstanceRepository.findInstancesByJobIdAndParams(definitionId, params, pageable);
 		}
 		return toInstanceList(instanceEntities);
+	}
+
+	public String originalRequestUrlTruncation(String theParams) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+			mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+			JsonNode rootNode = mapper.readTree(theParams);
+
+			if (rootNode instanceof ObjectNode) {
+				ObjectNode objectNode = (ObjectNode) rootNode;
+
+				if (objectNode.has("originalRequestUrl")) {
+					String url = objectNode.get("originalRequestUrl").asText();
+					if (url.contains("?")) {
+						objectNode.put("originalRequestUrl", url.split("\\?")[0]);
+					}
+				}
+				return mapper.writeValueAsString(objectNode);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null; // Return null in case of an error
 	}
 
 	@Override

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/bulk/BulkExportJobParameters.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/bulk/BulkExportJobParameters.java
@@ -84,7 +84,7 @@ public class BulkExportJobParameters implements IModelJson {
 	 * Patient id(s)
 	 */
 	@JsonProperty("patientIds")
-	private List<String> myPatientIds;
+	private List<String> myPatientIds = new ArrayList<>();
 
 	/**
 	 * The request which originated the request.

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -183,6 +183,14 @@ public class BulkDataExportProvider {
 			theOptions.setResourceTypes(resourceTypes);
 		}
 
+		String tester = theOptions.getOriginalRequestUrl();
+		Character displacer = '?';
+		int index = tester.indexOf(displacer);
+		if(index!=-1){
+			tester = tester.substring(0,index);
+			theOptions.setOriginalRequestUrl(tester);
+		}
+
 		// Determine and validate partition permissions (if needed).
 		RequestPartitionId partitionId =
 				myRequestPartitionHelperService.determineReadPartitionForRequest(theRequestDetails, null);

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -183,14 +183,6 @@ public class BulkDataExportProvider {
 			theOptions.setResourceTypes(resourceTypes);
 		}
 
-		String tester = theOptions.getOriginalRequestUrl();
-		Character displacer = '?';
-		int index = tester.indexOf(displacer);
-		if (index != -1) {
-			tester = tester.substring(0, index);
-			theOptions.setOriginalRequestUrl(tester);
-		}
-
 		// Determine and validate partition permissions (if needed).
 		RequestPartitionId partitionId =
 				myRequestPartitionHelperService.determineReadPartitionForRequest(theRequestDetails, null);

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -186,8 +186,8 @@ public class BulkDataExportProvider {
 		String tester = theOptions.getOriginalRequestUrl();
 		Character displacer = '?';
 		int index = tester.indexOf(displacer);
-		if(index!=-1){
-			tester = tester.substring(0,index);
+		if (index != -1) {
+			tester = tester.substring(0, index);
 			theOptions.setOriginalRequestUrl(tester);
 		}
 


### PR DESCRIPTION
**Describe the bug**
The reuse functionality does not return the same job Id for a bulk export task that has been requested with POST and then a GET export.

**Steps to Reproduce**
It shows up when somebody issues a POST/GET request for a bulk export job, and then uses a GET/POST to request the same job over again. Previously, it would have created a new job ID and not utilized the reuse function from bulk export. This fix remediates that.