### PR TITLE
Resolve all unused and deprecated warnnings

### DIFF
--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/client/JaxRsHttpRequest.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/client/JaxRsHttpRequest.java
@@ -19,21 +19,21 @@
  */
 package ca.uhn.fhir.jaxrs.client;
 
-import ca.uhn.fhir.i18n.Msg;
-import ca.uhn.fhir.rest.api.RequestTypeEnum;
-import ca.uhn.fhir.rest.client.api.BaseHttpRequest;
-import ca.uhn.fhir.rest.client.api.IHttpRequest;
-import ca.uhn.fhir.rest.client.api.IHttpResponse;
-import ca.uhn.fhir.util.StopWatch;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.client.api.BaseHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+import ca.uhn.fhir.util.StopWatch;
 
 /**
  * A Http Request based on JaxRs. This is an adapter around the class
@@ -41,7 +41,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Peter Van Houte | peter.vanhoute@agfa.com | Agfa Healthcare
  */
-public class JaxRsHttpRequest extends BaseHttpRequest implements IHttpRequest {
+public class JaxRsHttpRequest extends BaseHttpRequest {
 
 	private final Map<String, List<String>> myHeaders = new HashMap<>();
 	private Invocation.Builder myRequest;

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/client/JaxRsHttpResponse.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/client/JaxRsHttpResponse.java
@@ -19,23 +19,27 @@
  */
 package ca.uhn.fhir.jaxrs.client;
 
-import ca.uhn.fhir.rest.client.api.IHttpResponse;
-import ca.uhn.fhir.rest.client.impl.BaseHttpResponse;
-import ca.uhn.fhir.util.StopWatch;
-
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import ca.uhn.fhir.rest.client.impl.BaseHttpResponse;
+import ca.uhn.fhir.util.StopWatch;
 
 /**
  * A Http Response based on JaxRs. This is an adapter around the class {@link javax.ws.rs.core.Response Response}
  * @author Peter Van Houte | peter.vanhoute@agfa.com | Agfa Healthcare
  */
-public class JaxRsHttpResponse extends BaseHttpResponse implements IHttpResponse {
+public class JaxRsHttpResponse extends BaseHttpResponse {
 
 	private boolean myBufferedEntity = false;
 	private final Response myResponse;

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProvider.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProvider.java
@@ -19,6 +19,31 @@
  */
 package ca.uhn.fhir.jaxrs.server;
 
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.dstu2.hapi.rest.server.ServerConformanceProvider;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.slf4j.LoggerFactory;
+
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -40,31 +65,6 @@ import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.method.BaseMethodBinding;
 import ca.uhn.fhir.rest.server.provider.ServerCapabilityStatementProvider;
 import ca.uhn.fhir.util.ReflectionUtil;
-import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.dstu2.hapi.rest.server.ServerConformanceProvider;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.CapabilityStatement;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
-
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import javax.ws.rs.GET;
-import javax.ws.rs.OPTIONS;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 /**
  * This is the conformance provider for the jax rs servers. It requires all providers to be registered during startup because the conformance profile is generated during the postconstruct phase.
@@ -139,7 +139,7 @@ public abstract class AbstractJaxRsConformanceProvider extends AbstractJaxRsProv
 	 * This method will set the conformance during the Context Refreshed phase. The method {@link AbstractJaxRsConformanceProvider#getProviders()} is used to get all the resource providers include in the
 	 * conformance
 	 */
-	@EventListener(ContextRefreshedEvent.class)
+//	@EventListener(ContextRefreshedEvent.class)
 	protected synchronized void buildCapabilityStatement() {
 		if (myInitialized) {
 			return;

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProvider.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProvider.java
@@ -48,9 +48,9 @@ import javax.ws.rs.core.UriInfo;
  */
 public abstract class AbstractJaxRsProvider implements IRestfulServerDefaults {
 
-	private static final String ERROR = "error";
+//	private static final String ERROR = "error";
 
-	private static final String PROCESSING = "processing";
+//	private static final String PROCESSING = "processing";
 
 	private final FhirContext CTX;
 	/** the http headers */

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/util/JaxRsRequest.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/util/JaxRsRequest.java
@@ -300,6 +300,7 @@ public class JaxRsRequest extends RequestDetails {
 			result.setCompartmentName(myCompartment);
 			result.setCompleteUrl(myRequestUrl);
 			result.setResourceName(myResourceName);
+			result.setRequestPath(result.getResourceName());
 
 			return result;
 		}

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu2Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu2Test.java
@@ -1,5 +1,45 @@
 package ca.uhn.fhir.jaxrs.client;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.model.api.Include;
@@ -34,42 +74,6 @@ import ca.uhn.fhir.rest.client.exceptions.InvalidResponseException;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.test.utilities.JettyUtil;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.apache.commons.io.Charsets;
-import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class GenericJaxRsClientDstu2Test {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(GenericJaxRsClientDstu2Test.class);
@@ -102,21 +106,15 @@ public class GenericJaxRsClientDstu2Test {
 
 	private String getPatientFeedWithOneResult() {
 
-		String msg = "<Bundle xmlns=\"http://hl7.org/fhir\">\n" +
-			"<id>d039f91a-cc3c-4013-988e-af4d8d0614bd</id>\n" +
-			"<entry>\n" +
-			"<resource>"
-			+ "<Patient>"
-			+ "<text><status value=\"generated\" /><div xmlns=\"http://www.w3.org/1999/xhtml\">John Cardinal:            444333333        </div></text>"
-			+ "<identifier><label value=\"SSN\" /><system value=\"http://orionhealth.com/mrn\" /><value value=\"PRP1660\" /></identifier>"
-			+ "<name><use value=\"official\" /><family value=\"Cardinal\" /><given value=\"John\" /></name>"
-			+ "<name><family value=\"Kramer\" /><given value=\"Doe\" /></name>"
-			+ "<telecom><system value=\"phone\" /><value value=\"555-555-2004\" /><use value=\"work\" /></telecom>"
-			+ "<address><use value=\"home\" /><line value=\"2222 Home Street\" /></address><active value=\"true\" />"
-			+ "</Patient>"
-			+ "</resource>\n"
-			+ "   </entry>\n"
-			+ "</Bundle>";
+		String msg = "<Bundle xmlns=\"http://hl7.org/fhir\">\n" + "<id>d039f91a-cc3c-4013-988e-af4d8d0614bd</id>\n"
+				+ "<entry>\n" + "<resource>" + "<Patient>"
+				+ "<text><status value=\"generated\" /><div xmlns=\"http://www.w3.org/1999/xhtml\">John Cardinal:            444333333        </div></text>"
+				+ "<identifier><label value=\"SSN\" /><system value=\"http://orionhealth.com/mrn\" /><value value=\"PRP1660\" /></identifier>"
+				+ "<name><use value=\"official\" /><family value=\"Cardinal\" /><given value=\"John\" /></name>"
+				+ "<name><family value=\"Kramer\" /><given value=\"Doe\" /></name>"
+				+ "<telecom><system value=\"phone\" /><value value=\"555-555-2004\" /><use value=\"work\" /></telecom>"
+				+ "<address><use value=\"home\" /><line value=\"2222 Home Street\" /></address><active value=\"true\" />"
+				+ "</Patient>" + "</resource>\n" + "   </entry>\n" + "</Bundle>";
 
 		return msg;
 	}
@@ -134,20 +132,18 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		client.fetchConformance().ofType(Conformance.class).execute();
+		client.capabilities().ofType(Conformance.class).execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/metadata", ourRequestUri);
 		assertEquals(1, ourRequestHeaders.get("Accept").size());
-		assertThat(ourRequestHeaders.get("Accept").get(0).getValue(), containsString(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY));
+		assertThat(ourRequestHeaders.get("Accept").get(0).getValue(),
+				containsString(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY));
 
-
-		client.fetchConformance().ofType(Conformance.class).encodedJson().execute();
+		client.capabilities().ofType(Conformance.class).encodedJson().execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/metadata?_format=json", ourRequestUri);
 		assertEquals(1, ourRequestHeaders.get("Accept").size());
 		assertThat(ourRequestHeaders.get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_JSON));
 
-
-		client.fetchConformance().ofType(Conformance.class).encodedXml().execute();
+		client.capabilities().ofType(Conformance.class).encodedXml().execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/metadata?_format=xml", ourRequestUri);
 		assertEquals(1, ourRequestHeaders.get("Accept").size());
 		assertThat(ourRequestHeaders.get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_XML));
@@ -165,21 +161,23 @@ public class GenericJaxRsClientDstu2Test {
 		patient.addName().addFamily("FAMILY");
 
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
-		ourResponseBodies = new String[]{p.encodeResourceToString(conf), p.encodeResourceToString(patient)};
+		ourResponseBodies = new String[] { p.encodeResourceToString(conf), p.encodeResourceToString(patient) };
 
 		ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.ONCE);
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-		Patient resp = client.read(Patient.class, new IdDt("123"));
+		Patient resp = client.read().resource(Patient.class).withId(new IdDt("123")).execute();
 		assertEquals("FAMILY", resp.getName().get(0).getFamily().get(0).getValue());
 		assertEquals("http://localhost:" + ourPort + "/fhir/metadata", ourRequestUriAll.get(0));
 		assertEquals(1, ourRequestHeadersAll.get(0).get("Accept").size());
-		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(), containsString(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY));
+		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(),
+				containsString(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY));
 		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_XML));
 		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_JSON));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123", ourRequestUriAll.get(1));
 		assertEquals(1, ourRequestHeadersAll.get(1).get("Accept").size());
-		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(), containsString(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY));
+		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(),
+				containsString(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY));
 		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_XML));
 		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_JSON));
 	}
@@ -195,26 +193,27 @@ public class GenericJaxRsClientDstu2Test {
 		patient.addName().addFamily("FAMILY");
 
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
-		ourResponseBodies = new String[]{p.encodeResourceToString(conf), p.encodeResourceToString(patient)};
+		ourResponseBodies = new String[] { p.encodeResourceToString(conf), p.encodeResourceToString(patient) };
 
 		ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.ONCE);
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 		client.setEncoding(EncodingEnum.JSON);
 
-		Patient resp = client.read(Patient.class, new IdDt("123"));
+		Patient resp = client.read().resource(Patient.class).withId(new IdDt("123")).execute();
 		assertEquals("FAMILY", resp.getName().get(0).getFamily().get(0).getValue());
 		assertEquals("http://localhost:" + ourPort + "/fhir/metadata?_format=json", ourRequestUriAll.get(0));
 		assertEquals(1, ourRequestHeadersAll.get(0).get("Accept").size());
 		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_JSON));
-		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(), not(containsString(Constants.CT_FHIR_XML)));
+		assertThat(ourRequestHeadersAll.get(0).get("Accept").get(0).getValue(),
+				not(containsString(Constants.CT_FHIR_XML)));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123?_format=json", ourRequestUriAll.get(1));
 		assertEquals(1, ourRequestHeadersAll.get(1).get("Accept").size());
 		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(), containsString(Constants.CT_FHIR_JSON));
-		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(), not(containsString(Constants.CT_FHIR_XML)));
+		assertThat(ourRequestHeadersAll.get(1).get("Accept").get(0).getValue(),
+				not(containsString(Constants.CT_FHIR_XML)));
 	}
 
 	@Test
-	@SuppressWarnings("deprecation")
 	public void testConformance() {
 		IParser p = ourCtx.newXmlParser();
 
@@ -234,7 +233,6 @@ public class GenericJaxRsClientDstu2Test {
 		assertEquals("COPY", resp.getCopyright());
 		assertEquals("GET", ourRequestMethod);
 
-
 	}
 
 	@Test
@@ -248,7 +246,9 @@ public class GenericJaxRsClientDstu2Test {
 			ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 			fail();
 		} catch (IllegalStateException e) {
-			assertEquals(Msg.code(1355) + "JaxRsRestfulClientFactory does not have FhirContext defined. This must be set via JaxRsRestfulClientFactory#setFhirContext(FhirContext)", e.getMessage());
+			assertEquals(Msg.code(1355)
+					+ "JaxRsRestfulClientFactory does not have FhirContext defined. This must be set via JaxRsRestfulClientFactory#setFhirContext(FhirContext)",
+					e.getMessage());
 		}
 	}
 
@@ -256,95 +256,93 @@ public class GenericJaxRsClientDstu2Test {
 	public void testCreate() {
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		Patient p = new Patient();
 		p.addName().addFamily("FOOFAMILY");
 
 		client.create().resource(p).encodedXml().execute();
 
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
-
 
 		p.setId("123");
 
 		client.create().resource(p).encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		String body = ourRequestBodyString;
 		assertThat(body, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertThat(body, not(containsString("123")));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
 
-
 	}
 
 	@Test
 	public void testCreateConditional() {
 
-
 		ourResponseStatus = Constants.STATUS_HTTP_204_NO_CONTENT;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
-
 
 		Patient p = new Patient();
 		p.addName().addFamily("FOOFAMILY");
 
 		client.create().resource(p).conditionalByUrl("Patient?name=foo").encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo", ourRequestFirstHeaders.get(Constants.HEADER_IF_NONE_EXIST).getValue());
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo",
+				ourRequestFirstHeaders.get(Constants.HEADER_IF_NONE_EXIST).getValue());
 		assertEquals("POST", ourRequestMethod);
-
 
 		client.create().resource(p).conditionalByUrl("Patient?name=http://foo|bar").encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar", ourRequestFirstHeaders.get(Constants.HEADER_IF_NONE_EXIST).getValue());
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar",
+				ourRequestFirstHeaders.get(Constants.HEADER_IF_NONE_EXIST).getValue());
 		assertEquals("POST", ourRequestMethod);
-
 
 		client.create().resource(p).conditional().where(Patient.NAME.matches().value("foo")).encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo", ourRequestFirstHeaders.get(Constants.HEADER_IF_NONE_EXIST).getValue());
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo",
+				ourRequestFirstHeaders.get(Constants.HEADER_IF_NONE_EXIST).getValue());
 		assertEquals("POST", ourRequestMethod);
-
 
 	}
 
 	@Test
 	public void testCreatePrefer() {
 
-
 		ourResponseStatus = Constants.STATUS_HTTP_204_NO_CONTENT;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
-
 
 		Patient p = new Patient();
 		p.addName().addFamily("FOOFAMILY");
 
 		client.create().resource(p).prefer(PreferReturnEnum.MINIMAL).execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_PREFER).size());
-		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_MINIMAL, ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
-
+		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_MINIMAL,
+				ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
 
 		client.create().resource(p).prefer(PreferReturnEnum.REPRESENTATION).execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_PREFER).size());
-		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION, ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
-
+		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION,
+				ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
 
 	}
 
@@ -353,7 +351,6 @@ public class GenericJaxRsClientDstu2Test {
 		Patient p = new Patient();
 		p.setId("123");
 		final String formatted = ourCtx.newXmlParser().encodeResourceToString(p);
-
 
 		ourResponseStatus = Constants.STATUS_HTTP_200_OK;
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
@@ -376,21 +373,17 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		client.delete().resourceById(new IdDt("Patient/123")).execute();
 		assertEquals("DELETE", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123", ourRequestUri);
-
 
 		client.delete().resourceConditionalByUrl("Patient?name=foo").execute();
 		assertEquals("DELETE", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo", ourRequestUri);
 
-
 		client.delete().resourceConditionalByType("Patient").where(Patient.NAME.matches().value("foo")).execute();
 		assertEquals("DELETE", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo", ourRequestUri);
-
 
 	}
 
@@ -399,7 +392,6 @@ public class GenericJaxRsClientDstu2Test {
 		ourResponseStatus = Constants.STATUS_HTTP_204_NO_CONTENT;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
-
 
 		client.delete().resourceById(new IdDt("Patient/123")).execute();
 		assertEquals("DELETE", ourRequestMethod);
@@ -417,81 +409,51 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		ca.uhn.fhir.model.dstu2.resource.Bundle response;
 
-
-		response = client
-			.history()
-			.onServer()
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+		response = client.history().onServer().returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/_history", ourRequestUri);
 		assertEquals(1, response.getEntry().size());
 
-
-		response = client
-			.history()
-			.onServer()
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.since((Date) null)
-			.count(null)
-			.execute();
+		response = client.history().onServer().returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.since((Date) null).count(null).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/_history", ourRequestUri);
 		assertEquals(1, response.getEntry().size());
 
-
-		response = client
-			.history()
-			.onServer()
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.since(new InstantDt())
-			.execute();
+		response = client.history().onServer().returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.since(new InstantDt()).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/_history", ourRequestUri);
 		assertEquals(1, response.getEntry().size());
 
-
-		response = client
-			.history()
-			.onType(Patient.class)
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+		response = client.history().onType(Patient.class).returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/_history", ourRequestUri);
 		assertEquals(1, response.getEntry().size());
 
-
-		response = client
-			.history()
-			.onInstance(new IdDt("Patient", "123"))
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+		response = client.history().onInstance(new IdDt("Patient", "123"))
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/_history", ourRequestUri);
 		assertEquals(1, response.getEntry().size());
 
+		response = client.history().onInstance(new IdDt("Patient", "123"))
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).count(123)
+				.since(new InstantDt("2001-01-02T11:22:33Z")).execute();
 
-		response = client
-			.history()
-			.onInstance(new IdDt("Patient", "123"))
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.count(123)
-			.since(new InstantDt("2001-01-02T11:22:33Z"))
-			.execute();
-
-		assertThat(ourRequestUri, either(equalTo("http://localhost:" + ourPort + "/fhir/Patient/123/_history?_since=2001-01-02T11:22:33Z&_count=123")).or(equalTo("http://localhost:" + ourPort + "/fhir/Patient/123/_history?_count=123&_since=2001-01-02T11:22:33Z")));
+		assertThat(ourRequestUri,
+				either(equalTo("http://localhost:" + ourPort
+						+ "/fhir/Patient/123/_history?_since=2001-01-02T11:22:33Z&_count=123"))
+						.or(equalTo("http://localhost:" + ourPort
+								+ "/fhir/Patient/123/_history?_count=123&_since=2001-01-02T11:22:33Z")));
 		assertEquals(1, response.getEntry().size());
 
-
-		response = client
-			.history()
-			.onInstance(new IdDt("Patient", "123"))
-			.andReturnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.since(new InstantDt("2001-01-02T11:22:33Z").getValue())
-			.execute();
+		response = client.history().onInstance(new IdDt("Patient", "123"))
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.since(new InstantDt("2001-01-02T11:22:33Z").getValue()).execute();
 
 		assertThat(ourRequestUri, containsString("_since=2001-01"));
 		assertEquals(1, response.getEntry().size());
@@ -513,20 +475,14 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		MetaDt resp = client
-			.meta()
-			.add()
-			.onResource(new IdDt("Patient/123"))
-			.meta(inMeta)
-			.encodedXml()
-			.execute();
+		MetaDt resp = client.meta().add().onResource(new IdDt("Patient/123")).meta(inMeta).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$meta-add", ourRequestUri);
 		assertEquals("urn:profile:out", resp.getProfile().get(0).getValue());
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"meta\"/><valueMeta><profile value=\"urn:profile:in\"/></valueMeta></parameter></Parameters>", ourRequestBodyString);
-
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"meta\"/><valueMeta><profile value=\"urn:profile:in\"/></valueMeta></parameter></Parameters>",
+				ourRequestBodyString);
 
 	}
 
@@ -546,39 +502,23 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		MetaDt resp = client
-			.meta()
-			.get(MetaDt.class)
-			.fromServer()
-			.execute();
+		MetaDt resp = client.meta().get(MetaDt.class).fromServer().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$meta", ourRequestUri);
 		assertEquals("urn:profile:out", resp.getProfile().get(0).getValue());
 		assertEquals("GET", ourRequestMethod);
 
-
-		resp = client
-			.meta()
-			.get(MetaDt.class)
-			.fromType("Patient")
-			.execute();
+		resp = client.meta().get(MetaDt.class).fromType("Patient").execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$meta", ourRequestUri);
 		assertEquals("urn:profile:out", resp.getProfile().get(0).getValue());
 		assertEquals("GET", ourRequestMethod);
 
-
-		resp = client
-			.meta()
-			.get(MetaDt.class)
-			.fromResource(new IdDt("Patient/123"))
-			.execute();
+		resp = client.meta().get(MetaDt.class).fromResource(new IdDt("Patient/123")).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$meta", ourRequestUri);
 		assertEquals("urn:profile:out", resp.getProfile().get(0).getValue());
 		assertEquals("GET", ourRequestMethod);
-
 
 	}
 
@@ -596,51 +536,39 @@ public class GenericJaxRsClientDstu2Test {
 		outParams.addParameter().setValue(new StringDt("STRINGVALOUT2"));
 		final String respString = p.encodeResourceToString(outParams);
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = respString;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		Parameters resp = client.operation().onServer().named("$SOMEOPERATION").withParameters(inParams).useHttpGet()
+				.execute();
 
-		Parameters resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withParameters(inParams)
-			.useHttpGet()
-			.execute();
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2", ourRequestUri);
+		assertEquals(
+				"http://localhost:" + ourPort
+						+ "/fhir/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2",
+				ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals("GET", ourRequestMethod);
 
+		resp = client.operation().onType(Patient.class).named("$SOMEOPERATION").withParameters(inParams).useHttpGet()
+				.execute();
 
-		resp = client
-			.operation()
-			.onType(Patient.class)
-			.named("$SOMEOPERATION")
-			.withParameters(inParams)
-			.useHttpGet()
-			.execute();
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2", ourRequestUri);
+		assertEquals(
+				"http://localhost:" + ourPort
+						+ "/fhir/Patient/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2",
+				ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals("GET", ourRequestMethod);
 
+		resp = client.operation().onInstance(new IdDt("Patient", "123")).named("$SOMEOPERATION")
+				.withParameters(inParams).useHttpGet().execute();
 
-		resp = client
-			.operation()
-			.onInstance(new IdDt("Patient", "123"))
-			.named("$SOMEOPERATION")
-			.withParameters(inParams)
-			.useHttpGet()
-			.execute();
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2", ourRequestUri);
+		assertEquals("http://localhost:" + ourPort
+				+ "/fhir/Patient/123/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2",
+				ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals("GET", ourRequestMethod);
-
 
 		// @formatter:off
 		resp = client
@@ -651,7 +579,9 @@ public class GenericJaxRsClientDstu2Test {
 			.useHttpGet()
 			.execute();
 		// @formatter:on
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2", ourRequestUri);
+		assertEquals("http://localhost:" + ourPort
+				+ "/fhir/Patient/123/$SOMEOPERATION?param1=STRINGVALIN1&param1=STRINGVALIN1b&param2=STRINGVALIN2",
+				ourRequestUri);
 
 	}
 
@@ -669,45 +599,26 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Parameters resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withNoParameters(Parameters.class)
-			.useHttpGet()
-			.execute();
+		Parameters resp = client.operation().onServer().named("$SOMEOPERATION").withNoParameters(Parameters.class)
+				.useHttpGet().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals("GET", ourRequestMethod);
 
-
-		resp = client
-			.operation()
-			.onType(Patient.class)
-			.named("$SOMEOPERATION")
-			.withNoParameters(Parameters.class)
-			.useHttpGet()
-			.execute();
+		resp = client.operation().onType(Patient.class).named("$SOMEOPERATION").withNoParameters(Parameters.class)
+				.useHttpGet().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals("GET", ourRequestMethod);
 
-
-		resp = client
-			.operation()
-			.onInstance(new IdDt("Patient", "123"))
-			.named("$SOMEOPERATION")
-			.withNoParameters(Parameters.class)
-			.useHttpGet()
-			.execute();
+		resp = client.operation().onInstance(new IdDt("Patient", "123")).named("$SOMEOPERATION")
+				.withNoParameters(Parameters.class).useHttpGet().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals("GET", ourRequestMethod);
-
 
 		// @formatter:off
 		resp = client
@@ -726,7 +637,9 @@ public class GenericJaxRsClientDstu2Test {
 	public void testOperationWithBundleResponseJson() {
 
 		ourResponseContentType = Constants.CT_FHIR_JSON;
-		final String respString = "{\n" + "    \"resourceType\":\"Bundle\",\n" + "    \"id\":\"8cef5f2a-0ba9-43a5-be26-c8dde9ff0e19\",\n" + "    \"base\":\"http://localhost:" + ourPort + "/fhir\"\n" + "}";
+		final String respString = "{\n" + "    \"resourceType\":\"Bundle\",\n"
+				+ "    \"id\":\"8cef5f2a-0ba9-43a5-be26-c8dde9ff0e19\",\n" + "    \"base\":\"http://localhost:"
+				+ ourPort + "/fhir\"\n" + "}";
 		ourResponseBody = respString;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
@@ -739,14 +652,17 @@ public class GenericJaxRsClientDstu2Test {
 		inParams.addParameter().setName("end").setValue(new DateDt("2015-03-01"));
 
 		// Invoke $everything on "Patient/1"
-		Parameters outParams = client.operation().onInstance(new IdDt("Patient", "18066")).named("$everything").withParameters(inParams).execute();
+		Parameters outParams = client.operation().onInstance(new IdDt("Patient", "18066")).named("$everything")
+				.withParameters(inParams).execute();
 
 		/*
-		 * Note that the $everything operation returns a Bundle instead of a Parameters resource. The client operation
-		 * methods return a Parameters instance however, so HAPI creates a Parameters object
-		 * with a single parameter containing the value.
+		 * Note that the $everything operation returns a Bundle instead of a Parameters
+		 * resource. The client operation methods return a Parameters instance however,
+		 * so HAPI creates a Parameters object with a single parameter containing the
+		 * value.
 		 */
-		ca.uhn.fhir.model.dstu2.resource.Bundle responseBundle = (ca.uhn.fhir.model.dstu2.resource.Bundle) outParams.getParameter().get(0).getResource();
+		ca.uhn.fhir.model.dstu2.resource.Bundle responseBundle = (ca.uhn.fhir.model.dstu2.resource.Bundle) outParams
+				.getParameter().get(0).getResource();
 
 		// Print the response bundle
 		assertEquals("8cef5f2a-0ba9-43a5-be26-c8dde9ff0e19", responseBundle.getId().getIdPart());
@@ -770,20 +686,18 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Parameters resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withParameters(inParams).encodedXml().execute();
+		Parameters resp = client.operation().onServer().named("$SOMEOPERATION").withParameters(inParams).encodedXml()
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
 		assertEquals(1, resp.getParameter().size());
-		assertEquals(ca.uhn.fhir.model.dstu2.resource.Bundle.class, resp.getParameter().get(0).getResource().getClass());
+		assertEquals(ca.uhn.fhir.model.dstu2.resource.Bundle.class,
+				resp.getParameter().get(0).getResource().getClass());
 
 	}
 
@@ -801,70 +715,55 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Parameters resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withParameter(Parameters.class, "name1", new StringDt("value1"))
-			.andParameter("name2", new StringDt("value1"))
-			.encodedXml()
-			.execute();
+		Parameters resp = client.operation().onServer().named("$SOMEOPERATION")
+				.withParameter(Parameters.class, "name1", new StringDt("value1"))
+				.andParameter("name2", new StringDt("value1")).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"name1\"/><valueString value=\"value1\"/></parameter><parameter><name value=\"name2\"/><valueString value=\"value1\"/></parameter></Parameters>", (ourRequestBodyString));
-
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"name1\"/><valueString value=\"value1\"/></parameter><parameter><name value=\"name2\"/><valueString value=\"value1\"/></parameter></Parameters>",
+				(ourRequestBodyString));
 
 		/*
 		 * Composite type
 		 */
 
-
-		resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withParameter(Parameters.class, "name1", new IdentifierDt("system1", "value1"))
-			.andParameter("name2", new StringDt("value1"))
-			.encodedXml()
-			.execute();
+		resp = client.operation().onServer().named("$SOMEOPERATION")
+				.withParameter(Parameters.class, "name1", new IdentifierDt("system1", "value1"))
+				.andParameter("name2", new StringDt("value1")).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"name1\"/><valueIdentifier><system value=\"system1\"/><value value=\"value1\"/></valueIdentifier></parameter><parameter><name value=\"name2\"/><valueString value=\"value1\"/></parameter></Parameters>",
-			(ourRequestBodyString));
-
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"name1\"/><valueIdentifier><system value=\"system1\"/><value value=\"value1\"/></valueIdentifier></parameter><parameter><name value=\"name2\"/><valueString value=\"value1\"/></parameter></Parameters>",
+				(ourRequestBodyString));
 
 		/*
 		 * Resource
 		 */
 
-
-		resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withParameter(Parameters.class, "name1", new IdentifierDt("system1", "value1"))
-			.andParameter("name2", new Patient().setActive(true))
-			.encodedXml()
-			.execute();
+		resp = client.operation().onServer().named("$SOMEOPERATION")
+				.withParameter(Parameters.class, "name1", new IdentifierDt("system1", "value1"))
+				.andParameter("name2", new Patient().setActive(true)).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals("POST", ourRequestMethod);
 		assertEquals(
-			"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"name1\"/><valueIdentifier><system value=\"system1\"/><value value=\"value1\"/></valueIdentifier></parameter><parameter><name value=\"name2\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><active value=\"true\"/></Patient></resource></parameter></Parameters>",
-			(ourRequestBodyString));
-
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"name1\"/><valueIdentifier><system value=\"system1\"/><value value=\"value1\"/></valueIdentifier></parameter><parameter><name value=\"name2\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><active value=\"true\"/></Patient></resource></parameter></Parameters>",
+				(ourRequestBodyString));
 
 	}
 
@@ -908,12 +807,8 @@ public class GenericJaxRsClientDstu2Test {
 		};
 
 		assertThrows(IllegalArgumentException.class, () -> {
-			client
-				.operation()
-				.onServer()
-				.named("$SOMEOPERATION")
-				.withParameter(Parameters.class, "name1", weirdBase)
-				.execute();
+			client.operation().onServer().named("$SOMEOPERATION").withParameter(Parameters.class, "name1", weirdBase)
+					.execute();
 		});
 
 	}
@@ -927,40 +822,27 @@ public class GenericJaxRsClientDstu2Test {
 		outParams.addParameter().setValue(new StringDt("STRINGVALOUT2"));
 		final String respString = p.encodeResourceToString(outParams);
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = respString;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		client.operation().onInstance(new IdDt("http://foo/Patient/1")).named("validate-code")
+				.withParameter(Parameters.class, "code", new CodeDt("8495-4"))
+				.andParameter("system", new UriDt("http://loinc.org")).useHttpGet().execute();
 
-		client
-			.operation()
-			.onInstance(new IdDt("http://foo/Patient/1"))
-			.named("validate-code")
-			.withParameter(Parameters.class, "code", new CodeDt("8495-4"))
-			.andParameter("system", new UriDt("http://loinc.org"))
-			.useHttpGet()
-			.execute();
+		assertEquals("http://localhost:" + ourPort
+				+ "/fhir/Patient/1/$validate-code?code=8495-4&system=http%3A%2F%2Floinc.org", ourRequestUri);
 
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/1/$validate-code?code=8495-4&system=http%3A%2F%2Floinc.org", ourRequestUri);
-
-
-		client
-			.operation()
-			.onInstance(new IdDt("http://foo/Patient/1"))
-			.named("validate-code")
-			.withParameter(Parameters.class, "code", new CodeDt("8495-4"))
-			.andParameter("system", new UriDt("http://loinc.org"))
-			.encodedXml()
-			.encodedXml()
-			.execute();
-
+		client.operation().onInstance(new IdDt("http://foo/Patient/1")).named("validate-code")
+				.withParameter(Parameters.class, "code", new CodeDt("8495-4"))
+				.andParameter("system", new UriDt("http://loinc.org")).encodedXml().encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/1/$validate-code", ourRequestUri);
 		ourLog.info(ourRequestBodyString);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"code\"/><valueCode value=\"8495-4\"/></parameter><parameter><name value=\"system\"/><valueUri value=\"http://loinc.org\"/></parameter></Parameters>", ourRequestBodyString);
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"code\"/><valueCode value=\"8495-4\"/></parameter><parameter><name value=\"system\"/><valueUri value=\"http://loinc.org\"/></parameter></Parameters>",
+				ourRequestBodyString);
 
 	}
 
@@ -978,58 +860,46 @@ public class GenericJaxRsClientDstu2Test {
 		outParams.addParameter().setValue(new StringDt("STRINGVALOUT2"));
 		final String respString = p.encodeResourceToString(outParams);
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = respString;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Parameters resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withParameters(inParams).encodedXml().execute();
+		Parameters resp = client.operation().onServer().named("$SOMEOPERATION").withParameters(inParams).encodedXml()
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
 
-
-		resp = client
-			.operation()
-			.onType(Patient.class)
-			.named("$SOMEOPERATION")
-			.withParameters(inParams).encodedXml().execute();
+		resp = client.operation().onType(Patient.class).named("$SOMEOPERATION").withParameters(inParams).encodedXml()
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
 
-
-		resp = client
-			.operation()
-			.onInstance(new IdDt("Patient", "123"))
-			.named("$SOMEOPERATION")
-			.withParameters(inParams)
-			.encodedXml()
-			.execute();
+		resp = client.operation().onInstance(new IdDt("Patient", "123")).named("$SOMEOPERATION")
+				.withParameters(inParams).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
 
-
-		resp = client.operation().onInstance(new IdDt("http://foo.com/bar/baz/Patient/123/_history/22")).named("$SOMEOPERATION").withParameters(inParams).execute();
+		resp = client.operation().onInstance(new IdDt("http://foo.com/bar/baz/Patient/123/_history/22"))
+				.named("$SOMEOPERATION").withParameters(inParams).execute();
 		// @formatter:on
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$SOMEOPERATION", ourRequestUri);
 
@@ -1047,54 +917,43 @@ public class GenericJaxRsClientDstu2Test {
 		outParams.addParameter().setValue(new StringDt("STRINGVALOUT2"));
 		final String respString = p.encodeResourceToString(outParams);
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = respString;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Parameters resp = client
-			.operation()
-			.onServer()
-			.named("$SOMEOPERATION")
-			.withNoParameters(Parameters.class).encodedXml().execute();
+		Parameters resp = client.operation().onServer().named("$SOMEOPERATION").withNoParameters(Parameters.class)
+				.encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
 
-
-		resp = client
-			.operation()
-			.onType(Patient.class)
-			.named("$SOMEOPERATION")
-			.withNoParameters(Parameters.class).encodedXml().execute();
+		resp = client.operation().onType(Patient.class).named("$SOMEOPERATION").withNoParameters(Parameters.class)
+				.encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
 
-
-		resp = client
-			.operation()
-			.onInstance(new IdDt("Patient", "123"))
-			.named("$SOMEOPERATION")
-			.withNoParameters(Parameters.class).encodedXml().execute();
+		resp = client.operation().onInstance(new IdDt("Patient", "123")).named("$SOMEOPERATION")
+				.withNoParameters(Parameters.class).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123/$SOMEOPERATION", ourRequestUri);
 		assertEquals(respString, p.encodeResourceToString(resp));
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertEquals(ourRequestBodyString, reqString);
 		assertEquals("POST", ourRequestMethod);
-
 
 		// @formatter:off
 		resp = client
@@ -1116,21 +975,14 @@ public class GenericJaxRsClientDstu2Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		ca.uhn.fhir.model.dstu2.resource.Bundle sourceBundle = new ca.uhn.fhir.model.dstu2.resource.Bundle();
 		sourceBundle.getLinkOrCreate(IBaseBundle.LINK_PREV).setUrl("http://localhost:" + ourPort + "/fhir/prev");
 		sourceBundle.getLinkOrCreate(IBaseBundle.LINK_NEXT).setUrl("http://localhost:" + ourPort + "/fhir/next");
 
-
-		ca.uhn.fhir.model.dstu2.resource.Bundle resp = client
-			.loadPage()
-			.next(sourceBundle)
-			.execute();
-
+		ca.uhn.fhir.model.dstu2.resource.Bundle resp = client.loadPage().next(sourceBundle).execute();
 
 		assertEquals(1, resp.getEntry().size());
 		assertEquals("http://localhost:" + ourPort + "/fhir/next", ourRequestUri);
-
 
 	}
 
@@ -1142,33 +994,26 @@ public class GenericJaxRsClientDstu2Test {
 		try {
 			client.loadPage().next(sourceBundle).execute();
 		} catch (IllegalArgumentException e) {
-			assertThat(e.getMessage(), containsString("Can not perform paging operation because no link was found in Bundle with relation \"next\""));
+			assertThat(e.getMessage(), containsString(
+					"Can not perform paging operation because no link was found in Bundle with relation \"next\""));
 		}
 	}
 
 	@Test
 	public void testPagePrev() {
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = getPatientFeedWithOneResult();
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		ca.uhn.fhir.model.dstu2.resource.Bundle sourceBundle = new ca.uhn.fhir.model.dstu2.resource.Bundle();
 		sourceBundle.getLinkOrCreate("previous").setUrl("http://localhost:" + ourPort + "/fhir/prev");
 
-
-		ca.uhn.fhir.model.dstu2.resource.Bundle resp = client
-			.loadPage()
-			.previous(sourceBundle)
-			.execute();
-
+		ca.uhn.fhir.model.dstu2.resource.Bundle resp = client.loadPage().previous(sourceBundle).execute();
 
 		assertEquals(1, resp.getEntry().size());
 		assertEquals("http://localhost:" + ourPort + "/fhir/prev", ourRequestUri);
-
 
 		/*
 		 * Try with "prev" instead of "previous"
@@ -1177,16 +1022,10 @@ public class GenericJaxRsClientDstu2Test {
 		sourceBundle = new ca.uhn.fhir.model.dstu2.resource.Bundle();
 		sourceBundle.getLinkOrCreate("prev").setUrl("http://localhost:" + ourPort + "/fhir/prev");
 
-
-		resp = client
-			.loadPage()
-			.previous(sourceBundle)
-			.execute();
-
+		resp = client.loadPage().previous(sourceBundle).execute();
 
 		assertEquals(1, resp.getEntry().size());
 		assertEquals("http://localhost:" + ourPort + "/fhir/prev", ourRequestUri);
-
 
 	}
 
@@ -1204,8 +1043,8 @@ public class GenericJaxRsClientDstu2Test {
 
 		Patient response;
 
-
-		response = (Patient) client.read(new UriDt("http://localhost:" + ourPort + "/fhir/Patient/123"));
+		response = (Patient) client.read().resource(Patient.class).withUrl(
+				new UriDt("http://localhost:" + ourPort + "/fhir/Patient/123").getValue()).execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123", ourRequestUri);
 		assertEquals("FAM", response.getName().get(0).getFamily().get(0).getValue());
 	}
@@ -1224,7 +1063,8 @@ public class GenericJaxRsClientDstu2Test {
 
 		Patient response;
 
-		response = client.read().resource(Patient.class).withUrl(new IdDt("http://localhost:" + ourPort + "/AAA/Patient/123")).execute();
+		response = client.read().resource(Patient.class)
+				.withUrl(new IdDt("http://localhost:" + ourPort + "/AAA/Patient/123")).execute();
 		assertEquals("http://localhost:" + ourPort + "/AAA/Patient/123", ourRequestUri);
 		assertEquals("FAM", response.getName().get(0).getFamily().get(0).getValue());
 	}
@@ -1232,21 +1072,13 @@ public class GenericJaxRsClientDstu2Test {
 	@Test
 	public void testReadUpdatedHeaderDoesntOverwriteResourceValue() {
 
-
-		final String input = "<Bundle xmlns=\"http://hl7.org/fhir\">\n" +
-			"   <id value=\"e2ee823b-ee4d-472d-b79d-495c23f16b99\"/>\n" +
-			"   <meta>\n" +
-			"      <lastUpdated value=\"2015-06-22T15:48:57.554-04:00\"/>\n" +
-			"   </meta>\n" +
-			"   <type value=\"searchset\"/>\n" +
-			"   <base value=\"http://localhost:58109/fhir/context\"/>\n" +
-			"   <total value=\"0\"/>\n" +
-			"   <link>\n" +
-			"      <relation value=\"self\"/>\n" +
-			"      <url value=\"http://localhost:58109/fhir/context/Patient?_pretty=true\"/>\n" +
-			"   </link>\n" +
-			"</Bundle>";
-
+		final String input = "<Bundle xmlns=\"http://hl7.org/fhir\">\n"
+				+ "   <id value=\"e2ee823b-ee4d-472d-b79d-495c23f16b99\"/>\n" + "   <meta>\n"
+				+ "      <lastUpdated value=\"2015-06-22T15:48:57.554-04:00\"/>\n" + "   </meta>\n"
+				+ "   <type value=\"searchset\"/>\n" + "   <base value=\"http://localhost:58109/fhir/context\"/>\n"
+				+ "   <total value=\"0\"/>\n" + "   <link>\n" + "      <relation value=\"self\"/>\n"
+				+ "      <url value=\"http://localhost:58109/fhir/context/Patient?_pretty=true\"/>\n" + "   </link>\n"
+				+ "</Bundle>";
 
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = input;
@@ -1255,11 +1087,8 @@ public class GenericJaxRsClientDstu2Test {
 
 		ca.uhn.fhir.model.dstu2.resource.Bundle response;
 
-		response = client
-			.search()
-			.forResource(Patient.class)
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+		response = client.search().forResource(Patient.class)
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 
 		assertEquals("2015-06-22T15:48:57.554-04:00", ResourceMetadataKeyEnum.UPDATED.get(response).getValueAsString());
 	}
@@ -1268,19 +1097,17 @@ public class GenericJaxRsClientDstu2Test {
 	public void testReadWithElementsParam() {
 		String msg = "{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-		IBaseResource response = client.read()
-			.resource("Patient")
-			.withId("123")
-			.elementsSubset("name", "identifier")
-			.execute();
+		IBaseResource response = client.read().resource("Patient").withId("123").elementsSubset("name", "identifier")
+				.execute();
 
-		assertThat(ourRequestUri, either(equalTo("http://localhost:" + ourPort + "/fhir/Patient/123?_elements=name%2Cidentifier")).or(equalTo("http://localhost:" + ourPort + "/fhir/Patient/123?_elements=identifier%2Cname")));
+		assertThat(ourRequestUri,
+				either(equalTo("http://localhost:" + ourPort + "/fhir/Patient/123?_elements=name%2Cidentifier"))
+						.or(equalTo("http://localhost:" + ourPort + "/fhir/Patient/123?_elements=identifier%2Cname")));
 		assertEquals(Patient.class, response.getClass());
 
 	}
@@ -1289,20 +1116,13 @@ public class GenericJaxRsClientDstu2Test {
 	public void testReadWithSummaryInvalid() {
 		String msg = "<>>>><<<<>";
 
-
 		ourResponseContentType = Constants.CT_HTML + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		try {
-			client.read()
-				.resource(Patient.class)
-				.withId("123")
-				.summaryMode(SummaryEnum.TEXT)
-				.execute();
+			client.read().resource(Patient.class).withId("123").summaryMode(SummaryEnum.TEXT).execute();
 			fail();
 		} catch (InvalidResponseException e) {
 			assertThat(e.getMessage(), containsString("String does not appear to be valid"));
@@ -1313,22 +1133,17 @@ public class GenericJaxRsClientDstu2Test {
 	public void testReadWithSummaryParamHtml() {
 		String msg = "<div>HELP IM A DIV</div>";
 
-
 		ourResponseContentType = Constants.CT_HTML + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-		Patient response = client.read()
-			.resource(Patient.class)
-			.withId("123")
-			.summaryMode(SummaryEnum.TEXT)
-			.execute();
+		Patient response = client.read().resource(Patient.class).withId("123").summaryMode(SummaryEnum.TEXT).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123?_summary=text", ourRequestUri);
 		assertEquals(Patient.class, response.getClass());
-		assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">HELP IM A DIV</div>", response.getText().getDiv().getValueAsString());
+		assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">HELP IM A DIV</div>",
+				response.getText().getDiv().getValueAsString());
 
 	}
 
@@ -1336,18 +1151,13 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchByString() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-		Bundle response = client.search()
-			.forResource("Patient")
-			.where(Patient.NAME.matches().value("james"))
-			.returnBundle(Bundle.class)
-			.execute();
+		Bundle response = client.search().forResource("Patient").where(Patient.NAME.matches().value("james"))
+				.returnBundle(Bundle.class).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=james", ourRequestUri);
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
@@ -1359,65 +1169,50 @@ public class GenericJaxRsClientDstu2Test {
 
 		final String msg = getPatientFeedWithOneResult();
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = msg;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
 		ca.uhn.fhir.model.dstu2.resource.Bundle response = client.search()
-			.byUrl("http://localhost:" + ourPort + "/AAA?name=http://foo|bar")
-			.encodedJson()
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+				.byUrl("http://localhost:" + ourPort + "/AAA?name=http://foo|bar").encodedJson()
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/AAA?name=http%3A//foo%7Cbar&_format=json", ourRequestUri);
 		assertNotNull(response);
 
+		response = client.search().byUrl("Patient?name=http://foo|bar").encodedJson()
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 
-		response = client.search()
-			.byUrl("Patient?name=http://foo|bar")
-			.encodedJson()
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar&_format=json", ourRequestUri);
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar&_format=json",
+				ourRequestUri);
 		assertNotNull(response);
 
+		response = client.search().byUrl("/Patient?name=http://foo|bar").encodedJson()
+				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 
-		response = client.search()
-			.byUrl("/Patient?name=http://foo|bar")
-			.encodedJson()
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar&_format=json", ourRequestUri);
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar&_format=json",
+				ourRequestUri);
 		assertNotNull(response);
 
-
-		response = client.search()
-			.byUrl("Patient")
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+		response = client.search().byUrl("Patient").returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
 		assertNotNull(response);
 
-
-		response = client.search()
-			.byUrl("Patient?")
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
+		response = client.search().byUrl("Patient?").returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient", ourRequestUri);
 		assertNotNull(response);
-
 
 		try {
 			client.search().byUrl("foo/bar?test=1");
 		} catch (IllegalArgumentException e) {
-			assertEquals(Msg.code(1393) + "Search URL must be either a complete URL starting with http: or https:, or a relative FHIR URL in the form [ResourceType]?[Params]", e.getMessage());
+			assertEquals(Msg.code(1393)
+					+ "Search URL must be either a complete URL starting with http: or https:, or a relative FHIR URL in the form [ResourceType]?[Params]",
+					e.getMessage());
 		}
 	}
 
@@ -1426,22 +1221,17 @@ public class GenericJaxRsClientDstu2Test {
 	 */
 	@Test
 	public void testSearchReturningDstu2Bundle() throws Exception {
-		String msg = IOUtils.toString(GenericJaxRsClientDstu2Test.class.getResourceAsStream("/bundle_orion.xml"));
-
+		String msg = new String(Files
+				.readAllBytes(Paths.get(GenericJaxRsClientDstu2Test.class.getResource("/bundle_orion.xml").toURI())));
 
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		ca.uhn.fhir.model.dstu2.resource.Bundle response = client.search()
-			.forResource("Observation")
-			.where(Patient.NAME.matches().value("FOO"))
-			.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
-			.execute();
-
+		ca.uhn.fhir.model.dstu2.resource.Bundle response = client.search().forResource("Observation")
+				.where(Patient.NAME.matches().value("FOO")).returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class)
+				.execute();
 
 		Link link = response.getLink().get(0);
 		assertEquals("just trying add link", link.getRelation());
@@ -1457,23 +1247,17 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchWithElementsParam() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		Bundle response = client.search().forResource("Patient").where(Patient.NAME.matches().value("james"))
+				.elementsSubset("name", "identifier").returnBundle(Bundle.class).execute();
 
-		Bundle response = client.search()
-			.forResource("Patient")
-			.where(Patient.NAME.matches().value("james"))
-			.elementsSubset("name", "identifier")
-			.returnBundle(Bundle.class)
-			.execute();
-
-
-		assertThat(ourRequestUri, either(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
+		assertThat(ourRequestUri, either(
+				equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=name%2Cidentifier"))
+				.or(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
 
 	}
@@ -1482,33 +1266,29 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchByPost() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		Bundle response = client.search().forResource("Patient").where(Patient.NAME.matches().value("james"))
+				.elementsSubset("name", "identifier").usingStyle(SearchStyleEnum.POST).returnBundle(Bundle.class)
+				.execute();
 
-		Bundle response = client.search()
-			.forResource("Patient")
-			.where(Patient.NAME.matches().value("james"))
-			.elementsSubset("name", "identifier")
-			.usingStyle(SearchStyleEnum.POST)
-			.returnBundle(Bundle.class)
-			.execute();
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/_search?_elements=identifier%2Cname",
+				ourRequestUri);
 
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/_search?_elements=identifier%2Cname", ourRequestUri);
-
-		//		assertThat(ourRequestUri,
-		//				either(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
+		// assertThat(ourRequestUri,
+		// either(equalTo("http://localhost:" + ourPort +
+		// "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo("http://localhost:"
+		// + ourPort + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
 
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
 
 		assertEquals("name=james", ourRequestBodyString);
 
-		assertEquals("application/x-www-form-urlencoded", ourRequestContentType.replace(";char", "; char").toLowerCase());
+		assertEquals("application/x-www-form-urlencoded",
+				ourRequestContentType.replace(";char", "; char").toLowerCase());
 		assertEquals(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY, ourRequestFirstHeaders.get("Accept").getValue());
 		assertThat(ourRequestFirstHeaders.get("User-Agent").getValue(), not(emptyString()));
 	}
@@ -1517,29 +1297,22 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchByPostUseJson() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Bundle response = client.search()
-			.forResource("Patient")
-			.where(Patient.NAME.matches().value("james"))
-			.elementsSubset("name", "identifier")
-			.usingStyle(SearchStyleEnum.POST)
-			.encodedJson()
-			.returnBundle(Bundle.class)
-			.execute();
-
+		Bundle response = client.search().forResource("Patient").where(Patient.NAME.matches().value("james"))
+				.elementsSubset("name", "identifier").usingStyle(SearchStyleEnum.POST).encodedJson()
+				.returnBundle(Bundle.class).execute();
 
 		assertThat(ourRequestUri, containsString("http://localhost:" + ourPort + "/fhir/Patient/_search?"));
 		assertThat(ourRequestUri, containsString("_elements=identifier%2Cname"));
 
-		//		assertThat(ourRequestUri,
-		//				either(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo("http://localhost:" + ourPort + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
+		// assertThat(ourRequestUri,
+		// either(equalTo("http://localhost:" + ourPort +
+		// "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo("http://localhost:"
+		// + ourPort + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
 
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
 
@@ -1553,23 +1326,18 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchWithLastUpdated() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		Bundle response = client.search().forResource("Patient").where(Patient.NAME.matches().value("james"))
+				.returnBundle(Bundle.class).lastUpdated(new DateRangeParam("2011-01-01", "2012-01-01")).execute();
 
-		Bundle response = client.search()
-			.forResource("Patient")
-			.where(Patient.NAME.matches().value("james"))
-			.returnBundle(Bundle.class)
-			.lastUpdated(new DateRangeParam("2011-01-01", "2012-01-01"))
-			.execute();
-
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=james&_lastUpdated=ge2011-01-01&_lastUpdated=le2012-01-01", ourRequestUri);
+		assertEquals(
+				"http://localhost:" + ourPort
+						+ "/fhir/Patient?name=james&_lastUpdated=ge2011-01-01&_lastUpdated=le2012-01-01",
+				ourRequestUri);
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
 
 	}
@@ -1578,25 +1346,17 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchWithProfileAndSecurity() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		Bundle response = client.search().forResource("Patient").withProfile("http://foo1").withProfile("http://foo2")
+				.withSecurity("system1", "code1").withSecurity("system2", "code2").returnBundle(Bundle.class).execute();
 
-		Bundle response = client.search()
-			.forResource("Patient")
-			.withProfile("http://foo1")
-			.withProfile("http://foo2")
-			.withSecurity("system1", "code1")
-			.withSecurity("system2", "code2")
-			.returnBundle(Bundle.class)
-			.execute();
-
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?_security=system1%7Ccode1&_security=system2%7Ccode2&_profile=http%3A%2F%2Ffoo1&_profile=http%3A%2F%2Ffoo2", ourRequestUri);
+		assertEquals("http://localhost:" + ourPort
+				+ "/fhir/Patient?_security=system1%7Ccode1&_security=system2%7Ccode2&_profile=http%3A%2F%2Ffoo1&_profile=http%3A%2F%2Ffoo2",
+				ourRequestUri);
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
 
 	}
@@ -1607,23 +1367,16 @@ public class GenericJaxRsClientDstu2Test {
 
 		String msg = getPatientFeedWithOneResult();
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
+		Bundle response = client.search().forResource(Patient.class).encodedJson()
+				.revInclude(new Include("Provenance:target")).returnBundle(Bundle.class).execute();
 
-		Bundle response = client.search()
-			.forResource(Patient.class)
-			.encodedJson()
-			.revInclude(new Include("Provenance:target"))
-			.returnBundle(Bundle.class)
-			.execute();
-
-
-		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?_revinclude=Provenance%3Atarget&_format=json", ourRequestUri);
+		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?_revinclude=Provenance%3Atarget&_format=json",
+				ourRequestUri);
 
 	}
 
@@ -1631,21 +1384,13 @@ public class GenericJaxRsClientDstu2Test {
 	public void testSearchWithSummaryParam() {
 		String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = msg;
 
-
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		Bundle response = client.search()
-			.forResource("Patient")
-			.where(Patient.NAME.matches().value("james"))
-			.summaryMode(SummaryEnum.FALSE)
-			.returnBundle(Bundle.class)
-			.execute();
-
+		Bundle response = client.search().forResource("Patient").where(Patient.NAME.matches().value("james"))
+				.summaryMode(SummaryEnum.FALSE).returnBundle(Bundle.class).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=james&_summary=false", ourRequestUri);
 		assertEquals(Patient.class, response.getEntry().get(0).getResource().getClass());
@@ -1659,7 +1404,6 @@ public class GenericJaxRsClientDstu2Test {
 		resp.addEntry().getResponse().setLocation("Patient/1/_history/1");
 		resp.addEntry().getResponse().setLocation("Patient/2/_history/2");
 		String respString = ourCtx.newJsonParser().encodeResourceToString(resp);
-
 
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = respString;
@@ -1677,18 +1421,14 @@ public class GenericJaxRsClientDstu2Test {
 		p2.setId("http://example.com/Patient/2");
 		input.add(p2);
 
-
-		List<IBaseResource> response = client.transaction()
-			.withResources(input)
-			.encodedJson()
-			.execute();
-
+		List<IBaseResource> response = client.transaction().withResources(input).encodedJson().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir", ourRequestUri);
 		assertEquals(2, response.size());
 
 		String requestString = ourRequestBodyString;
-		ca.uhn.fhir.model.dstu2.resource.Bundle requestBundle = ourCtx.newJsonParser().parseResource(ca.uhn.fhir.model.dstu2.resource.Bundle.class, requestString);
+		ca.uhn.fhir.model.dstu2.resource.Bundle requestBundle = ourCtx.newJsonParser()
+				.parseResource(ca.uhn.fhir.model.dstu2.resource.Bundle.class, requestString);
 		assertEquals(2, requestBundle.getEntry().size());
 		assertEquals("POST", requestBundle.getEntry().get(0).getRequest().getMethod());
 		assertEquals("PUT", requestBundle.getEntry().get(1).getRequest().getMethod());
@@ -1719,28 +1459,18 @@ public class GenericJaxRsClientDstu2Test {
 		resp.addEntry().getResponse().setLocation("Patient/1/_history/1");
 		resp.addEntry().getResponse().setLocation("Patient/2/_history/2");
 
-
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = reqString;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 
-
-		String response = client.transaction()
-			.withBundle(reqString)
-			.execute();
-
+		String response = client.transaction().withBundle(reqString).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/", ourRequestUri);
 		assertThat(response, containsString("\"Bundle\""));
 		assertEquals("application/json+fhir;charset=UTF-8", ourRequestFirstHeaders.get("Content-Type").getValue());
 
-
-		response = client.transaction()
-			.withBundle(reqString)
-			.encodedXml()
-			.execute();
-
+		response = client.transaction().withBundle(reqString).encodedXml().execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/", ourRequestUri);
 		assertEquals("application/xml+fhir;charset=UTF-8", ourRequestFirstHeaders.get("Content-Type").getValue());
@@ -1754,7 +1484,6 @@ public class GenericJaxRsClientDstu2Test {
 		resp.addEntry().getResponse().setLocation("Patient/1/_history/1");
 		resp.addEntry().getResponse().setLocation("Patient/2/_history/2");
 		String respString = ourCtx.newJsonParser().encodeResourceToString(resp);
-
 
 		ourResponseContentType = Constants.CT_FHIR_JSON + "; charset=UTF-8";
 		ourResponseBody = respString;
@@ -1772,12 +1501,8 @@ public class GenericJaxRsClientDstu2Test {
 		p2.setId("Patient/2");
 		input.addEntry().setResource(p2);
 
-
-		ca.uhn.fhir.model.dstu2.resource.Bundle response = client.transaction()
-			.withBundle(input)
-			.encodedJson()
-			.execute();
-
+		ca.uhn.fhir.model.dstu2.resource.Bundle response = client.transaction().withBundle(input).encodedJson()
+				.execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir", ourRequestUri);
 		assertEquals(2, response.getEntry().size());
@@ -1789,81 +1514,82 @@ public class GenericJaxRsClientDstu2Test {
 	@Test
 	public void testUpdateConditional() {
 
-
 		ourResponseStatus = Constants.STATUS_HTTP_204_NO_CONTENT;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
-
 
 		Patient p = new Patient();
 		p.addName().addFamily("FOOFAMILY");
 
 		client.update().resource(p).conditionalByUrl("Patient?name=foo").encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("PUT", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo", ourRequestUri);
 
-
 		client.update().resource(p).conditionalByUrl("Patient?name=http://foo|bar").encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("PUT", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=http%3A//foo%7Cbar", ourRequestUri);
 
-
-		client.update().resource(ourCtx.newXmlParser().encodeResourceToString(p)).conditionalByUrl("Patient?name=foo").encodedXml().execute();
+		client.update().resource(ourCtx.newXmlParser().encodeResourceToString(p)).conditionalByUrl("Patient?name=foo")
+				.encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("PUT", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo", ourRequestUri);
 
-
-		client.update().resource(p).conditional().where(Patient.NAME.matches().value("foo")).and(Patient.ADDRESS.matches().value("AAA|BBB")).encodedXml().execute();
+		client.update().resource(p).conditional().where(Patient.NAME.matches().value("foo"))
+				.and(Patient.ADDRESS.matches().value("AAA|BBB")).encodedXml().execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("PUT", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo&address=AAA%5C%7CBBB", ourRequestUri);
 
-
-		client.update().resource(ourCtx.newXmlParser().encodeResourceToString(p)).conditional().where(Patient.NAME.matches().value("foo")).and(Patient.ADDRESS.matches().value("AAA|BBB")).encodedXml().execute();
+		client.update().resource(ourCtx.newXmlParser().encodeResourceToString(p)).conditional()
+				.where(Patient.NAME.matches().value("foo")).and(Patient.ADDRESS.matches().value("AAA|BBB")).encodedXml()
+				.execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("PUT", ourRequestMethod);
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient?name=foo&address=AAA%5C%7CBBB", ourRequestUri);
-
 
 	}
 
 	@Test
 	public void testUpdateNonFluent() {
 
-
 		ourResponseStatus = Constants.STATUS_HTTP_204_NO_CONTENT;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
 		client.setEncoding(EncodingEnum.XML);
 
-
 		Patient p = new Patient();
 		p.addName().addFamily("FOOFAMILY");
 
-		client.update(new IdDt("Patient/123"), p);
+		client.update().resource(p).withId(new IdDt("Patient/123")).execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123?_format=xml", ourRequestUri);
 		assertEquals("PUT", ourRequestMethod);
 
-
-		client.update("123", p);
+		client.update().resource(p).withId("123").execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_CONTENT_TYPE).size());
-		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8, ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
+		assertEquals(EncodingEnum.XML.getResourceContentType() + Constants.HEADER_SUFFIX_CT_UTF_8,
+				ourRequestFirstHeaders.get(Constants.HEADER_CONTENT_TYPE).getValue().replace(";char", "; char"));
 		assertThat(ourRequestBodyString, containsString("<family value=\"FOOFAMILY\"/>"));
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/123?_format=xml", ourRequestUri);
 		assertEquals("PUT", ourRequestMethod);
@@ -1873,11 +1599,9 @@ public class GenericJaxRsClientDstu2Test {
 	@Test
 	public void testUpdatePrefer() {
 
-
 		ourResponseStatus = Constants.STATUS_HTTP_204_NO_CONTENT;
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://localhost:" + ourPort + "/fhir");
-
 
 		Patient p = new Patient();
 		p.setId(new IdDt("1"));
@@ -1885,13 +1609,13 @@ public class GenericJaxRsClientDstu2Test {
 
 		client.update().resource(p).prefer(PreferReturnEnum.MINIMAL).execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_PREFER).size());
-		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_MINIMAL, ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
-
+		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_MINIMAL,
+				ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
 
 		client.update().resource(p).prefer(PreferReturnEnum.REPRESENTATION).execute();
 		assertEquals(1, ourRequestHeaders.get(Constants.HEADER_PREFER).size());
-		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION, ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
-
+		assertEquals(Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION,
+				ourRequestHeaders.get(Constants.HEADER_PREFER).get(0).getValue());
 
 	}
 
@@ -1900,7 +1624,6 @@ public class GenericJaxRsClientDstu2Test {
 		Patient p = new Patient();
 		p.setId("123");
 		final String formatted = ourCtx.newXmlParser().encodeResourceToString(p);
-
 
 		ourResponseStatus = Constants.STATUS_HTTP_200_OK;
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
@@ -1924,7 +1647,6 @@ public class GenericJaxRsClientDstu2Test {
 		oo.addIssue().setDiagnostics("FOOBAR");
 		final String msg = ourCtx.newXmlParser().encodeResourceToString(oo);
 
-
 		ourResponseContentType = Constants.CT_FHIR_XML + "; charset=UTF-8";
 		ourResponseBody = msg;
 
@@ -1933,39 +1655,45 @@ public class GenericJaxRsClientDstu2Test {
 		Patient p = new Patient();
 		p.addName().addGiven("GIVEN");
 
-
 		MethodOutcome response;
 
 		response = client.validate().resource(p).encodedXml().execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$validate", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"resource\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><name><given value=\"GIVEN\"/></name></Patient></resource></parameter></Parameters>", ourRequestBodyString);
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"resource\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><name><given value=\"GIVEN\"/></name></Patient></resource></parameter></Parameters>",
+				ourRequestBodyString);
 		assertNotNull(response.getOperationOutcome());
-		assertEquals("FOOBAR", toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
-
+		assertEquals("FOOBAR",
+				toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
 
 		response = client.validate().resource(ourCtx.newXmlParser().encodeResourceToString(p)).encodedXml().execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$validate", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"resource\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><name><given value=\"GIVEN\"/></name></Patient></resource></parameter></Parameters>", ourRequestBodyString);
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"resource\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><name><given value=\"GIVEN\"/></name></Patient></resource></parameter></Parameters>",
+				ourRequestBodyString);
 		assertNotNull(response.getOperationOutcome());
-		assertEquals("FOOBAR", toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
-
+		assertEquals("FOOBAR",
+				toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
 
 		response = client.validate().resource(ourCtx.newJsonParser().encodeResourceToString(p)).execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$validate", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("{\"resourceType\":\"Parameters\",\"parameter\":[{\"name\":\"resource\",\"resource\":{\"resourceType\":\"Patient\",\"name\":[{\"given\":[\"GIVEN\"]}]}}]}", ourRequestBodyString);
+		assertEquals(
+				"{\"resourceType\":\"Parameters\",\"parameter\":[{\"name\":\"resource\",\"resource\":{\"resourceType\":\"Patient\",\"name\":[{\"given\":[\"GIVEN\"]}]}}]}",
+				ourRequestBodyString);
 		assertNotNull(response.getOperationOutcome());
-		assertEquals("FOOBAR", toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
-
+		assertEquals("FOOBAR",
+				toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
 
 		response = client.validate().resource(ourCtx.newJsonParser().encodeResourceToString(p)).prettyPrint().execute();
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$validate?_pretty=true", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
 		assertThat(ourRequestBodyString, containsString("\"resourceType\": \"Parameters\",\n"));
 		assertNotNull(response.getOperationOutcome());
-		assertEquals("FOOBAR", toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
+		assertEquals("FOOBAR",
+				toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
 
 	}
 
@@ -1984,18 +1712,18 @@ public class GenericJaxRsClientDstu2Test {
 		Patient p = new Patient();
 		p.addName().addGiven("GIVEN");
 
-
 		MethodOutcome response;
 
-
-		response = client.validate(p);
-
+		response = client.validate().resource(p).execute();
 
 		assertEquals("http://localhost:" + ourPort + "/fhir/Patient/$validate?_format=xml", ourRequestUri);
 		assertEquals("POST", ourRequestMethod);
-		assertEquals("<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"resource\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><name><given value=\"GIVEN\"/></name></Patient></resource></parameter></Parameters>", ourRequestBodyString);
+		assertEquals(
+				"<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"resource\"/><resource><Patient xmlns=\"http://hl7.org/fhir\"><name><given value=\"GIVEN\"/></name></Patient></resource></parameter></Parameters>",
+				ourRequestBodyString);
 		assertNotNull(response.getOperationOutcome());
-		assertEquals("FOOBAR", toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
+		assertEquals("FOOBAR",
+				toOo(response.getOperationOutcome()).getIssueFirstRep().getDiagnosticsElement().getValue());
 
 	}
 
@@ -2030,22 +1758,26 @@ public class GenericJaxRsClientDstu2Test {
 		ourServer.setHandler(new AbstractHandler() {
 
 			@Override
-			public void handle(String theArg0, Request theRequest, HttpServletRequest theServletRequest, HttpServletResponse theResp) throws IOException {
+			public void handle(String theArg0, Request theRequest, HttpServletRequest theServletRequest,
+					HttpServletResponse theResp) throws IOException {
 				theRequest.setHandled(true);
 				ourRequestUri = theRequest.getHttpURI().toString();
 				ourRequestUriAll.add(ourRequestUri);
 				ourRequestMethod = theRequest.getMethod();
 				ourRequestContentType = theServletRequest.getContentType();
-				ourRequestBodyBytes = IOUtils.toByteArray(theServletRequest.getInputStream());
-				ourRequestBodyString = new String(ourRequestBodyBytes, Charsets.UTF_8);
+				ourRequestBodyBytes = theServletRequest.getInputStream().readAllBytes();
+
+				ourRequestBodyString = new String(ourRequestBodyBytes, StandardCharsets.UTF_8);
 
 				ourRequestHeaders = ArrayListMultimap.create();
 				ourRequestHeadersAll.add(ourRequestHeaders);
 				ourRequestFirstHeaders = Maps.newHashMap();
 
-				for (Enumeration<String> headerNameEnum = theRequest.getHeaderNames(); headerNameEnum.hasMoreElements(); ) {
+				for (Enumeration<String> headerNameEnum = theRequest.getHeaderNames(); headerNameEnum
+						.hasMoreElements();) {
 					String nextName = headerNameEnum.nextElement();
-					for (Enumeration<String> headerValueEnum = theRequest.getHeaders(nextName); headerValueEnum.hasMoreElements(); ) {
+					for (Enumeration<String> headerValueEnum = theRequest.getHeaders(nextName); headerValueEnum
+							.hasMoreElements();) {
 						String nextValue = headerValueEnum.nextElement();
 						if (ourRequestFirstHeaders.containsKey(nextName) == false) {
 							ourRequestFirstHeaders.put(nextName, new Header(nextName, nextValue));

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/JaxRsRestfulClientFactoryTest.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/JaxRsRestfulClientFactoryTest.java
@@ -1,9 +1,20 @@
 package ca.uhn.fhir.jaxrs.client;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
-import ca.uhn.fhir.test.BaseFhirVersionParameterizedTest;
-import com.google.common.net.MediaType;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.net.ssl.SSLException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,20 +23,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.google.common.net.MediaType;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.test.BaseFhirVersionParameterizedTest;
 
 /**
  * Created by Sebastien Riviere on 31/07/2017.

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderDstu2Hl7OrgTest.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderDstu2Hl7OrgTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 public class AbstractJaxRsConformanceProviderDstu2Hl7OrgTest {
 
 	private static final String BASEURI = "http://basiuri";
-	private static final String REQUESTURI = BASEURI + "/metadata";
+//	private static final String REQUESTURI = BASEURI + "/metadata";
 	AbstractJaxRsConformanceProvider provider;
 	private ConcurrentHashMap<Class<? extends IResourceProvider>, IResourceProvider> providers;
 	private ResteasyHttpHeaders headers;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderDstu2_1Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderDstu2_1Test.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 public class AbstractJaxRsConformanceProviderDstu2_1Test {
 
 	private static final String BASEURI = "http://basiuri";
-	private static final String REQUESTURI = BASEURI + "/metadata";
+//	private static final String REQUESTURI = BASEURI + "/metadata";
 	AbstractJaxRsConformanceProvider provider;
 	private ConcurrentHashMap<Class<? extends IResourceProvider>, IResourceProvider> providers;
 	private ResteasyHttpHeaders headers;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderDstu3Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderDstu3Test.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 public class AbstractJaxRsConformanceProviderDstu3Test {
 
 	private static final String BASEURI = "http://basiuri";
-	private static final String REQUESTURI = BASEURI + "/metadata";
+//	private static final String REQUESTURI = BASEURI + "/metadata";
 	AbstractJaxRsConformanceProvider provider;
 	private ConcurrentHashMap<Class<? extends IResourceProvider>, IResourceProvider> providers;
 	private ResteasyHttpHeaders headers;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderR4Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderR4Test.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 public class AbstractJaxRsConformanceProviderR4Test {
 
 	private static final String BASEURI = "http://basiuri";
-	private static final String REQUESTURI = BASEURI + "/metadata";
+//	private static final String REQUESTURI = BASEURI + "/metadata";
 	AbstractJaxRsConformanceProvider provider;
 	private ConcurrentHashMap<Class<? extends IResourceProvider>, IResourceProvider> providers;
 	private ResteasyHttpHeaders headers;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderTest.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsConformanceProviderTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 public class AbstractJaxRsConformanceProviderTest {
 
 	private static final String BASEURI = "http://basiuri";
-	private static final String REQUESTURI = BASEURI + "/metadata";
+//	private static final String REQUESTURI = BASEURI + "/metadata";
 	AbstractJaxRsConformanceProvider provider;
 	private ConcurrentHashMap<Class<? extends IResourceProvider>, IResourceProvider> providers;
 	private ResteasyHttpHeaders headers;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProviderTest.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProviderTest.java
@@ -73,6 +73,7 @@ public class AbstractJaxRsProviderTest {
 
 		final RuntimeException theException = new RuntimeException();
 		final UriInfo mockUriInfo = mock(UriInfo.class);
+		@SuppressWarnings("unchecked")
 		final MultivaluedMap<String, String> mockMap = mock(MultivaluedMap.class);
 		when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://www.test.com"));
 		when(mockUriInfo.getRequestUri()).thenReturn(new URI("http://www.test.com/test"));

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsResourceProviderDstu3Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsResourceProviderDstu3Test.java
@@ -1,56 +1,5 @@
 package ca.uhn.fhir.jaxrs.server;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.jaxrs.client.JaxRsRestfulClientFactory;
-import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsResponseException;
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsConformanceRestProviderDstu3;
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPageProviderDstu3;
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPatientRestProviderDstu3;
-import ca.uhn.fhir.model.primitive.UriDt;
-import ca.uhn.fhir.rest.api.EncodingEnum;
-import ca.uhn.fhir.rest.api.MethodOutcome;
-import ca.uhn.fhir.rest.api.PreferReturnEnum;
-import ca.uhn.fhir.rest.api.SearchStyleEnum;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
-import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
-import ca.uhn.fhir.rest.param.StringParam;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import ca.uhn.fhir.test.utilities.JettyUtil;
-import ca.uhn.fhir.util.TestUtil;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.dstu3.model.CapabilityStatement;
-import org.hl7.fhir.dstu3.model.DateType;
-import org.hl7.fhir.dstu3.model.IdType;
-import org.hl7.fhir.dstu3.model.Identifier;
-import org.hl7.fhir.dstu3.model.OperationOutcome;
-import org.hl7.fhir.dstu3.model.Parameters;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Resource;
-import org.hl7.fhir.dstu3.model.StringType;
-import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
-import org.mockito.ArgumentMatchers;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -64,10 +13,58 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.CapabilityStatement;
+import org.hl7.fhir.dstu3.model.DateType;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Parameters;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jaxrs.client.JaxRsRestfulClientFactory;
+import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsResponseException;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsConformanceRestProviderDstu3;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPageProviderDstu3;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPatientRestProviderDstu3;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.PreferReturnEnum;
+import ca.uhn.fhir.rest.api.SearchStyleEnum;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.test.utilities.JettyUtil;
+import ca.uhn.fhir.util.TestUtil;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class AbstractJaxRsResourceProviderDstu3Test {
 
-	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(AbstractJaxRsResourceProviderDstu3Test.class);
+//	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(AbstractJaxRsResourceProviderDstu3Test.class);
 	private static final String PATIENT_NAME = "Van Houte";
 	private static IGenericClient client;
 	private static FhirContext ourCtx = FhirContext.forDstu3();
@@ -107,26 +104,26 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void findUsingGenericClientById() {
 		when(mock.find(any(IdType.class))).thenReturn(createPatient(1));
-		Patient result = client.read(Patient.class, "1");
+		Patient result = client.read().resource(Patient.class).withId("1").execute();
 		compareResultId(1, result);
 		compareResultUrl("/Patient/1", result);
 		reset(mock);
 		when(mock.find(eq(result.getIdElement()))).thenReturn(createPatient(1));
-		result = (Patient) client.read(new UriDt(result.getId()));
+		result = client.read().resource(Patient.class).withUrl(result.getId()).execute();
 		compareResultId(1, result);
 		compareResultUrl("/Patient/1", result);
 	}
 
-	private Bundle getPatientBundle(int size) {
-		Bundle result = new Bundle();
-		for (long i = 0; i < size; i++) {
-			Patient patient = createPatient(i);
-			BundleEntryComponent entry = new BundleEntryComponent();
-			entry.setResource(patient);
-			result.addEntry(entry);
-		}
-		return result;
-	}
+	//	private Bundle getPatientBundle(int size) {
+	//		Bundle result = new Bundle();
+	//		for (long i = 0; i < size; i++) {
+	//			Patient patient = createPatient(i);
+	//			BundleEntryComponent entry = new BundleEntryComponent();
+	//			entry.setResource(patient);
+	//			result.addEntry(entry);
+	//		}
+	//		return result;
+	//	}
 
 	@BeforeEach
 	public void setUp() {
@@ -151,7 +148,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 		client.setEncoding(EncodingEnum.JSON);
 
 		MethodOutcome response = client.create().resource(toCreate).conditional()
-			.where(Patient.IDENTIFIER.exactly().identifier("2")).prefer(PreferReturnEnum.REPRESENTATION).execute();
+				.where(Patient.IDENTIFIER.exactly().identifier("2")).prefer(PreferReturnEnum.REPRESENTATION).execute();
 
 		assertEquals("myIdentifier", patientCaptor.getValue().getIdentifier().get(0).getValue());
 		IBaseResource resource = response.getResource();
@@ -163,7 +160,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	 */
 	@Test
 	public void testConformance() {
-		final CapabilityStatement conf = client.fetchConformance().ofType(CapabilityStatement.class).execute();
+		final CapabilityStatement conf = client.capabilities().ofType(CapabilityStatement.class).execute();
 		assertEquals(conf.getRest().get(0).getResource().get(0).getType(), "Patient");
 	}
 
@@ -177,7 +174,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 		when(mock.create(patientCaptor.capture(), isNull())).thenReturn(outcome);
 		client.setEncoding(EncodingEnum.JSON);
 		final MethodOutcome response = client.create().resource(toCreate).prefer(PreferReturnEnum.REPRESENTATION)
-			.execute();
+				.execute();
 		IBaseResource resource = response.getResource();
 		compareResultId(1, resource);
 		assertEquals("myIdentifier", patientCaptor.getValue().getIdentifier().get(0).getValue());
@@ -186,7 +183,8 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void testDeletePatient() {
 		when(mock.delete(idCaptor.capture(), conditionalCaptor.capture())).thenReturn(new MethodOutcome());
-		final IBaseOperationOutcome results = client.delete().resourceById("Patient", "1").execute().getOperationOutcome();
+		//		final IBaseOperationOutcome results = 
+		client.delete().resourceById("Patient", "1").execute().getOperationOutcome();
 		assertEquals("1", idCaptor.getValue().getIdPart());
 	}
 
@@ -213,7 +211,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 		inParams.addParameter().setName("dummy").setValue(new StringType("myAwesomeDummyValue"));
 		//invoke
 		Parameters outParams = client.operation().onInstance(new IdType("Patient", "1")).named("$someCustomOperation")
-			.withParameters(inParams).execute();
+				.withParameters(inParams).execute();
 		//verify
 		assertEquals("outputValue", ((StringType) outParams.getParameter().get(0).getValue()).getValueAsString());
 	}
@@ -232,12 +230,12 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 
 		// invoke
 		Parameters outParams = client
-			.operation()
-			.onInstance(new IdType("Patient", "1"))
-			.named("$someCustomOperation")
-			.withParameters(inParams)
-			.useHttpGet()
-			.execute();
+				.operation()
+				.onInstance(new IdType("Patient", "1"))
+				.named("$someCustomOperation")
+				.withParameters(inParams)
+				.useHttpGet()
+				.execute();
 
 		// verify
 		assertEquals("outputValue", ((StringType) outParams.getParameter().get(0).getValue()).getValueAsString());
@@ -246,7 +244,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void testRead() {
 		when(mock.find(idCaptor.capture())).thenReturn(createPatient(1));
-		final Patient patient = client.read(Patient.class, "1");
+		final Patient patient = client.read().resource(Patient.class).withId("1").execute();
 		compareResultId(1, patient);
 		compareResultUrl("/Patient/1", patient);
 		assertEquals("1", idCaptor.getValue().getIdPart());
@@ -259,7 +257,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	public void testSearchCompartments() {
 		when(mock.searchCompartment(any(IdType.class))).thenReturn(Arrays.asList((IBaseResource) createPatient(1)));
 		org.hl7.fhir.dstu3.model.Bundle response = client.search().forResource(Patient.class).withIdAndCompartment("1", "Condition")
-			.returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
+				.returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
 		Resource resource = response.getEntry().get(0).getResource();
 		compareResultId(1, resource);
 		compareResultUrl("/Patient/1", resource);
@@ -271,9 +269,9 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void testSearchPost() {
 		when(mock.search(ArgumentMatchers.isNull(), ArgumentMatchers.isNull()))
-			.thenReturn(createPatients(1, 13));
+		.thenReturn(createPatients(1, 13));
 		org.hl7.fhir.dstu3.model.Bundle result = client.search().forResource("Patient").usingStyle(SearchStyleEnum.POST)
-			.returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
+				.returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
 		Resource resource = result.getEntry().get(0).getResource();
 		compareResultId(1, resource);
 		compareResultUrl("/Patient/1", resource);
@@ -286,9 +284,9 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	public void testSearchUsingGenericClientBySearch() {
 		// Perform a search
 		when(mock.search(any(StringParam.class), isNull()))
-			.thenReturn(Arrays.asList(createPatient(1)));
+		.thenReturn(Arrays.asList(createPatient(1)));
 		final Bundle results = client.search().forResource(Patient.class)
-			.where(Patient.NAME.matchesExactly().value(PATIENT_NAME)).returnBundle(Bundle.class).execute();
+				.where(Patient.NAME.matchesExactly().value(PATIENT_NAME)).returnBundle(Bundle.class).execute();
 		verify(mock).search(any(StringParam.class), isNull());
 		IBaseResource resource = results.getEntry().get(0).getResource();
 
@@ -302,11 +300,11 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void testSearchUsingGenericClientBySearchWithMultiValues() {
 		when(mock.search(any(StringParam.class), ArgumentMatchers.notNull()))
-			.thenReturn(Arrays.asList(createPatient(1)));
+		.thenReturn(Arrays.asList(createPatient(1)));
 		final Bundle results = client.search().forResource(Patient.class)
-			.where(Patient.ADDRESS.matches().values("Toronto")).and(Patient.ADDRESS.matches().values("Ontario"))
-			.and(Patient.ADDRESS.matches().values("Canada"))
-			.where(Patient.NAME.matches().value("SHORTNAME")).returnBundle(Bundle.class).execute();
+				.where(Patient.ADDRESS.matches().values("Toronto")).and(Patient.ADDRESS.matches().values("Ontario"))
+				.and(Patient.ADDRESS.matches().values("Canada"))
+				.where(Patient.NAME.matches().value("SHORTNAME")).returnBundle(Bundle.class).execute();
 		IBaseResource resource = results.getEntry().get(0).getResource();
 
 		compareResultId(1, resource);
@@ -320,9 +318,9 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	public void testSearchWithPaging() {
 		// Perform a search
 		when(mock.search(ArgumentMatchers.isNull(), ArgumentMatchers.isNull()))
-			.thenReturn(createPatients(1, 13));
+		.thenReturn(createPatients(1, 13));
 		final org.hl7.fhir.dstu3.model.Bundle results = client.search().forResource(Patient.class).count(8).returnBundle(org.hl7.fhir.dstu3.model.Bundle.class)
-			.execute();
+				.execute();
 
 		assertEquals(results.getEntry().size(), 8);
 		IBaseResource resource = results.getEntry().get(0).getResource();
@@ -330,10 +328,10 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 		compareResultUrl("/Patient/1", resource);
 		compareResultId(8, results.getEntry().get(7).getResource());
 
-//		ourLog.info("Next: " + results.getLink("next").getUrl());
-//		String url = results.getLink("next").getUrl().replace("?", "Patient?");
-//		results.getLink("next").setUrl(url);
-//		ourLog.info("New Next: " + results.getLink("next").getUrl());
+		//		ourLog.info("Next: " + results.getLink("next").getUrl());
+		//		String url = results.getLink("next").getUrl().replace("?", "Patient?");
+		//		results.getLink("next").setUrl(url);
+		//		ourLog.info("New Next: " + results.getLink("next").getUrl());
 
 		// load next page
 		final org.hl7.fhir.dstu3.model.Bundle nextPage = client.loadPage().next(results).execute();
@@ -349,31 +347,31 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	@Disabled
 	public void testSummary() {
-		Object response = client.search().forResource(Patient.class)
-			.returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
+//		Object response = 
+		client.search().forResource(Patient.class).returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
 	}
 
 	/**
 	 * Transaction - Server
 	 */
-//	@Disabled
-//	@Test
-//	public void testTransaction() {
-//		ca.uhn.fhir.model.api.Bundle bundle = new ca.uhn.fhir.model.api.Bundle();
-//		BundleEntry entry = bundle.addEntry();
-//		final Patient existing = new Patient();
-//		existing.getName().get(0).addFamily("Created with bundle");
-//		entry.setResource(existing);
-//
-//		BoundCodeDt<BundleEntryTransactionMethodEnum> theTransactionOperation = new BoundCodeDt(
-//				BundleEntryTransactionMethodEnum.VALUESET_BINDER, BundleEntryTransactionMethodEnum.POST);
-//		entry.setTransactionMethod(theTransactionOperation);
-//		ca.uhn.fhir.model.api.Bundle response = client.transaction().withBundle(bundle).execute();
-//	}
+	//	@Disabled
+	//	@Test
+	//	public void testTransaction() {
+	//		ca.uhn.fhir.model.api.Bundle bundle = new ca.uhn.fhir.model.api.Bundle();
+	//		BundleEntry entry = bundle.addEntry();
+	//		final Patient existing = new Patient();
+	//		existing.getName().get(0).addFamily("Created with bundle");
+	//		entry.setResource(existing);
+	//
+	//		BoundCodeDt<BundleEntryTransactionMethodEnum> theTransactionOperation = new BoundCodeDt(
+	//				BundleEntryTransactionMethodEnum.VALUESET_BINDER, BundleEntryTransactionMethodEnum.POST);
+	//		entry.setTransactionMethod(theTransactionOperation);
+	//		ca.uhn.fhir.model.api.Bundle response = client.transaction().withBundle(bundle).execute();
+	//	}
 	@Test
 	public void testUpdateById() throws Exception {
 		when(mock.update(idCaptor.capture(), patientCaptor.capture(), conditionalCaptor.capture())).thenReturn(new MethodOutcome());
-		client.update("1", createPatient(1));
+		client.update().resource(createPatient(1)).withId("1").execute();
 		assertEquals("1", idCaptor.getValue().getIdPart());
 		compareResultId(1, patientCaptor.getValue());
 	}
@@ -388,13 +386,13 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 		assertEquals("Patient?identifier=2&_format=json", conditionalCaptor.getValue());
 	}
 
-	@SuppressWarnings("unchecked")
+	//@SuppressWarnings("unchecked")
 	@Disabled
 	@Test
 	public void testResourceNotFound() throws Exception {
 		when(mock.update(idCaptor.capture(), patientCaptor.capture(), conditionalCaptor.capture())).thenThrow(ResourceNotFoundException.class);
 		try {
-			client.update("1", createPatient(2));
+			client.update().resource(createPatient(2)).withId("1").execute();
 			fail();
 		} catch (ResourceNotFoundException e) {
 			// good
@@ -404,7 +402,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void testVRead() {
 		when(mock.findHistory(idCaptor.capture())).thenReturn(createPatient(1));
-		final Patient patient = client.vread(Patient.class, "1", "2");
+		final Patient patient = client.read().resource(Patient.class).withIdAndVersion("1", "2").execute();
 		compareResultId(1, patient);
 		compareResultUrl("/Patient/1", patient);
 		assertEquals("1", idCaptor.getValue().getIdPart());
@@ -416,7 +414,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 		try {
 			JaxRsResponseException notFoundException = new JaxRsResponseException(new ResourceNotFoundException(new IdType("999955541264")));
 			when(mock.find(idCaptor.capture())).thenThrow(notFoundException);
-			client.read(Patient.class, "999955541264");
+			client.read().resource(Patient.class).withId("999955541264").execute();
 			fail();
 		} catch (final ResourceNotFoundException e) {
 			assertEquals(ResourceNotFoundException.STATUS_CODE, e.getStatusCode());
@@ -427,7 +425,7 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 	@Test
 	public void testValidate() {
 		// prepare mock
-		final OperationOutcome oo = new OperationOutcome();
+//		final OperationOutcome oo = new OperationOutcome();
 		final Patient patient = new Patient();
 		patient.addIdentifier((new Identifier().setValue("1")));
 		//invoke
@@ -470,12 +468,12 @@ public class AbstractJaxRsResourceProviderDstu3Test {
 
 		//@formatter:off
 		jerseyServlet.setInitParameter("resteasy.resources",
-			StringUtils.join(Arrays.asList(
-				TestJaxRsMockPatientRestProviderDstu3.class.getCanonicalName(),
-//					JaxRsExceptionInterceptor.class.getCanonicalName(),
-				TestJaxRsConformanceRestProviderDstu3.class.getCanonicalName(),
-				TestJaxRsMockPageProviderDstu3.class.getCanonicalName()
-			), ","));
+				StringUtils.join(Arrays.asList(
+						TestJaxRsMockPatientRestProviderDstu3.class.getCanonicalName(),
+						//					JaxRsExceptionInterceptor.class.getCanonicalName(),
+						TestJaxRsConformanceRestProviderDstu3.class.getCanonicalName(),
+						TestJaxRsMockPageProviderDstu3.class.getCanonicalName()
+						), ","));
 		//@formatter:on
 
 		JettyUtil.startServer(jettyServer);

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsResourceProviderTest.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsResourceProviderTest.java
@@ -1,54 +1,5 @@
 package ca.uhn.fhir.jaxrs.server;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.jaxrs.client.JaxRsRestfulClientFactory;
-import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsResponseException;
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsConformanceRestProvider;
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPageProvider;
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPatientRestProvider;
-import ca.uhn.fhir.model.api.IResource;
-import ca.uhn.fhir.model.dstu2.composite.IdentifierDt;
-import ca.uhn.fhir.model.dstu2.resource.Bundle;
-import ca.uhn.fhir.model.dstu2.resource.Conformance;
-import ca.uhn.fhir.model.dstu2.resource.OperationOutcome;
-import ca.uhn.fhir.model.dstu2.resource.Parameters;
-import ca.uhn.fhir.model.dstu2.resource.Patient;
-import ca.uhn.fhir.model.primitive.DateDt;
-import ca.uhn.fhir.model.primitive.IdDt;
-import ca.uhn.fhir.model.primitive.StringDt;
-import ca.uhn.fhir.model.primitive.UriDt;
-import ca.uhn.fhir.rest.api.EncodingEnum;
-import ca.uhn.fhir.rest.api.MethodOutcome;
-import ca.uhn.fhir.rest.api.PreferReturnEnum;
-import ca.uhn.fhir.rest.api.SearchStyleEnum;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
-import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
-import ca.uhn.fhir.rest.param.StringAndListParam;
-import ca.uhn.fhir.rest.param.StringParam;
-import ca.uhn.fhir.rest.server.SimpleBundleProvider;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import ca.uhn.fhir.test.utilities.JettyUtil;
-import ca.uhn.fhir.util.TestUtil;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.mockito.ArgumentCaptor;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -62,7 +13,54 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.ArgumentCaptor;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jaxrs.client.JaxRsRestfulClientFactory;
+import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsResponseException;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsConformanceRestProvider;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPageProvider;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsMockPatientRestProvider;
+import ca.uhn.fhir.model.api.IResource;
+import ca.uhn.fhir.model.dstu2.composite.IdentifierDt;
+import ca.uhn.fhir.model.dstu2.resource.Bundle;
+import ca.uhn.fhir.model.dstu2.resource.Conformance;
+import ca.uhn.fhir.model.dstu2.resource.Parameters;
+import ca.uhn.fhir.model.dstu2.resource.Patient;
+import ca.uhn.fhir.model.primitive.DateDt;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.model.primitive.StringDt;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.PreferReturnEnum;
+import ca.uhn.fhir.rest.api.SearchStyleEnum;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.server.SimpleBundleProvider;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.test.utilities.JettyUtil;
+import ca.uhn.fhir.util.TestUtil;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class AbstractJaxRsResourceProviderTest {
 
 	private static IGenericClient client;
@@ -88,7 +86,7 @@ public class AbstractJaxRsResourceProviderTest {
 
 	@AfterAll
 	public static void afterClassClearContext() throws Exception {
-        JettyUtil.closeServer(jettyServer);
+		JettyUtil.closeServer(jettyServer);
 		TestUtil.randomizeLocaleAndTimezone();
 	}
 
@@ -116,12 +114,12 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	public void findUsingGenericClientById() {
 		when(mock.find(any(IdDt.class))).thenReturn(createPatient(1));
-		Patient result = client.read(Patient.class, "1");
+		Patient result = client.read().resource(Patient.class).withId("1").execute();
 		compareResultId(1, result);
 		compareResultUrl("/Patient/1", result);
 		reset(mock);
 		when(mock.find(withId(result.getId()))).thenReturn(createPatient(1));
-		result = (Patient) client.read(new UriDt(result.getId().getValue()));
+		result = (Patient) client.read().resource(Patient.class).withUrl(result.getId().getValue()).execute();
 		compareResultId(1, result);
 		compareResultUrl("/Patient/1", result);
 	}
@@ -157,7 +155,7 @@ public class AbstractJaxRsResourceProviderTest {
 	/** Conformance - Server */
 	@Test
 	public void testConformance() {
-		final Conformance conf = client.fetchConformance().ofType(Conformance.class).execute();
+		final Conformance conf = client.capabilities().ofType(Conformance.class).execute();
 		assertEquals(conf.getRest().get(0).getResource().get(0).getType(), "Patient");
 	}
 
@@ -180,7 +178,8 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	public void testDeletePatient() {
 		when(mock.delete(idCaptor.capture(), conditionalCaptor.capture())).thenReturn(new MethodOutcome());
-		final IBaseOperationOutcome results = client.delete().resourceById("Patient", "1").execute().getOperationOutcome();
+//		final IBaseOperationOutcome results = 
+		client.delete().resourceById("Patient", "1").execute().getOperationOutcome();
 		assertEquals("1", idCaptor.getValue().getIdPart());
 	}
 
@@ -196,8 +195,10 @@ public class AbstractJaxRsResourceProviderTest {
 	public void testExtendedOperations() {
 		// prepare mock
 		Parameters resultParameters = new Parameters();
-		resultParameters.addParameter().setName("return").setResource(createPatient(1)).setValue(new StringDt("outputValue"));
-		when(mock.someCustomOperation(any(IdDt.class), eq(new StringDt("myAwesomeDummyValue")))).thenReturn(resultParameters);
+		resultParameters.addParameter().setName("return").setResource(createPatient(1))
+				.setValue(new StringDt("outputValue"));
+		when(mock.someCustomOperation(any(IdDt.class), eq(new StringDt("myAwesomeDummyValue"))))
+				.thenReturn(resultParameters);
 		// Create the input parameters to pass to the server
 		Parameters inParams = new Parameters();
 		inParams.addParameter().setName("start").setValue(new DateDt("2001-01-01"));
@@ -214,8 +215,10 @@ public class AbstractJaxRsResourceProviderTest {
 	public void testExtendedOperationsUsingGet() {
 		// prepare mock
 		Parameters resultParameters = new Parameters();
-		resultParameters.addParameter().setName("return").setResource(createPatient(1)).setValue(new StringDt("outputValue"));
-		when(mock.someCustomOperation(any(IdDt.class), eq(new StringDt("myAwesomeDummyValue")))).thenReturn(resultParameters);
+		resultParameters.addParameter().setName("return").setResource(createPatient(1))
+				.setValue(new StringDt("outputValue"));
+		when(mock.someCustomOperation(any(IdDt.class), eq(new StringDt("myAwesomeDummyValue"))))
+				.thenReturn(resultParameters);
 		// Create the input parameters to pass to the server
 		Parameters inParams = new Parameters();
 		inParams.addParameter().setName("start").setValue(new DateDt("2001-01-01"));
@@ -232,7 +235,7 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	public void testRead() {
 		when(mock.find(idCaptor.capture())).thenReturn(createPatient(1));
-		final Patient patient = client.read(Patient.class, "1");
+		final Patient patient = client.read().resource(Patient.class).withId("1").execute();
 		compareResultId(1, patient);
 		compareResultUrl("/Patient/1", patient);
 		assertEquals("1", idCaptor.getValue().getIdPart());
@@ -300,7 +303,7 @@ public class AbstractJaxRsResourceProviderTest {
 		// Perform a search
 		when(mock.search(isNull(), isNull()))
 				.thenReturn(createPatients(1, 13));
-		final Bundle results = client.search().forResource(Patient.class).limitTo(8).returnBundle(Bundle.class)
+		final Bundle results = client.search().forResource(Patient.class).count(8).returnBundle(Bundle.class)
 				.execute();
 
 		assertEquals(results.getEntry().size(), 8);
@@ -326,14 +329,15 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	@Disabled
 	public void testSummary() {
-		Object response = client.search().forResource(Patient.class)
+//		Object response = 
+				client.search().forResource(Patient.class)
 				.returnBundle(ca.uhn.fhir.model.dstu2.resource.Bundle.class).execute();
 	}
 
 	@Test
 	public void testUpdateById() throws Exception {
 		when(mock.update(idCaptor.capture(), patientCaptor.capture(), conditionalCaptor.capture())).thenReturn(new MethodOutcome());
-		client.update("1", createPatient(1));
+		client.update().resource(createPatient(1)).withId("1").execute();
 		assertEquals("1", idCaptor.getValue().getIdPart());
 		compareResultId(1, patientCaptor.getValue());
 	}
@@ -347,13 +351,13 @@ public class AbstractJaxRsResourceProviderTest {
 		assertEquals("Patient?identifier=2&_format=json", conditionalCaptor.getValue());
 	}
 
-	@SuppressWarnings("unchecked")
+//	@SuppressWarnings("unchecked")
 	@Disabled
 	@Test
 	public void testResourceNotFound() throws Exception {
 		when(mock.update(idCaptor.capture(), patientCaptor.capture(), conditionalCaptor.capture())).thenThrow(ResourceNotFoundException.class);
 		try {
-			client.update("1", createPatient(2));
+			client.update().resource(createPatient(2)).withId("1").execute();
 			fail();
 		} catch (ResourceNotFoundException e) {
 			// good
@@ -363,7 +367,7 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	public void testVRead() {
 		when(mock.findVersion(idCaptor.capture())).thenReturn(createPatient(1));
-		final Patient patient = client.vread(Patient.class, "1", "2");
+		final Patient patient = client.read().resource(Patient.class).withIdAndVersion("1", "2").execute();
 		compareResultId(1, patient);
 		compareResultUrl("/Patient/1", patient);
 		assertEquals("1", idCaptor.getValue().getIdPart());
@@ -393,9 +397,10 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	public void testXFindUnknownPatient() {
 		try {
-			JaxRsResponseException notFoundException = new JaxRsResponseException(new ResourceNotFoundException(new IdDt("999955541264")));
+			JaxRsResponseException notFoundException = new JaxRsResponseException(
+					new ResourceNotFoundException(new IdDt("999955541264")));
 			when(mock.find(idCaptor.capture())).thenThrow(notFoundException);
-			client.read(Patient.class, "999955541264");
+			client.read().resource(Patient.class).withId("999955541264").execute();
 			fail();
 		} catch (final ResourceNotFoundException e) {
 			assertEquals(ResourceNotFoundException.STATUS_CODE, e.getStatusCode());
@@ -406,7 +411,7 @@ public class AbstractJaxRsResourceProviderTest {
 	@Test
 	public void testValidate() {
 		// prepare mock
-		final OperationOutcome oo = new OperationOutcome();
+//		final OperationOutcome oo = new OperationOutcome();
 		final Patient patient = new Patient();
 		patient.addIdentifier((new IdentifierDt().setValue("1")));
 		// invoke
@@ -439,7 +444,8 @@ public class AbstractJaxRsResourceProviderTest {
 		context.setContextPath("/");
 		jettyServer = new Server(0);
 		jettyServer.setHandler(context);
-		ServletHolder jerseyServlet = context.addServlet(org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher.class, "/*");
+		ServletHolder jerseyServlet = context
+				.addServlet(org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher.class, "/*");
 		jerseyServlet.setInitOrder(0);
 
 		//@formatter:off
@@ -452,7 +458,7 @@ public class AbstractJaxRsResourceProviderTest {
 		//@formatter:on
 
 		JettyUtil.startServer(jettyServer);
-        ourPort = JettyUtil.getPortForStartedServer(jettyServer);
+		ourPort = JettyUtil.getPortForStartedServer(jettyServer);
 
 		ourCtx.setRestfulClientFactory(new JaxRsRestfulClientFactory(ourCtx));
 		ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/test/TestJaxRsDummyPatientProviderDstu3.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/test/TestJaxRsDummyPatientProviderDstu3.java
@@ -1,6 +1,5 @@
 package ca.uhn.fhir.jaxrs.server.test;
 
-import ca.uhn.fhir.interceptor.api.IInterceptorService;
 import org.hl7.fhir.dstu3.model.Patient;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/test/TestJaxRsMockPatientRestProvider.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/test/TestJaxRsMockPatientRestProvider.java
@@ -1,30 +1,46 @@
 package ca.uhn.fhir.jaxrs.server.test;
 
-import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import javax.ejb.Stateless;
 import javax.interceptor.Interceptors;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import ca.uhn.fhir.rest.api.server.IBundleProvider;
-import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.mockito.Mockito;
 
 import ca.uhn.fhir.jaxrs.server.AbstractJaxRsResourceProvider;
 import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsExceptionInterceptor;
 import ca.uhn.fhir.model.api.IResource;
-import ca.uhn.fhir.model.dstu2.resource.*;
+import ca.uhn.fhir.model.dstu2.resource.OperationOutcome;
+import ca.uhn.fhir.model.dstu2.resource.Parameters;
+import ca.uhn.fhir.model.dstu2.resource.Patient;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.model.primitive.StringDt;
-import ca.uhn.fhir.rest.annotation.*;
-import ca.uhn.fhir.rest.api.*;
+import ca.uhn.fhir.rest.annotation.ConditionalUrlParam;
+import ca.uhn.fhir.rest.annotation.Create;
+import ca.uhn.fhir.rest.annotation.Delete;
+import ca.uhn.fhir.rest.annotation.History;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.annotation.Read;
+import ca.uhn.fhir.rest.annotation.RequiredParam;
+import ca.uhn.fhir.rest.annotation.ResourceParam;
+import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Update;
+import ca.uhn.fhir.rest.annotation.Validate;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/util/JaxRsRequestDstu3Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/util/JaxRsRequestDstu3Test.java
@@ -1,29 +1,34 @@
 package ca.uhn.fhir.jaxrs.server.util;
 
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsDummyPatientProviderDstu3;
-import ca.uhn.fhir.rest.api.RequestTypeEnum;
-import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
-import ca.uhn.fhir.rest.server.exceptions.NotImplementedOperationException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsDummyPatientProviderDstu3;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 
 public class JaxRsRequestDstu3Test {
 	
 	private static final String RESOURCE_STRING = "</Patient>";
 	private static final String BASEURI = "http://baseuri";
-	private static final String REQUESTURI = "http://baseuri/test";
+//	private static final String REQUESTURI = "http://baseuri/test";
 	
 	private JaxRsRequest details;
 	private MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<String, String>();

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/util/JaxRsRequestTest.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/util/JaxRsRequestTest.java
@@ -1,29 +1,35 @@
 package ca.uhn.fhir.jaxrs.server.util;
 
-import ca.uhn.fhir.jaxrs.server.test.TestJaxRsDummyPatientProvider;
-import ca.uhn.fhir.rest.api.RequestTypeEnum;
-import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
-import ca.uhn.fhir.rest.server.exceptions.NotImplementedOperationException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import ca.uhn.fhir.jaxrs.server.test.TestJaxRsDummyPatientProvider;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 
 public class JaxRsRequestTest {
 	
 	private static final String RESOURCE_STRING = "</Patient>";
 	private static final String BASEURI = "http://baseuri";
-	private static final String REQUESTURI = "http://baseuri/test";
+//	private static final String REQUESTURI = "http://baseuri/test";
 	
 	private JaxRsRequest details;
 	private MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<String, String>();

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/util/JaxRsResponseDstu3Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/server/util/JaxRsResponseDstu3Test.java
@@ -11,13 +11,15 @@ import java.util.Set;
 
 import javax.ws.rs.core.Response;
 
-import org.hl7.fhir.dstu3.model.*;
+import org.hl7.fhir.dstu3.model.Binary;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.instance.model.api.IBaseBinary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import ca.uhn.fhir.rest.api.Constants;
-import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.server.RestfulServerUtils;
 
@@ -38,7 +40,7 @@ public class JaxRsResponseDstu3Test {
 	
 	@Test
 	public void testGetResponseWriterNoZipNoBrowser() throws IOException {
-		boolean theRequestIsBrowser = false;
+//		boolean theRequestIsBrowser = false;
 		boolean respondGzip = false;
 		Set<SummaryEnum> theSummaryMode = Collections.<SummaryEnum>emptySet();
         boolean theAddContentLocationHeader = false;
@@ -51,7 +53,7 @@ public class JaxRsResponseDstu3Test {
 
 	@Test
 	public void testSendAttachmentResponse() throws IOException {
-		boolean theRequestIsBrowser = true;
+//		boolean theRequestIsBrowser = true;
 		boolean respondGzip = true;
 		IBaseBinary binary = new Binary();
 		String contentType = "foo";
@@ -67,7 +69,7 @@ public class JaxRsResponseDstu3Test {
 	
 	@Test
 	public void testSendAttachmentResponseNoContent() throws IOException {
-		boolean theRequestIsBrowser = true;
+//		boolean theRequestIsBrowser = true;
 		boolean respondGzip = true;
 		IBaseBinary binary = new Binary();
 		binary.setContent(new byte[]{});
@@ -80,7 +82,7 @@ public class JaxRsResponseDstu3Test {
 	
 	@Test
 	public void testSendAttachmentResponseEmptyContent() throws IOException {
-		boolean theRequestIsBrowser = true;
+//		boolean theRequestIsBrowser = true;
 		boolean respondGzip = true;
 		IBaseBinary binary = new Binary();
 		boolean theAddContentLocationHeader = false;
@@ -93,11 +95,11 @@ public class JaxRsResponseDstu3Test {
 
 	@Test
 	public void testReturnResponse() throws IOException {
-		IdType theId = new IdType(15L);
-		int operationStatus = 200;
-		boolean allowPrefer = true;
-		String resourceName = "Patient";
-		MethodOutcome methodOutcome = new MethodOutcome(theId);
+//		IdType theId = new IdType(15L);
+//		int operationStatus = 200;
+//		boolean allowPrefer = true;
+//		String resourceName = "Patient";
+//		MethodOutcome methodOutcome = new MethodOutcome(theId);
 		boolean addContentLocationHeader = true;
 		boolean respondGzip = true;
 		Response result = (Response) RestfulServerUtils.streamResponseAsResource(request.getServer(), createPatient(), theSummaryMode, 200, addContentLocationHeader, respondGzip, this.request);
@@ -110,11 +112,11 @@ public class JaxRsResponseDstu3Test {
 	
 	@Test
 	public void testReturnResponseAsXml() throws IOException {
-		IdType theId = new IdType(15L);
-		int operationStatus = 200;
-		boolean allowPrefer = true;
-		String resourceName = "Patient";
-		MethodOutcome methodOutcome = new MethodOutcome(theId);
+//		IdType theId = new IdType(15L);
+//		int operationStatus = 200;
+//		boolean allowPrefer = true;
+//		String resourceName = "Patient";
+//		MethodOutcome methodOutcome = new MethodOutcome(theId);
 		response.getRequestDetails().addParameter(Constants.PARAM_FORMAT, new String[]{Constants.CT_XML});
 		boolean addContentLocationHeader = true;
 		boolean respondGzip = true;


### PR DESCRIPTION
- cleanup imports
- Remove all unused varaiables (Tests)
- Replace all depreacated calls by fluent Api like client.read(Patient.class, "1") ; to client.read().resource(Patient.class).withId("1").execute();
