### PR TITLE
Removal of meta tags during updates do not trigger subscription

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5182-fix-removing-tags-does-not-trigger-subscription.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5182-fix-removing-tags-does-not-trigger-subscription.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5182
+jira: SMILE-6857
+title: "Previously, removing tags in a resource update with proper headers and versioning flag would not trigger a 
+new subscription.  This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -137,18 +137,6 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -163,9 +151,22 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.XMLEvent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static org.apache.commons.collections4.CollectionUtils.isEqualCollection;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.left;
@@ -302,7 +303,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 		}
 	}
 
-	private void extractTagsHapi(
+	private void extractHapiTags(
 			TransactionDetails theTransactionDetails,
 			IResource theResource,
 			ResourceTable theEntity,
@@ -359,7 +360,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 		}
 	}
 
-	private void extractTagsRi(
+	private void extractRiTags(
 			TransactionDetails theTransactionDetails,
 			IAnyResource theResource,
 			ResourceTable theEntity,
@@ -412,6 +413,25 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 					theAllTags.add(tag);
 					theEntity.setHasTags(true);
 				}
+			}
+		}
+	}
+
+	private void extractProfileTags(
+			TransactionDetails theTransactionDetails,
+									IBaseResource theResource,
+									ResourceTable theEntity,
+									Set<ResourceTag> theAllTags){
+		RuntimeResourceDefinition def = myContext.getResourceDefinition(theResource);
+		if (!def.isStandardType()) {
+			String profile = def.getResourceProfile("");
+			if (isNotBlank(profile)) {
+				TagDefinition profileDef = getTagOrNull(
+						theTransactionDetails, TagTypeEnum.PROFILE, NS_JPA_PROFILE, profile, null, null, null);
+
+				ResourceTag tag = theEntity.addTag(profileDef);
+				theAllTags.add(tag);
+				theEntity.setHasTags(true);
 			}
 		}
 	}
@@ -840,44 +860,43 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 		return sourceExtension;
 	}
 
+
+
 	private boolean updateTags(
 			TransactionDetails theTransactionDetails,
 			RequestDetails theRequest,
 			IBaseResource theResource,
 			ResourceTable theEntity) {
-		Set<ResourceTag> allDefs = new HashSet<>();
-		Set<ResourceTag> allTagsOld = getAllTagDefinitions(theEntity);
+		Set<ResourceTag> allResourceTagsFromTheResource = new HashSet<>();
+		Set<ResourceTag> allOriginalResourceTagsFromTheEntity = getAllTagDefinitions(theEntity);
 
 		if (theResource instanceof IResource) {
-			extractTagsHapi(theTransactionDetails, (IResource) theResource, theEntity, allDefs);
+			extractHapiTags(theTransactionDetails, (IResource) theResource, theEntity, allResourceTagsFromTheResource);
 		} else {
-			extractTagsRi(theTransactionDetails, (IAnyResource) theResource, theEntity, allDefs);
+			extractRiTags(theTransactionDetails, (IAnyResource) theResource, theEntity, allResourceTagsFromTheResource);
 		}
 
-		RuntimeResourceDefinition def = myContext.getResourceDefinition(theResource);
-		if (!def.isStandardType()) {
-			String profile = def.getResourceProfile("");
-			if (isNotBlank(profile)) {
-				TagDefinition profileDef = getTagOrNull(
-						theTransactionDetails, TagTypeEnum.PROFILE, NS_JPA_PROFILE, profile, null, null, null);
+		extractProfileTags(theTransactionDetails, theResource, theEntity, allResourceTagsFromTheResource);
 
-				ResourceTag tag = theEntity.addTag(profileDef);
-				allDefs.add(tag);
-				theEntity.setHasTags(true);
-			}
-		}
+		// the extract[Hapi|Ri|Profile]Tags methods above will have populated the allResourceTagsFromTheResource Set
+		// AND
+		// added all tags from theResource.meta.tags to theEntity.meta.tags.  the next steps are to:
+		// 1- remove duplicates;
+		// 2- remove tags from theEntity that are not present in theResource if header HEADER_META_SNAPSHOT_MODE
+		// is present in the request;
+		//
+		Set<ResourceTag> allResourceTagsNewAndOldFromTheEntity = getAllTagDefinitions(theEntity);
+		Set<TagDefinition> allTagDefinitionsPresent = new HashSet<>();
 
-		Set<ResourceTag> allTagsNew = getAllTagDefinitions(theEntity);
-		Set<TagDefinition> allDefsPresent = new HashSet<>();
-		allTagsNew.forEach(tag -> {
+		allResourceTagsNewAndOldFromTheEntity.forEach(tag -> {
 
 			// Don't keep duplicate tags
-			if (!allDefsPresent.add(tag.getTag())) {
+			if (!allTagDefinitionsPresent.add(tag.getTag())) {
 				theEntity.getTags().remove(tag);
 			}
 
 			// Drop any tags that have been removed
-			if (!allDefs.contains(tag)) {
+			if (!allResourceTagsFromTheResource.contains(tag)) {
 				if (shouldDroppedTagBeRemovedOnUpdate(theRequest, tag)) {
 					theEntity.getTags().remove(tag);
 				} else if (HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY.equals(
@@ -887,21 +906,33 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			}
 		});
 
-		// Update the resource to contain the old tags
-		allTagsOld.forEach(tag -> {
-			IBaseCoding iBaseCoding = theResource
-					.getMeta()
-					.addTag()
-					.setCode(tag.getTag().getCode())
-					.setSystem(tag.getTag().getSystem())
-					.setVersion(tag.getTag().getVersion());
-			if (tag.getTag().getUserSelected() != null) {
-				iBaseCoding.setUserSelected(tag.getTag().getUserSelected());
+		// at this point, theEntity.meta.tags will be up to date:
+		// 1- it was stripped from tags that needed removing;
+		// 2- it has new tags from a resource update through theResource;
+		// 3- it has tags from the previous version;
+		//
+		// Since tags are merged on updates, we add tags from theEntity that theResource does not have
+		Set<ResourceTag> allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity = getAllTagDefinitions(theEntity);
+
+		allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity.forEach(aResourcetag ->{
+			if(!allResourceTagsFromTheResource.contains(aResourcetag)){
+				IBaseCoding iBaseCoding = theResource.getMeta()
+						.addTag()
+						.setCode(aResourcetag.getTag().getCode())
+						.setSystem(aResourcetag.getTag().getSystem())
+						.setVersion(aResourcetag.getTag().getVersion());
+
+				allResourceTagsFromTheResource.add(aResourcetag);
+
+				if (aResourcetag.getTag().getUserSelected() != null) {
+					iBaseCoding.setUserSelected(aResourcetag.getTag().getUserSelected());
+				}
 			}
 		});
 
-		theEntity.setHasTags(!allTagsNew.isEmpty());
-		return !allTagsOld.equals(allTagsNew);
+
+		theEntity.setHasTags(!allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity.isEmpty());
+		return !isEqualCollection(allOriginalResourceTagsFromTheEntity, allResourceTagsFromTheResource);
 	}
 
 	/**
@@ -947,7 +978,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 	 * The default implementation removes any profile declarations, but leaves tags and security labels in place. Subclasses may choose to override and change this behaviour.
 	 * </p>
 	 * <p>
-	 * See <a href="http://hl7.org/fhir/resource.html#tag-updates">Updates to Tags, Profiles, and Security Labels</a> for a description of the logic that the default behaviour folows.
+	 * See <a href="http://hl7.org/fhir/resource.html#tag-updates">Updates to Tags, Profiles, and Security Labels</a> for a description of the logic that the default behaviour follows.
 	 * </p>
 	 *
 	 * @param theTag The tag

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -137,6 +137,18 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -151,18 +163,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.XMLEvent;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -419,9 +419,9 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 
 	private void extractProfileTags(
 			TransactionDetails theTransactionDetails,
-									IBaseResource theResource,
-									ResourceTable theEntity,
-									Set<ResourceTag> theAllTags){
+			IBaseResource theResource,
+			ResourceTable theEntity,
+			Set<ResourceTag> theAllTags) {
 		RuntimeResourceDefinition def = myContext.getResourceDefinition(theResource);
 		if (!def.isStandardType()) {
 			String profile = def.getResourceProfile("");
@@ -860,8 +860,6 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 		return sourceExtension;
 	}
 
-
-
 	private boolean updateTags(
 			TransactionDetails theTransactionDetails,
 			RequestDetails theRequest,
@@ -914,9 +912,10 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 		// Since tags are merged on updates, we add tags from theEntity that theResource does not have
 		Set<ResourceTag> allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity = getAllTagDefinitions(theEntity);
 
-		allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity.forEach(aResourcetag ->{
-			if(!allResourceTagsFromTheResource.contains(aResourcetag)){
-				IBaseCoding iBaseCoding = theResource.getMeta()
+		allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity.forEach(aResourcetag -> {
+			if (!allResourceTagsFromTheResource.contains(aResourcetag)) {
+				IBaseCoding iBaseCoding = theResource
+						.getMeta()
 						.addTag()
 						.setCode(aResourcetag.getTag().getCode())
 						.setSystem(aResourcetag.getTag().getSystem())
@@ -929,7 +928,6 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 				}
 			}
 		});
-
 
 		theEntity.setHasTags(!allUpdatedResourceTagsNewAndOldMinusRemovalsFromTheEntity.isEmpty());
 		return !isEqualCollection(allOriginalResourceTagsFromTheEntity, allResourceTagsFromTheResource);

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
@@ -83,7 +83,7 @@ public class JpaConstants {
 	 * Header name for the "X-Meta-Snapshot-Mode" header, which
 	 * specifies that properties in meta (tags, profiles, security labels)
 	 * should be treated as a snapshot, meaning that these things will
-	 * be removed if they are nt explicitly included in updates
+	 * be removed if they are not explicitly included in updates
 	 */
 	public static final String HEADER_META_SNAPSHOT_MODE = "X-Meta-Snapshot-Mode";
 	/**

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4UpdateTagSnapshotTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4UpdateTagSnapshotTest.java
@@ -39,7 +39,7 @@ public class FhirResourceDaoR4UpdateTagSnapshotTest extends BaseJpaR4Test {
 		myPatientDao.update(p, mySrd);
 
 		p = myPatientDao.read(new IdType("A"), mySrd);
-		assertEquals("1", p.getIdElement().getVersionIdPart());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
 		assertEquals(true, p.getActive());
 		assertEquals(1, p.getMeta().getTag().size());
 	}
@@ -84,7 +84,7 @@ public class FhirResourceDaoR4UpdateTagSnapshotTest extends BaseJpaR4Test {
 		myPatientDao.update(p, mySrd);
 
 		p = myPatientDao.read(new IdType("A"), mySrd);
-		assertEquals("1", p.getIdElement().getVersionIdPart());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
 		assertEquals(true, p.getActive());
 		assertEquals(1, p.getMeta().getTag().size());
 		assertEquals("urn:foo", p.getMeta().getTag().get(0).getSystem());
@@ -132,7 +132,27 @@ public class FhirResourceDaoR4UpdateTagSnapshotTest extends BaseJpaR4Test {
 		p = myPatientDao.read(new IdType("A"), mySrd);
 		assertEquals(true, p.getActive());
 		assertEquals(0, p.getMeta().getTag().size());
-		assertEquals("1", p.getIdElement().getVersionIdPart());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
+	}
+
+	@Test
+	public void testUpdateResource_withNewTags_willCreateNewResourceVersion() {
+
+		Patient p = new Patient();
+		p.setId("A");
+		p.setActive(true);
+		myPatientDao.update(p, mySrd);
+
+		p = new Patient();
+		p.setId("A");
+		p.getMeta().addTag("urn:foo", "bar", "baz");
+		p.setActive(true);
+		myPatientDao.update(p, mySrd);
+
+		p = myPatientDao.read(new IdType("A"), mySrd);
+		assertEquals(true, p.getActive());
+		assertEquals(1, p.getMeta().getTag().size());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
 	}
 
 


### PR DESCRIPTION
**What was done:**

-  fixed issue where tags would not be removed when performing a resource update with header` X-Meta-Snapshot-Mode` and `flag trigger_on_non_versioning_changes` set to `true`;
- added tests to cover multiple scenarios regarding a resource update with modified tags;
- fixing documentation;
- added changelog;