### PR TITLE
Slf4j api change

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>6.7.15-SNAPSHOT</version>
+		 <version>6.8.0-SNAPSHOT</version>
 
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/UriParamQualifierEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/UriParamQualifierEnum.java
@@ -48,7 +48,16 @@ public enum UriParamQualifierEnum {
 	 * Value <code>:below</code>
 	 * </p>
 	 */
-	BELOW(":below");
+	BELOW(":below"),
+
+	/**
+	 * The contains modifier allows clients to indicate that a supplied URI input should be matched
+	 * as a case-insensitive and combining-character insensitive match anywhere in the target URI.
+	 * <p>
+	 * Value <code>:contains</code>
+	 * </p>
+	 */
+	CONTAINS(":contains");
 
 	private static final Map<String, UriParamQualifierEnum> KEY_TO_VALUE;
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -40,6 +40,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -600,6 +602,39 @@ public class UrlUtil {
 		}
 
 		return parameters;
+	}
+
+	/**
+	 * Creates list of sub URIs candidates for search with :above modifier
+	 * Example input: http://[host]/[pathPart1]/[pathPart2]
+	 * Example output: http://[host], http://[host]/[pathPart1], http://[host]/[pathPart1]/[pathPart2]
+	 *
+	 * @param theUri String URI parameter
+	 * @return List of URI candidates
+	 */
+	public static List<String> getAboveUriCandidates(String theUri) {
+		try {
+			URI uri = new URI(theUri);
+			if (uri.getScheme() == null || uri.getHost() == null) {
+				throwInvalidRequestExceptionForNotValidUri(theUri, null);
+			}
+		} catch (URISyntaxException theCause) {
+			throwInvalidRequestExceptionForNotValidUri(theUri, theCause);
+		}
+
+		List<String> candidates = new ArrayList<>();
+		Path path = Paths.get(theUri);
+		candidates.add(path.toString().replace(":/", "://"));
+		while (path.getParent() != null && path.getParent().toString().contains("/")) {
+			candidates.add(path.getParent().toString().replace(":/", "://"));
+			path = path.getParent();
+		}
+		return candidates;
+	}
+
+	private static void throwInvalidRequestExceptionForNotValidUri(String theUri, Exception theCause) {
+		throw new InvalidRequestException(
+				Msg.code(2419) + String.format("Provided URI is not valid: %s", theUri), theCause);
 	}
 
 	public static class UrlParts {

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>6.7.15-SNAPSHOT</version>
+	<version>6.8.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5095-add-support-for-source-search-parameter-modifiers.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5095-add-support-for-source-search-parameter-modifiers.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 5095
+title: "Added support for :above, :below, :contains and :missing _source search parameter modifiers."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5117-fix-no-match-mdm-score-included-in-total-score.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5117-fix-no-match-mdm-score-included-in-total-score.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5117
+title: "Previously, all MDM field scores, including `NO_MATCH`es, were included in the final total MDM score. This has 
+now been fixed so that only `MATCH`ed fields are included in the total MDM score."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5119-consent-removing-all-resources-suppresses-next-link-in-bundle.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5119-consent-removing-all-resources-suppresses-next-link-in-bundle.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5119
+jira: SMILE-7090
+title: "Previously, when the consent service would remove all resources to be returned, the response bundle would
+ not provide the previous/next link(s). This has been corrected."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5126-hfj_res_ver_prov-might-cause-migration-error-on-db-that-automatically-indexes-the-primary-key.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5126-hfj_res_ver_prov-might-cause-migration-error-on-db-that-automatically-indexes-the-primary-key.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5126
+title: "Previously, updating from Hapi-fhir 6.6.0 to 6.8.0 would cause migration error, it is now fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5150--delete-expunge-over-10k-resources-deletes-only-10k.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5150--delete-expunge-over-10k-resources-deletes-only-10k.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5150
+title: "When running a $delete-expunge with over 10,000 resources, only the first 10,000 resources were deleted.
+        This is now fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5155-expunge-operation-on-codesystem-may-return-500.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5155-expunge-operation-on-codesystem-may-return-500.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5155
+title: "Previously, requesting an $expunge operation on CodeSystem resources while CS batch deletion is underway would return HTTP 500.
+ This has been fixed to return HTTP 412 (precondition failed)."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5158-add-support-for-subscription-matching-of-source-search-parameter-modifiers.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5158-add-support-for-subscription-matching-of-source-search-parameter-modifiers.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 5158
+title: "Added support for Subscription matching of ':above', ':below', ':contains' and ':missing' '_source' search parameter modifiers."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5167-fix-jdbc-deps.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5167-fix-jdbc-deps.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5167
+title: "Fixed a dependency in the HSQL JDBC driver referencing a non-bundled class (javax.ServletOutputStream)"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5173-gateway-everything-doesnt-return-all-patients.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5173-gateway-everything-doesnt-return-all-patients.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5173
+title: "Fix gateway `$everything` operation to respect server configured default and maximum page sizes."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5182-fix-removing-tags-does-not-trigger-subscription.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5182-fix-removing-tags-does-not-trigger-subscription.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5182
+jira: SMILE-6857
+title: "Previously, removing tags in a resource update with proper headers and versioning flag would not trigger a 
+new subscription.  This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5183-us-core-ig-ingestion-fails-value-set-version-id-conflict.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5183-us-core-ig-ingestion-fails-value-set-version-id-conflict.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5183
+title: "The latest US Core IG includes two ValueSets with different contents, but the same FHIR Id and OID via two different included IGs (i.e. `2.16.840.1.113762.1.4.1010.9` via us.cdc.phinvads and us.nlm.vsac).  Ingesting these duplicates in US Core failed with a 500 error. This has been resolved by logging the error and allowing the rest of the ingestion to proceed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/hfql/hfql.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/hfql/hfql.md
@@ -14,8 +14,8 @@ A simple example query is shown below:
 
 ```sql
 SELECT
-    name.family as family, 
-    name.given as given, 
+    name[0].family as family, 
+    name[0].given[0] as given, 
     birthDate,
     identifier.where(system='http://hl7.org/fhir/sid/us-ssn').value as SSN
 FROM

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_details.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_details.md
@@ -22,10 +22,7 @@ Below are some simplifying principles HAPI MDM follows to reduce complexity and 
 
 1. The only source resources in the system that do not have a MATCH link are those that have the 'NO-MDM' tag or those that have POSSIBLE_MATCH links pending review.
 
-1. The HAPI MDM rules define a single identifier system that holds the external enterprise id ("EID"). If a source resource has an external EID, then the Golden Resource it links to always has the same EID. If a source resource has no EID when it arrives, a unique UUID will be assigned as that source resource's EID.
-
-1. A Golden Resource can have both an internal EID (auto-created by HAPI), and an external EID (provided by an 
-external system).
+1. The HAPI MDM rules define a single identifier system that holds the external enterprise id ("EID"). If a source resource has an external EID, then the Golden Resource it links to always has the same EID.
 
 1. Two different Golden Resources cannot have the same EID.
 
@@ -85,7 +82,7 @@ possible that hundreds of John Doe's could be linked to the same Golden Resource
 
 When a new source resource is compared with all other resources of the same type in the repository, there are four possible outcomes:
 
-* CASE 1: No MATCH and no POSSIBLE_MATCH outcomes -> a new Golden Resource is created and linked to that source resource as MATCH. If the incoming resource has an EID, it is copied to the Golden Resource. Otherwise a new UUID is generated and used as the internal EID.
+* CASE 1: No MATCH and no POSSIBLE_MATCH outcomes -> a new Golden Resource is created and linked to that source resource as MATCH. If the incoming resource has an EID, it is copied to the Golden Resource.
 
 * CASE 2: All of the MATCH source resources are already linked to the same Golden Resource -> a new Link is created between the new source resource and that Golden Resource and is set to MATCH.
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_eid.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_eid.md
@@ -1,8 +1,9 @@
 # MDM Enterprise Identifiers
 
-An Enterprise Identifier (EID) is a unique identifier that can be attached to source resources. Each implementation is expected to use exactly one EID system for incoming resources, defined in the MDM Rules file. If a source resource with a valid EID is submitted, that EID will be copied over to the Golden Resource that was matched. In the case that the incoming source resource had no EID assigned, an internal EID will be created for it. There are thus two classes of EID:
- * Internal EIDs, created by HAPI-MDM, and 
- * External EIDs, provided by the submitted resources.
+An Enterprise Identifier (EID) is a unique identifier that can be attached to source resources.
+Each implementation is expected to use exactly one EID system for incoming resources,
+defined in the MDM Rules file.
+If a source resource with a valid EID is submitted, that EID will be copied over to the Golden Resource that was matched.
 
 ## MDM EID Settings
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_rules.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_rules.md
@@ -111,9 +111,26 @@ Here is a description of how each section of this document is configured.
 
 ### candidateSearchParams
 
-These define fields which must have at least one exact match before two resources are considered for matching. This is like a list of "pre-searches" that find potential candidates for matches, to avoid the expensive operation of running a match score calculation on all resources in the system. E.g. you may only wish to consider matching two Patients if they either share at least one identifier in common or have the same birthday or the same phone number. The HAPI FHIR server executes each of these searches separately and then takes the union of the results, so you can think of these as `OR` criteria that cast a wide net for potential candidates. In some MDM systems, these "pre-searches" are called "blocking" searches (since they identify "blocks" of candidates that will be searched for matches).
+These define one or more fields which must have a match before two resources are considered for matching.
+This is like a list of "pre-searches" that find potential candidates for matches,
+to avoid the expensive operation of running a match score calculation on all resources in the system.
+`candidateSearchParameters` are capable of making exact searches and phonetic searches
+(see the list of [phonetic search parameters](/hapi-fhir/docs/fhir_repository/search_parameter_phonetic.html))
+E.g. you may only wish to consider matching two Patients if they either share at least one identifier in
+common or have the same birthday or the same phone number. The HAPI FHIR server executes each of these searches
+separately and then takes the union of the results, so you can think of these as `OR` criteria that
+cast a wide net for potential candidates. In some MDM systems, these "pre-searches" are called "blocking"
+searches (since they identify "blocks" of candidates that will be searched for matches).
 
-If a list of searchParams is specified in a given candidateSearchParams item, then these search parameters are treated as `AND` parameters. In the following candidateSearchParams definition, hapi-fhir will extract given name, family name and identifiers from the incoming Patient and perform two separate searches, first for all Patient resources that have the same given `AND` the same family name as the incoming Patient, and second for all Patient resources that share at least one identifier as the incoming Patient. Note that if the incoming Patient was missing any of these searchParam values, then that search would be skipped. E.g. if the incoming Patient had a given name but no family name, then only a search for matching identifiers would be performed.
+If a list of searchParams is specified in a given candidateSearchParams item,
+then these search parameters are treated as `AND` parameters.
+In the following candidateSearchParams definition, hapi-fhir will extract given name,
+family name and identifiers from the incoming Patient and perform two separate searches,
+first for all Patient resources that have the same given `AND` the same family name as
+the incoming Patient, and second for all Patient resources that share at least one
+identifier as the incoming Patient. Note that if the incoming Patient was missing any of these searchParam values,
+then that search would be skipped. E.g. if the incoming Patient had a given name but no family name,
+then only a search for matching identifiers would be performed.
 
 ```json
 {

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
@@ -19,16 +19,21 @@
  */
 package ca.uhn.fhir.jpa.config;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
 import ca.uhn.fhir.jpa.api.svc.IDeleteExpungeSvc;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
 import ca.uhn.fhir.jpa.dao.data.IResourceLinkDao;
+import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
 import ca.uhn.fhir.jpa.dao.expunge.ResourceTableFKProvider;
+import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSqlBuilder;
 import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSvcImpl;
 import ca.uhn.fhir.jpa.reindex.Batch2DaoSvcImpl;
+import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 
@@ -37,8 +42,20 @@ import javax.persistence.EntityManager;
 public class Batch2SupportConfig {
 
 	@Bean
-	public IBatch2DaoSvc batch2DaoSvc() {
-		return new Batch2DaoSvcImpl();
+	public IBatch2DaoSvc batch2DaoSvc(
+			IResourceTableDao theResourceTableDao,
+			MatchUrlService theMatchUrlService,
+			DaoRegistry theDaoRegistry,
+			FhirContext theFhirContext,
+			IHapiTransactionService theTransactionService,
+			JpaStorageSettings theJpaStorageSettings) {
+		return new Batch2DaoSvcImpl(
+				theResourceTableDao,
+				theMatchUrlService,
+				theDaoRegistry,
+				theFhirContext,
+				theTransactionService,
+				theJpaStorageSettings);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -107,7 +107,6 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
-import ca.uhn.fhir.util.ObjectUtil;
 import ca.uhn.fhir.util.ReflectionUtil;
 import ca.uhn.fhir.util.StopWatch;
 import ca.uhn.fhir.util.UrlUtil;
@@ -143,7 +142,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -1118,9 +1116,9 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 
 		for (TagDefinition nextDef : tags) {
 			for (BaseTag next : new ArrayList<BaseTag>(theEntity.getTags())) {
-				if (ObjectUtil.equals(next.getTag().getTagType(), nextDef.getTagType())
-						&& ObjectUtil.equals(next.getTag().getSystem(), nextDef.getSystem())
-						&& ObjectUtil.equals(next.getTag().getCode(), nextDef.getCode())) {
+				if (Objects.equals(next.getTag().getTagType(), nextDef.getTagType())
+						&& Objects.equals(next.getTag().getSystem(), nextDef.getSystem())
+						&& Objects.equals(next.getTag().getCode(), nextDef.getCode())) {
 					myEntityManager.remove(next);
 					theEntity.getTags().remove(next);
 				}
@@ -1236,10 +1234,9 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		IBundleProvider retVal = myTransactionService
 				.withRequest(theRequestDetails)
 				.withRequestPartitionId(requestPartitionId)
-				.execute(() -> {
-					return myPersistedJpaBundleProviderFactory.history(
-							theRequestDetails, myResourceName, null, theSince, theUntil, theOffset, requestPartitionId);
-				});
+				.execute(() -> myPersistedJpaBundleProviderFactory.history(
+						theRequestDetails, myResourceName, null, theSince, theUntil, theOffset, requestPartitionId));
+
 		ourLog.debug("Processed history on {} in {}ms", myResourceName, w.getMillisAndRestart());
 		return retVal;
 	}
@@ -1503,7 +1500,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		JpaPid jpaPid = (JpaPid) thePid;
 
 		Optional<ResourceTable> entity = myResourceTableDao.findById(jpaPid.getId());
-		if (!entity.isPresent()) {
+		if (entity.isEmpty()) {
 			throw new ResourceNotFoundException(Msg.code(975) + "No resource found with PID " + jpaPid);
 		}
 		if (isDeleted(entity.get()) && !theDeletedOk) {
@@ -1554,7 +1551,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 
 		T retVal = myJpaStorageResourceParser.toResource(myResourceType, entity, null, false);
 
-		if (theDeletedOk == false) {
+		if (!theDeletedOk) {
 			if (isDeleted(entity)) {
 				throw createResourceGoneException(entity);
 			}
@@ -1588,7 +1585,6 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				.execute(() -> readEntity(theId, true, theRequest, requestPartitionId));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public ReindexOutcome reindex(
 			IResourcePersistentId thePid,
@@ -1657,7 +1653,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			CURRENTLY_REINDEXING.put(theResource, Boolean.TRUE);
 		}
 
-		ResourceTable resourceTable = updateEntity(
+		updateEntity(
 				null, theResource, theEntity, theEntity.getDeleted(), true, false, transactionDetails, true, false);
 		if (theResource != null) {
 			CURRENTLY_REINDEXING.put(theResource, null);
@@ -1743,7 +1739,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			} else {
 				if (readPartitions.contains(null)) {
 					List<Integer> readPartitionsWithoutNull =
-							readPartitions.stream().filter(t -> t != null).collect(Collectors.toList());
+							readPartitions.stream().filter(Objects::nonNull).collect(Collectors.toList());
 					entity = myResourceTableDao
 							.readByPartitionIdsOrNull(readPartitionsWithoutNull, pid.getId())
 							.orElse(null);
@@ -1771,7 +1767,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 
 		if (theId.hasVersionIdPart()) {
-			if (theId.isVersionIdPartValidLong() == false) {
+			if (!theId.isVersionIdPartValidLong()) {
 				throw new ResourceNotFoundException(Msg.code(978)
 						+ getContext()
 								.getLocalizer()
@@ -1884,9 +1880,9 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 
 		for (BaseTag next : new ArrayList<>(entity.getTags())) {
-			if (ObjectUtil.equals(next.getTag().getTagType(), theTagType)
-					&& ObjectUtil.equals(next.getTag().getSystem(), theScheme)
-					&& ObjectUtil.equals(next.getTag().getCode(), theTerm)) {
+			if (Objects.equals(next.getTag().getTagType(), theTagType)
+					&& Objects.equals(next.getTag().getSystem(), theScheme)
+					&& Objects.equals(next.getTag().getCode(), theTerm)) {
 				myEntityManager.remove(next);
 				entity.getTags().remove(next);
 			}
@@ -1937,7 +1933,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 
 		translateListSearchParams(theParams);
 
-		notifySearchInterceptors(theParams, theRequest);
+		setOffsetAndCount(theParams, theRequest);
 
 		CacheControlDirective cacheControlDirective = new CacheControlDirective();
 		if (theRequest != null) {
@@ -1965,11 +1961,9 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	}
 
 	private void translateListSearchParams(SearchParameterMap theParams) {
-		Iterator<String> keyIterator = theParams.keySet().iterator();
 
 		// Translate _list=42 to _has=List:item:_id=42
-		while (keyIterator.hasNext()) {
-			String key = keyIterator.next();
+		for (String key : theParams.keySet()) {
 			if (Constants.PARAM_LIST.equals((key))) {
 				List<List<IQueryParameterType>> andOrValues = theParams.get(key);
 				theParams.remove(key);
@@ -1990,7 +1984,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 	}
 
-	private void notifySearchInterceptors(SearchParameterMap theParams, RequestDetails theRequest) {
+	protected void setOffsetAndCount(SearchParameterMap theParams, RequestDetails theRequest) {
 		if (theRequest != null) {
 
 			if (theRequest.isSubRequest()) {
@@ -2000,7 +1994,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 							1,
 							Integer.MAX_VALUE,
 							max,
-							"Maximum search result count in transaction ust be a positive integer");
+							"Maximum search result count in transaction must be a positive integer");
 					theParams.setLoadSynchronousUpTo(getStorageSettings().getMaximumSearchResultCountInTransaction());
 				}
 			}
@@ -2051,7 +2045,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 						theParams.setLoadSynchronousUpTo(myStorageSettings.getInternalSynchronousSearchSize());
 					}
 
-					ISearchBuilder builder =
+					ISearchBuilder<?> builder =
 							mySearchBuilderFactory.newSearchBuilder(this, getResourceName(), getResourceType());
 
 					List<JpaPid> ids = new ArrayList<>();
@@ -2208,9 +2202,8 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			RequestDetails theRequest,
 			TransactionDetails theTransactionDetails,
 			RequestPartitionId theRequestPartitionId) {
-		T resource = theResource;
 
-		preProcessResourceForStorage(resource);
+		preProcessResourceForStorage(theResource);
 		preProcessResourceForStorage(theResource, theRequest, theTransactionDetails, thePerformIndexing);
 
 		ResourceTable entity = null;
@@ -2235,8 +2228,8 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				entity = myEntityManager.find(ResourceTable.class, pid.getId());
 				resourceId = entity.getIdDt();
 				if (myFhirContext.getVersion().getVersion().isEqualOrNewerThan(FhirVersionEnum.R4)
-						&& resource.getIdElement().getIdPart() != null) {
-					if (!Objects.equals(resource.getIdElement().getIdPart(), resourceId.getIdPart())) {
+						&& theResource.getIdElement().getIdPart() != null) {
+					if (!Objects.equals(theResource.getIdElement().getIdPart(), resourceId.getIdPart())) {
 						String msg = getContext()
 								.getLocalizer()
 								.getMessageSanitized(
@@ -2257,7 +2250,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				}
 				DaoMethodOutcome outcome = doCreateForPostOrPut(
 						theRequest,
-						resource,
+						theResource,
 						theMatchUrl,
 						false,
 						thePerformIndexing,
@@ -2303,7 +2296,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			if (create) {
 				return doCreateForPostOrPut(
 						theRequest,
-						resource,
+						theResource,
 						null,
 						false,
 						thePerformIndexing,
@@ -2320,7 +2313,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				theMatchUrl,
 				thePerformIndexing,
 				theForceUpdateVersion,
-				resource,
+				theResource,
 				entity,
 				update,
 				theTransactionDetails);
@@ -2413,7 +2406,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		entity.setDeleted(null);
 		boolean isUpdatingCurrent = resourceId.hasVersionIdPart()
 				&& Long.parseLong(resourceId.getVersionIdPart()) == currentEntity.getVersion();
-		IBasePersistedResource savedEntity = updateHistoryEntity(
+		IBasePersistedResource<?> savedEntity = updateHistoryEntity(
 				theRequest, theResource, currentEntity, entity, resourceId, theTransactionDetails, isUpdatingCurrent);
 		DaoMethodOutcome outcome = toMethodOutcome(
 						theRequest, savedEntity, theResource, null, RestOperationTypeEnum.UPDATE)
@@ -2437,7 +2430,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		TransactionDetails transactionDetails = new TransactionDetails();
 
 		if (theMode == ValidationModeEnum.DELETE) {
-			if (theId == null || theId.hasIdPart() == false) {
+			if (theId == null || !theId.hasIdPart()) {
 				throw new InvalidRequestException(
 						Msg.code(991) + "No ID supplied. ID is required when validating with mode=DELETE");
 			}
@@ -2570,7 +2563,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 							Msg.code(997) + "Resource has an ID - ID must not be populated for a FHIR create");
 				}
 			} else if (myMode == ValidationModeEnum.UPDATE) {
-				if (hasId == false) {
+				if (!hasId) {
 					throw new UnprocessableEntityException(
 							Msg.code(998) + "Resource has no ID - ID must be populated for a FHIR update");
 				}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -126,8 +126,13 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.withColumns("RES_VER_PID")
 				.failureAllowed();
 
+		// drop the index for any database that has RES_PID column already indexed from previous migrations
 		version.onTable("HFJ_RES_VER_PROV")
-				.addIndex("20230510.2", "IDX_RESVERPROV_RES_PID")
+				.dropIndex("20230510.2", "FK_RESVERPROV_RES_PID")
+				.failureAllowed();
+
+		version.onTable("HFJ_RES_VER_PROV")
+				.addIndex("20230510.3", "IDX_RESVERPROV_RES_PID")
 				.unique(false)
 				.withColumns("RES_PID");
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -336,8 +336,13 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 
 			String dirName = "package";
 			NpmPackage.NpmPackageFolder packageFolder = npmPackage.getFolders().get(dirName);
-			for (Map.Entry<String, List<String>> nextTypeToFiles :
-					packageFolder.getTypes().entrySet()) {
+			Map<String, List<String>> packageFolderTypes = null;
+			try {
+				packageFolderTypes = packageFolder.getTypes();
+			} catch (IOException e) {
+				throw new InternalErrorException(Msg.code(2371) + e);
+			}
+			for (Map.Entry<String, List<String>> nextTypeToFiles : packageFolderTypes.entrySet()) {
 				String nextType = nextTypeToFiles.getKey();
 				for (String nextFile : nextTypeToFiles.getValue()) {
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -44,6 +44,7 @@ import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
+import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
 import ca.uhn.fhir.util.FhirTerser;
 import ca.uhn.fhir.util.SearchParameterUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -53,6 +54,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.utilities.json.model.JsonObject;
 import org.hl7.fhir.utilities.npm.IPackageCacheManager;
 import org.hl7.fhir.utilities.npm.NpmPackage;
@@ -342,7 +344,8 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 	/**
 	 * ============================= Utility methods ===============================
 	 */
-	private void create(
+	@VisibleForTesting
+	void create(
 			IBaseResource theResource,
 			PackageInstallationSpec theInstallationSpec,
 			PackageInstallOutcomeJson theOutcome) {
@@ -365,8 +368,30 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 						String newIdPart = "npm-" + id.getIdPart();
 						id.setParts(id.getBaseUrl(), id.getResourceType(), newIdPart, id.getVersionIdPart());
 					}
-					updateResource(dao, theResource);
-					ourLog.info("Created resource with existing id");
+
+					try {
+						updateResource(dao, theResource);
+
+						ourLog.info("Created resource with existing id");
+					} catch (ResourceVersionConflictException exception) {
+						final Optional<IBaseResource> optResource = readResourceById(dao, id);
+
+						final String existingResourceUrlOrNull = optResource
+								.filter(MetadataResource.class::isInstance)
+								.map(MetadataResource.class::cast)
+								.map(MetadataResource::getUrl)
+								.orElse(null);
+						final String newResourceUrlOrNull = (theResource instanceof MetadataResource)
+								? ((MetadataResource) theResource).getUrl()
+								: null;
+
+						ourLog.error(
+								"Version conflict error:  This is possibly due to a collision between ValueSets from different IGs that are coincidentally using the same resource ID: [{}] and new resource URL: [{}], with the exisitng resource having URL: [{}].  Ignoring this update and continuing:  The first IG wins.  ",
+								id.getIdPart(),
+								newResourceUrlOrNull,
+								existingResourceUrlOrNull,
+								exception);
+					}
 				}
 			} else {
 				if (theInstallationSpec.isReloadExisting()) {
@@ -392,6 +417,18 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 					theResource.fhirType(),
 					theResource.getIdElement().getValue());
 		}
+	}
+
+	private Optional<IBaseResource> readResourceById(IFhirResourceDao dao, IIdType id) {
+		try {
+			return Optional.ofNullable(dao.read(id.toUnqualifiedVersionless(), newSystemRequestDetails()));
+
+		} catch (Exception exception) {
+			// ignore because we're running this query to help build the log
+			ourLog.warn("Exception when trying to read resource with ID: {}, message: {}", id, exception.getMessage());
+		}
+
+		return Optional.empty();
 	}
 
 	private IBundleProvider searchResource(IFhirResourceDao theDao, SearchParameterMap theMap) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/loader/PackageResourceParsingSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/loader/PackageResourceParsingSvc.java
@@ -49,8 +49,13 @@ public class PackageResourceParsingSvc {
 			return Collections.emptyList();
 		}
 		ArrayList<IBaseResource> resources = new ArrayList<>();
-		List<String> filesForType =
-				thePkg.getFolders().get("package").getTypes().get(theType);
+		List<String> filesForType = null;
+		try {
+			filesForType = thePkg.getFolders().get("package").getTypes().get(theType);
+		} catch (IOException e) {
+			throw new InternalErrorException(
+					Msg.code(2370) + "Cannot install resource of type " + theType + ": Could not get types", e);
+		}
 		if (filesForType != null) {
 			for (String file : filesForType) {
 				try {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImpl.java
@@ -21,7 +21,9 @@ package ca.uhn.fhir.jpa.reindex;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.pid.EmptyResourcePidList;
@@ -39,93 +41,121 @@ import ca.uhn.fhir.rest.api.SortOrderEnum;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
-import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.util.DateRangeUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-
 public class Batch2DaoSvcImpl implements IBatch2DaoSvc {
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(Batch2DaoSvcImpl.class);
 
-	@Autowired
-	private IResourceTableDao myResourceTableDao;
+	private final IResourceTableDao myResourceTableDao;
 
-	@Autowired
-	private MatchUrlService myMatchUrlService;
+	private final MatchUrlService myMatchUrlService;
 
-	@Autowired
-	private DaoRegistry myDaoRegistry;
+	private final DaoRegistry myDaoRegistry;
 
-	@Autowired
-	private FhirContext myFhirContext;
+	private final FhirContext myFhirContext;
 
-	@Autowired
-	private IHapiTransactionService myTransactionService;
+	private final IHapiTransactionService myTransactionService;
+
+	private final JpaStorageSettings myJpaStorageSettings;
 
 	@Override
 	public boolean isAllResourceTypeSupported() {
 		return true;
 	}
 
+	public Batch2DaoSvcImpl(
+			IResourceTableDao theResourceTableDao,
+			MatchUrlService theMatchUrlService,
+			DaoRegistry theDaoRegistry,
+			FhirContext theFhirContext,
+			IHapiTransactionService theTransactionService,
+			JpaStorageSettings theJpaStorageSettings) {
+		myResourceTableDao = theResourceTableDao;
+		myMatchUrlService = theMatchUrlService;
+		myDaoRegistry = theDaoRegistry;
+		myFhirContext = theFhirContext;
+		myTransactionService = theTransactionService;
+		myJpaStorageSettings = theJpaStorageSettings;
+	}
+
 	@Override
 	public IResourcePidList fetchResourceIdsPage(
-			Date theStart,
-			Date theEnd,
-			@Nonnull Integer thePageSize,
-			@Nullable RequestPartitionId theRequestPartitionId,
-			@Nullable String theUrl) {
+			Date theStart, Date theEnd, @Nullable RequestPartitionId theRequestPartitionId, @Nullable String theUrl) {
 		return myTransactionService
 				.withSystemRequest()
 				.withRequestPartitionId(theRequestPartitionId)
 				.execute(() -> {
 					if (theUrl == null) {
-						return fetchResourceIdsPageNoUrl(theStart, theEnd, thePageSize, theRequestPartitionId);
+						return fetchResourceIdsPageNoUrl(theStart, theEnd, theRequestPartitionId);
 					} else {
-						return fetchResourceIdsPageWithUrl(
-								theStart, theEnd, thePageSize, theUrl, theRequestPartitionId);
+						return fetchResourceIdsPageWithUrl(theEnd, theUrl, theRequestPartitionId);
 					}
 				});
 	}
 
-	private IResourcePidList fetchResourceIdsPageWithUrl(
-			Date theStart, Date theEnd, int thePageSize, String theUrl, RequestPartitionId theRequestPartitionId) {
+	@Nonnull
+	private HomogeneousResourcePidList fetchResourceIdsPageWithUrl(
+			Date theEnd, @Nonnull String theUrl, @Nullable RequestPartitionId theRequestPartitionId) {
+		if (!theUrl.contains("?")) {
+			throw new InternalErrorException(Msg.code(2422) + "this should never happen: URL is missing a '?'");
+		}
 
+		final Integer internalSynchronousSearchSize = myJpaStorageSettings.getInternalSynchronousSearchSize();
+
+		if (internalSynchronousSearchSize == null || internalSynchronousSearchSize <= 0) {
+			throw new InternalErrorException(Msg.code(2423)
+					+ "this should never happen: internalSynchronousSearchSize is null or less than or equal to 0");
+		}
+
+		List<IResourcePersistentId> currentIds = fetchResourceIdsPageWithUrl(0, theUrl, theRequestPartitionId);
+		ourLog.debug("FIRST currentIds: {}", currentIds.size());
+
+		final List<IResourcePersistentId> allIds = new ArrayList<>(currentIds);
+
+		while (internalSynchronousSearchSize < currentIds.size()) {
+			// Ensure the offset is set to the last ID in the cumulative List, otherwise, we'll be stuck in an infinite
+			// loop here:
+			currentIds = fetchResourceIdsPageWithUrl(allIds.size(), theUrl, theRequestPartitionId);
+			ourLog.debug("NEXT currentIds: {}", currentIds.size());
+
+			allIds.addAll(currentIds);
+		}
+
+		final String resourceType = theUrl.substring(0, theUrl.indexOf('?'));
+
+		return new HomogeneousResourcePidList(resourceType, allIds, theEnd, theRequestPartitionId);
+	}
+
+	private List<IResourcePersistentId> fetchResourceIdsPageWithUrl(
+			int theOffset, String theUrl, RequestPartitionId theRequestPartitionId) {
 		String resourceType = theUrl.substring(0, theUrl.indexOf('?'));
 		RuntimeResourceDefinition def = myFhirContext.getResourceDefinition(resourceType);
 
 		SearchParameterMap searchParamMap = myMatchUrlService.translateMatchUrl(theUrl, def);
-		searchParamMap.setSort(new SortSpec(Constants.PARAM_LASTUPDATED, SortOrderEnum.ASC));
-		DateRangeParam chunkDateRange =
-				DateRangeUtil.narrowDateRange(searchParamMap.getLastUpdated(), theStart, theEnd);
-		searchParamMap.setLastUpdated(chunkDateRange);
-		searchParamMap.setCount(thePageSize);
+		searchParamMap.setSort(new SortSpec(Constants.PARAM_ID, SortOrderEnum.ASC));
+		searchParamMap.setOffset(theOffset);
+		searchParamMap.setLoadSynchronousUpTo(myJpaStorageSettings.getInternalSynchronousSearchSize() + 1);
 
 		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(resourceType);
 		SystemRequestDetails request = new SystemRequestDetails();
 		request.setRequestPartitionId(theRequestPartitionId);
-		List<IResourcePersistentId> ids = dao.searchForIds(searchParamMap, request);
 
-		Date lastDate = null;
-		if (isNotEmpty(ids)) {
-			IResourcePersistentId lastResourcePersistentId = ids.get(ids.size() - 1);
-			lastDate = dao.readByPid(lastResourcePersistentId, true).getMeta().getLastUpdated();
-		}
-
-		return new HomogeneousResourcePidList(resourceType, ids, lastDate, theRequestPartitionId);
+		return dao.searchForIds(searchParamMap, request);
 	}
 
 	@Nonnull
 	private IResourcePidList fetchResourceIdsPageNoUrl(
-			Date theStart, Date theEnd, int thePagesize, RequestPartitionId theRequestPartitionId) {
-		Pageable page = Pageable.ofSize(thePagesize);
+			Date theStart, Date theEnd, RequestPartitionId theRequestPartitionId) {
+		final Pageable page = Pageable.unpaged();
 		Slice<Object[]> slice;
 		if (theRequestPartitionId == null || theRequestPartitionId.isAllPartitions()) {
 			slice = myResourceTableDao.findIdsTypesAndUpdateTimesOfResourcesWithinUpdatedRangeOrderedFromOldest(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -117,6 +117,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1854,14 +1855,23 @@ public class QueryStack {
 			throw new InvalidRequestException(Msg.code(1216) + msg);
 		}
 
-		SourcePredicateBuilder join = createOrReusePredicateBuilder(
-						PredicateBuilderTypeEnum.SOURCE,
-						theSourceJoinColumn,
-						Constants.PARAM_SOURCE,
-						() -> mySqlBuilder.addSourcePredicateBuilder(theSourceJoinColumn))
-				.getResult();
-
 		List<Condition> orPredicates = new ArrayList<>();
+
+		// :missing=true modifier processing requires "LEFT JOIN" with HFJ_RESOURCE table to return correct results
+		// if both sourceUri and requestId are not populated for the resource
+		Optional<? extends IQueryParameterType> isMissingSourceOptional = theList.stream()
+				.filter(nextParameter -> nextParameter.getMissing() != null && nextParameter.getMissing())
+				.findFirst();
+
+		if (isMissingSourceOptional.isPresent()) {
+			SourcePredicateBuilder join =
+					getSourcePredicateBuilder(theSourceJoinColumn, SelectQuery.JoinType.LEFT_OUTER);
+			orPredicates.add(join.createPredicateMissingSourceUri());
+			return toOrPredicate(orPredicates);
+		}
+		// for all other cases we use "INNER JOIN" to match search parameters
+		SourcePredicateBuilder join = getSourcePredicateBuilder(theSourceJoinColumn, SelectQuery.JoinType.INNER);
+
 		for (IQueryParameterType nextParameter : theList) {
 			SourceParam sourceParameter = new SourceParam(nextParameter.getValueAsQueryToken(myFhirContext));
 			String sourceUri = sourceParameter.getSourceUri();
@@ -1870,13 +1880,24 @@ public class QueryStack {
 				orPredicates.add(toAndPredicate(
 						join.createPredicateSourceUri(sourceUri), join.createPredicateRequestId(requestId)));
 			} else if (isNotBlank(sourceUri)) {
-				orPredicates.add(join.createPredicateSourceUri(sourceUri));
+				orPredicates.add(
+						join.createPredicateSourceUriWithModifiers(nextParameter, myStorageSettings, sourceUri));
 			} else if (isNotBlank(requestId)) {
 				orPredicates.add(join.createPredicateRequestId(requestId));
 			}
 		}
 
 		return toOrPredicate(orPredicates);
+	}
+
+	private SourcePredicateBuilder getSourcePredicateBuilder(
+			@Nullable DbColumn theSourceJoinColumn, SelectQuery.JoinType theJoinType) {
+		return createOrReusePredicateBuilder(
+						PredicateBuilderTypeEnum.SOURCE,
+						theSourceJoinColumn,
+						Constants.PARAM_SOURCE,
+						() -> mySqlBuilder.addSourcePredicateBuilder(theSourceJoinColumn, theJoinType))
+				.getResult();
 	}
 
 	public Condition createPredicateString(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/SourcePredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/SourcePredicateBuilder.java
@@ -19,12 +19,28 @@
  */
 package ca.uhn.fhir.jpa.search.builder.predicate;
 
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.search.builder.sql.SearchQueryBuilder;
+import ca.uhn.fhir.jpa.util.QueryParameterUtils;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.UriParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
+import ca.uhn.fhir.util.StringUtil;
+import ca.uhn.fhir.util.UrlUtil;
 import com.healthmarketscience.sqlbuilder.BinaryCondition;
 import com.healthmarketscience.sqlbuilder.Condition;
+import com.healthmarketscience.sqlbuilder.FunctionCall;
+import com.healthmarketscience.sqlbuilder.UnaryCondition;
 import com.healthmarketscience.sqlbuilder.dbspec.basic.DbColumn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static ca.uhn.fhir.jpa.search.builder.predicate.StringPredicateBuilder.createLeftAndRightMatchLikeExpression;
+import static ca.uhn.fhir.jpa.search.builder.predicate.StringPredicateBuilder.createLeftMatchLikeExpression;
 
 public class SourcePredicateBuilder extends BaseJoiningPredicateBuilder {
 
@@ -51,6 +67,57 @@ public class SourcePredicateBuilder extends BaseJoiningPredicateBuilder {
 
 	public Condition createPredicateSourceUri(String theSourceUri) {
 		return BinaryCondition.equalTo(myColumnSourceUri, generatePlaceholder(theSourceUri));
+	}
+
+	public Condition createPredicateMissingSourceUri() {
+		return UnaryCondition.isNull(myColumnSourceUri);
+	}
+
+	public Condition createPredicateSourceUriWithModifiers(
+			IQueryParameterType theQueryParameter, JpaStorageSettings theStorageSetting, String theSourceUri) {
+		if (theQueryParameter.getMissing() != null && !theQueryParameter.getMissing()) {
+			return UnaryCondition.isNotNull(myColumnSourceUri);
+		} else if (theQueryParameter instanceof UriParam && theQueryParameter.getQueryParameterQualifier() != null) {
+			UriParam uriParam = (UriParam) theQueryParameter;
+			switch (uriParam.getQualifier()) {
+				case ABOVE:
+					return createPredicateSourceAbove(theSourceUri);
+				case BELOW:
+					return createPredicateSourceBelow(theSourceUri);
+				case CONTAINS:
+					return createPredicateSourceContains(theStorageSetting, theSourceUri);
+				default:
+					throw new InvalidRequestException(Msg.code(2418)
+							+ String.format(
+									"Unsupported qualifier specified, qualifier=%s",
+									theQueryParameter.getQueryParameterQualifier()));
+			}
+		} else {
+			return createPredicateSourceUri(theSourceUri);
+		}
+	}
+
+	private Condition createPredicateSourceAbove(String theSourceUri) {
+		List<String> aboveUriCandidates = UrlUtil.getAboveUriCandidates(theSourceUri);
+		List<String> aboveUriPlaceholders = generatePlaceholders(aboveUriCandidates);
+		return QueryParameterUtils.toEqualToOrInPredicate(myColumnSourceUri, aboveUriPlaceholders);
+	}
+
+	private Condition createPredicateSourceBelow(String theSourceUri) {
+		String belowLikeExpression = createLeftMatchLikeExpression(theSourceUri);
+		return BinaryCondition.like(myColumnSourceUri, generatePlaceholder(belowLikeExpression));
+	}
+
+	private Condition createPredicateSourceContains(JpaStorageSettings theStorageSetting, String theSourceUri) {
+		if (theStorageSetting.isAllowContainsSearches()) {
+			FunctionCall upperFunction = new FunctionCall("UPPER");
+			upperFunction.addCustomParams(myColumnSourceUri);
+			String normalizedString = StringUtil.normalizeStringForSearchIndexing(theSourceUri);
+			String containsLikeExpression = createLeftAndRightMatchLikeExpression(normalizedString);
+			return BinaryCondition.like(upperFunction, generatePlaceholder(containsLikeExpression));
+		} else {
+			throw new MethodNotAllowedException(Msg.code(2417) + ":contains modifier is disabled on this server");
+		}
 	}
 
 	public Condition createPredicateRequestId(String theRequestId) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryBuilder.java
@@ -288,9 +288,10 @@ public class SearchQueryBuilder {
 	/**
 	 * Add and return a predicate builder (or a root query if no root query exists yet) for selecting on a <code>_source</code> search parameter
 	 */
-	public SourcePredicateBuilder addSourcePredicateBuilder(@Nullable DbColumn theSourceJoinColumn) {
+	public SourcePredicateBuilder addSourcePredicateBuilder(
+			@Nullable DbColumn theSourceJoinColumn, SelectQuery.JoinType theJoinType) {
 		SourcePredicateBuilder retVal = mySqlBuilderFactory.newSourcePredicateBuilder(this);
-		addTable(retVal, theSourceJoinColumn);
+		addTable(retVal, theSourceJoinColumn, theJoinType);
 		return retVal;
 	}
 

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-elastic-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithElasticSearchIT.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.search.StorageProcessingMessage;
 import ca.uhn.fhir.jpa.search.CompositeSearchParameterTestCases;
 import ca.uhn.fhir.jpa.search.QuantitySearchParameterTestCases;
+import ca.uhn.fhir.jpa.search.BaseSourceSearchParameterTestCases;
 import ca.uhn.fhir.jpa.search.reindex.IResourceReindexingSvc;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.sp.ISearchParamPresenceSvc;
@@ -88,7 +89,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.aop.support.Pointcuts;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.annotation.DirtiesContext;
@@ -113,7 +113,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.model.util.UcumServiceUtil.UCUM_CODESYSTEM_URL;
@@ -124,10 +123,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -1565,7 +1560,7 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest impl
 		public void tagSourceSearch() {
 			String id = myTestDataBuilder.createObservation(List.of(
 				myTestDataBuilder.withObservationCode("http://example.com/", "theCode"),
-				myTestDataBuilder.withSource(myFhirContext, "http://example.com/theSource"))).getIdPart();
+				myTestDataBuilder.withSource("http://example.com/theSource"))).getIdPart();
 
 			myCaptureQueriesListener.clear();
 			List<String> allIds = myTestDaoSearch.searchForIds("/Observation?_source=http://example.com/theSource");
@@ -2362,6 +2357,18 @@ public class FhirResourceDaoR4SearchWithElasticSearchIT extends BaseJpaTest impl
 		@Override
 		protected boolean isCorrelatedSupported() {
 			return true;
+		}
+	}
+
+	@Nested
+	class SourceSearchParameterTestCases extends BaseSourceSearchParameterTestCases {
+		SourceSearchParameterTestCases() {
+			super(myTestDataBuilder.getTestDataBuilderSupport(), myTestDaoSearch, myStorageSettings);
+		}
+
+		@Override
+		protected boolean isRequestIdSupported() {
+			return false;
 		}
 	}
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -32,6 +32,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/jdbc/HfqlRestClient.java
+++ b/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/jdbc/HfqlRestClient.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.jpa.fql.jdbc;
 
 import ca.uhn.fhir.jpa.fql.executor.IHfqlExecutionResult;
+import ca.uhn.fhir.jpa.fql.util.HfqlConstants;
 import ca.uhn.fhir.rest.client.impl.HttpBasicAuthInterceptor;
 import ca.uhn.fhir.util.IoUtil;
 import org.apache.commons.csv.CSVFormat;
@@ -27,10 +28,14 @@ import org.apache.commons.lang3.Validate;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
 
 import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 import static ca.uhn.fhir.jpa.fql.util.HfqlConstants.DEFAULT_FETCH_SIZE;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
@@ -65,6 +70,18 @@ public class HfqlRestClient {
 			httpClientBuilder.addInterceptorLast(new HttpBasicAuthInterceptor(theUsername, thePassword));
 		}
 		myClient = httpClientBuilder.build();
+	}
+
+	@Nonnull
+	public static Parameters newQueryRequestParameters(String sql, Integer limit, int fetchSize) {
+		Parameters input = new Parameters();
+		input.addParameter(HfqlConstants.PARAM_ACTION, new CodeType(HfqlConstants.PARAM_ACTION_SEARCH));
+		input.addParameter(HfqlConstants.PARAM_QUERY, new StringType(sql));
+		if (limit != null) {
+			input.addParameter(HfqlConstants.PARAM_LIMIT, new IntegerType(limit));
+		}
+		input.addParameter(HfqlConstants.PARAM_FETCH_SIZE, new IntegerType(fetchSize));
+		return input;
 	}
 
 	public IHfqlExecutionResult execute(

--- a/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/jdbc/JdbcStatement.java
+++ b/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/jdbc/JdbcStatement.java
@@ -20,7 +20,6 @@
 package ca.uhn.fhir.jpa.fql.jdbc;
 
 import ca.uhn.fhir.jpa.fql.executor.IHfqlExecutionResult;
-import ca.uhn.fhir.jpa.fql.provider.HfqlRestProvider;
 import ca.uhn.fhir.jpa.fql.util.HfqlConstants;
 import org.hl7.fhir.r4.model.Parameters;
 
@@ -43,8 +42,8 @@ class JdbcStatement implements Statement {
 	}
 
 	@Override
-	public ResultSet executeQuery(String sql) throws SQLException {
-		execute(sql);
+	public ResultSet executeQuery(String theSqlText) throws SQLException {
+		execute(theSqlText);
 		return getResultSet();
 	}
 
@@ -122,7 +121,7 @@ class JdbcStatement implements Statement {
 
 		int fetchSize = myFetchSize;
 
-		Parameters input = HfqlRestProvider.newQueryRequestParameters(sql, limit, fetchSize);
+		Parameters input = HfqlRestClient.newQueryRequestParameters(sql, limit, fetchSize);
 		IHfqlExecutionResult result = myConnection.getClient().execute(input, true, getFetchSize());
 
 		myResultSet = new JdbcResultSet(result, this);

--- a/hapi-fhir-jpaserver-hfql/src/test/java/ca/uhn/fhir/jpa/fql/jdbc/ArchitectureTest.java
+++ b/hapi-fhir-jpaserver-hfql/src/test/java/ca/uhn/fhir/jpa/fql/jdbc/ArchitectureTest.java
@@ -1,0 +1,27 @@
+package ca.uhn.fhir.jpa.fql.jdbc;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+@AnalyzeClasses(
+	packages = "ca.uhn.fhir.jpa.fql..",
+	importOptions = {
+		ImportOption.DoNotIncludeTests.class
+	}
+)
+public class ArchitectureTest {
+	/**
+	 * This project has a "provided" dependency on javax.servlet, but the packaged jdbc driver doesn't bundle it.
+	 */
+	@ArchTest
+	void verifyNoDepsOnProvidedServlet(JavaClasses theJavaClasses) {
+
+		ArchRuleDefinition.noClasses().that().resideInAPackage("ca.uhn.fhir.jpa.fql.jdbc")
+			.should().transitivelyDependOnClassesThat().resideInAPackage("javax.servlet")
+			.check(theJavaClasses);
+	}
+
+}

--- a/hapi-fhir-jpaserver-ips/pom.xml
+++ b/hapi-fhir-jpaserver-ips/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/GoldenResourceSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/GoldenResourceSearchSvcImpl.java
@@ -82,7 +82,6 @@ public class GoldenResourceSearchSvcImpl implements IGoldenResourceSearchSvc {
 		DateRangeParam chunkDateRange =
 				DateRangeUtil.narrowDateRange(searchParamMap.getLastUpdated(), theStart, theEnd);
 		searchParamMap.setLastUpdated(chunkDateRange);
-		searchParamMap.setCount(thePageSize); // request this many pids
 		searchParamMap.add(
 				"_tag", new TokenParam(MdmConstants.SYSTEM_GOLDEN_RECORD_STATUS, MdmConstants.CODE_GOLDEN_RECORD));
 

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/MdmExpungeTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/MdmExpungeTest.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.mdm.interceptor.IMdmStorageInterceptor;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,7 @@ public class MdmExpungeTest extends BaseMdmR4Test {
 		try {
 			myPatientDao.expunge(myTargetId.toVersionless(), expungeOptions, null);
 			fail();
-		} catch (InternalErrorException e) {
+		} catch (PreconditionFailedException e) {
 			assertThat(e.getMessage(), containsString("ViolationException"));
 			assertThat(e.getMessage(), containsString("FK_EMPI_LINK_TARGET"));
 		}

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
@@ -83,7 +83,7 @@ public class JpaConstants {
 	 * Header name for the "X-Meta-Snapshot-Mode" header, which
 	 * specifies that properties in meta (tags, profiles, security labels)
 	 * should be treated as a snapshot, meaning that these things will
-	 * be removed if they are nt explicitly included in updates
+	 * be removed if they are not explicitly included in updates
 	 */
 	public static final String HEADER_META_SNAPSHOT_MODE = "X-Meta-Snapshot-Mode";
 	/**

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-dstu2/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-dstu3/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu3/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SourceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SourceTest.java
@@ -8,23 +8,28 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
-import ca.uhn.fhir.rest.param.TokenOrListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.param.UriParam;
+import ca.uhn.fhir.rest.param.UriParamQualifierEnum;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
 import org.apache.commons.text.RandomStringGenerator;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import static ca.uhn.fhir.rest.api.Constants.PARAM_SOURCE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings({"Duplicates"})
@@ -64,107 +69,6 @@ public class FhirResourceDaoR4SourceTest extends BaseJpaR4Test {
 		assertThat(toUnqualifiedVersionlessIdValues(result), containsInAnyOrder(pt0id.getValue()));
 		pt0 = (Patient) result.getResources(0, 1).get(0);
 		assertEquals("urn:source:0#a_request_id", pt0.getMeta().getSource());
-
-		// Search by request ID
-		params = new SearchParameterMap();
-		params.setLoadSynchronous(true);
-		params.add(Constants.PARAM_SOURCE, new TokenParam("#a_request_id"));
-		result = myPatientDao.search(params);
-		assertThat(toUnqualifiedVersionlessIdValues(result), containsInAnyOrder(pt0id.getValue(), pt1id.getValue()));
-
-		// Search by source URI and request ID
-		params = new SearchParameterMap();
-		params.setLoadSynchronous(true);
-		params.add(Constants.PARAM_SOURCE, new TokenParam("urn:source:0#a_request_id"));
-		result = myPatientDao.search(params);
-		assertThat(toUnqualifiedVersionlessIdValues(result), containsInAnyOrder(pt0id.getValue()));
-
-	}
-
-	@Test
-	public void testSearchSource_whenSameSourceForMultipleResourceTypes_willMatchSearchResourceTypeOnly(){
-		String sourceUrn = "urn:source:0";
-		String requestId = "a_request_id";
-
-		when(mySrd.getRequestId()).thenReturn(requestId);
-		Patient patient = new Patient();
-		patient.getMeta().setSource(sourceUrn);
-		patient.setActive(true);
-		IIdType ptId = myPatientDao.create(patient, mySrd).getId().toUnqualifiedVersionless();
-
-		Observation observation = new Observation();
-		observation.setStatus(Observation.ObservationStatus.FINAL);
-		observation.getMeta().setSource(sourceUrn);
-		myObservationDao.create(observation, mySrd).getId().toUnqualifiedVersionless();
-
-		SearchParameterMap params = new SearchParameterMap();
-		params.setLoadSynchronous(true);
-		params.add(Constants.PARAM_SOURCE, new TokenParam("urn:source:0"));
-		IBundleProvider result = myPatientDao.search(params);
-
-		assertThat(toUnqualifiedVersionlessIdValues(result), containsInAnyOrder(ptId.getValue()));
-
-	}
-
-	@Test
-	public void testSearchWithOr() {
-		String requestId = "a_request_id";
-
-		when(mySrd.getRequestId()).thenReturn(requestId);
-		Patient pt0 = new Patient();
-		pt0.getMeta().setSource("urn:source:0");
-		pt0.setActive(true);
-		IIdType pt0id = myPatientDao.create(pt0, mySrd).getId().toUnqualifiedVersionless();
-
-		Patient pt1 = new Patient();
-		pt1.getMeta().setSource("urn:source:1");
-		pt1.setActive(true);
-		IIdType pt1id = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless();
-
-		Patient pt2 = new Patient();
-		pt2.getMeta().setSource("urn:source:2");
-		pt2.setActive(true);
-		myPatientDao.create(pt2, mySrd).getId().toUnqualifiedVersionless();
-
-		// Search
-		SearchParameterMap params = new SearchParameterMap();
-		params.setLoadSynchronous(true);
-		params.add(Constants.PARAM_SOURCE, new TokenOrListParam()
-			.addOr(new TokenParam("urn:source:0"))
-			.addOr(new TokenParam("urn:source:1")));
-		IBundleProvider result = myPatientDao.search(params);
-		assertThat(toUnqualifiedVersionlessIdValues(result), containsInAnyOrder(pt0id.getValue(), pt1id.getValue()));
-
-	}
-
-	@Test
-	public void testSearchWithAnd() {
-		String requestId = "a_request_id";
-
-		when(mySrd.getRequestId()).thenReturn(requestId);
-		Patient pt0 = new Patient();
-		pt0.getMeta().setSource("urn:source:0");
-		pt0.setActive(true);
-		IIdType pt0id = myPatientDao.create(pt0, mySrd).getId().toUnqualifiedVersionless();
-
-		Patient pt1 = new Patient();
-		pt1.getMeta().setSource("urn:source:1");
-		pt1.setActive(true);
-		IIdType pt1id = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless();
-
-		Patient pt2 = new Patient();
-		pt2.getMeta().setSource("urn:source:2");
-		pt2.setActive(true);
-		myPatientDao.create(pt2, mySrd).getId().toUnqualifiedVersionless();
-
-		// Search
-		SearchParameterMap params = new SearchParameterMap();
-		params.setLoadSynchronous(true);
-		params.add(Constants.PARAM_SOURCE, new TokenAndListParam()
-			.addAnd(new TokenParam("urn:source:0"), new TokenParam("@a_request_id")));
-		IBundleProvider result = myPatientDao.search(params);
-		assertThat(toUnqualifiedVersionlessIdValues(result), containsInAnyOrder(pt0id.getValue()));
-
 	}
 
 	@Test
@@ -268,6 +172,21 @@ public class FhirResourceDaoR4SourceTest extends BaseJpaR4Test {
 			assertEquals(0, result.size());
 		}
 
+	}
+
+	@Test
+	public void testSearchSource_withContainsModifierAndContainsSearchesDisabled_throwsException() {
+		myStorageSettings.setAllowContainsSearches(false);
+
+		UriParam uriParam = new UriParam("some-source").setQualifier(UriParamQualifierEnum.CONTAINS);
+		try {
+			SearchParameterMap searchParameter = SearchParameterMap.newSynchronous();
+			searchParameter.add(Constants.PARAM_SOURCE, uriParam);
+			myPatientDao.search(searchParameter);
+			fail();
+		} catch (MethodNotAllowedException e) {
+			assertEquals(Msg.code(2417) + ":contains modifier is disabled on this server", e.getMessage());
+		}
 	}
 
 	public static void assertConflictException(String theResourceType, ResourceVersionConflictException e) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4StandardQueriesNoFTTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4StandardQueriesNoFTTest.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.TestDaoSearch;
 import ca.uhn.fhir.jpa.search.CompositeSearchParameterTestCases;
 import ca.uhn.fhir.jpa.search.QuantitySearchParameterTestCases;
+import ca.uhn.fhir.jpa.search.BaseSourceSearchParameterTestCases;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.test.BaseJpaTest;
 import ca.uhn.fhir.jpa.test.config.TestHSearchAddInConfig;
@@ -515,6 +516,18 @@ public class FhirResourceDaoR4StandardQueriesNoFTTest extends BaseJpaTest {
 		@Override
 		protected boolean isCorrelatedSupported() {
 			return false;
+		}
+	}
+
+	@Nested
+	class SourceSearchParameterTestCases extends BaseSourceSearchParameterTestCases {
+		SourceSearchParameterTestCases() {
+			super(myDataBuilder, myTestDaoSearch, myStorageSettings);
+		}
+
+		@Override
+		protected boolean isRequestIdSupported() {
+			return true;
 		}
 	}
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4UpdateTagSnapshotTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4UpdateTagSnapshotTest.java
@@ -39,7 +39,7 @@ public class FhirResourceDaoR4UpdateTagSnapshotTest extends BaseJpaR4Test {
 		myPatientDao.update(p, mySrd);
 
 		p = myPatientDao.read(new IdType("A"), mySrd);
-		assertEquals("1", p.getIdElement().getVersionIdPart());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
 		assertEquals(true, p.getActive());
 		assertEquals(1, p.getMeta().getTag().size());
 	}
@@ -84,7 +84,7 @@ public class FhirResourceDaoR4UpdateTagSnapshotTest extends BaseJpaR4Test {
 		myPatientDao.update(p, mySrd);
 
 		p = myPatientDao.read(new IdType("A"), mySrd);
-		assertEquals("1", p.getIdElement().getVersionIdPart());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
 		assertEquals(true, p.getActive());
 		assertEquals(1, p.getMeta().getTag().size());
 		assertEquals("urn:foo", p.getMeta().getTag().get(0).getSystem());
@@ -132,7 +132,27 @@ public class FhirResourceDaoR4UpdateTagSnapshotTest extends BaseJpaR4Test {
 		p = myPatientDao.read(new IdType("A"), mySrd);
 		assertEquals(true, p.getActive());
 		assertEquals(0, p.getMeta().getTag().size());
-		assertEquals("1", p.getIdElement().getVersionIdPart());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
+	}
+
+	@Test
+	public void testUpdateResource_withNewTags_willCreateNewResourceVersion() {
+
+		Patient p = new Patient();
+		p.setId("A");
+		p.setActive(true);
+		myPatientDao.update(p, mySrd);
+
+		p = new Patient();
+		p.setId("A");
+		p.getMeta().addTag("urn:foo", "bar", "baz");
+		p.setActive(true);
+		myPatientDao.update(p, mySrd);
+
+		p = myPatientDao.read(new IdType("A"), mySrd);
+		assertEquals(true, p.getActive());
+		assertEquals(1, p.getMeta().getTag().size());
+		assertEquals("2", p.getIdElement().getVersionIdPart());
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/ForceOffsetSearchModeInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/ForceOffsetSearchModeInterceptorTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -125,6 +126,36 @@ public class ForceOffsetSearchModeInterceptorTest extends BaseResourceProviderR4
 
 	}
 
+	@Test
+	public void testPagingNextLink_whenAllResourcesHaveBeenReturned_willNotBePresent(){
+
+		myServer.setDefaultPageSize(5);
+
+		for (int i = 0; i < 10; i++) {
+			createPatient(withId("A" + i), withActiveTrue());
+		}
+
+		Bundle outcome = myClient
+			.search()
+			.forResource("Patient")
+			.where(Patient.ACTIVE.exactly().code("true"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		assertThat(outcome.getEntry(), hasSize(5));
+
+		Bundle secondPageBundle = myClient.loadPage().next(outcome).execute();
+
+		assertThat(secondPageBundle.getEntry(), hasSize(5));
+
+		Bundle thirdPageBundle = myClient.loadPage().next(secondPageBundle).execute();
+
+		assertThat(thirdPageBundle.getEntry(), hasSize(0));
+		assertNull(thirdPageBundle.getLink("next"), () -> thirdPageBundle.getLink("next").getUrl());
+
+	}
+
+
 
 	@Test
 	public void testSearch_WithExplicitCount() {
@@ -179,7 +210,6 @@ public class ForceOffsetSearchModeInterceptorTest extends BaseResourceProviderR4
 		assertEquals(1, myCaptureQueriesListener.countCommits());
 		assertEquals(0, myCaptureQueriesListener.countRollbacks());
 
-		assertThat(outcome.getLink(Constants.LINK_NEXT).getUrl(), containsString("Patient?_count=7&_offset=14&active=true"));
 		assertThat(outcome.getLink(Constants.LINK_PREVIOUS).getUrl(), containsString("Patient?_count=7&_offset=0&active=true"));
 
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
@@ -1,0 +1,247 @@
+package ca.uhn.fhir.jpa.packages;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.jpa.dao.data.ITermValueSetDao;
+import ca.uhn.fhir.jpa.entity.TermValueSet;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.NamingSystem;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.hl7.fhir.utilities.npm.PackageGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PackageInstallerSvcImplCreateTest extends BaseJpaR4Test {
+	private static final String PACKAGE_ID_1 = "package1";
+	private static final String PACKAGE_VERSION = "1.0";
+	private static final String VALUE_SET_OID_FIRST = "2.16.840.1.113762.1.4.1010.9";
+	private static final String VALUE_SET_OID_SECOND = "2.16.840.1.113762.1.4.1010.10";
+	private static final String IG_FIRST = "first.ig.gov";
+	private static final String IG_SECOND = "second.ig.gov";
+	private static final String FIRST_IG_URL_FIRST_OID = String.format("http://%s/fhir/ValueSet/%s", IG_FIRST, VALUE_SET_OID_FIRST);
+	private static final String SECOND_IG_URL_FIRST_OID = String.format("http://%s/fhir/ValueSet/%s", IG_SECOND, VALUE_SET_OID_FIRST);
+	private static final String SECOND_IG_URL_SECOND_OID = String.format("http://%s/fhir/ValueSet/%s", IG_SECOND, VALUE_SET_OID_SECOND);
+	private static final FhirContext ourCtx = FhirContext.forR4Cached();
+	private static final CodeSystem CODE_SYSTEM = createCodeSystem();
+	private static final NpmPackage PACKAGE = createPackage();
+	private static final SystemRequestDetails REQUEST_DETAILS = new SystemRequestDetails();
+
+	@Autowired
+	private ITermValueSetDao myTermValueSetDao;
+
+	@Autowired
+	private PackageInstallerSvcImpl mySvc;
+	@Test
+	void createNamingSystem() throws IOException {
+		final NamingSystem namingSystem = new NamingSystem();
+		namingSystem.getUniqueId().add(new NamingSystem.NamingSystemUniqueIdComponent().setValue("123"));
+
+		create(namingSystem);
+
+		assertEquals(1, myNamingSystemDao.search(SearchParameterMap.newSynchronous(), REQUEST_DETAILS).getAllResources().size());
+	}
+
+	@Test
+	void createWithNoExistingResourcesNoIdOnValueSet() throws IOException {
+		final String version1 = "abc";
+		final String copyright1 = "first";
+
+		createValueSetAndCallCreate(VALUE_SET_OID_FIRST, null, version1, FIRST_IG_URL_FIRST_OID, copyright1);
+
+		final ValueSet actualValueSet1 = getFirstValueSet();
+
+		assertEquals("ValueSet/" + VALUE_SET_OID_FIRST, actualValueSet1.getIdElement().toUnqualifiedVersionless().getValue());
+		assertEquals(FIRST_IG_URL_FIRST_OID, actualValueSet1.getUrl());
+		assertEquals(version1, actualValueSet1.getVersion());
+		assertEquals(copyright1, actualValueSet1.getCopyright());
+	}
+
+	@Test
+	void createWithNoExistingResourcesIdOnValueSet() throws IOException {
+		final String version1 = "abc";
+		final String copyright1 = "first";
+
+		createValueSetAndCallCreate(VALUE_SET_OID_FIRST, null, version1, FIRST_IG_URL_FIRST_OID, copyright1);
+		createValueSetAndCallCreate(VALUE_SET_OID_FIRST, "43", version1, SECOND_IG_URL_FIRST_OID, copyright1);
+
+		final TermValueSet termValueSet = getFirstTermValueSet();
+
+		assertEquals(FIRST_IG_URL_FIRST_OID, termValueSet.getUrl());
+
+		final ValueSet actualValueSet1 = getFirstValueSet();
+
+		assertEquals("ValueSet/" + VALUE_SET_OID_FIRST, actualValueSet1.getIdElement().toUnqualifiedVersionless().getValue());
+		assertEquals(FIRST_IG_URL_FIRST_OID, actualValueSet1.getUrl());
+		assertEquals(version1, actualValueSet1.getVersion());
+		assertEquals(copyright1, actualValueSet1.getCopyright());
+	}
+
+	@Test
+	void createValueSetThenUpdateSameUrl() throws IOException {
+		final String version1 = "abc";
+		final String version2 = "def";
+		final String copyright1 = "first";
+		final String copyright2 = "second";
+
+		createValueSetAndCallCreate(VALUE_SET_OID_FIRST, null, version1, FIRST_IG_URL_FIRST_OID, copyright1);
+		createValueSetAndCallCreate(VALUE_SET_OID_FIRST, "43", version2, FIRST_IG_URL_FIRST_OID, copyright2);
+
+		final ValueSet actualValueSet1 = getFirstValueSet();
+
+		assertEquals("ValueSet/" + VALUE_SET_OID_FIRST, actualValueSet1.getIdElement().toUnqualifiedVersionless().getValue());
+		assertEquals(FIRST_IG_URL_FIRST_OID, actualValueSet1.getUrl());
+		assertEquals(version2, actualValueSet1.getVersion());
+		assertEquals(copyright2, actualValueSet1.getCopyright());
+	}
+
+	@Test
+	void createTwoDifferentValueSets() throws IOException {
+		final String version1 = "abc";
+		final String version2 = "def";
+		final String copyright1 = "first";
+		final String copyright2 = "second";
+
+		createValueSetAndCallCreate(VALUE_SET_OID_FIRST, null, version1, FIRST_IG_URL_FIRST_OID, copyright1);
+		createValueSetAndCallCreate(VALUE_SET_OID_SECOND, "43", version2, SECOND_IG_URL_SECOND_OID, copyright2);
+
+		final List<TermValueSet> all2 = myTermValueSetDao.findAll();
+
+		assertEquals(2, all2.size());
+
+		final TermValueSet termValueSet1 = all2.get(0);
+		final TermValueSet termValueSet2 = all2.get(1);
+
+		assertEquals(FIRST_IG_URL_FIRST_OID, termValueSet1.getUrl());
+		assertEquals(SECOND_IG_URL_SECOND_OID, termValueSet2.getUrl());
+
+		final List<ValueSet> allValueSets = getAllValueSets();
+
+		assertEquals(2, allValueSets.size());
+
+		final ValueSet actualValueSet1 = allValueSets.get(0);
+
+		assertEquals("ValueSet/" + VALUE_SET_OID_FIRST, actualValueSet1.getIdElement().toUnqualifiedVersionless().getValue());
+		assertEquals(FIRST_IG_URL_FIRST_OID, actualValueSet1.getUrl());
+		assertEquals(version1, actualValueSet1.getVersion());
+		assertEquals(copyright1, actualValueSet1.getCopyright());
+
+		final ValueSet actualValueSet2 = allValueSets.get(1);
+
+		assertEquals("ValueSet/" + VALUE_SET_OID_SECOND, actualValueSet2.getIdElement().toUnqualifiedVersionless().getValue());
+		assertEquals(SECOND_IG_URL_SECOND_OID, actualValueSet2.getUrl());
+		assertEquals(version2, actualValueSet2.getVersion());
+		assertEquals(copyright2, actualValueSet2.getCopyright());
+	}
+
+	@Nonnull
+	private List<ValueSet> getAllValueSets() {
+		final List<IBaseResource> allResources = myValueSetDao.search(SearchParameterMap.newSynchronous(), REQUEST_DETAILS).getAllResources();
+
+		assertFalse(allResources.isEmpty());
+		assertTrue(allResources.get(0) instanceof ValueSet);
+
+		return allResources.stream()
+			.map(ValueSet.class::cast)
+			.toList();
+	}
+
+	@Nonnull
+	private ValueSet getFirstValueSet() {
+		final List<IBaseResource> allResources = myValueSetDao.search(SearchParameterMap.newSynchronous(), REQUEST_DETAILS).getAllResources();
+
+		assertEquals(1, allResources.size());
+
+		final IBaseResource resource1 = allResources.get(0);
+		assertTrue(resource1 instanceof ValueSet);
+
+		return (ValueSet) resource1;
+	}
+
+	@Nonnull
+	private TermValueSet getFirstTermValueSet() {
+		final List<TermValueSet> all2 = myTermValueSetDao.findAll();
+
+		assertEquals(1, all2.size());
+
+		return all2.get(0);
+	}
+
+	private void createValueSetAndCallCreate(String theOid, String theResourceVersion, String theValueSetVersion, String theUrl, String theCopyright) throws IOException {
+		create(createValueSet(theOid, theResourceVersion, theValueSetVersion, theUrl, theCopyright));
+	}
+
+	@Nonnull
+	private static ValueSet createValueSet(String theOid, String theResourceVersion, String theValueSetVersion, String theUrl, String theCopyright) {
+		final ValueSet valueSetFromFirstIg = new ValueSet();
+
+		valueSetFromFirstIg.setUrl(theUrl);
+		valueSetFromFirstIg.setId(new IdDt(null, "ValueSet", theOid, theResourceVersion));
+		valueSetFromFirstIg.setVersion(theValueSetVersion);
+		valueSetFromFirstIg.setCopyright(theCopyright);
+
+		return valueSetFromFirstIg;
+	}
+
+	private void create(IBaseResource theResource) throws IOException {
+		mySvc.create(theResource, createInstallationSpec(packageToBytes()), new PackageInstallOutcomeJson());
+	}
+
+	@Nonnull
+	private static CodeSystem createCodeSystem() {
+		final CodeSystem cs = new CodeSystem();
+		cs.setId("CodeSystem/mycs");
+		cs.setUrl("http://my-code-system");
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		return cs;
+	}
+
+	@Nonnull
+	private static NpmPackage createPackage() {
+		PackageGenerator manifestGenerator = new PackageGenerator();
+		manifestGenerator.name(PackageInstallerSvcImplCreateTest.PACKAGE_ID_1);
+		manifestGenerator.version(PACKAGE_VERSION);
+		manifestGenerator.description("a package");
+		manifestGenerator.fhirVersions(List.of(FhirVersionEnum.R4.getFhirVersionString()));
+
+		NpmPackage pkg = NpmPackage.empty(manifestGenerator);
+
+		String csString = ourCtx.newJsonParser().encodeResourceToString(CODE_SYSTEM);
+		pkg.addFile("package", "cs.json", csString.getBytes(StandardCharsets.UTF_8), "CodeSystem");
+
+		return pkg;
+	}
+
+	@Nonnull
+	private static PackageInstallationSpec createInstallationSpec(byte[] thePackageContents) {
+		final PackageInstallationSpec spec = new PackageInstallationSpec();
+		spec.setName(PACKAGE_ID_1);
+		spec.setVersion(PACKAGE_VERSION);
+		spec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+		spec.setPackageContents(thePackageContents);
+		return spec;
+	}
+
+	@Nonnull
+	private static byte[] packageToBytes() throws IOException {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		PackageInstallerSvcImplCreateTest.PACKAGE.save(stream);
+		return stream.toByteArray();
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ExpungeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ExpungeR4Test.java
@@ -95,6 +95,8 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 	private ISearchResultDao mySearchResultDao;
 	@Autowired
 	private ThreadSafeResourceDeleterSvc myThreadSafeResourceDeleterSvc;
+	@Autowired
+	private ExpungeService myExpungeService;
 
 	@AfterEach
 	public void afterDisableExpunge() {
@@ -212,25 +214,27 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 
 	}
 
-	public void createStandardCodeSystems() {
+	public void createStandardCodeSystemWithOneVersion(){
 		CodeSystem codeSystem1 = new CodeSystem();
 		codeSystem1.setUrl(URL_MY_CODE_SYSTEM);
 		codeSystem1.setName("CS1-V1");
 		codeSystem1.setVersion("1");
 		codeSystem1.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
 		codeSystem1
-			.addConcept().setCode("C").setDisplay("Code C").addDesignation(
-				new CodeSystem.ConceptDefinitionDesignationComponent().setLanguage("en").setValue("CodeCDesignation")).addProperty(
-				new CodeSystem.ConceptPropertyComponent().setCode("CodeCProperty").setValue(new StringType("CodeCPropertyValue"))
-			)
-			.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CA").setDisplay("Code CA")
-				.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CAA").setDisplay("Code CAA"))
-			)
-			.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CB").setDisplay("Code CB"));
+				.addConcept().setCode("C").setDisplay("Code C").addDesignation(
+						new CodeSystem.ConceptDefinitionDesignationComponent().setLanguage("en").setValue("CodeCDesignation")).addProperty(
+						new CodeSystem.ConceptPropertyComponent().setCode("CodeCProperty").setValue(new StringType("CodeCPropertyValue"))
+				)
+				.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CA").setDisplay("Code CA")
+						.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CAA").setDisplay("Code CAA"))
+				)
+				.addConcept(new CodeSystem.ConceptDefinitionComponent().setCode("CB").setDisplay("Code CB"));
 		codeSystem1
-			.addConcept().setCode("D").setDisplay("Code D");
+				.addConcept().setCode("D").setDisplay("Code D");
 		myOneVersionCodeSystemId = myCodeSystemDao.create(codeSystem1).getId();
+	}
 
+	public void createStandardCodeSystemWithTwoVersions(){
 		CodeSystem cs2v1 = new CodeSystem();
 		cs2v1.setUrl(URL_MY_CODE_SYSTEM_2);
 		cs2v1.setVersion("1");
@@ -244,6 +248,11 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 		cs2v2.setName("CS2-V2");
 		cs2v2.addConcept().setCode("F").setDisplay("Code F");
 		myTwoVersionCodeSystemIdV2 = myCodeSystemDao.create(cs2v2).getId();
+	}
+
+	public void createStandardCodeSystems() {
+		createStandardCodeSystemWithOneVersion();
+		createStandardCodeSystemWithTwoVersions();
 	}
 
 	private IFhirResourceDao<?> getDao(IIdType theId) {
@@ -670,10 +679,6 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 		assertExpunged(myDeletedPatientId.withVersion("2"));
 	}
 
-
-	@Autowired
-	private ExpungeService myExpungeService;
-
 	@Test
 	public void testExpungeDeletedWhereResourceInSearchResults() {
 		createStandardPatients();
@@ -900,25 +905,26 @@ public class ExpungeR4Test extends BaseResourceProviderR4Test {
 	}
 
 	@Test
-	public void testDeleteCodeSystemByUrlThenExpungeWithoutWaitingForBatch() {
+	public void testExpungeCodeSystem_whenCsIsBeingBatchDeleted_willGracefullyHandleConstraintViolationException(){
 		//set up
-		createStandardCodeSystems();
+		createStandardCodeSystemWithOneVersion();
 
 		myCodeSystemDao.deleteByUrl("CodeSystem?url=" + URL_MY_CODE_SYSTEM, null);
 		myTerminologyDeferredStorageSvc.saveDeferred();
+
 		try {
 			// execute
 			myCodeSystemDao.expunge(new ExpungeOptions()
 				.setExpungeDeletedResources(true)
 				.setExpungeOldVersions(true), null);
-			fail("expunge should not succeed since the delete batch job is not complete");
-		} catch (InternalErrorException e){
+			fail();
+		} catch (PreconditionFailedException preconditionFailedException){
 			// verify
-			assertNotExpunged(myOneVersionCodeSystemId.withVersion("2"));
-			assertThat(e.getMessage(), startsWith(
-				"HAPI-1084: ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException: HAPI-2415: The resource could not be ex" +
-					"punged. It is likely due to unfinished asynchronous deletions, please try again later:"));
+			assertThat(preconditionFailedException.getMessage(), startsWith(
+				"HAPI-2415: The resource could not be expunged. It is likely due to unfinished asynchronous deletions, please try again later"));
 		}
+
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
 	}
 
 	private List<Patient> createPatientsWithForcedIds(int theNumPatients) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantBatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantBatchOperationR4Test.java
@@ -32,10 +32,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.DEFAULT_PARTITION_NAME;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -108,7 +106,7 @@ public class MultitenantBatchOperationR4Test extends BaseMultitenantResourceProv
 		String jobId = BatchHelperR4.jobIdFromBatch2Parameters(response);
 		myBatch2JobHelper.awaitJobCompletion(jobId);
 
-		assertThat(interceptor.requestPartitionIds, hasSize(5));
+		assertThat(interceptor.requestPartitionIds, hasSize(4));
 		RequestPartitionId partitionId = interceptor.requestPartitionIds.get(0);
 		assertEquals(TENANT_B_ID, partitionId.getFirstPartitionIdOrNull());
 		assertEquals(TENANT_B, partitionId.getFirstPartitionNameOrNull());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -2482,12 +2482,8 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 			"Patient/A/_history/1"
 		));
 
-		history = myClient
-			.loadPage()
-			.next(history)
-			.execute();
-
-		assertEquals(0, history.getEntry().size());
+		// we got them all
+		assertNull(history.getLink("next"));
 
 		/*
 		 * Try with a date offset

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/Batch2DaoSvcImplTest.java
@@ -1,0 +1,144 @@
+package ca.uhn.fhir.jpa.reindex;
+
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
+import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
+import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
+import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.Nonnull;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class Batch2DaoSvcImplTest extends BaseJpaR4Test {
+
+	private static final Date PREVIOUS_MILLENNIUM = toDate(LocalDate.of(1999, Month.DECEMBER, 31));
+	private static final Date TOMORROW = toDate(LocalDate.now().plusDays(1));
+	private static final String URL_PATIENT_EXPUNGE_TRUE = "Patient?_expunge=true";
+	private static final String PATIENT = "Patient";
+	private static final int INTERNAL_SYNCHRONOUS_SEARCH_SIZE = 10;
+
+	@Autowired
+	private JpaStorageSettings myJpaStorageSettings;
+	@Autowired
+	private MatchUrlService myMatchUrlService;
+	@Autowired
+	private IHapiTransactionService myIHapiTransactionService ;
+
+	private DaoRegistry mySpiedDaoRegistry;
+
+	private IBatch2DaoSvc mySubject;
+
+	@BeforeEach
+	void beforeEach() {
+		myJpaStorageSettings.setInternalSynchronousSearchSize(INTERNAL_SYNCHRONOUS_SEARCH_SIZE);
+
+		mySpiedDaoRegistry = spy(myDaoRegistry);
+
+		mySubject = new Batch2DaoSvcImpl(myResourceTableDao, myMatchUrlService, mySpiedDaoRegistry, myFhirContext, myIHapiTransactionService, myJpaStorageSettings);
+	}
+
+	// TODO: LD this test won't work with the nonUrl variant yet:  error:   No existing transaction found for transaction marked with propagation 'mandatory'
+
+	@Test
+	void fetchResourcesByUrlEmptyUrl() {
+		final InternalErrorException exception = assertThrows(InternalErrorException.class, () -> mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), ""));
+
+		assertEquals("HAPI-2422: this should never happen: URL is missing a '?'", exception.getMessage());
+	}
+
+	@Test
+	void fetchResourcesByUrlSingleQuestionMark() {
+		final InternalErrorException exception = assertThrows(InternalErrorException.class, () -> mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "?"));
+
+		assertEquals("HAPI-2223: theResourceName must not be blank", exception.getMessage());
+	}
+
+	@Test
+	void fetchResourcesByUrlNonsensicalResource() {
+		final InternalErrorException exception = assertThrows(InternalErrorException.class, () -> mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), "Banana?_expunge=true"));
+
+		assertEquals("HAPI-2223: HAPI-1684: Unknown resource name \"Banana\" (this name is not known in FHIR version \"R4\")", exception.getMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 9, 10, 11, 21, 22, 23, 45})
+	void fetchResourcesByUrl(int expectedNumResults) {
+		final List<IIdType> patientIds = IntStream.range(0, expectedNumResults)
+			.mapToObj(num -> createPatient())
+			.toList();
+
+		final IResourcePidList resourcePidList = mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, 800, RequestPartitionId.defaultPartition(), URL_PATIENT_EXPUNGE_TRUE);
+
+		final List<? extends IIdType> actualPatientIds =
+			resourcePidList.getTypedResourcePids()
+				.stream()
+				.map(typePid -> new IdDt(typePid.resourceType, (Long) typePid.id.getId()))
+				.toList();
+		assertIdsEqual(patientIds, actualPatientIds);
+
+		verify(mySpiedDaoRegistry, times(getExpectedNumOfInvocations(expectedNumResults))).getResourceDao(PATIENT);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 9, 10, 11, 21, 22, 23, 45})
+	void fetchResourcesNoUrl(int expectedNumResults) {
+		final int pageSizeWellBelowThreshold = 2;
+		final List<IIdType> patientIds = IntStream.range(0, expectedNumResults)
+			.mapToObj(num -> createPatient())
+			.toList();
+
+		final IResourcePidList resourcePidList = mySubject.fetchResourceIdsPage(PREVIOUS_MILLENNIUM, TOMORROW, pageSizeWellBelowThreshold, RequestPartitionId.defaultPartition(), null);
+
+		final List<? extends IIdType> actualPatientIds =
+			resourcePidList.getTypedResourcePids()
+				.stream()
+				.map(typePid -> new IdDt(typePid.resourceType, (Long) typePid.id.getId()))
+				.toList();
+		assertIdsEqual(patientIds, actualPatientIds);
+	}
+
+	private int getExpectedNumOfInvocations(int expectedNumResults) {
+		final int maxResultsPerQuery = INTERNAL_SYNCHRONOUS_SEARCH_SIZE + 1;
+		final int division = expectedNumResults / maxResultsPerQuery;
+		return division + 1;
+	}
+
+	private static void assertIdsEqual(List<IIdType> expectedResourceIds, List<? extends IIdType> actualResourceIds) {
+		assertEquals(expectedResourceIds.size(), actualResourceIds.size());
+
+		for (int index = 0; index < expectedResourceIds.size(); index++) {
+			final IIdType expectedIdType = expectedResourceIds.get(index);
+			final IIdType actualIdType = actualResourceIds.get(index);
+
+			assertEquals(expectedIdType.getResourceType(), actualIdType.getResourceType());
+			assertEquals(expectedIdType.getIdPartAsLong(), actualIdType.getIdPartAsLong());
+		}
+	}
+
+	@Nonnull
+	private static Date toDate(LocalDate theLocalDate) {
+		return Date.from(theLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/ResourceReindexSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/reindex/ResourceReindexSvcImplTest.java
@@ -3,16 +3,13 @@ package ca.uhn.fhir.jpa.reindex;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
-import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
-import org.hl7.fhir.r4.model.DateType;
-import org.hl7.fhir.r4.model.InstantType;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -111,26 +108,26 @@ public class ResourceReindexSvcImplTest extends BaseJpaR4Test {
 
 		// Setup
 
-		createPatient(withActiveFalse());
+		final Long patientId0 = createPatient(withActiveFalse()).getIdPartAsLong();
 		sleepUntilTimeChanges();
 
 		// Start of resources within range
 		Date start = new Date();
 		sleepUntilTimeChanges();
-		Long id0 = createPatient(withActiveFalse()).getIdPartAsLong();
+		Long patientId1 = createPatient(withActiveFalse()).getIdPartAsLong();
 		createObservation(withObservationCode("http://foo", "bar"));
 		createObservation(withObservationCode("http://foo", "bar"));
 		sleepUntilTimeChanges();
 		Date beforeLastInRange = new Date();
 		sleepUntilTimeChanges();
-		Long id1 = createPatient(withActiveFalse()).getIdPartAsLong();
+		Long patientId2 = createPatient(withActiveFalse()).getIdPartAsLong();
 		sleepUntilTimeChanges();
 		Date end = new Date();
 		sleepUntilTimeChanges();
 		// End of resources within range
 
 		createObservation(withObservationCode("http://foo", "bar"));
-		createPatient(withActiveFalse());
+		final Long patientId3 = createPatient(withActiveFalse()).getIdPartAsLong();
 		sleepUntilTimeChanges();
 
 		// Execute
@@ -140,13 +137,17 @@ public class ResourceReindexSvcImplTest extends BaseJpaR4Test {
 
 		// Verify
 
-		assertEquals(2, page.size());
+		assertEquals(4, page.size());
 		List<TypedResourcePid> typedResourcePids = page.getTypedResourcePids();
-		assertThat(page.getTypedResourcePids(), contains(new TypedResourcePid("Patient", id0), new TypedResourcePid("Patient", id1)));
+		assertThat(page.getTypedResourcePids(),
+			contains(new TypedResourcePid("Patient", patientId0),
+				new TypedResourcePid("Patient", patientId1),
+				new TypedResourcePid("Patient", patientId2),
+				new TypedResourcePid("Patient", patientId3)));
 		assertTrue(page.getLastDate().after(beforeLastInRange));
-		assertTrue(page.getLastDate().before(end));
+		assertTrue(page.getLastDate().before(end) || page.getLastDate().equals(end));
 
-		assertEquals(3, myCaptureQueriesListener.logSelectQueries().size());
+		assertEquals(1, myCaptureQueriesListener.logSelectQueries().size());
 		assertEquals(0, myCaptureQueriesListener.countInsertQueries());
 		assertEquals(0, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
@@ -1,8 +1,6 @@
 package ca.uhn.fhir.jpa.subscription.message;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
-import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
-import ca.uhn.fhir.jpa.model.entity.NormalizedQuantitySearchLevel;
 import ca.uhn.fhir.jpa.subscription.BaseSubscriptionsR4Test;
 import ca.uhn.fhir.jpa.subscription.channel.api.ChannelConsumerSettings;
 import ca.uhn.fhir.jpa.subscription.channel.api.IChannelReceiver;
@@ -10,6 +8,9 @@ import ca.uhn.fhir.jpa.subscription.channel.subscription.SubscriptionChannelFact
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import ca.uhn.fhir.jpa.test.util.StoppableSubscriptionDeliveringRestHookSubscriber;
+import ca.uhn.fhir.rest.client.api.Header;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.interceptor.AdditionalRequestHeadersInterceptor;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Coding;
@@ -18,7 +19,6 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,11 +30,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static ca.uhn.fhir.jpa.model.util.JpaConstants.HEADER_META_SNAPSHOT_MODE;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Test the rest-hook subscriptions
@@ -117,58 +121,98 @@ public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
 		assertThat(receivedObs.getMeta().getSource(), is(equalTo(theExpectedSourceValue)));
 	}
 
-	@Test
-	public void testUpdateResourceRetainCorrectMetaTagsThroughDelivery() throws Exception {
+
+	private static Stream<Arguments> metaTagsSource(){
+		List<Header> snapshotModeHeader = asList(new Header(HEADER_META_SNAPSHOT_MODE, "TAG"));
+
+		return Stream.of(
+				Arguments.of(asList("tag-1","tag-2"), asList("tag-3"), asList("tag-1","tag-2","tag-3"), emptyList()),
+				Arguments.of(asList("tag-1","tag-2"), asList("tag-1","tag-2","tag-3"), asList("tag-1","tag-2","tag-3"), emptyList()),
+				Arguments.of(emptyList(), asList("tag-1","tag-2"), asList("tag-1","tag-2"), emptyList()),
+//				Arguments.of(asList("tag-1","tag-2"), emptyList(), asList("tag-1","tag-2"), emptyList()), // will not trigger an update since tags are merged
+				Arguments.of(asList("tag-1","tag-2"), emptyList(), emptyList(), snapshotModeHeader),
+				Arguments.of(asList("tag-1","tag-2"), asList("tag-3"), asList("tag-3"), snapshotModeHeader),
+				Arguments.of(asList("tag-1","tag-2","tag-3"), asList("tag-1","tag-2"), asList("tag-1","tag-2"), snapshotModeHeader),
+				Arguments.of(asList("tag-1","tag-2","tag-3"), asList("tag-2","tag-3"), asList("tag-2","tag-3"), snapshotModeHeader),
+				Arguments.of(asList("tag-1","tag-2","tag-3"), asList("tag-1","tag-3"), asList("tag-1","tag-3"), snapshotModeHeader)
+				);
+	}
+	@ParameterizedTest
+	@MethodSource("metaTagsSource")
+	public void testUpdateResource_withHeaderSnapshotMode_willRetainCorrectMetaTagsThroughDelivery(List<String> theTagsForCreate, List<String> theTagsForUpdate, List<String> theExpectedTags, List<Header> theHeaders) throws Exception {
 		myStorageSettings.setTagStorageMode(JpaStorageSettings.TagStorageModeEnum.NON_VERSIONED);
 		createSubscriptionWithCriteria("[Patient]");
 
 		waitForActivatedSubscriptionCount(1);
 
-		// Create Patient with two meta tags
 		Patient patient = new Patient();
 		patient.setActive(true);
-		patient.getMeta().addTag().setSystem("http://www.example.com/tags").setCode("tag-1");
-		patient.getMeta().addTag().setSystem("http://www.example.com/tags").setCode("tag-2");
+		patient.getMeta().setTag(toSimpleCodingList(theTagsForCreate));
 
 		IIdType id = myClient.create().resource(patient).execute().getId();
 
-		// Should see 1 subscription notification for CREATE
 		waitForQueueToDrain();
 
-		// Should receive two meta tags
-		IBaseResource resource = fetchSingleResourceFromSubscriptionTerminalEndpoint();
-		assertThat(resource, instanceOf(Patient.class));
-		Patient receivedPatient = (Patient) resource;
-		assertThat(receivedPatient.getMeta().getTag().size(), is(equalTo(2)));
+		Patient receivedPatient = fetchSingleResourceFromSubscriptionTerminalEndpoint();
+		assertThat(receivedPatient.getMeta().getTag(), hasSize(theTagsForCreate.size()));
 
-		// Update the previous Patient and add one more tag
 		patient = new Patient();
 		patient.setId(id);
 		patient.setActive(true);
-		patient.getMeta().getTag().add(new Coding().setSystem("http://www.example.com/tags").setCode("tag-3"));
+		patient.getMeta().setTag(toSimpleCodingList(theTagsForUpdate));
+
+		maybeAddHeaderInterceptor(myClient, theHeaders);
+
 		myClient.update().resource(patient).execute();
 
 		waitForQueueToDrain();
 
-		// Should receive all three meta tags
-		List<String> expected = List.of("tag-1", "tag-2", "tag-3");
-		resource = fetchSingleResourceFromSubscriptionTerminalEndpoint();
-		receivedPatient = (Patient) resource;
-		List<Coding> receivedTagList = receivedPatient.getMeta().getTag();
+		receivedPatient = fetchSingleResourceFromSubscriptionTerminalEndpoint();;
+
 		ourLog.info(getFhirContext().newJsonParser().setPrettyPrint(true).encodeResourceToString(receivedPatient));
-		assertThat(receivedTagList.size(), is(equalTo(3)));
-		List<String> actual = receivedTagList.stream().map(t -> t.getCode()).sorted().collect(Collectors.toList());
-		assertTrue(expected.equals(actual));
+
+		List<String> receivedTagList = toSimpleTagList(receivedPatient.getMeta().getTag());
+		assertThat(receivedTagList, containsInAnyOrder(theExpectedTags.toArray()));
+
 	}
 
-	private IBaseResource fetchSingleResourceFromSubscriptionTerminalEndpoint() {
+	private void maybeAddHeaderInterceptor(IGenericClient theClient, List<Header> theHeaders) {
+		if(theHeaders.isEmpty()){
+			return;
+		}
+
+		AdditionalRequestHeadersInterceptor additionalRequestHeadersInterceptor = new AdditionalRequestHeadersInterceptor();
+
+		theHeaders.forEach(aHeader ->
+			additionalRequestHeadersInterceptor
+				.addHeaderValue(
+					aHeader.getName(),
+					aHeader.getValue()
+				)
+		);
+		theClient.registerInterceptor(additionalRequestHeadersInterceptor);
+	}
+
+	private List<Coding> toSimpleCodingList(List<String> theTags) {
+		return theTags.stream().map(theString -> new Coding().setCode(theString)).collect(Collectors.toList());
+	}
+
+	private List<String> toSimpleTagList(List<Coding> theTags) {
+		return theTags.stream().map(t -> t.getCode()).collect(Collectors.toList());
+	}
+
+	private static Coding toSimpleCode(String theCode){
+		return new Coding().setCode(theCode);
+	}
+
+	private <T> T fetchSingleResourceFromSubscriptionTerminalEndpoint() {
 		assertThat(handler.getMessages().size(), is(equalTo(1)));
 		ResourceModifiedJsonMessage resourceModifiedJsonMessage = handler.getMessages().get(0);
 		ResourceModifiedMessage payload = resourceModifiedJsonMessage.getPayload();
 		String payloadString = payload.getPayloadString();
 		IBaseResource resource = myFhirContext.newJsonParser().parseResource(payloadString);
 		handler.clearMessages();
-		return resource;
+		return (T) resource;
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-r4b/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/pom.xml
+++ b/hapi-fhir-jpaserver-test-r5/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/dao/TestDaoSearch.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/dao/TestDaoSearch.java
@@ -72,7 +72,7 @@ public class TestDaoSearch {
 		}
 	}
 
-	@Autowired
+	@Autowired(required = false)
 	private IFulltextSearchSvc myFulltextSearchSvc;
 
 	final FhirContext myFhirCtx;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/search/BaseSourceSearchParameterTestCases.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/search/BaseSourceSearchParameterTestCases.java
@@ -1,0 +1,281 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.search;
+
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.dao.TestDaoSearch;
+import ca.uhn.fhir.test.utilities.ITestDataBuilder;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/**
+ * Test cases for _source search parameter.
+ */
+public abstract class BaseSourceSearchParameterTestCases implements ITestDataBuilder.WithSupport {
+
+	final ITestDataBuilder.Support myTestDataBuilder;
+	final TestDaoSearch myTestDaoSearch;
+
+	final JpaStorageSettings myStorageSettings;
+
+	protected BaseSourceSearchParameterTestCases(
+			ITestDataBuilder.Support theTestDataBuilder,
+			TestDaoSearch theTestDaoSearch,
+			JpaStorageSettings theStorageSettings) {
+		myTestDataBuilder = theTestDataBuilder;
+		myTestDaoSearch = theTestDaoSearch;
+		myStorageSettings = theStorageSettings;
+	}
+
+	/**
+	 * Enable if requestId within _source Search Parameter is supported
+	 * Example: _source={sourceURI}#{requestId}
+	 */
+	protected abstract boolean isRequestIdSupported();
+
+	@Override
+	public Support getTestDataBuilderSupport() {
+		return myTestDataBuilder;
+	}
+
+	@AfterEach
+	public final void after() {
+		myTestDataBuilder.setRequestId(null);
+		myStorageSettings.setStoreMetaSourceInformation(new JpaStorageSettings().getStoreMetaSourceInformation());
+	}
+
+	@BeforeEach
+	public void before() {
+		myStorageSettings.setStoreMetaSourceInformation(
+				JpaStorageSettings.StoreMetaSourceInformationEnum.SOURCE_URI_AND_REQUEST_ID);
+	}
+
+	@Test
+	public void testSearch_withSource_returnsCorrectBundle() {
+		IIdType pt0id = createPatient(withSource("http://host/0"), withActiveTrue());
+		IIdType pt1id = createPatient(withSource("http://host/1"), withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds("search by source URI finds", "Patient?_source=http://host/0", pt0id);
+		myTestDaoSearch.assertSearchNotFound("search by source URI not found", "Patient?_source=http://host/0", pt1id);
+	}
+
+	@EnabledIf("isRequestIdSupported")
+	@Test
+	public void testSearch_withRequestIdAndSource_returnsCorrectBundle() {
+		myTestDataBuilder.setRequestId("a_request_id");
+		IIdType pt0id = createPatient(withSource("http://host/0"), withActiveTrue());
+
+		IIdType pt1id = createPatient(withSource("http://host/1"), withActiveTrue());
+
+		myTestDataBuilder.setRequestId("b_request_id");
+		IIdType pt2id = createPatient(withSource("http://host/1"), withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds("search by requestId finds", "Patient?_source=#a_request_id", pt0id, pt1id);
+		myTestDaoSearch.assertSearchNotFound("search by requestId not found", "Patient?_source=#a_request_id", pt2id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search by source URI and requestId finds", "Patient?_source=http://host/0#a_request_id", pt0id);
+		myTestDaoSearch.assertSearchNotFound(
+				"search by source URI and requestId not found",
+				"Patient?_source=http://host/0#a_request_id",
+				pt1id,
+				pt2id);
+	}
+
+	@Test
+	public void testSearchSource_whenSameSourceForMultipleResourceTypes_willMatchSearchResourceTypeOnly() {
+		String sourceUrn = "http://host/0";
+		myTestDataBuilder.setRequestId("a_request_id");
+
+		IIdType pt0id = createPatient(withSource(sourceUrn), withActiveTrue());
+		IIdType ob0id = createObservation(withSource(sourceUrn), withStatus("final"));
+
+		myTestDaoSearch.assertSearchFinds(
+				"search source URI for Patient finds", "Patient?_source=http://host/0", pt0id);
+		myTestDaoSearch.assertSearchNotFound(
+				"search source URI for Patient - Observation not found", "Patient?_source=http://host/0", ob0id);
+	}
+
+	@Test
+	public void testSearchSource_withOrJoinedParameter_returnsUnionResultBundle() {
+		myTestDataBuilder.setRequestId("a_request_id");
+
+		IIdType pt0id = createPatient(withSource("http://host/0"), withActiveTrue());
+		IIdType pt1id = createPatient(withSource("http://host/1"), withActiveTrue());
+		createPatient(withSource("http://host/2"), withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds(
+				"search source URI with union", "Patient?_source=http://host/0,http://host/1", pt0id, pt1id);
+	}
+
+	@EnabledIf("isRequestIdSupported")
+	@Test
+	public void testSearch_withSourceAndRequestId_returnsIntersectionResultBundle() {
+		myTestDataBuilder.setRequestId("a_request_id");
+		IIdType pt0id = createPatient(withSource("http://host/0"), withActiveTrue());
+
+		myTestDataBuilder.setRequestId("b_request_id");
+		IIdType pt1id = createPatient(withSource("http://host/0"), withActiveTrue());
+		IIdType pt2id = createPatient(withSource("http://host/1"), withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds(
+				"search for source URI and requestId intersection finds",
+				"Patient?_source=http://host/0&_source=#a_request_id",
+				pt0id);
+		myTestDaoSearch.assertSearchNotFound(
+				"search for source URI and requestId intersection not found",
+				"Patient?_source=http://host/0&_source=#a_request_id",
+				pt1id,
+				pt2id);
+	}
+
+	@Test
+	public void testSearchSource_withContainsModifier_returnsCorrectBundle() {
+		myStorageSettings.setAllowContainsSearches(true);
+
+		IIdType p1Id = createPatient(withSource("http://some-source"), withActiveTrue(), withFamily("Family"));
+		IIdType p2Id = createPatient(withSource("http://some-source/v1/321"), withActiveTrue());
+		IIdType p3Id = createPatient(withSource(("http://another-source/v1")), withActiveTrue(), withFamily("Family"));
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches both sources (same case search)", "Patient?_source:contains=some-source", p1Id, p2Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches both sources (case insensitive search)",
+				"Patient?_source:contains=Some-Source",
+				p1Id,
+				p2Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches all sources (union search)",
+				"Patient?_source:contains=Another-Source,some-source",
+				p1Id,
+				p2Id,
+				p3Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches one sources (intersection with family SearchParameter)",
+				"Patient?_source:contains=Another-Source,some-source&family=Family,YourFamily",
+				p3Id);
+
+		myTestDaoSearch.assertSearchNotFound(
+				"search returns empty bundle (contains with missing=true)",
+				"Patient?_source:contains=Another-Source,some-source&_source:missing=true",
+				p1Id,
+				p2Id,
+				p3Id);
+	}
+
+	@Test
+	public void testSearchSource_withMissingModifierFalse_returnsNonEmptySources() {
+		IIdType p1Id = createPatient(withSource("http://some-source/v1"), withActiveTrue());
+		createPatient(withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds("search matches non-empty source", "Patient?_source:missing=false", p1Id);
+	}
+
+	@Test
+	public void testSearchSource_withMissingModifierTrue_returnsEmptySources() {
+		createPatient(withSource("http://some-source/v1"), withActiveTrue(), withFamily("Family"));
+		IIdType p2Id = createPatient(withActiveTrue(), withFamily("Family"));
+
+		myTestDaoSearch.assertSearchFinds("search matches empty source", "Patient?_source:missing=true", p2Id);
+		myTestDaoSearch.assertSearchFinds(
+				"search matches empty source with family parameter intersection",
+				"Patient?_source:missing=true&family=Family",
+				p2Id);
+	}
+
+	@Test
+	public void testSearchSource_withAboveModifier_returnsSourcesAbove() {
+		IIdType p1Id = createPatient(withSource("http://some-source/v1/123"), withActiveTrue());
+		IIdType p2Id = createPatient(withSource("http://some-source/v1/321"), withActiveTrue());
+		IIdType p3Id = createPatient(withSource("http://some-source/v1/321/v2"), withActiveTrue());
+		IIdType p4Id = createPatient(withSource("http://another-source"), withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches all sources above",
+				"Patient?_source:above=http://some-source/v1/321/v2/456",
+				p2Id,
+				p3Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches all sources above", "Patient?_source:above=http://some-source/v1/321/v2", p2Id, p3Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches source above", "Patient?_source:above=http://some-source/v1/321", p2Id);
+
+		myTestDaoSearch.assertSearchNotFound(
+				"search not matches if sources is not above",
+				"Patient?_source:above=http://some-source/fhir/v5/789",
+				p1Id,
+				p2Id,
+				p3Id,
+				p4Id);
+
+		myTestDaoSearch.assertSearchNotFound(
+				"search not matches if sources is not above",
+				"Patient?_source:above=http://some-source",
+				p1Id,
+				p2Id,
+				p3Id,
+				p4Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search not matches for another source",
+				"Patient?_source:above=http://another-source,http://some-source/v1/321/v2",
+				p2Id,
+				p3Id,
+				p4Id);
+	}
+
+	@Test
+	public void testSearchSource_withBelowModifier_returnsSourcesBelow() {
+		IIdType p1Id = createPatient(withSource("http://some-source/v1/123"), withActiveTrue());
+		IIdType p2Id = createPatient(withSource("http://some-source/v1"), withActiveTrue());
+		IIdType p3Id = createPatient(withSource("http://some-source"), withActiveTrue());
+		IIdType p4Id = createPatient(withSource("http://another-source"), withActiveTrue());
+
+		myTestDaoSearch.assertSearchFinds(
+				"search matches all sources below", "Patient?_source:below=http://some-source", p1Id, p2Id, p3Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search below with union",
+				"Patient?_source:below=http://some-source/v1,http://another-source",
+				p1Id,
+				p2Id,
+				p4Id);
+
+		myTestDaoSearch.assertSearchFinds(
+				"search below with intersection",
+				"Patient?_source:below=http://some-source/v1&_source:below=http://some-source/v1/123",
+				p1Id);
+
+		myTestDaoSearch.assertSearchNotFound(
+				"search below with intersection not matches",
+				"Patient?_source:below=http://some-source/v1&_source:below=http://some-source/v1/123",
+				p2Id,
+				p3Id,
+				p4Id);
+	}
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4StandardQueriesLuceneTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4StandardQueriesLuceneTest.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.TestDaoSearch;
 import ca.uhn.fhir.jpa.search.CompositeSearchParameterTestCases;
 import ca.uhn.fhir.jpa.search.QuantitySearchParameterTestCases;
+import ca.uhn.fhir.jpa.search.BaseSourceSearchParameterTestCases;
 import ca.uhn.fhir.jpa.test.BaseJpaTest;
 import ca.uhn.fhir.jpa.test.config.TestR4Config;
 import ca.uhn.fhir.storage.test.BaseDateSearchDaoTests;
@@ -88,6 +89,18 @@ public class FhirResourceDaoR4StandardQueriesLuceneTest extends BaseJpaTest {
 		@Override
 		protected boolean isCorrelatedSupported() {
 			return true;
+		}
+	}
+
+	@Nested
+	class SourceSearchParameterTestCases extends BaseSourceSearchParameterTestCases {
+		SourceSearchParameterTestCases() {
+			super(myDataBuilder, myTestDaoSearch, myStorageSettings);
+		}
+
+		@Override
+		protected boolean isRequestIdSupported() {
+			return false;
 		}
 	}
 

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsHooksContextBooterTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsHooksContextBooterTest.java
@@ -28,7 +28,7 @@ class CdsHooksContextBooterTest {
 	@Test
 	void validateJsonThrowsExceptionWhenInputIsInvalid() {
 		// setup
-		final String expected = "Invalid JSON: Unrecognized token 'abc': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
+		final String expected = "HAPI-2378: Invalid JSON: Unrecognized token 'abc': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
 			" at [Source: (String)\"abc\"; line: 1, column: 4]";
 		// execute
 		final UnprocessableEntityException actual = assertThrows(UnprocessableEntityException.class, () -> myFixture.validateJson("abc"));

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvcTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvcTest.java
@@ -93,7 +93,7 @@ class CdsPrefetchFhirClientSvcTest {
 			IBaseResource srq = myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "1234");
 			fail("should throw, no resource present");
 		} catch (InvalidRequestException e) {
-			assertEquals("Unable to translate url 1234 into a resource or a bundle.", e.getMessage());
+			assertEquals("HAPI-2384: Unable to translate url 1234 into a resource or a bundle.", e.getMessage());
 		}
 	}
 
@@ -106,7 +106,7 @@ class CdsPrefetchFhirClientSvcTest {
 			IBaseResource srq = myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "/1234");
 			fail("should throw, no resource present");
 		} catch (InvalidRequestException e) {
-			assertEquals("Failed to resolve /1234. Url does not start with a resource type.", e.getMessage());
+			assertEquals("HAPI-2383: Failed to resolve /1234. Url does not start with a resource type.", e.getMessage());
 		}
 	}
 }

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilTest.java
@@ -36,7 +36,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
+			assertEquals("HAPI-2375: Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
 		}
 	}
 
@@ -50,7 +50,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
+			assertEquals("HAPI-2375: Either request context was empty or it did not provide a value for key <userId>.  Please make sure you are including a context with valid keys.", e.getMessage());
 		}
 	}
 
@@ -63,7 +63,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Request context did not provide a value for key <draftOrders>.  Available keys in context are: [patientId]", e.getMessage());
+			assertEquals("HAPI-2372: Request context did not provide a value for key <draftOrders>.  Available keys in context are: [patientId]", e.getMessage());
 		}
 	}
 
@@ -119,7 +119,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail("substituteTemplate call was successful with a null context field.");
 		} catch (InvalidRequestException e) {
-			assertEquals("Request context did not provide for resource(s) matching template. ResourceType missing is: ServiceRequest", e.getMessage());
+			assertEquals("HAPI-2373: Request context did not provide for resource(s) matching template. ResourceType missing is: ServiceRequest", e.getMessage());
 		}
 	}
 
@@ -134,7 +134,7 @@ class PrefetchTemplateUtilTest {
 			PrefetchTemplateUtil.substituteTemplate(template, context, FhirContext.forR4());
 			fail();
 		} catch (InvalidRequestException e) {
-			assertEquals("Request context did not provide valid " + fhirContextR4.getVersion().getVersion() + " Bundle resource for template key <draftOrders>" , e.getMessage());
+			assertEquals("HAPI-2374: Request context did not provide valid " + fhirContextR4.getVersion().getVersion() + " Bundle resource for template key <draftOrders>", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -151,13 +151,13 @@ public class MdmResourceMatcherSvc {
 						fieldComparator.getName(),
 						matchEvaluation.score,
 						vector);
+				score += matchEvaluation.score;
 			} else {
 				ourLog.trace(
 						"No match: Matcher {} did not match (score: {}).",
 						fieldComparator.getName(),
 						matchEvaluation.score);
 			}
-			score += matchEvaluation.score;
 			appliedRuleCount += 1;
 		}
 

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcR4Test.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvcR4Test.java
@@ -57,4 +57,19 @@ public class MdmResourceMatcherSvcR4Test extends BaseMdmRulesR4Test {
 		patient3.addName().addGiven("Henry");
 		assertMatchResult(MdmMatchResultEnum.NO_MATCH, 0L, 0.0, false, false, myMdmResourceMatcherSvc.getMatchResult(myJohn, patient3));
 	}
+
+	@Test
+	public void testScoreOnlySummedWhenMatchFieldMatches() {
+		MdmMatchOutcome outcome = myMdmResourceMatcherSvc.getMatchResult(myJohn, myJohny);
+		assertMatchResult(MdmMatchResultEnum.POSSIBLE_MATCH, 1L, 0.816, false, false, outcome);
+
+		myJohn.addName().setFamily("Smith");
+		myJohny.addName().setFamily("htims");
+		outcome = myMdmResourceMatcherSvc.getMatchResult(myJohn, myJohny);
+		assertMatchResult(MdmMatchResultEnum.POSSIBLE_MATCH, 1L, 0.816, false, false, outcome);
+
+		myJohny.addName().setFamily("Smith");
+		outcome = myMdmResourceMatcherSvc.getMatchResult(myJohn, myJohny);
+		assertMatchResult(MdmMatchResultEnum.MATCH, 3L, 1.816, false, false, outcome);
+	}
 }

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ResponseBundleBuilder.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ResponseBundleBuilder.java
@@ -234,6 +234,7 @@ public class ResponseBundleBuilder {
 				theResponseBundleRequest.includes,
 				RestfulServerUtils.prettyPrintResponse(server, theResponseBundleRequest.requestDetails),
 				theResponseBundleRequest.bundleType);
+
 		retval.setSelf(theResponseBundleRequest.linkSelf);
 
 		if (bundleProvider.getCurrentPageOffset() != null) {
@@ -264,21 +265,22 @@ public class ResponseBundleBuilder {
 			// Paging without caching
 			// We're doing offset pages
 			int requestedToReturn = theResponsePage.numToReturn;
-			if (server.getPagingProvider() == null && pageRequest.offset != null) {
-				// There is no paging provider at all, so assume we're querying up to all the results we need every time
+
+			if (pageRequest.offset != null) {
 				requestedToReturn += pageRequest.offset;
 			}
+
 			if (theResponsePage.numTotalResults == null || requestedToReturn < theResponsePage.numTotalResults) {
-				if (!theResponsePage.resourceList.isEmpty()) {
-					retval.setNext(RestfulServerUtils.createOffsetPagingLink(
-							retval,
-							theResponseBundleRequest.requestDetails.getRequestPath(),
-							theResponseBundleRequest.requestDetails.getTenantId(),
-							ObjectUtils.defaultIfNull(pageRequest.offset, 0) + theResponsePage.numToReturn,
-							theResponsePage.numToReturn,
-							theResponseBundleRequest.getRequestParameters()));
-				}
+
+				retval.setNext(RestfulServerUtils.createOffsetPagingLink(
+						retval,
+						theResponseBundleRequest.requestDetails.getRequestPath(),
+						theResponseBundleRequest.requestDetails.getTenantId(),
+						ObjectUtils.defaultIfNull(pageRequest.offset, 0) + theResponsePage.numToReturn,
+						theResponsePage.numToReturn,
+						theResponseBundleRequest.getRequestParameters()));
 			}
+
 			if (pageRequest.offset != null && pageRequest.offset > 0) {
 				int start = Math.max(0, pageRequest.offset - theResponsePage.pageSize);
 				retval.setPrev(RestfulServerUtils.createOffsetPagingLink(
@@ -289,6 +291,7 @@ public class ResponseBundleBuilder {
 						theResponsePage.pageSize,
 						theResponseBundleRequest.getRequestParameters()));
 			}
+
 		} else if (StringUtils.isNotBlank(bundleProvider.getCurrentPageId())) {
 			// We're doing named pages
 			final String uuid = bundleProvider.getUuid();
@@ -300,6 +303,7 @@ public class ResponseBundleBuilder {
 						bundleProvider.getNextPageId(),
 						theResponseBundleRequest.getRequestParameters()));
 			}
+
 			if (StringUtils.isNotBlank(bundleProvider.getPreviousPageId())) {
 				retval.setPrev(RestfulServerUtils.createPagingLink(
 						retval,
@@ -308,37 +312,33 @@ public class ResponseBundleBuilder {
 						bundleProvider.getPreviousPageId(),
 						theResponseBundleRequest.getRequestParameters()));
 			}
+
 		} else if (theResponsePage.searchId != null) {
-			/*
-			 * We're doing offset pages - Note that we only return paging links if we actually
-			 * included some results in the response. We do this to avoid situations where
-			 * people have faked the offset number to some huge number to avoid them getting
-			 * back paging links that don't make sense.
-			 */
-			if (theResponsePage.size() > 0) {
-				if (theResponsePage.numTotalResults == null
-						|| theResponseBundleRequest.offset + theResponsePage.numToReturn
-								< theResponsePage.numTotalResults) {
-					retval.setNext((RestfulServerUtils.createPagingLink(
-							retval,
-							theResponseBundleRequest.requestDetails,
-							theResponsePage.searchId,
-							theResponseBundleRequest.offset + theResponsePage.numToReturn,
-							theResponsePage.numToReturn,
-							theResponseBundleRequest.getRequestParameters())));
-				}
-				if (theResponseBundleRequest.offset > 0) {
-					int start = Math.max(0, theResponseBundleRequest.offset - theResponsePage.pageSize);
-					retval.setPrev(RestfulServerUtils.createPagingLink(
-							retval,
-							theResponseBundleRequest.requestDetails,
-							theResponsePage.searchId,
-							start,
-							theResponsePage.pageSize,
-							theResponseBundleRequest.getRequestParameters()));
-				}
+
+			if (theResponsePage.numTotalResults == null
+					|| theResponseBundleRequest.offset + theResponsePage.numToReturn
+							< theResponsePage.numTotalResults) {
+				retval.setNext((RestfulServerUtils.createPagingLink(
+						retval,
+						theResponseBundleRequest.requestDetails,
+						theResponsePage.searchId,
+						theResponseBundleRequest.offset + theResponsePage.numToReturn,
+						theResponsePage.numToReturn,
+						theResponseBundleRequest.getRequestParameters())));
+			}
+
+			if (theResponseBundleRequest.offset > 0) {
+				int start = Math.max(0, theResponseBundleRequest.offset - theResponsePage.pageSize);
+				retval.setPrev(RestfulServerUtils.createPagingLink(
+						retval,
+						theResponseBundleRequest.requestDetails,
+						theResponsePage.searchId,
+						start,
+						theResponsePage.pageSize,
+						theResponseBundleRequest.getRequestParameters()));
 			}
 		}
+
 		return retval;
 	}
 

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>6.7.15-SNAPSHOT</version>
+			<version>6.8.0-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>6.7.15-SNAPSHOT</version>
+      <version>6.8.0-SNAPSHOT</version>
 
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/pom.xml
+++ b/hapi-fhir-storage-batch2-test-utilities/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
@@ -100,7 +100,9 @@ public class ReductionStepDataSink<PT extends IModelJson, IT extends IModelJson,
 					"Finalizing job instance {} with report length {} chars",
 					instance.getInstanceId(),
 					dataString.length());
-			ourLog.atTrace().addArgument(() -> JsonUtil.serialize(instance)).log("New instance state: {}");
+			if (ourLog.isTraceEnabled()) {
+				ourLog.trace("New instance state: {}", JsonUtil.serialize(instance));
+			}
 
 			return true;
 		});

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -30,18 +30,17 @@ import ca.uhn.fhir.batch2.jobs.chunk.TypedPidJson;
 import ca.uhn.fhir.batch2.jobs.parameters.PartitionedJobParameters;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
-import ca.uhn.fhir.jpa.api.pid.TypedResourcePid;
-import ca.uhn.fhir.system.HapiSystemProperties;
 import ca.uhn.fhir.util.Logs;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.UnmodifiableIterator;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends ChunkRangeJson>
@@ -75,11 +74,8 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 
 		ourLog.info("Beginning scan for reindex IDs in range {} to {}", start, end);
 
-		Date nextStart = start;
 		RequestPartitionId requestPartitionId =
 				theStepExecutionDetails.getParameters().getRequestPartitionId();
-		Set<TypedPidJson> idBuffer = new LinkedHashSet<>();
-		long previousLastTime = 0L;
 		int totalIdsFound = 0;
 		int chunkCount = 0;
 
@@ -88,55 +84,29 @@ public class ResourceIdListStep<PT extends PartitionedJobParameters, IT extends 
 			// we won't go over MAX_BATCH_OF_IDS
 			maxBatchId = Math.min(batchSize.intValue(), maxBatchId);
 		}
-		while (true) {
-			IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
-					nextStart, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
-			if (nextChunk.isEmpty()) {
-				ourLog.info("No data returned");
-				break;
-			}
+		final IResourcePidList nextChunk = myIdChunkProducer.fetchResourceIdsPage(
+				start, end, pageSize, requestPartitionId, theStepExecutionDetails.getData());
 
-			// If we get the same last time twice in a row, we've clearly reached the end
-			if (nextChunk.getLastDate().getTime() == previousLastTime) {
-				ourLog.info("Matching final timestamp of {}, loading is completed", new Date(previousLastTime));
-				break;
-			}
-
-			ourLog.info("Found {} IDs from {} to {}", nextChunk.size(), nextStart, nextChunk.getLastDate());
-			if (nextChunk.size() < 10 && HapiSystemProperties.isTestModeEnabled()) {
-				// TODO: I've added this in order to troubleshoot MultitenantBatchOperationR4Test
-				// which is failing intermittently. If that stops, makes sense to remove this
-				ourLog.info(" * PIDS: {}", nextChunk);
-			}
-
-			for (TypedResourcePid typedResourcePid : nextChunk.getTypedResourcePids()) {
-				TypedPidJson nextId = new TypedPidJson(typedResourcePid);
-				idBuffer.add(nextId);
-			}
-
-			previousLastTime = nextChunk.getLastDate().getTime();
-			nextStart = nextChunk.getLastDate();
-
-			while (idBuffer.size() > maxBatchId) {
-				List<TypedPidJson> submissionIds = new ArrayList<>();
-				for (Iterator<TypedPidJson> iter = idBuffer.iterator(); iter.hasNext(); ) {
-					submissionIds.add(iter.next());
-					iter.remove();
-					if (submissionIds.size() == maxBatchId) {
-						break;
-					}
-				}
-
-				totalIdsFound += submissionIds.size();
-				chunkCount++;
-				submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
-			}
+		if (nextChunk.isEmpty()) {
+			ourLog.info("No data returned");
 		}
 
-		totalIdsFound += idBuffer.size();
-		chunkCount++;
-		submitWorkChunk(idBuffer, requestPartitionId, theDataSink);
+		ourLog.debug("Found {} IDs from {} to {}", nextChunk.size(), start, nextChunk.getLastDate());
+
+		final Set<TypedPidJson> idBuffer = nextChunk.getTypedResourcePids().stream()
+				.map(TypedPidJson::new)
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+
+		final UnmodifiableIterator<List<TypedPidJson>> partition = Iterators.partition(idBuffer.iterator(), maxBatchId);
+
+		while (partition.hasNext()) {
+			final List<TypedPidJson> submissionIds = partition.next();
+
+			totalIdsFound += submissionIds.size();
+			chunkCount++;
+			submitWorkChunk(submissionIds, nextChunk.getRequestPartitionId(), theDataSink);
+		}
 
 		ourLog.info("Submitted {} chunks with {} resource IDs", chunkCount, totalIdsFound);
 		return RunOutcome.SUCCESS;

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/LoadIdsStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/LoadIdsStepTest.java
@@ -6,7 +6,6 @@ import ca.uhn.fhir.batch2.jobs.chunk.PartitionedUrlChunkRangeJson;
 import ca.uhn.fhir.batch2.jobs.chunk.ResourceIdListWorkChunkJson;
 import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrlListJobParameters;
 import ca.uhn.fhir.batch2.model.JobInstance;
-import ca.uhn.fhir.jpa.api.pid.EmptyResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.HomogeneousResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
@@ -39,8 +38,6 @@ public class LoadIdsStepTest {
 
 	public static final Date DATE_1 = new InstantType("2022-01-01T00:00:00Z").getValue();
 	public static final Date DATE_2 = new InstantType("2022-01-02T00:00:00Z").getValue();
-	public static final Date DATE_3 = new InstantType("2022-01-03T00:00:00Z").getValue();
-	public static final Date DATE_4 = new InstantType("2022-01-04T00:00:00Z").getValue();
 	public static final Date DATE_END = new InstantType("2022-02-01T00:00:00Z").getValue();
 
 	@Mock
@@ -73,24 +70,20 @@ public class LoadIdsStepTest {
 
 		when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_1), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
 			.thenReturn(createIdChunk(0L, 20000L, DATE_2));
-		when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_2), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
-			.thenReturn(createIdChunk(20000L, 40000L, DATE_3));
-		when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_3), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
-			.thenReturn(createIdChunk(40000L, 40040L, DATE_4));
-		when(myBatch2DaoSvc.fetchResourceIdsPage(eq(DATE_4), eq(DATE_END), eq(DEFAULT_PAGE_SIZE), isNull(), isNull()))
-			.thenReturn(new EmptyResourcePidList());
 
 		mySvc.run(details, mySink);
 
-		verify(mySink, times(81)).accept(myChunkIdsCaptor.capture());
-		for (int i = 0; i < 80; i++) {
+		final int expectedLoops = 40;
+		verify(mySink, times(40)).accept(myChunkIdsCaptor.capture());
+
+		final List<ResourceIdListWorkChunkJson> allCapturedValues = myChunkIdsCaptor.getAllValues();
+		for (int i = 0; i < expectedLoops ; i++) {
 			String expected = createIdChunk(i * 500, (i * 500) + 500).toString();
-			String actual = myChunkIdsCaptor.getAllValues().get(i).toString();
+			String actual = allCapturedValues.get(i).toString();
 			assertEquals(expected, actual);
 		}
-		assertEquals(createIdChunk(40000, 40040).toString(),
-			myChunkIdsCaptor.getAllValues().get(80).toString());
-
+		final ResourceIdListWorkChunkJson expectedIdChunk = createIdChunk(19500, 20000);
+		assertEquals(expectedIdChunk.toString(), allCapturedValues.get(expectedLoops -1).toString());
 	}
 
 	@Nonnull

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
@@ -56,7 +56,7 @@ class ResourceIdListStepTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {1, 100, 500, 501, 2345})
+	@ValueSource(ints = {1, 100, 500, 501, 2345, 10500})
 	void testResourceIdListBatchSizeLimit(int theListSize) {
 		List<TypedResourcePid> idList = generateIdList(theListSize);
 		when(myStepExecutionDetails.getData()).thenReturn(myData);

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -212,7 +212,7 @@
 		<dependency>
 			<groupId>io.specto</groupId>
 			<artifactId>hoverfly-java-junit5</artifactId>
-			<version>0.14.3</version>
+			<version>0.14.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/src/main/java/ca/uhn/fhir/storage/test/DaoTestDataBuilder.java
+++ b/hapi-fhir-storage-test-utilities/src/main/java/ca/uhn/fhir/storage/test/DaoTestDataBuilder.java
@@ -83,6 +83,11 @@ public class DaoTestDataBuilder implements ITestDataBuilder.WithSupport, ITestDa
 	}
 
 	@Override
+	public void setRequestId(String theRequestId) {
+		mySrd.setRequestId(theRequestId);
+	}
+
+	@Override
 	public FhirContext getFhirContext() {
 		return myFhirCtx;
 	}

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IBatch2DaoSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/svc/IBatch2DaoSvc.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.api.svc;
 
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidList;
 
@@ -38,14 +39,33 @@ public interface IBatch2DaoSvc {
 	 *
 	 * @param theStart The start of the date range, must be inclusive.
 	 * @param theEnd   The end of the date range, should be exclusive.
-	 * @param thePageSize  The number of records to query in each pass.
-	 * @param theRequestPartitionId The request partition ID (may be <code>null</code> on nonpartitioned systems)
+	 * @param theRequestPartitionId The request partition ID (may be <code>null</code> on non-partitioned systems)
 	 * @param theUrl   The search URL, or <code>null</code> to return IDs for all resources across all resource types. Null will only be supplied if {@link #isAllResourceTypeSupported()} returns <code>true</code>.
 	 */
-	IResourcePidList fetchResourceIdsPage(
+	default IResourcePidList fetchResourceIdsPage(
+			Date theStart, Date theEnd, @Nullable RequestPartitionId theRequestPartitionId, @Nullable String theUrl) {
+		throw new UnsupportedOperationException(Msg.code(2425) + "Not implemented unless explicitly overridden");
+	}
+
+	// TODO: LD:  eliminate this call in all other implementors
+	/**
+	 * @deprecated Please call (@link {@link #fetchResourceIdsPage(Date, Date, RequestPartitionId, String)} instead.
+	 * <p/>
+	 * Fetches a page of resource IDs for all resource types. The page size is up to the discretion of the implementation.
+	 *
+	 * @param theStart The start of the date range, must be inclusive.
+	 * @param theEnd   The end of the date range, should be exclusive.
+	 * @param thePageSize  The number of records to query in each pass.
+	 * @param theRequestPartitionId The request partition ID (may be <code>null</code> on non-partitioned systems)
+	 * @param theUrl   The search URL, or <code>null</code> to return IDs for all resources across all resource types. Null will only be supplied if {@link #isAllResourceTypeSupported()} returns <code>true</code>.
+	 */
+	@Deprecated
+	default IResourcePidList fetchResourceIdsPage(
 			Date theStart,
 			Date theEnd,
 			@Nonnull Integer thePageSize,
 			@Nullable RequestPartitionId theRequestPartitionId,
-			@Nullable String theUrl);
+			@Nullable String theUrl) {
+		return fetchResourceIdsPage(theStart, theEnd, theRequestPartitionId, theUrl);
+	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.util.StopWatch;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
@@ -105,6 +106,8 @@ public class PartitionRunner {
 			try {
 				runnableTasks.get(0).call();
 				return;
+			} catch (PreconditionFailedException preconditionFailedException) {
+				throw preconditionFailedException;
 			} catch (Exception e) {
 				ourLog.error("Error while " + myProcessName, e);
 				throw new InternalErrorException(Msg.code(1084) + e);

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/rest/server/method/ResponseBundleBuilderTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/rest/server/method/ResponseBundleBuilderTest.java
@@ -435,8 +435,8 @@ class ResponseBundleBuilderTest {
 
 	private void setCanStoreSearchResults(boolean theCanStoreSearchResults) {
 		when(myServer.canStoreSearchResults()).thenReturn(theCanStoreSearchResults);
-		when(myServer.getPagingProvider()).thenReturn(myPagingProvider);
 		if (theCanStoreSearchResults) {
+			when(myServer.getPagingProvider()).thenReturn(myPagingProvider);
 			if (myLimit == null) {
 				when(myPagingProvider.getDefaultPageSize()).thenReturn(DEFAULT_PAGE_SIZE);
 			} else {

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/interceptor/ConsentInterceptorTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/interceptor/ConsentInterceptorTest.java
@@ -2,14 +2,11 @@ package ca.uhn.fhir.rest.server.interceptor;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
-import ca.uhn.fhir.interceptor.api.Hook;
-import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.annotation.RequiredParam;
 import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.api.Constants;
-import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.param.StringParam;
@@ -53,7 +50,6 @@ import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -64,18 +60,14 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsentInterceptorTest {

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlPathTokenizerTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlPathTokenizerTest.java
@@ -1,0 +1,78 @@
+package ca.uhn.fhir.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UrlPathTokenizerTest {
+
+	@Test
+	void urlPathTokenizer_withValidPath_tokenizesCorrectly() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("/root/subdir/subsubdir/file.html");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals(4, tokenizer.countTokens());
+		assertEquals("root", tokenizer.nextTokenUnescapedAndSanitized());
+		assertEquals("subdir", tokenizer.nextTokenUnescapedAndSanitized());
+		assertEquals("subsubdir", tokenizer.nextTokenUnescapedAndSanitized());
+		assertEquals("file.html", tokenizer.nextTokenUnescapedAndSanitized());
+		assertFalse(tokenizer.hasMoreTokens());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"",               // actually empty
+		"///////",        // effectively empty
+		"//  / / /  /   " // effectively empty with extraneous whitespace
+	})
+	void urlPathTokenizer_withEmptyPath_returnsEmpty(String thePath) {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer(thePath);
+		assertEquals(0, tokenizer.countTokens());
+	}
+
+	@Test
+	void urlPathTokenizer_withNullPath_returnsEmpty() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer(null);
+		assertEquals(0, tokenizer.countTokens());
+	}
+
+	@Test
+	void urlPathTokenizer_withSinglePathElement_returnsSingleToken() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("hello");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("hello", tokenizer.nextTokenUnescapedAndSanitized());
+	}
+
+	@Test
+	void urlPathTokenizer_withEscapedPath_shouldUnescape() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("Homer%20Simpson");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("Homer Simpson", tokenizer.nextTokenUnescapedAndSanitized());
+
+		tokenizer = new UrlPathTokenizer("hack%2Fslash");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("hack/slash", tokenizer.nextTokenUnescapedAndSanitized());
+	}
+
+	@Test
+	void urlPathTokenizer_peek_shouldNotConsumeTokens() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("this/that");
+		assertEquals(2, tokenizer.countTokens());
+		tokenizer.peek();
+		assertEquals(2, tokenizer.countTokens());
+	}
+
+	@Test
+	void urlPathTokenizer_withSuspiciousCharacters_sanitizesCorrectly() {
+		UrlPathTokenizer tokenizer = new UrlPathTokenizer("<DROP TABLE USERS>");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("&lt;DROP TABLE USERS&gt;", tokenizer.nextTokenUnescapedAndSanitized());
+
+		tokenizer = new UrlPathTokenizer("'\n\r\"");
+		assertTrue(tokenizer.hasMoreTokens());
+		assertEquals("&apos;&#10;&#13;&quot;", tokenizer.nextTokenUnescapedAndSanitized());
+	}
+}

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
@@ -322,6 +322,11 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
 	}
 
 	@Override
+	public <T extends Resource> T fetchResourceRaw(Class<T> class_, String uri) {
+		return fetchResource(class_, uri);
+	}
+
+	@Override
 	public <T extends org.hl7.fhir.r5.model.Resource> T fetchResource(Class<T> theClass, String theUri) {
 		if (myValidationSupport == null || theUri == null) {
 			return null;

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/ITestDataBuilder.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/ITestDataBuilder.java
@@ -191,6 +191,10 @@ public interface ITestDataBuilder {
 		return t -> MetaUtil.setSource(theContext, ((IBaseResource)t).getMeta(), theSource);
 	}
 
+	default ICreationArgument withSource(String theSource) {
+		return t -> MetaUtil.setSource(getFhirContext(), ((IBaseResource)t).getMeta(), theSource);
+	}
+
 	default ICreationArgument withLastUpdated(Date theLastUpdated) {
 		return t -> ((IBaseResource)t).getMeta().setLastUpdated(theLastUpdated);
 	}
@@ -404,6 +408,8 @@ public interface ITestDataBuilder {
 	}
 
 	interface Support {
+		void setRequestId(String theRequestId);
+
 		FhirContext getFhirContext();
 
 		IIdType doCreateResource(IBaseResource theResource);
@@ -443,6 +449,11 @@ public interface ITestDataBuilder {
 
 		public SupportNoDao(FhirContext theFhirContext) {
 			myFhirContext = theFhirContext;
+		}
+
+		@Override
+		public void setRequestId(String theRequestId) {
+			// do nothing
 		}
 
 		@Override

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
@@ -1,0 +1,173 @@
+package ca.uhn.fhir.rest.server.tenant;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.HapiLocalizer;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.util.UrlPathTokenizer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UrlBaseTenantIdentificationStrategyTest {
+
+	private final static String BASE_URL = "http://localhost:8888";
+
+	@Mock
+	private RequestDetails myRequestDetails;
+	private static SystemRequestDetails ourSystemRequestDetails;
+	@Mock
+	private IRestfulServerDefaults myRestfulServerDefaults;
+	@Mock
+	private FhirContext myFHIRContext;
+	@Mock
+	private HapiLocalizer myHapiLocalizer;
+
+	private static UrlBaseTenantIdentificationStrategy ourTenantStrategy;
+	private UrlPathTokenizer myUrlTokenizer;
+
+	@BeforeAll
+	static void setup() {
+		ourSystemRequestDetails = new SystemRequestDetails();
+		ourTenantStrategy = new UrlBaseTenantIdentificationStrategy();
+	}
+
+	@Test
+	void massageBaseUrl_givenBaseUrlAndTenant_shouldApplyTenant() {
+		//given a tenant id of TENANT1
+		when(myRequestDetails.getTenantId()).thenReturn("TENANT1");
+
+		//when we massage the server base url
+		String actual = ourTenantStrategy.massageServerBaseUrl(BASE_URL, myRequestDetails);
+
+		//then we should see /TENANT1 in the url
+		assertEquals(BASE_URL + "/TENANT1", actual);
+	}
+
+	@Test
+	void massageBaseUrl_givenBaseUrlAndNullTenant_shouldReturnBaseUrl() {
+		//given a null tenant id
+		when(myRequestDetails.getTenantId()).thenReturn(null);
+
+		//when we massage our base url
+		String actual = ourTenantStrategy.massageServerBaseUrl(BASE_URL, myRequestDetails);
+
+		//then nothing should happen
+		assertEquals(BASE_URL, actual);
+	}
+
+	@Test
+	void extractTenant_givenNormalRequestAndExplicitTenant_shouldUseTenant() {
+		//given a Patient request on MYTENANT
+		myUrlTokenizer = new UrlPathTokenizer("MYTENANT/Patient");
+
+		//when we extract the tenant identifier
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see MYTENANT
+		verify(myRequestDetails, times(1)).setTenantId("MYTENANT");
+	}
+
+	@Test
+	void extractTenant_givenSystemRequestWithNoTenant_shouldUseDefault() {
+		//given any request that starts with $ and no given partition name
+		myUrlTokenizer = new UrlPathTokenizer("$partition-management-create-partition");
+
+		//when we try to extract the tenant id
+		ourTenantStrategy.extractTenant(myUrlTokenizer, ourSystemRequestDetails);
+
+		//then we should see that it defaulted to the DEFAULT partition
+		assertEquals("DEFAULT", ourSystemRequestDetails.getTenantId());
+	}
+
+	@Test
+	void extractTenant_givenSystemRequestWithExplicitTenant_shouldUseTenant() {
+		//given a request that starts with $ on a named partition
+		myUrlTokenizer = new UrlPathTokenizer("MYTENANT/$partition-management-create-partition");
+
+		//when we extract the tenant from the request
+		ourTenantStrategy.extractTenant(myUrlTokenizer, ourSystemRequestDetails);
+
+		//then we should see MYTENANT
+		assertEquals("MYTENANT", ourSystemRequestDetails.getTenantId());
+	}
+
+	@Test
+	void extractTenant_givenMetadataRequestWithNoTenant_shouldUseDefault() {
+		//given a metadata request with no specified partition name
+		myUrlTokenizer = new UrlPathTokenizer("metadata");
+
+		//when we try to extract the tenant from the request
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see that it defaulted to the DEFAULT partition
+		verify(myRequestDetails, times(1)).setTenantId("DEFAULT");
+	}
+
+	@Test
+	void extractTenant_givenMetadataRequestWithExplicitTenant_shouldUseTenant() {
+		//given a metadata request on a named partition
+		myUrlTokenizer = new UrlPathTokenizer("MYTENANT/metadata");
+
+		//when we extract the tenant id
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see MYTENANT
+		verify(myRequestDetails, times(1)).setTenantId("MYTENANT");
+	}
+
+	@Test
+	void extractTenant_givenPatientRequestAndNoTenant_shouldInterpretPatientAsPartition() {
+		//given a Patient request with no partition name specified
+		myUrlTokenizer = new UrlPathTokenizer("Patient");
+
+		//when we try to extract the tenant from the request
+		ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+
+		//then we should see that it interpreted Patient as the partition name
+		verify(myRequestDetails, times(1)).setTenantId("Patient");
+	}
+
+	@Test
+	void extractTenant_givenEmptyURLNoPartition_shouldThrowException() {
+		//given an empty URL with no partition name
+		when(myRequestDetails.getServer()).thenReturn(myRestfulServerDefaults);
+		when(myRestfulServerDefaults.getFhirContext()).thenReturn(myFHIRContext);
+		when(myFHIRContext.getLocalizer()).thenReturn(myHapiLocalizer);
+		myUrlTokenizer = new UrlPathTokenizer("");
+
+		//when we try to extract the tenant from the request
+		InvalidRequestException ire = assertThrows(InvalidRequestException.class, () -> {
+			ourTenantStrategy.extractTenant(myUrlTokenizer, myRequestDetails);
+		});
+
+		//then we should see an exception thrown with HAPI-0307 in it
+		verify(myHapiLocalizer, times(1)).getMessage(RestfulServer.class, "rootRequest.multitenant");
+		assertTrue(ire.getMessage().contains("HAPI-0307"));
+	}
+
+	@Test
+	void extractTenant_givenSystemRequestWithEmptyUrl_shouldUseDefaultPartition() {
+		//given a system request with a blank url (is this even a valid test case?)
+		myUrlTokenizer = new UrlPathTokenizer("");
+
+		//when we try to extract the tenant id
+		ourTenantStrategy.extractTenant(myUrlTokenizer, ourSystemRequestDetails);
+
+		//then we should see that it defaulted to the DEFAULT partition
+		assertEquals("DEFAULT", ourSystemRequestDetails.getTenantId());
+	}
+}

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/Controller.java
+++ b/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/Controller.java
@@ -6,9 +6,9 @@ import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.fql.executor.HfqlDataTypeEnum;
 import ca.uhn.fhir.jpa.fql.executor.IHfqlExecutionResult;
+import ca.uhn.fhir.jpa.fql.jdbc.HfqlRestClient;
 import ca.uhn.fhir.jpa.fql.jdbc.RemoteHfqlExecutionResult;
 import ca.uhn.fhir.jpa.fql.parser.HfqlStatement;
-import ca.uhn.fhir.jpa.fql.provider.HfqlRestProvider;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.dstu2.valueset.ResourceTypeEnum;
 import ca.uhn.fhir.model.primitive.BoundCodeDt;
@@ -19,9 +19,17 @@ import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.client.impl.GenericClient;
+import ca.uhn.fhir.rest.gclient.ICreateTyped;
+import ca.uhn.fhir.rest.gclient.IHistory;
+import ca.uhn.fhir.rest.gclient.IHistoryTyped;
+import ca.uhn.fhir.rest.gclient.IHistoryUntyped;
+import ca.uhn.fhir.rest.gclient.IQuery;
+import ca.uhn.fhir.rest.gclient.IUntypedQuery;
 import ca.uhn.fhir.rest.gclient.NumberClientParam.IMatches;
+import ca.uhn.fhir.rest.gclient.QuantityClientParam;
 import ca.uhn.fhir.rest.gclient.QuantityClientParam.IAndUnits;
-import ca.uhn.fhir.rest.gclient.*;
+import ca.uhn.fhir.rest.gclient.StringClientParam;
+import ca.uhn.fhir.rest.gclient.TokenClientParam;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.to.model.HomeRequest;
 import ca.uhn.fhir.to.model.ResourceRequest;
@@ -60,7 +68,10 @@ import javax.servlet.http.HttpServletRequest;
 
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.DIFF_OPERATION_NAME;
 import static ca.uhn.fhir.util.UrlUtil.sanitizeUrlPart;
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @org.springframework.stereotype.Controller()
 public class Controller extends BaseController {
@@ -417,8 +428,7 @@ public class Controller extends BaseController {
 	protected IHfqlExecutionResult executeHfqlStatement(
 			HttpServletRequest theServletRequest, String theHfqlQuery, HomeRequest theRequest, int theRowLimit)
 			throws IOException {
-		Parameters requestParameters =
-				HfqlRestProvider.newQueryRequestParameters(theHfqlQuery, theRowLimit, theRowLimit);
+		Parameters requestParameters = HfqlRestClient.newQueryRequestParameters(theHfqlQuery, theRowLimit, theRowLimit);
 		GenericClient client = theRequest.newClient(theServletRequest, getContext(theRequest), myConfig, null);
 		return new RemoteHfqlExecutionResult(requestParameters, client);
 	}

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4b/pom.xml
+++ b/hapi-fhir-validation-resources-r4b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
@@ -377,6 +377,11 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	@Override
+	public <T extends Resource> T fetchResourceRaw(Class<T> class_, String uri) {
+		return fetchResource(class_, uri);
+	}
+
+	@Override
 	public <T extends Resource> T fetchResource(Class<T> class_, String uri) {
 
 		if (isBlank(uri)) {
@@ -443,8 +448,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	@Override
-	public List<StructureDefinition> fetchTypeDefinitions(String n) {
-		throw new UnsupportedOperationException(Msg.code(2329));
+	public List<StructureDefinition> fetchTypeDefinitions(String typeName) {
+		List<StructureDefinition> allStructures = new ArrayList<>(allStructures());
+		allStructures.removeIf(sd -> !sd.hasType() || !sd.getType().equals(typeName));
+		return allStructures;
 	}
 
 	@Override

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.0.15</fhir_core_version>
+		<fhir_core_version>6.0.22</fhir_core_version>
 		<spotless_version>2.37.0</spotless_version>
 		<ucum_version>1.0.3</ucum_version>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>6.7.15-SNAPSHOT</version>
+	<version>6.8.0-SNAPSHOT</version>
 
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1189,6 +1189,13 @@
 				<artifactId>jakarta.activation</artifactId>
 				<version>2.0.0</version>
 			</dependency>
+			<!-- Architecture Test -->
+			<dependency>
+				<groupId>com.tngtech.archunit</groupId>
+				<artifactId>archunit-junit5</artifactId>
+				<version>1.0.1</version>
+				<scope>test</scope>
+			</dependency>
 			<dependency>
 				<groupId>com.vladsch.flexmark</groupId>
 				<artifactId>flexmark</artifactId>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.7.15-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>


### PR DESCRIPTION
- Currently JPA-Server-Starter cannot use the new SLF4J API, so we are just sticking to the old API for now. 