### PR TITLE
dont use new API for a bit

### DIFF
--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
@@ -100,7 +100,9 @@ public class ReductionStepDataSink<PT extends IModelJson, IT extends IModelJson,
 					"Finalizing job instance {} with report length {} chars",
 					instance.getInstanceId(),
 					dataString.length());
-			ourLog.atTrace().addArgument(() -> JsonUtil.serialize(instance)).log("New instance state: {}");
+			if (ourLog.isTraceEnabled()) {
+				ourLog.trace("New instance state: {}", JsonUtil.serialize(instance));
+			}
 
 			return true;
 		});


### PR DESCRIPTION
- Currently JPA-Server-Starter cannot use the new SLF4J API, so we are just sticking to the old API for now. 

Closes https://github.com/hapifhir/hapi-fhir/issues/5186