### PR TITLE
Return DropIdGeneratorTask from the Builder to permit clients to mutate the  DropIdGeneratorTask.

### DIFF
--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -163,9 +163,10 @@ public class Builder {
 		addTask(task);
 	}
 
-	public void dropIdGenerator(String theVersion, String theIdGeneratorName) {
+	public DropIdGeneratorTask dropIdGenerator(String theVersion, String theIdGeneratorName) {
 		DropIdGeneratorTask task = new DropIdGeneratorTask(myRelease, theVersion, theIdGeneratorName);
 		addTask(task);
+		return task;
 	}
 
 	public void addNop(String theVersion) {


### PR DESCRIPTION
- Tiny change to Builder.dropIdGenerator() to return the DropIdGeneratorTask instead of void