### PR TITLE
Fixing terminology upload with large file.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/jackson/JacksonStructure.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/jackson/JacksonStructure.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.parser.json.BaseJsonLikeWriter;
 import ca.uhn.fhir.parser.json.JsonLikeStructure;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -388,6 +389,13 @@ public class JacksonStructure implements JsonLikeStructure {
 		retVal = retVal.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
 		retVal = retVal.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
 		retVal = retVal.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+
+		retVal.getFactory().setStreamReadConstraints(createStreamReadConstraints());
+
 		return retVal;
+	}
+
+	private static StreamReadConstraints createStreamReadConstraints(){
+		return StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build();
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/jackson/JacksonStructure.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/jackson/JacksonStructure.java
@@ -395,7 +395,9 @@ public class JacksonStructure implements JsonLikeStructure {
 		return retVal;
 	}
 
-	private static StreamReadConstraints createStreamReadConstraints(){
-		return StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build();
+	private static StreamReadConstraints createStreamReadConstraints() {
+		return StreamReadConstraints.builder()
+				.maxStringLength(Integer.MAX_VALUE)
+				.build();
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5205-uploading-large-vocabulary-file-returns-error.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5205-uploading-large-vocabulary-file-returns-error.yaml
@@ -2,4 +2,4 @@
 type: fix
 issue: 5205
 title: "Previously, uploading a large vocabulary file (like Loinc) through the upload-external-code-system command would
-return an error.  The issue has been fixe."
+return an error.  The issue has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5205-uploading-large-vocabulary-file-returns-error.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_8_0/5205-uploading-large-vocabulary-file-returns-error.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5205
+title: "Previously, uploading a large vocabulary file (like Loinc) through the upload-external-code-system command would
+return an error.  The issue has been fixe."


### PR DESCRIPTION
**What was done:**

- Added registration of a custom `StreamReadConstraints` object allowing upload of a file with more than 20M characters;
- Added relevant test;
- Added changelog.