### PR TITLE
5231 MDM Link History gives 404 after MDM clear and submit

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5231-fix-mdm-link-history-gives-404-after-mdm-clear.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5231-fix-mdm-link-history-gives-404-after-mdm-clear.yaml
@@ -1,6 +1,5 @@
 ---
 type: fix
 issue: 5231
-title: "Previously, when the `$mdm-link-history` operation was executed after a `$mdm-clear`, the links in the history 
-response would refer to golden resources that have already been deleted and expunged by running `$mdm-clear`, resulting 
-in a 404 response. This has now been fixed."
+title: "Previously, the `$mdm-link-history` operation would result in a 404 response when it was executed after a 
+`$mdm-clear`. This has now been fixed by removing link history on `$mdm-clear`."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5231-fix-mdm-link-history-gives-404-after-mdm-clear.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5231-fix-mdm-link-history-gives-404-after-mdm-clear.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5231
+title: "Previously, when the `$mdm-link-history` operation was executed after a `$mdm-clear`, the links in the history 
+response would refer to golden resources that have already been deleted and expunged by running `$mdm-clear`, resulting 
+in a 404 response. This has now been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
@@ -839,7 +839,8 @@ your ruleset. It permits the user to reset the state of their MDM system without
 and Golden Resources.
 
 After the operation is complete, all targeted MDM links are removed from the system, and their related Golden Resources
-are deleted and expunged from the server.
+are deleted and expunged from the server. Additionally, the link history for targeted links and their related golden 
+resources will also be expunged.
 
 This operation takes two optional Parameters.
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkJpaRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkJpaRepository.java
@@ -50,6 +50,10 @@ public interface IMdmLinkJpaRepository
 	@Query("DELETE FROM MdmLink f WHERE myGoldenResourcePid IN (:goldenPids) OR mySourcePid IN (:goldenPids)")
 	void deleteLinksWithAnyReferenceToPids(@Param("goldenPids") List<Long> theResourcePids);
 
+	@Modifying
+	@Query(value = "DELETE FROM MPI_LINK_AUD f WHERE GOLDEN_RESOURCE_PID IN (:goldenPids) OR TARGET_PID IN (:goldenPids)", nativeQuery = true)
+	void deleteLinksHistoryWithAnyReferenceToPids(@Param("goldenPids") List<Long> theResourcePids);
+
 	@Query("SELECT ml2.myGoldenResourcePid as goldenPid, ml2.mySourcePid as sourcePid FROM MdmLink ml2 "
 			+ "WHERE ml2.myMatchResult=:matchResult "
 			+ "AND ml2.myGoldenResourcePid IN ("

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkJpaRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkJpaRepository.java
@@ -51,7 +51,10 @@ public interface IMdmLinkJpaRepository
 	void deleteLinksWithAnyReferenceToPids(@Param("goldenPids") List<Long> theResourcePids);
 
 	@Modifying
-	@Query(value = "DELETE FROM MPI_LINK_AUD f WHERE GOLDEN_RESOURCE_PID IN (:goldenPids) OR TARGET_PID IN (:goldenPids)", nativeQuery = true)
+	@Query(
+			value =
+					"DELETE FROM MPI_LINK_AUD f WHERE GOLDEN_RESOURCE_PID IN (:goldenPids) OR TARGET_PID IN (:goldenPids)",
+			nativeQuery = true)
 	void deleteLinksHistoryWithAnyReferenceToPids(@Param("goldenPids") List<Long> theResourcePids);
 
 	@Query("SELECT ml2.myGoldenResourcePid as goldenPid, ml2.mySourcePid as sourcePid FROM MdmLink ml2 "

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmLinkDaoJpaImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmLinkDaoJpaImpl.java
@@ -350,6 +350,7 @@ public class MdmLinkDaoJpaImpl implements IMdmLinkDao<JpaPid, MdmLink> {
 		List<List<Long>> chunks = ListUtils.partition(goldenResourcePids, 500);
 		for (List<Long> chunk : chunks) {
 			myMdmLinkDao.deleteLinksWithAnyReferenceToPids(chunk);
+			myMdmLinkDao.deleteLinksHistoryWithAnyReferenceToPids(chunk);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseLinkR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseLinkR4Test.java
@@ -4,14 +4,15 @@ import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.entity.MdmLink;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.mdm.api.IMdmLink;
+import ca.uhn.fhir.mdm.api.MdmHistorySearchParameters;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
+import ca.uhn.fhir.mdm.api.MdmLinkWithRevision;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -70,5 +71,13 @@ public abstract class BaseLinkR4Test extends BaseProviderR4Test {
 	@Nonnull
 	protected List<? extends IMdmLink> getPatientLinks() {
 		return myMdmLinkDaoSvc.findMdmLinksBySourceResource(myPatient);
+	}
+
+	protected List<MdmLinkWithRevision<MdmLink>> getHistoricalLinks(List<String> theGoldenResourceIds, List<String> theResourceIds) {
+		MdmHistorySearchParameters historySearchParameters = new MdmHistorySearchParameters()
+			.setGoldenResourceIds(theGoldenResourceIds)
+			.setSourceIds(theResourceIds);
+
+		return myMdmLinkDaoSvc.findMdmLinkHistory(historySearchParameters);
 	}
 }

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderClearLinkR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderClearLinkR4Test.java
@@ -30,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -171,6 +172,7 @@ public class MdmProviderClearLinkR4Test extends BaseLinkR4Test {
 		assertLinkCount(2);
 		clearMdmLinks();
 		assertNoLinksExist();
+		assertNoHistoricalLinksExist(List.of(myPractitionerGoldenResourceId.getValueAsString(), mySourcePatientId.getValueAsString()), new ArrayList<>());
 	}
 
 	private void assertNoLinksExist() {
@@ -180,6 +182,10 @@ public class MdmProviderClearLinkR4Test extends BaseLinkR4Test {
 
 	private void assertNoPatientLinksExist() {
 		assertThat(getPatientLinks(), hasSize(0));
+	}
+
+	private void assertNoHistoricalLinksExist(List<String> theGoldenResourceIds, List<String> theResourceIds) {
+		assertThat(getHistoricalLinks(theGoldenResourceIds, theResourceIds), hasSize(0));
 	}
 
 	private void assertNoPractitionerLinksExist() {

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
@@ -99,13 +99,11 @@ public class MdmLinkHistoryProviderDstu3Plus extends BaseMdmProvider {
 			if (isNotEmpty(theResourceIds)) {
 				historyEvent.setSourceIds(theResourceIds.stream()
 						.map(IPrimitiveType::getValueAsString)
-//						.map(t->"Patient/" + t)
 						.collect(Collectors.toList()));
 			}
 			if (isNotEmpty(theMdmGoldenResourceIds)) {
 				historyEvent.setGoldenResourceIds(theMdmGoldenResourceIds.stream()
 						.map(IPrimitiveType::getValueAsString)
-//						.map(t->"Patient/" + t)
 						.collect(Collectors.toList()));
 			}
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmLinkHistoryProviderDstu3Plus.java
@@ -99,11 +99,13 @@ public class MdmLinkHistoryProviderDstu3Plus extends BaseMdmProvider {
 			if (isNotEmpty(theResourceIds)) {
 				historyEvent.setSourceIds(theResourceIds.stream()
 						.map(IPrimitiveType::getValueAsString)
+//						.map(t->"Patient/" + t)
 						.collect(Collectors.toList()));
 			}
 			if (isNotEmpty(theMdmGoldenResourceIds)) {
 				historyEvent.setGoldenResourceIds(theMdmGoldenResourceIds.stream()
 						.map(IPrimitiveType::getValueAsString)
+//						.map(t->"Patient/" + t)
 						.collect(Collectors.toList()));
 			}
 


### PR DESCRIPTION
- `$mdm-clear` now deletes link history since the links in the response for the `$mdm-link-history` operation refers to golden resources that have been deleted by `$mdm-clear`
- Added tests and changelog

closes #5231 