### PR TITLE
5230 cast errorcount to string for batchjob failure message

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5230-batch2-job-cannot-transition-to-failed-status-on-mssql.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5230-batch2-job-cannot-transition-to-failed-status-on-mssql.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5230
+title: "batch2 jobs on MS SQL Server were failing to transition to FAILED state after max retrials
+   for the job are exhausted. This is now fixed."
+   

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -300,7 +300,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		Validate.isTrue(changeCount > 0, "changed chunk matching %s", chunkId);
 
 		Query query = myEntityManager.createQuery("update Batch2WorkChunkEntity " + "set myStatus = :failed "
-				+ ",myErrorMessage = CONCAT('Too many errors: ',  myErrorCount, '. Last error msg was ', myErrorMessage) "
+				+ ",myErrorMessage = CONCAT('Too many errors: ', CAST(myErrorCount as string), '. Last error msg was ', myErrorMessage) "
 				+ "where myId = :chunkId and myErrorCount > :maxCount");
 		query.setParameter("chunkId", chunkId);
 		query.setParameter("failed", WorkChunkStatusEnum.FAILED);


### PR DESCRIPTION
Fixed the update statement by adding an explicit cast to string for myErrorCount field, which makes the statement work for mssql. Tested manually with MS SQL Server, H2, and Postgres. 

This is related to [this hibernate issue](https://hibernate.atlassian.net/jira/software/c/projects/HHH/issues/HHH-3627).

Closes #5230 