### PR TITLE
Resolve 5256-made-requestdetails-part-of-the-parameter-when-doing-cleanuppossiblematches

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5256-made-requestdetails-part-of-the-parameter-when-doing-cleanuppossiblematches.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5256-made-requestdetails-part-of-the-parameter-when-doing-cleanuppossiblematches.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5256
+title: "Added RequestDetails as part of the parameters when cleaning up possible matches to enable interceptors to 
+access it."

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/interceptor/MdmStorageInterceptor.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/interceptor/MdmStorageInterceptor.java
@@ -219,7 +219,7 @@ public class MdmStorageInterceptor implements IMdmStorageInterceptor {
 				IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(theResource);
 				IResourcePersistentId goldenPid = extractGoldenPid(theResource, matches.get(0));
 
-				cleanUpPossibleMatches(possibleMatches, dao, goldenPid);
+				cleanUpPossibleMatches(possibleMatches, dao, goldenPid, theRequest);
 
 				IAnyResource goldenResource = (IAnyResource) dao.readByPid(goldenPid);
 				myMdmLinkDeleteSvc.deleteWithAnyReferenceTo(goldenResource);
@@ -261,7 +261,10 @@ public class MdmStorageInterceptor implements IMdmStorageInterceptor {
 	 *  Possible match resources are resubmitted for matching
 	 */
 	private void cleanUpPossibleMatches(
-			List<IMdmLink> possibleMatches, IFhirResourceDao<?> theDao, IResourcePersistentId theGoldenPid) {
+			List<IMdmLink> possibleMatches,
+			IFhirResourceDao<?> theDao,
+			IResourcePersistentId theGoldenPid,
+			RequestDetails theRequestDetails) {
 		IAnyResource goldenResource = (IAnyResource) theDao.readByPid(theGoldenPid);
 		for (IMdmLink possibleMatch : possibleMatches) {
 			if (possibleMatch.getGoldenResourcePersistenceId().equals(theGoldenPid)) {
@@ -273,6 +276,7 @@ public class MdmStorageInterceptor implements IMdmStorageInterceptor {
 				MdmTransactionContext mdmContext =
 						createMdmContext(MdmTransactionContext.OperationType.UPDATE_LINK, sourceResource.fhirType());
 				params.setMdmContext(mdmContext);
+				params.setRequestDetails(theRequestDetails);
 
 				mdmLinkUpdaterSvc.updateLink(params);
 			}


### PR DESCRIPTION
What was done:

- added requestDetails to MdmStorageInterceptor.cleanUpPossibleMatches so that it can be passed to pointcuts.