### PR TITLE
Fix Group Export default resource types. 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5265-group-bulk-export-forward-refs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5265-group-bulk-export-forward-refs.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+jira: SMILE-7307
+title: "Previously, executing a Group Bulk Export without defining the `_type` parameter would accidentally omit `Patient` and `Organization` types. This has been corrected."

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -264,6 +264,10 @@ public class BulkDataExportProvider {
 		} else {
 			// all patient resource types
 			Set<String> groupTypes = new HashSet<>(getPatientCompartmentResources());
+
+			// Add the forward reference resource types from the patients, e.g. Practitioner, Organization
+			groupTypes.addAll(PATIENT_BULK_EXPORT_FORWARD_REFERENCE_RESOURCE_TYPES);
+
 			groupTypes.removeIf(t -> !myDaoRegistry.isResourceTypeSupported(t));
 			BulkExportJobParameters.setResourceTypes(groupTypes);
 		}


### PR DESCRIPTION
- Add Test
- Add Changelog 
- Add forward refs if `_type` is absent.

Closes #5265 