### PR TITLE
Transaction with conditional delete and update on the same resource should not fail

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5316-transaction-bundle-with-conditional-delete-and-update-on-same-resource-should-not-fail.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5316-transaction-bundle-with-conditional-delete-and-update-on-same-resource-should-not-fail.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5316
+jira: SMILE-7168
+title: "Previously, performing a FHIR transaction containing both a conditional delete and a conditional update 
+on the same resource would fail. This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -1544,7 +1544,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 				provenance = historyEntry.getProvenance();
 			}
 			if (provenance == null) {
-				provenance = new ResourceHistoryProvenanceEntity();
+				provenance = historyEntry.toProvenance();
 			}
 			provenance.setResourceHistoryTable(historyEntry);
 			provenance.setResourceTable(theEntity);

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
@@ -111,6 +111,9 @@ public class ResourceHistoryTable extends BaseHasResource implements Serializabl
 	@Column(name = "REQUEST_ID", length = Constants.REQUEST_ID_LENGTH, nullable = true)
 	private String myRequestId;
 
+	@Transient
+	private transient ResourceHistoryProvenanceEntity myNewHistoryProvenanceEntity;
+
 	/**
 	 * Constructor
 	 */
@@ -301,5 +304,20 @@ public class ResourceHistoryTable extends BaseHasResource implements Serializabl
 	 */
 	public boolean hasResource() {
 		return myResource != null || myResourceTextVc != null;
+	}
+
+	/**
+	 * This method creates a new HistoryProvenance entity, or might reuse the current one if we've
+	 * already created one in the current transaction. This is because we can only increment
+	 * the version once in a DB transaction (since hibernate manages that number) so creating
+	 * multiple {@link ResourceHistoryProvenanceEntity} entities will result in a constraint error.
+	 */
+	public ResourceHistoryProvenanceEntity toProvenance() {
+		ResourceHistoryProvenanceEntity resourceHistoryProvenance = myNewHistoryProvenanceEntity;
+		if (resourceHistoryProvenance == null) {
+			resourceHistoryProvenance = new ResourceHistoryProvenanceEntity();
+			myNewHistoryProvenanceEntity = resourceHistoryProvenance;
+		}
+		return resourceHistoryProvenance;
 	}
 }

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
@@ -313,11 +313,9 @@ public class ResourceHistoryTable extends BaseHasResource implements Serializabl
 	 * multiple {@link ResourceHistoryProvenanceEntity} entities will result in a constraint error.
 	 */
 	public ResourceHistoryProvenanceEntity toProvenance() {
-		ResourceHistoryProvenanceEntity resourceHistoryProvenance = myNewHistoryProvenanceEntity;
-		if (resourceHistoryProvenance == null) {
-			resourceHistoryProvenance = new ResourceHistoryProvenanceEntity();
-			myNewHistoryProvenanceEntity = resourceHistoryProvenance;
+		if (myNewHistoryProvenanceEntity == null) {
+			myNewHistoryProvenanceEntity = new ResourceHistoryProvenanceEntity();
 		}
-		return resourceHistoryProvenance;
+		return myNewHistoryProvenanceEntity;
 	}
 }

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
@@ -27,11 +27,11 @@ import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.when;
 
 public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 
@@ -451,11 +451,21 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 	/**
 	 * If a conditional delete and conditional update are both used on the same condition,
 	 * the update should win.
+	 * We need to test this scenario with both empty and non-empty RequestDetails.requestId parameter,
+	 * as providing RequestDetails.requestId previously caused javax.persistence.EntityExistsException
+	 * during persistence of ResourceHistoryProvenanceEntity.
+	 *
+	 * @param theReturnRequestId if RequestDetails.requestId should return non-null value
 	 */
-	@Test
-	public void testConditionalDeleteAndConditionalUpdateOnSameResource() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void createBundle_withConditionalDeleteAndConditionalUpdateOnSameResource_updatesResource(boolean theReturnRequestId) {
 		Bundle outcome;
 		Patient actual;
+
+		if (theReturnRequestId) {
+			when(mySrd.getRequestId()).thenReturn("requestId");
+		}
 
 		// First pass (resource doesn't already exist)
 


### PR DESCRIPTION
Performing a FHIR transaction containing both a conditional delete and a conditional update 
on the same resource would fail. This has been fixed in this PR.