### PR TITLE
Resolve MDM query links operation score field imprecise value

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
@@ -403,7 +403,7 @@ public class ParametersUtil {
 	public static void addPartDecimal(FhirContext theContext, IBase theParameter, String theName, Double theValue) {
 		IPrimitiveType<BigDecimal> value = (IPrimitiveType<BigDecimal>)
 				theContext.getElementDefinition("decimal").newInstance();
-		value.setValue(theValue == null ? null : new BigDecimal(theValue));
+		value.setValue(theValue == null ? null : BigDecimal.valueOf(theValue));
 
 		addPart(theContext, theParameter, theName, value);
 	}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5331-mdm-query-links-operation-score-field-imprecise-value.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5331-mdm-query-links-operation-score-field-imprecise-value.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5331
+title: "Previously, the score field returned by $mdm-query-links operation would contain imprecise decimal values. This 
+is now fixed and rounded to 4 decimal places."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/MdmLink.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/MdmLink.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.mdm.api.IMdmLink;
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
@@ -161,6 +162,7 @@ public class MdmLink extends AuditableBasePartitionable implements IMdmLink<JpaP
 	private Boolean myHadToCreateNewGoldenResource;
 
 	@Column(name = "VECTOR")
+	@JsonIgnore
 	private Long myVector;
 
 	@Column(name = "SCORE")

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImpl.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.mdm.api.IMdmLink;
 import ca.uhn.fhir.mdm.api.MdmLinkWithRevision;
 import ca.uhn.fhir.mdm.model.mdmevents.MdmLinkJson;
 import ca.uhn.fhir.mdm.model.mdmevents.MdmLinkWithRevisionJson;
+import org.apache.commons.math3.util.Precision;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class MdmModelConverterSvcImpl implements IMdmModelConverterSvc {
@@ -49,9 +50,9 @@ public class MdmModelConverterSvcImpl implements IMdmModelConverterSvc {
 		retVal.setLinkSource(theLink.getLinkSource());
 		retVal.setMatchResult(theLink.getMatchResult());
 		retVal.setLinkCreatedNewResource(theLink.getHadToCreateNewGoldenResource());
-		retVal.setScore(theLink.getScore());
+		Double score = theLink.getScore() == null ? null : Precision.round(theLink.getScore(), 4);
+		retVal.setScore(score);
 		retVal.setUpdated(theLink.getUpdated());
-		retVal.setVector(theLink.getVector());
 		retVal.setVersion(theLink.getVersion());
 		retVal.setRuleCount(theLink.getRuleCount());
 		return retVal;

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImpl.java
@@ -52,7 +52,11 @@ public class MdmModelConverterSvcImpl implements IMdmModelConverterSvc {
 		retVal.setLinkSource(theLink.getLinkSource());
 		retVal.setMatchResult(theLink.getMatchResult());
 		retVal.setLinkCreatedNewResource(theLink.getHadToCreateNewGoldenResource());
-		Double score = theLink.getScore() == null ? null : BigDecimal.valueOf(theLink.getScore()).setScale(4, RoundingMode.HALF_UP).doubleValue();
+		Double score = theLink.getScore() == null
+				? null
+				: BigDecimal.valueOf(theLink.getScore())
+						.setScale(4, RoundingMode.HALF_UP)
+						.doubleValue();
 		retVal.setScore(score);
 		retVal.setUpdated(theLink.getUpdated());
 		retVal.setVersion(theLink.getVersion());

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImpl.java
@@ -24,8 +24,10 @@ import ca.uhn.fhir.mdm.api.IMdmLink;
 import ca.uhn.fhir.mdm.api.MdmLinkWithRevision;
 import ca.uhn.fhir.mdm.model.mdmevents.MdmLinkJson;
 import ca.uhn.fhir.mdm.model.mdmevents.MdmLinkWithRevisionJson;
-import org.apache.commons.math3.util.Precision;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class MdmModelConverterSvcImpl implements IMdmModelConverterSvc {
 
@@ -50,7 +52,7 @@ public class MdmModelConverterSvcImpl implements IMdmModelConverterSvc {
 		retVal.setLinkSource(theLink.getLinkSource());
 		retVal.setMatchResult(theLink.getMatchResult());
 		retVal.setLinkCreatedNewResource(theLink.getHadToCreateNewGoldenResource());
-		Double score = theLink.getScore() == null ? null : Precision.round(theLink.getScore(), 4);
+		Double score = theLink.getScore() == null ? null : BigDecimal.valueOf(theLink.getScore()).setScale(4, RoundingMode.HALF_UP).doubleValue();
 		retVal.setScore(score);
 		retVal.setUpdated(theLink.getUpdated());
 		retVal.setVersion(theLink.getVersion());

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImplTest.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmModelConverterSvcImplTest.java
@@ -10,7 +10,6 @@ import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;
 import ca.uhn.fhir.mdm.api.MdmLinkWithRevision;
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
-import org.apache.commons.math3.util.Precision;
 import org.hibernate.envers.RevisionType;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -19,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
@@ -37,7 +38,7 @@ public class MdmModelConverterSvcImplTest extends BaseMdmR4Test {
 		final String version = "1";
 		final boolean isLinkCreatedResource = false;
 		final double score = 0.8333333333333;
-		final double scoreRounded = Precision.round(score, 4);
+		final double scoreRounded = BigDecimal.valueOf(score).setScale(4, RoundingMode.HALF_UP).doubleValue();
 
 		MdmLink mdmLink = createGoldenPatientAndLinkToSourcePatient(MdmMatchResultEnum.MATCH, MdmLinkSourceEnum.MANUAL, version, createTime, updateTime, isLinkCreatedResource);
 		mdmLink.setScore(score);
@@ -63,7 +64,7 @@ public class MdmModelConverterSvcImplTest extends BaseMdmR4Test {
 		final boolean isLinkCreatedResource = false;
 		final long revisionNumber = 2L;
 		final double score = 0.8333333333333;
-		final double scoreRounded = Precision.round(score, 4);
+		final double scoreRounded = BigDecimal.valueOf(score).setScale(4, RoundingMode.HALF_UP).doubleValue();
 
 		MdmLink mdmLink = createGoldenPatientAndLinkToSourcePatient(MdmMatchResultEnum.MATCH, MdmLinkSourceEnum.MANUAL, version, createTime, updateTime, isLinkCreatedResource);
 		mdmLink.setScore(score);


### PR DESCRIPTION
What was done:
- Fixed precision error and rounded to 4 decimal places.
- Removed the `vector` field from the return value of `MdmModelConverterSvcImpl.toJson`.
- modified tests for the above changes.