### PR TITLE
5353 iterate on revincludes and includes does not return correct resources when used with non iterate revincludes

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5353-iterate-on-revincludes-and-includes-does-not-return-correct-resources-when-used-with-non-iterate-revincludes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5353-iterate-on-revincludes-and-includes-does-not-return-correct-resources-when-used-with-non-iterate-revincludes.yaml
@@ -2,5 +2,5 @@
 type: fix
 issue: 5353
 jira: SMILE-7451
-title: "Previously, using revincludes without iterate and revincludes and includes with iterate together,
-will omit some resources that should be included. This issue has been fixed."
+title: "Previously, when using revincludes and includes with iterate, while also using revincludes without iterate,
+the result omitted some resources that should have been included. This issue has now been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5353-iterate-on-revincludes-and-includes-does-not-return-correct-resources-when-used-with-non-iterate-revincludes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5353-iterate-on-revincludes-and-includes-does-not-return-correct-resources-when-used-with-non-iterate-revincludes.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5353
+jira: SMILE-7451
+title: "Previously, using revincludes without iterate and revincludes and includes with iterate together,
+will omit some resources that should be included. This issue has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkJpaMetricsRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IMdmLinkJpaMetricsRepository.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.dao.data;
 
 import ca.uhn.fhir.jpa.entity.MdmLink;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmMetricSvcJpaImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/mdm/MdmMetricSvcJpaImpl.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.dao.mdm;
 
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Search.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Search.java
@@ -408,14 +408,24 @@ public class Search implements ICachedSearchDetails, Serializable {
 		myLastUpdatedHigh = theUpperBound;
 	}
 
-	private Set<Include> toIncList(boolean theWantReverse) {
+	private Set<Include> toIncList(boolean theWantReverse, boolean theIncludeAll, boolean theWantIterate) {
 		HashSet<Include> retVal = new HashSet<>();
 		for (SearchInclude next : getIncludes()) {
 			if (theWantReverse == next.isReverse()) {
-				retVal.add(new Include(next.getInclude(), next.isRecurse()));
+				if (theIncludeAll) {
+					retVal.add(new Include(next.getInclude(), next.isRecurse()));
+				} else {
+					if (theWantIterate == next.isRecurse()) {
+						retVal.add(new Include(next.getInclude(), next.isRecurse()));
+					}
+				}
 			}
 		}
 		return Collections.unmodifiableSet(retVal);
+	}
+
+	private Set<Include> toIncList(boolean theWantReverse) {
+		return toIncList(theWantReverse, true, true);
 	}
 
 	public Set<Include> toIncludesList() {
@@ -424,6 +434,14 @@ public class Search implements ICachedSearchDetails, Serializable {
 
 	public Set<Include> toRevIncludesList() {
 		return toIncList(true);
+	}
+
+	public Set<Include> toIncludesList(boolean iterate) {
+		return toIncList(false, false, iterate);
+	}
+
+	public Set<Include> toRevIncludesList(boolean iterate) {
+		return toIncList(true, false, iterate);
 	}
 
 	public void addInclude(SearchInclude theInclude) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
@@ -46,7 +46,6 @@ import ca.uhn.fhir.jpa.search.cache.SearchCacheStatusEnum;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.jpa.util.QueryParameterUtils;
-import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.primitive.InstantDt;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.IPreResourceAccessDetails;
@@ -463,72 +462,70 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 		if (mySearchEntity.getSearchType() == SearchTypeEnum.SEARCH) {
 			Integer maxIncludes = myStorageSettings.getMaximumIncludesToLoadPerPage();
 
-			// Decide whether to perform include or revincludes first based on which one has iterate.
-			boolean performIncludesBeforeRevincludes = shouldPerformIncludesBeforeRevincudes();
-
-			if (performIncludesBeforeRevincludes) {
-				// Load _includes
-				Set<JpaPid> includedPids = theSearchBuilder.loadIncludes(
-						myContext,
-						myEntityManager,
-						thePids,
-						mySearchEntity.toIncludesList(),
-						false,
-						mySearchEntity.getLastUpdated(),
-						myUuid,
-						myRequest,
-						maxIncludes);
-				if (maxIncludes != null) {
-					maxIncludes -= includedPids.size();
-				}
-				thePids.addAll(includedPids);
-				includedPidList.addAll(includedPids);
-
-				// Load _revincludes
-				Set<JpaPid> revIncludedPids = theSearchBuilder.loadIncludes(
-						myContext,
-						myEntityManager,
-						thePids,
-						mySearchEntity.toRevIncludesList(),
-						true,
-						mySearchEntity.getLastUpdated(),
-						myUuid,
-						myRequest,
-						maxIncludes);
-				thePids.addAll(revIncludedPids);
-				includedPidList.addAll(revIncludedPids);
-			} else {
-				// Load _revincludes
-				Set<JpaPid> revIncludedPids = theSearchBuilder.loadIncludes(
-						myContext,
-						myEntityManager,
-						thePids,
-						mySearchEntity.toRevIncludesList(),
-						true,
-						mySearchEntity.getLastUpdated(),
-						myUuid,
-						myRequest,
-						maxIncludes);
-				if (maxIncludes != null) {
-					maxIncludes -= revIncludedPids.size();
-				}
-				thePids.addAll(revIncludedPids);
-				includedPidList.addAll(revIncludedPids);
-
-				// Load _includes
-				Set<JpaPid> includedPids = theSearchBuilder.loadIncludes(
-						myContext,
-						myEntityManager,
-						thePids,
-						mySearchEntity.toIncludesList(),
-						false,
-						mySearchEntity.getLastUpdated(),
-						myUuid,
-						myRequest,
-						maxIncludes);
-				thePids.addAll(includedPids);
-				includedPidList.addAll(includedPids);
+			// Load non-iterate _includes
+			Set<JpaPid> nonIterateIncludedPids = theSearchBuilder.loadIncludes(
+					myContext,
+					myEntityManager,
+					thePids,
+					mySearchEntity.toIncludesList(false),
+					false,
+					mySearchEntity.getLastUpdated(),
+					myUuid,
+					myRequest,
+					maxIncludes);
+			if (maxIncludes != null) {
+				maxIncludes -= nonIterateIncludedPids.size();
 			}
+			thePids.addAll(nonIterateIncludedPids);
+			includedPidList.addAll(nonIterateIncludedPids);
+
+			// Load non-iterate _revincludes
+			Set<JpaPid> nonIterateRevIncludedPids = theSearchBuilder.loadIncludes(
+					myContext,
+					myEntityManager,
+					thePids,
+					mySearchEntity.toRevIncludesList(false),
+					true,
+					mySearchEntity.getLastUpdated(),
+					myUuid,
+					myRequest,
+					maxIncludes);
+			if (maxIncludes != null) {
+				maxIncludes -= nonIterateRevIncludedPids.size();
+			}
+			thePids.addAll(nonIterateRevIncludedPids);
+			includedPidList.addAll(nonIterateRevIncludedPids);
+
+			// Load iterate _includes
+			Set<JpaPid> iterateIncludedPids = theSearchBuilder.loadIncludes(
+					myContext,
+					myEntityManager,
+					thePids,
+					mySearchEntity.toIncludesList(true),
+					false,
+					mySearchEntity.getLastUpdated(),
+					myUuid,
+					myRequest,
+					maxIncludes);
+			if (maxIncludes != null) {
+				maxIncludes -= iterateIncludedPids.size();
+			}
+			thePids.addAll(iterateIncludedPids);
+			includedPidList.addAll(iterateIncludedPids);
+
+			// Load iterate _revinclude
+			Set<JpaPid> iterateRevIncludedPids = theSearchBuilder.loadIncludes(
+					myContext,
+					myEntityManager,
+					thePids,
+					mySearchEntity.toRevIncludesList(true),
+					true,
+					mySearchEntity.getLastUpdated(),
+					myUuid,
+					myRequest,
+					maxIncludes);
+			thePids.addAll(iterateRevIncludedPids);
+			includedPidList.addAll(iterateRevIncludedPids);
 		}
 
 		// Execute the query and make sure we return distinct results
@@ -545,20 +542,6 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 		theResponsePageBuilder.setIncludedResourceCount(includedPidList.size());
 
 		return resources;
-	}
-
-	private boolean shouldPerformIncludesBeforeRevincudes() {
-		// When revincludes contain a :iterate, we should perform them last so they can iterate through the includes
-		// found so far
-		boolean retval = false;
-
-		for (Include nextInclude : mySearchEntity.toRevIncludesList()) {
-			if (nextInclude.isRecurse()) {
-				retval = true;
-				break;
-			}
-		}
-		return retval;
 	}
 
 	public void setInterceptorBroadcaster(IInterceptorBroadcaster theInterceptorBroadcaster) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
@@ -464,15 +464,15 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 
 			// Load non-iterate _revincludes
 			Set<JpaPid> nonIterateRevIncludedPids = theSearchBuilder.loadIncludes(
-				myContext,
-				myEntityManager,
-				thePids,
-				mySearchEntity.toRevIncludesList(false),
-				true,
-				mySearchEntity.getLastUpdated(),
-				myUuid,
-				myRequest,
-				maxIncludes);
+					myContext,
+					myEntityManager,
+					thePids,
+					mySearchEntity.toRevIncludesList(false),
+					true,
+					mySearchEntity.getLastUpdated(),
+					myUuid,
+					myRequest,
+					maxIncludes);
 			if (maxIncludes != null) {
 				maxIncludes -= nonIterateRevIncludedPids.size();
 			}
@@ -498,15 +498,15 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 
 			// Load iterate _revinclude
 			Set<JpaPid> iterateRevIncludedPids = theSearchBuilder.loadIncludes(
-				myContext,
-				myEntityManager,
-				thePids,
-				mySearchEntity.toRevIncludesList(true),
-				true,
-				mySearchEntity.getLastUpdated(),
-				myUuid,
-				myRequest,
-				maxIncludes);
+					myContext,
+					myEntityManager,
+					thePids,
+					mySearchEntity.toRevIncludesList(true),
+					true,
+					mySearchEntity.getLastUpdated(),
+					myUuid,
+					myRequest,
+					maxIncludes);
 			if (maxIncludes != null) {
 				maxIncludes -= iterateRevIncludedPids.size();
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
@@ -462,6 +462,23 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 		if (mySearchEntity.getSearchType() == SearchTypeEnum.SEARCH) {
 			Integer maxIncludes = myStorageSettings.getMaximumIncludesToLoadPerPage();
 
+			// Load non-iterate _revincludes
+			Set<JpaPid> nonIterateRevIncludedPids = theSearchBuilder.loadIncludes(
+				myContext,
+				myEntityManager,
+				thePids,
+				mySearchEntity.toRevIncludesList(false),
+				true,
+				mySearchEntity.getLastUpdated(),
+				myUuid,
+				myRequest,
+				maxIncludes);
+			if (maxIncludes != null) {
+				maxIncludes -= nonIterateRevIncludedPids.size();
+			}
+			thePids.addAll(nonIterateRevIncludedPids);
+			includedPidList.addAll(nonIterateRevIncludedPids);
+
 			// Load non-iterate _includes
 			Set<JpaPid> nonIterateIncludedPids = theSearchBuilder.loadIncludes(
 					myContext,
@@ -479,22 +496,22 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 			thePids.addAll(nonIterateIncludedPids);
 			includedPidList.addAll(nonIterateIncludedPids);
 
-			// Load non-iterate _revincludes
-			Set<JpaPid> nonIterateRevIncludedPids = theSearchBuilder.loadIncludes(
-					myContext,
-					myEntityManager,
-					thePids,
-					mySearchEntity.toRevIncludesList(false),
-					true,
-					mySearchEntity.getLastUpdated(),
-					myUuid,
-					myRequest,
-					maxIncludes);
+			// Load iterate _revinclude
+			Set<JpaPid> iterateRevIncludedPids = theSearchBuilder.loadIncludes(
+				myContext,
+				myEntityManager,
+				thePids,
+				mySearchEntity.toRevIncludesList(true),
+				true,
+				mySearchEntity.getLastUpdated(),
+				myUuid,
+				myRequest,
+				maxIncludes);
 			if (maxIncludes != null) {
-				maxIncludes -= nonIterateRevIncludedPids.size();
+				maxIncludes -= iterateRevIncludedPids.size();
 			}
-			thePids.addAll(nonIterateRevIncludedPids);
-			includedPidList.addAll(nonIterateRevIncludedPids);
+			thePids.addAll(iterateRevIncludedPids);
+			includedPidList.addAll(iterateRevIncludedPids);
 
 			// Load iterate _includes
 			Set<JpaPid> iterateIncludedPids = theSearchBuilder.loadIncludes(
@@ -507,25 +524,8 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 					myUuid,
 					myRequest,
 					maxIncludes);
-			if (maxIncludes != null) {
-				maxIncludes -= iterateIncludedPids.size();
-			}
 			thePids.addAll(iterateIncludedPids);
 			includedPidList.addAll(iterateIncludedPids);
-
-			// Load iterate _revinclude
-			Set<JpaPid> iterateRevIncludedPids = theSearchBuilder.loadIncludes(
-					myContext,
-					myEntityManager,
-					thePids,
-					mySearchEntity.toRevIncludesList(true),
-					true,
-					mySearchEntity.getLastUpdated(),
-					myUuid,
-					myRequest,
-					maxIncludes);
-			thePids.addAll(iterateRevIncludedPids);
-			includedPidList.addAll(iterateRevIncludedPids);
 		}
 
 		// Execute the query and make sure we return distinct results

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderRevIncludeTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderRevIncludeTest.java
@@ -212,8 +212,8 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 		assertEquals(4, foundResources.size());
 		assertEquals(episodeOfCareId.getIdPart(), foundResources.get(0).getIdElement().getIdPart());
 		assertEquals(encounterId.getIdPart(), foundResources.get(1).getIdElement().getIdPart());
-		assertEquals(pid.getIdPart(), foundResources.get(2).getIdElement().getIdPart());
-		assertEquals(taskId.getIdPart(), foundResources.get(3).getIdElement().getIdPart());
+		assertEquals(taskId.getIdPart(), foundResources.get(2).getIdElement().getIdPart());
+		assertEquals(pid.getIdPart(), foundResources.get(3).getIdElement().getIdPart());
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderRevIncludeTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderRevIncludeTest.java
@@ -12,11 +12,15 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CareTeam;
 import org.hl7.fhir.r4.model.DetectedIssue;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.EpisodeOfCare;
 import org.hl7.fhir.r4.model.Group;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.PractitionerRole;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Task;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,7 +144,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 
 		//Ensure that the revincludes are included in the query list of the sql trace.
 		//TODO GGG/KHS reduce this to something less than 6 by smarter iterating and getting the resource types earlier when needed.
-		assertEquals(6, sqlCapturingInterceptor.getQueryList().size());
+		assertEquals(5, sqlCapturingInterceptor.getQueryList().size());
 		myInterceptorRegistry.unregisterInterceptor(sqlCapturingInterceptor);
 	}
 
@@ -172,6 +176,44 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 		assertEquals(detectedIssueId.getIdPart(), foundResources.get(0).getIdElement().getIdPart());
 		assertEquals(practitionerId.getIdPart(), foundResources.get(1).getIdElement().getIdPart());
 		assertEquals(practitionerRoleId.getIdPart(), foundResources.get(2).getIdElement().getIdPart());
+	}
+
+	@Test
+	public void includeRevIncludeIterate() {
+		Patient p = new Patient();
+		String methodName = "includeRevIncludeIterate";
+		p.addName().setFamily(methodName);
+		IIdType pid = myClient.create().resource(p).execute().getId().toUnqualifiedVersionless();
+
+		EpisodeOfCare episodeOfCare = new EpisodeOfCare();
+		episodeOfCare.addIdentifier(new Identifier().setSystem("system1").setValue("value1"));
+		IIdType episodeOfCareId = myClient.create().resource(episodeOfCare).execute().getId().toUnqualifiedVersionless();
+
+		Encounter encounter = new Encounter();
+		encounter.setSubject(new Reference(pid));
+		encounter.addEpisodeOfCare(new Reference(episodeOfCareId));
+		IIdType encounterId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless();
+
+		Task task = new Task();
+		task.setEncounter(new Reference(encounterId));
+		IIdType taskId = myClient.create().resource(task).execute().getId().toUnqualifiedVersionless();
+
+		// EpisodeOfCare?identifier=system1|value1&_revinclude=Encounter:episode-of-care&_include:iterate=Encounter:patient&_revinclude:iterate=Task:encounter
+		Bundle bundle = myClient.search()
+			.forResource(EpisodeOfCare.class)
+			.where(EpisodeOfCare.IDENTIFIER.exactly().systemAndIdentifier("system1", "value1"))
+			.revInclude(new Include("Encounter:episode-of-care"))
+			.include(new Include("Encounter:patient").setRecurse(true))
+			.revInclude(new Include("Task:encounter").setRecurse(true))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		List<IBaseResource> foundResources = BundleUtil.toListOfResources(myFhirContext, bundle);
+		assertEquals(4, foundResources.size());
+		assertEquals(episodeOfCareId.getIdPart(), foundResources.get(0).getIdElement().getIdPart());
+		assertEquals(encounterId.getIdPart(), foundResources.get(1).getIdElement().getIdPart());
+		assertEquals(pid.getIdPart(), foundResources.get(2).getIdElement().getIdPart());
+		assertEquals(taskId.getIdPart(), foundResources.get(3).getIdElement().getIdPart());
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/IMdmMetricSvcTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/IMdmMetricSvcTest.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.mdm;
 
 import ca.uhn.fhir.jpa.mdm.models.GenerateMetricsTestParameters;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/GenerateMetricsTestParameters.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/GenerateMetricsTestParameters.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.mdm.models;
 
 import java.util.List;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/LinkMetricTestParameters.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/LinkMetricTestParameters.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.mdm.models;
 
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/LinkScoreMetricTestParams.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/LinkScoreMetricTestParams.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.mdm.models;
 
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/ResourceMetricTestParams.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/models/ResourceMetricTestParams.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.mdm.models;
 
 import java.util.ArrayList;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/package-info.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/package-info.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /**
  * This package is for persistence-agnostic mdm tests.
  * Even though the package is "jpaserver-test-utils", these

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/util/MdmMetricSvcTestUtil.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/mdm/util/MdmMetricSvcTestUtil.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.mdm.util;
 
 import ca.uhn.fhir.jpa.mdm.models.LinkMetricTestParameters;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/BaseMdmMetricSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/BaseMdmMetricSvc.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api;
 
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmMetricSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmMetricSvc.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api;
 
 import ca.uhn.fhir.mdm.api.params.GenerateMdmMetricsParameters;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmResourceDaoSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmResourceDaoSvc.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api;
 
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateMdmLinkMetricParameters.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateMdmLinkMetricParameters.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api.params;
 
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateMdmMetricsParameters.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateMdmMetricsParameters.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api.params;
 
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateMdmResourceMetricsParameters.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateMdmResourceMetricsParameters.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api.params;
 
 public class GenerateMdmResourceMetricsParameters {

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateScoreMetricsParameters.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/params/GenerateScoreMetricsParameters.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.api.params;
 
 import ca.uhn.fhir.mdm.api.MdmMatchResultEnum;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmLinkMetrics.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmLinkMetrics.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.model;
 
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmLinkScoreMetrics.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmLinkScoreMetrics.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.model;
 
 import java.util.LinkedHashMap;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmMetrics.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmMetrics.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.model;
 
 import ca.uhn.fhir.mdm.api.MdmLinkSourceEnum;

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmResourceMetrics.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/model/MdmResourceMetrics.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.model;
 
 public class MdmResourceMetrics {

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/util/MdmSearchParamBuildingUtils.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/util/MdmSearchParamBuildingUtils.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Master Data Management
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.mdm.util;
 
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/rest/server/provider/BulkDataExportProvider.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/rest/server/provider/BulkDataExportProvider.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.rest.server.provider;
 
 import ca.uhn.fhir.rest.annotation.IdParam;


### PR DESCRIPTION
- replace the check for revinlcudes with :iterate (or :recurse for earlier versions of FHIR) with separating of the search by revinclude, include, revinclude with iterate, and include with iterate.
- File to review: Search.java, PersistedJpaBundleProvider.java, and ResourceProviderRevIncludeTest.java
- Non-impact change: added generated docs

closes #5353