### PR TITLE
typo fix for mdm match operation documentation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa_mdm/mdm_operations.md
@@ -816,13 +816,13 @@ Content-Type: application/fhir+json; charset=UTF-8
         {
             "name":"resource",
             "resource": {
-                "resourceType":"Orgaization",
+                "resourceType":"Organization",
                 "name": "McMaster Family Practice"
             }
         },
         {
             "name":"resourceType",
-            "valueString": "Orgaization"
+            "valueString": "Organization"
         }
     ]
 }


### PR DESCRIPTION
What was done:
- changed "orgaization" to "organization" :)