### PR TITLE
Force _summary=false when fetching CodeSystems and ValueSets with remote terminology

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5371-force-summary-false-remote-validation.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5371-force-summary-false-remote-validation.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 5371
+title: "Remote terminology operations that fetch ValueSets or CodeSystems now force _summary=false to allow local validation."

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -8,7 +8,9 @@ import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.context.support.TranslateConceptResults;
 import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IQuery;
 import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.ParametersUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -24,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -141,16 +144,32 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 
 	@Override
 	public IBaseResource fetchCodeSystem(String theSystem) {
+		// callers of this want the whole resource.
+		return fetchCodeSystem(theSystem, SummaryEnum.FALSE);
+	}
+
+	/**
+	 * Fetch the code system, possibly a summary.
+	 * @param theSystem the canonical url
+	 * @param theSummaryParam to force a summary mode - or null to allow server default.
+	 * @return the CodeSystem
+	 */
+	@Nullable
+	private IBaseResource fetchCodeSystem(String theSystem, @Nullable SummaryEnum theSummaryParam) {
 		IGenericClient client = provideClient();
 		Class<? extends IBaseBundle> bundleType =
 				myCtx.getResourceDefinition("Bundle").getImplementingClass(IBaseBundle.class);
-		IBaseBundle results = client.search()
+		IQuery<IBaseBundle> codeSystemQuery = client.search()
 				.forResource("CodeSystem")
-				.where(CodeSystem.URL.matches().value(theSystem))
-				.returnBundle(bundleType)
-				.execute();
+				.where(CodeSystem.URL.matches().value(theSystem));
+
+		if (theSummaryParam != null) {
+			codeSystemQuery.summaryMode(theSummaryParam);
+		}
+
+		IBaseBundle results = codeSystemQuery.returnBundle(bundleType).execute();
 		List<IBaseResource> resultsList = BundleUtil.toListOfResources(myCtx, results);
-		if (resultsList.size() > 0) {
+		if (!resultsList.isEmpty()) {
 			return resultsList.get(0);
 		}
 
@@ -388,16 +407,36 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 
 	@Override
 	public IBaseResource fetchValueSet(String theValueSetUrl) {
+		// force the remote server to send the whole resource.
+		SummaryEnum summaryParam = SummaryEnum.FALSE;
+		return fetchValueSet(theValueSetUrl, summaryParam);
+	}
+
+	/**
+	 * Search for a ValueSet by canonical url via IGenericClient.
+	 *
+	 * @param theValueSetUrl the canonical url of the ValueSet
+	 * @param theSummaryParam force a summary mode - null allows server default
+	 * @return the ValueSet or null if none match the url
+	 */
+	@Nullable
+	private IBaseResource fetchValueSet(String theValueSetUrl, SummaryEnum theSummaryParam) {
 		IGenericClient client = provideClient();
 		Class<? extends IBaseBundle> bundleType =
 				myCtx.getResourceDefinition("Bundle").getImplementingClass(IBaseBundle.class);
-		IBaseBundle results = client.search()
+
+		IQuery<IBaseBundle> valueSetQuery = client.search()
 				.forResource("ValueSet")
-				.where(CodeSystem.URL.matches().value(theValueSetUrl))
-				.returnBundle(bundleType)
-				.execute();
+				.where(CodeSystem.URL.matches().value(theValueSetUrl));
+
+		if (theSummaryParam != null) {
+			valueSetQuery.summaryMode(theSummaryParam);
+		}
+
+		IBaseBundle results = valueSetQuery.returnBundle(bundleType).execute();
+
 		List<IBaseResource> resultsList = BundleUtil.toListOfResources(myCtx, results);
-		if (resultsList.size() > 0) {
+		if (!resultsList.isEmpty()) {
 			return resultsList.get(0);
 		}
 
@@ -406,12 +445,18 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 
 	@Override
 	public boolean isCodeSystemSupported(ValidationSupportContext theValidationSupportContext, String theSystem) {
-		return fetchCodeSystem(theSystem) != null;
+		// a summary is ok if we are just checking the presence.
+		SummaryEnum summaryParam = null;
+
+		return fetchCodeSystem(theSystem, summaryParam) != null;
 	}
 
 	@Override
 	public boolean isValueSetSupported(ValidationSupportContext theValidationSupportContext, String theValueSetUrl) {
-		return fetchValueSet(theValueSetUrl) != null;
+		// a summary is ok if we are just checking the presence.
+		SummaryEnum summaryParam = null;
+
+		return fetchValueSet(theValueSetUrl, summaryParam) != null;
 	}
 
 	@Override

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupportTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupportTest.java
@@ -12,6 +12,7 @@ import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.annotation.RequiredParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IHttpRequest;
@@ -173,6 +174,18 @@ public class RemoteTerminologyServiceValidationSupportTest {
 		assertEquals(CODE_SYSTEM, myValueSetProvider.myLastSystem.getValue());
 		assertEquals(VALUE_SET_URL, myValueSetProvider.myLastUrl.getValue());
 		assertEquals(null, myValueSetProvider.myLastValueSet);
+	}
+
+	@Test
+	void testFetchValueSet_forcesSummaryFalse() {
+	    // given
+		myValueSetProvider.myNextReturnValueSets = new ArrayList<>();
+
+		// when
+		IBaseResource valueSet = mySvc.fetchValueSet(VALUE_SET_URL);
+
+	    // then
+	    assertEquals(SummaryEnum.FALSE, myValueSetProvider.myLastSummaryParam);
 	}
 
 	@Test
@@ -373,6 +386,19 @@ public class RemoteTerminologyServiceValidationSupportTest {
 		assertNull(myConceptMapProvider.myLastTargetValueSet);
 		assertNull(myConceptMapProvider.myLastReverse);
 	}
+
+	@Test
+	void testFetchCodeSystem_forcesSummaryFalse() {
+		// given
+		myCodeSystemProvider.myNextReturnCodeSystems = new ArrayList<>();
+
+		// when
+		IBaseResource codeSystem = mySvc.fetchCodeSystem("http://loinc.org");
+
+		// then
+		assertEquals(SummaryEnum.FALSE, myCodeSystemProvider.myLastSummaryParam);
+	}
+
 
 	private void addMatchToTranslateRequest(Parameters params) {
 		Parameters.ParametersParameterComponent matchParam = params.addParameter().setName("match");
@@ -626,6 +652,7 @@ public class RemoteTerminologyServiceValidationSupportTest {
 
 	private static class MyCodeSystemProvider implements IResourceProvider {
 
+		private SummaryEnum myLastSummaryParam;
 		private UriParam myLastUrlParam;
 		private List<CodeSystem> myNextReturnCodeSystems;
 		private int myInvocationCount;
@@ -680,8 +707,9 @@ public class RemoteTerminologyServiceValidationSupportTest {
 		}
 
 		@Search
-		public List<CodeSystem> find(@RequiredParam(name = "url") UriParam theUrlParam) {
+		public List<CodeSystem> find(@RequiredParam(name = "url") UriParam theUrlParam, SummaryEnum theSummaryParam) {
 			myLastUrlParam = theUrlParam;
+			myLastSummaryParam = theSummaryParam;
 			assert myNextReturnCodeSystems != null;
 			return myNextReturnCodeSystems;
 		}
@@ -703,6 +731,7 @@ public class RemoteTerminologyServiceValidationSupportTest {
 		private StringType myLastDisplay;
 		private ValueSet myLastValueSet;
 		private UriParam myLastUrlParam;
+		private SummaryEnum myLastSummaryParam;
 
 		@Operation(name = "validate-code", idempotent = true, returnParameters = {
 			@OperationParam(name = "result", type = BooleanType.class, min = 1),
@@ -728,8 +757,9 @@ public class RemoteTerminologyServiceValidationSupportTest {
 		}
 
 		@Search
-		public List<ValueSet> find(@RequiredParam(name = "url") UriParam theUrlParam) {
+		public List<ValueSet> find(@RequiredParam(name = "url") UriParam theUrlParam, SummaryEnum theSummaryParam) {
 			myLastUrlParam = theUrlParam;
+			myLastSummaryParam = theSummaryParam;
 			assert myNextReturnValueSets != null;
 			return myNextReturnValueSets;
 		}


### PR DESCRIPTION
Fixes #5371 