### PR TITLE
Allow the search cache when using consent.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5378-allow-cached-search-with-consent.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5378-allow-cached-search-with-consent.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 5378
+title: "The search cache is now active when using the ConsentInterceptor."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -186,14 +186,6 @@ public class ConsentInterceptor {
 		return false;
 	}
 
-	@Hook(value = Pointcut.STORAGE_PRESEARCH_REGISTERED)
-	public void interceptPreSearchRegistered(
-			RequestDetails theRequestDetails, ICachedSearchDetails theCachedSearchDetails) {
-		if (!isRequestAuthorized(theRequestDetails)) {
-			theCachedSearchDetails.setCannotBeReused();
-		}
-	}
-
 	@Hook(value = Pointcut.STORAGE_PREACCESS_RESOURCES)
 	public void interceptPreAccess(
 			RequestDetails theRequestDetails, IPreResourceAccessDetails thePreResourceAccessDetails) {


### PR DESCRIPTION
We used to block reuse of the search cache between searches when the consent service was active.
The existence of a prior search leaks minimal information, and the speedup from a cached query is large.
