### PR TITLE
Allow cached search with consent active when safe

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5378-allow-cached-search-with-consent.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5378-allow-cached-search-with-consent.yaml
@@ -1,4 +1,0 @@
----
-type: change
-issue: 5378
-title: "The search cache is now active when using the ConsentInterceptor."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5378-allow-cached-search-with-consent.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5378-allow-cached-search-with-consent.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 5378
+title: "The search cache is now active when using the ConsentInterceptor."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5387-allow-cached-search-with-consent.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5387-allow-cached-search-with-consent.yaml
@@ -1,0 +1,6 @@
+---
+type: perf
+issue: 5387
+title: "Enable the cache when for some requests when a consent interceptor is active.  
+  If no consent server filters with canSeeResource (i.e. shouldProcessCanSeeResource() returns false), or startOperation()
+   returns AUTHORIZED, then cached results are safe."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5387-allow-cached-search-with-consent.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5387-allow-cached-search-with-consent.yaml
@@ -2,5 +2,5 @@
 type: perf
 issue: 5387
 title: "Enable the cache when for some requests when a consent interceptor is active.  
-  If no consent server filters with canSeeResource (i.e. shouldProcessCanSeeResource() returns false), or startOperation()
-   returns AUTHORIZED, then cached results are safe."
+  If no consent server uses canSeeResource (i.e. shouldProcessCanSeeResource() returns false);
+   or startOperation() returns AUTHORIZED; then cached results are safe."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/consent_interceptor.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/consent_interceptor.md
@@ -27,7 +27,7 @@ The ConsentInterceptor requires a user-supplied instance of the [IConsentService
 
 ## Performance and Privacy
 
-The `canSeeResource()` operation requires inspecting every resource while during a search and editing the results.
+The `canSeeResource()` operation requires inspecting every resource during a search and editing the results.
 This is slower than the normal path, and will block the use of the search cache.
 The `willSeeResource()` check is safe for cached searches, but removed resources may be 'visible' as holes in returned bundles.
 If this information leak is acceptable, then the search cache can be enabled by blocking the use of `canSeeResource()` by returning `false` from `processCanSeeResource()`.

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/consent_interceptor.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/consent_interceptor.md
@@ -24,3 +24,12 @@ The ConsentInterceptor requires a user-supplied instance of the [IConsentService
 ```java
 {{snippet:classpath:/ca/uhn/hapi/fhir/docs/ConsentInterceptors.java|service}}
 ``` 
+
+## Performance and Privacy
+
+The `canSeeResource()` operation requires inspecting every resource while during a search and editing the results.
+This is slower than the normal path, and will block the use of the search cache.
+The `willSeeResource()` check is safe for cached searches, but removed resources may be 'visible' as holes in returned bundles.
+If this information leak is acceptable, then the search cache can be enabled by blocking the use of `canSeeResource()` by returning `false` from `processCanSeeResource()`.
+
+

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4IT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4IT.java
@@ -518,6 +518,7 @@ public class ConsentInterceptorResourceProviderR4IT extends BaseResourceProvider
 
 		IConsentService svc = mock(IConsentService.class);
 		when(svc.startOperation(any(), any())).thenReturn(ConsentOutcome.PROCEED);
+		when(svc.shouldProcessCanSeeResource(any(), any())).thenReturn(true);
 		when(svc.canSeeResource(any(), any(), any())).thenReturn(ConsentOutcome.REJECT);
 
 		consentService.setTarget(svc);
@@ -550,6 +551,7 @@ public class ConsentInterceptorResourceProviderR4IT extends BaseResourceProvider
 
 		IConsentService svc = mock(IConsentService.class);
 		when(svc.startOperation(any(), any())).thenReturn(ConsentOutcome.PROCEED);
+		when(svc.shouldProcessCanSeeResource(any(), any())).thenReturn(true);
 		when(svc.canSeeResource(any(RequestDetails.class), any(IBaseResource.class), any())).thenAnswer(t -> {
 			IBaseResource resource = t.getArgument(1, IBaseResource.class);
 			if (resource instanceof Organization) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -186,14 +186,6 @@ public class ConsentInterceptor {
 		return false;
 	}
 
-	@Hook(value = Pointcut.STORAGE_PRESEARCH_REGISTERED)
-	public void interceptPreSearchRegistered(
-			RequestDetails theRequestDetails, ICachedSearchDetails theCachedSearchDetails) {
-		if (!isRequestAuthorized(theRequestDetails)) {
-			theCachedSearchDetails.setCannotBeReused();
-		}
-	}
-
 	@Hook(value = Pointcut.STORAGE_PREACCESS_RESOURCES)
 	public void interceptPreAccess(
 			RequestDetails theRequestDetails, IPreResourceAccessDetails thePreResourceAccessDetails) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -45,8 +45,6 @@ import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,6 +53,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static ca.uhn.fhir.rest.api.Constants.URL_TOKEN_METADATA;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_META;
@@ -201,7 +201,7 @@ public class ConsentInterceptor {
 	 */
 	@Hook(value = Pointcut.STORAGE_PRESEARCH_REGISTERED)
 	public void interceptPreSearchRegistered(
-		RequestDetails theRequestDetails, ICachedSearchDetails theCachedSearchDetails) {
+			RequestDetails theRequestDetails, ICachedSearchDetails theCachedSearchDetails) {
 		if (isProcessCanSeeResource(theRequestDetails, null)) {
 			theCachedSearchDetails.setCannotBeReused();
 		}
@@ -262,7 +262,8 @@ public class ConsentInterceptor {
 	 * @param theProcessConsentSvcsFlags filled in with the responses from shouldProcessCanSeeResource each service
 	 * @return true of any service responded true to shouldProcessCanSeeResource()
 	 */
-	private boolean isProcessCanSeeResource(@Nonnull RequestDetails theRequestDetails, @Nullable boolean[] theProcessConsentSvcsFlags) {
+	private boolean isProcessCanSeeResource(
+			@Nonnull RequestDetails theRequestDetails, @Nullable boolean[] theProcessConsentSvcsFlags) {
 		if (isRequestAuthorized(theRequestDetails)) {
 			return false;
 		}
@@ -273,7 +274,7 @@ public class ConsentInterceptor {
 			return false;
 		}
 
-		if (theProcessConsentSvcsFlags == null ) {
+		if (theProcessConsentSvcsFlags == null) {
 			theProcessConsentSvcsFlags = new boolean[myConsentService.size()];
 		}
 		Validate.isTrue(theProcessConsentSvcsFlags.length == myConsentService.size());

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/DelegatingConsentService.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/DelegatingConsentService.java
@@ -38,6 +38,11 @@ public class DelegatingConsentService implements IConsentService {
 	}
 
 	@Override
+	public boolean shouldProcessCanSeeResource(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+		return myTarget.shouldProcessCanSeeResource(theRequestDetails, theContextServices);
+	}
+
+	@Override
 	public ConsentOutcome canSeeResource(
 			RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
 		return myTarget.canSeeResource(theRequestDetails, theResource, theContextServices);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/DelegatingConsentService.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/DelegatingConsentService.java
@@ -38,7 +38,8 @@ public class DelegatingConsentService implements IConsentService {
 	}
 
 	@Override
-	public boolean shouldProcessCanSeeResource(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+	public boolean shouldProcessCanSeeResource(
+			RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
 		return myTarget.shouldProcessCanSeeResource(theRequestDetails, theContextServices);
 	}
 


### PR DESCRIPTION
If a consent interceptor removes any search results, then cached results can not be reused.
This change enables the cache when canSeeResource is not active.
