### PR TITLE
Transaction with conditional update fails if SearchNarrowingInterceptor is registered and Enabled Partitioning

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5388-fhir-transaction-fails-if-searchnarrowinginterceptor-is-registered-and-partitioning-enabled.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5388-fhir-transaction-fails-if-searchnarrowinginterceptor-is-registered-and-partitioning-enabled.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5388
+title: "Previously, with partitioning enabled and `UrlBaseTenantIdentificationStrategy` used, registering 
+`SearchNarrowingInterceptor` would cause to incorrect resolution of `entry.request.url` parameter during 
+transaction bundle processing. This has been fixed."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/MultitenantServerR4Test.java
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -452,8 +454,9 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 		assertEquals("Family", patient1.getName().get(0).getFamily());
 	}
 
-	@Test
-	public void testTransactionGet_withSearchNarrowingInterceptor_retrievesPatient() {
+	@ParameterizedTest
+	@ValueSource(strings = {"Patient/1234a", "TENANT-B/Patient/1234a"})
+	public void testTransactionGet_withSearchNarrowingInterceptor_retrievesPatient(String theEntryUrl) {
 		// setup
 		createPatient(withTenant(TENANT_B), withActiveTrue(), withId("1234a"),
 			withFamily("Family"), withGiven("Given"));
@@ -461,7 +464,7 @@ public class MultitenantServerR4Test extends BaseMultitenantResourceProviderR4Te
 		Bundle transactioBundle = new Bundle();
 		transactioBundle.setType(Bundle.BundleType.TRANSACTION);
 		transactioBundle.addEntry()
-			.getRequest().setUrl("Patient/1234a").setMethod(Bundle.HTTPVerb.GET);
+			.getRequest().setUrl(theEntryUrl).setMethod(Bundle.HTTPVerb.GET);
 
 		myServer.registerInterceptor(new SearchNarrowingInterceptor());
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -1598,9 +1598,16 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 		myUncompressIncomingContents = theUncompressIncomingContents;
 	}
 
+	private String resolveRequestPath(RequestDetails theRequestDetails, String theRequestPath) {
+		if (myTenantIdentificationStrategy != null) {
+			theRequestPath = myTenantIdentificationStrategy.resolveRelativeUrl(theRequestPath, theRequestDetails);
+		}
+		return theRequestPath;
+	}
+
 	public void populateRequestDetailsFromRequestPath(RequestDetails theRequestDetails, String theRequestPath) {
-		UrlPathTokenizer tok = new UrlPathTokenizer(theRequestPath);
-		String resourceName = null;
+		String resolvedRequestPath = resolveRequestPath(theRequestDetails, theRequestPath);
+		UrlPathTokenizer tok = new UrlPathTokenizer(resolvedRequestPath);
 
 		if (myTenantIdentificationStrategy != null) {
 			myTenantIdentificationStrategy.extractTenant(tok, theRequestDetails);
@@ -1609,6 +1616,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 		IIdType id = null;
 		String operation = null;
 		String compartment = null;
+		String resourceName = null;
 		if (tok.hasMoreTokens()) {
 			resourceName = tok.nextTokenUnescapedAndSanitized();
 			if (partIsOperation(resourceName)) {
@@ -1635,7 +1643,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 					String versionString = tok.nextTokenUnescapedAndSanitized();
 					if (id == null) {
 						throw new InvalidRequestException(
-								Msg.code(298) + "Don't know how to handle request path: " + theRequestPath);
+								Msg.code(298) + "Don't know how to handle request path: " + resolvedRequestPath);
 					}
 					id.setParts(null, resourceName, id.getIdPart(), UrlUtil.unescape(versionString));
 				} else {
@@ -1644,7 +1652,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 			} else if (partIsOperation(nextString)) {
 				if (operation != null) {
 					throw new InvalidRequestException(
-							Msg.code(299) + "URL Path contains two operations: " + theRequestPath);
+							Msg.code(299) + "URL Path contains two operations: " + resolvedRequestPath);
 				}
 				operation = nextString;
 			} else {
@@ -1663,7 +1671,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 				secondaryOperation = nextString;
 			} else {
 				throw new InvalidRequestException(Msg.code(300) + "URL path has unexpected token '" + nextString
-						+ "' at the end: " + theRequestPath);
+						+ "' at the end: " + resolvedRequestPath);
 			}
 		}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/tenant/ITenantIdentificationStrategy.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/tenant/ITenantIdentificationStrategy.java
@@ -26,7 +26,7 @@ public interface ITenantIdentificationStrategy {
 
 	/**
 	 * Implementations should use this method to determine the tenant ID
-	 * based on the incoming request andand populate it in the
+	 * based on the incoming request and populate it in the
 	 * {@link RequestDetails#setTenantId(String)}.
 	 *
 	 * @param theUrlPathTokenizer The tokenizer which is used to parse the request path
@@ -39,4 +39,13 @@ public interface ITenantIdentificationStrategy {
 	 * if necessary based on the tenant ID
 	 */
 	String massageServerBaseUrl(String theFhirServerBase, RequestDetails theRequestDetails);
+
+	/**
+	 * Implementations may use this method to resolve relative URL based on the tenant ID from RequestDetails.
+	 *
+	 * @param theRelativeUrl    URL that only includes the path, e.g. "Patient/123"
+	 * @param theRequestDetails The request details object which can be used to access tenant ID
+	 * @return Resolved relative URL that starts with tenant ID (if tenant ID present in RequestDetails). Example: "TENANT-A/Patient/123".
+	 */
+	String resolveRelativeUrl(String theRelativeUrl, RequestDetails theRequestDetails);
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategy.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategy.java
@@ -102,4 +102,12 @@ public class UrlBaseTenantIdentificationStrategy implements ITenantIdentificatio
 		}
 		return result;
 	}
+
+	@Override
+	public String resolveRelativeUrl(String theRelativeUrl, RequestDetails theRequestDetails) {
+		if (theRequestDetails.getTenantId() != null && !theRelativeUrl.startsWith(theRequestDetails.getTenantId())) {
+			return theRequestDetails.getTenantId() + "/" + theRelativeUrl;
+		}
+		return theRelativeUrl;
+	}
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ServletRequestUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ServletRequestUtil.java
@@ -63,6 +63,7 @@ public class ServletRequestUtil {
 
 		requestDetails.setRequestPath(url);
 		requestDetails.setFhirServerBase(theRequestDetails.getFhirServerBase());
+		requestDetails.setTenantId(theRequestDetails.getTenantId());
 
 		theRequestDetails.getServer().populateRequestDetailsFromRequestPath(requestDetails, url);
 		return requestDetails;


### PR DESCRIPTION
Previously, with partitioning enabled and `UrlBaseTenantIdentificationStrategy` used, registering 
`SearchNarrowingInterceptor` would cause to incorrect resolution of `entry.request.url` parameter during 
transaction bundle processing. This has been fixed.