### PR TITLE
5401 add terserutil clear by fhirpath

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/BaseRuntimeChildDefinition.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/BaseRuntimeChildDefinition.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.context;
 
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.model.api.annotation.Child;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 
@@ -76,6 +77,10 @@ public abstract class BaseRuntimeChildDefinition {
 
 	public void setReplacedParentDefinition(BaseRuntimeChildDefinition myReplacedParentDefinition) {
 		this.myReplacedParentDefinition = myReplacedParentDefinition;
+	}
+
+	public boolean isMultipleCardinality() {
+		return this.getMax() > 1 || this.getMax() == Child.MAX_UNLIMITED;
 	}
 
 	public interface IAccessor {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -39,7 +39,6 @@ import ca.uhn.fhir.model.api.ISupportsUndeclaredExtensions;
 import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
 import ca.uhn.fhir.model.api.Tag;
 import ca.uhn.fhir.model.api.TagList;
-import ca.uhn.fhir.model.api.annotation.Child;
 import ca.uhn.fhir.model.base.composite.BaseCodingDt;
 import ca.uhn.fhir.model.base.composite.BaseContainedDt;
 import ca.uhn.fhir.model.primitive.IdDt;
@@ -660,8 +659,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 					}
 					BaseRuntimeChildDefinition replacedParentDefinition = nextChild.getReplacedParentDefinition();
 					if (nextChild.isMultipleCardinality()
-							|| (replacedParentDefinition != null
-									&& replacedParentDefinition.isMultipleCardinality())) {
+							|| (replacedParentDefinition != null && replacedParentDefinition.isMultipleCardinality())) {
 						beginArray(theEventWriter, nextChildSpecificName);
 						inArray = true;
 						encodeChildElementToStreamWriter(
@@ -915,7 +913,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 					theResourceId, extensions, modifierExtensions, null, null, theEncodeContext, theContainedResource);
 			boolean haveExtension = !extensions.isEmpty();
 
-            if (theResourceId.hasFormatComment() || haveExtension) {
+			if (theResourceId.hasFormatComment() || haveExtension) {
 				beginObject(theEventWriter, "_id");
 				if (theResourceId.hasFormatComment()) {
 					writeCommentsPreAndPost(theResourceId, theEventWriter);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -659,9 +659,9 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 						theEventWriter.endArray();
 					}
 					BaseRuntimeChildDefinition replacedParentDefinition = nextChild.getReplacedParentDefinition();
-					if (isMultipleCardinality(nextChild.getMax())
+					if (nextChild.isMultipleCardinality()
 							|| (replacedParentDefinition != null
-									&& isMultipleCardinality(replacedParentDefinition.getMax()))) {
+									&& replacedParentDefinition.isMultipleCardinality())) {
 						beginArray(theEventWriter, nextChildSpecificName);
 						inArray = true;
 						encodeChildElementToStreamWriter(
@@ -728,14 +728,14 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 					List<HeldExtension> heldModExts = Collections.emptyList();
 					if (extensions.size() > i
 							&& extensions.get(i) != null
-							&& extensions.get(i).isEmpty() == false) {
+							&& !extensions.get(i).isEmpty()) {
 						haveContent = true;
 						heldExts = extensions.get(i);
 					}
 
 					if (modifierExtensions.size() > i
 							&& modifierExtensions.get(i) != null
-							&& modifierExtensions.get(i).isEmpty() == false) {
+							&& !modifierExtensions.get(i).isEmpty()) {
 						haveContent = true;
 						heldModExts = modifierExtensions.get(i);
 					}
@@ -746,7 +746,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 					} else {
 						nextComments = null;
 					}
-					if (nextComments != null && nextComments.isEmpty() == false) {
+					if (nextComments != null && !nextComments.isEmpty()) {
 						haveContent = true;
 					}
 
@@ -802,10 +802,6 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 			myIsSupportsFhirComment = isFhirVersionLessThanOrEqualTo(FhirVersionEnum.DSTU2_1);
 		}
 		return myIsSupportsFhirComment;
-	}
-
-	private boolean isMultipleCardinality(int maxCardinality) {
-		return maxCardinality > 1 || maxCardinality == Child.MAX_UNLIMITED;
 	}
 
 	private void encodeCompositeElementToStreamWriter(
@@ -917,12 +913,9 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 			// Undeclared extensions
 			extractUndeclaredExtensions(
 					theResourceId, extensions, modifierExtensions, null, null, theEncodeContext, theContainedResource);
-			boolean haveExtension = false;
-			if (!extensions.isEmpty()) {
-				haveExtension = true;
-			}
+			boolean haveExtension = !extensions.isEmpty();
 
-			if (theResourceId.hasFormatComment() || haveExtension) {
+            if (theResourceId.hasFormatComment() || haveExtension) {
 				beginObject(theEventWriter, "_id");
 				if (theResourceId.hasFormatComment()) {
 					writeCommentsPreAndPost(theResourceId, theEventWriter);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -351,6 +351,14 @@ public final class TerserUtil {
 		clear(childDefinition.getAccessor().getValues(theResource));
 	}
 
+	/**
+	 * Clears the specified field on the resource provided by the FHIRPath.  If more than one value matches
+	 * the FHIRPath, all values will be cleared.
+	 *
+	 * @param theFhirContext
+	 * @param theResource
+	 * @param theFhirPath
+	 */
 	public static void clearFieldByFhirPath(FhirContext theFhirContext, IBaseResource theResource, String theFhirPath) {
 
 		if (theFhirPath.contains(".")) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -390,7 +390,8 @@ public final class TerserUtil {
 		List<IBase> newValue = accessor.getValues(theBase);
 
 		if (newValue != null && !newValue.isEmpty()) {
-			// Our clear failed, probably because it was an immutable SingletonList returned by a FieldPlainAccessor that cannot be cleared.
+			// Our clear failed, probably because it was an immutable SingletonList returned by a FieldPlainAccessor
+			// that cannot be cleared.
 			// Let's just null it out instead.
 			childDefinition.getMutator().setValue(theBase, null);
 		}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeChildChoiceDefinition;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.model.api.annotation.Child;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -35,6 +36,7 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.slf4j.Logger;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -52,7 +54,7 @@ public final class TerserUtil {
 	 * Exclude for id, identifier and meta fields of a resource.
 	 */
 	public static final Collection<String> IDS_AND_META_EXCLUDES =
-			Collections.unmodifiableSet(Stream.of("id", "identifier", "meta").collect(Collectors.toSet()));
+		Collections.unmodifiableSet(Stream.of("id", "identifier", "meta").collect(Collectors.toSet()));
 	/**
 	 * Exclusion predicate for id, identifier, meta fields.
 	 */
@@ -67,20 +69,20 @@ public final class TerserUtil {
 	 * empty source fields will not results in erasure of target fields.
 	 */
 	public static final Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> EXCLUDE_IDS_META_AND_EMPTY =
-			new Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>>() {
-				@Override
-				public boolean test(Triple<BaseRuntimeChildDefinition, IBase, IBase> theTriple) {
-					if (!EXCLUDE_IDS_AND_META.test(theTriple.getLeft().getElementName())) {
-						return false;
-					}
-					BaseRuntimeChildDefinition childDefinition = theTriple.getLeft();
-					boolean isSourceFieldEmpty = childDefinition
-							.getAccessor()
-							.getValues(theTriple.getMiddle())
-							.isEmpty();
-					return !isSourceFieldEmpty;
+		new Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>>() {
+			@Override
+			public boolean test(Triple<BaseRuntimeChildDefinition, IBase, IBase> theTriple) {
+				if (!EXCLUDE_IDS_AND_META.test(theTriple.getLeft().getElementName())) {
+					return false;
 				}
-			};
+				BaseRuntimeChildDefinition childDefinition = theTriple.getLeft();
+				boolean isSourceFieldEmpty = childDefinition
+					.getAccessor()
+					.getValues(theTriple.getMiddle())
+					.isEmpty();
+				return !isSourceFieldEmpty;
+			}
+		};
 	/**
 	 * Exclusion predicate for keeping all fields.
 	 */
@@ -94,19 +96,20 @@ public final class TerserUtil {
 	private static final Logger ourLog = getLogger(TerserUtil.class);
 	private static final String EQUALS_DEEP = "equalsDeep";
 
-	private TerserUtil() {}
+	private TerserUtil() {
+	}
 
 	/**
 	 * Given an Child Definition of `identifier`, a R4/DSTU3 EID Identifier, and a new resource, clone the EID into that resources' identifier list.
 	 */
 	public static void cloneEidIntoResource(
-			FhirContext theFhirContext,
-			BaseRuntimeChildDefinition theIdentifierDefinition,
-			IBase theEid,
-			IBase theResourceToCloneEidInto) {
+		FhirContext theFhirContext,
+		BaseRuntimeChildDefinition theIdentifierDefinition,
+		IBase theEid,
+		IBase theResourceToCloneEidInto) {
 		// FHIR choice types - fields within fhir where we have a choice of ids
 		BaseRuntimeElementCompositeDefinition<?> childIdentifier = (BaseRuntimeElementCompositeDefinition<?>)
-				theIdentifierDefinition.getChildByName(FIELD_NAME_IDENTIFIER);
+			theIdentifierDefinition.getChildByName(FIELD_NAME_IDENTIFIER);
 		IBase resourceNewIdentifier = childIdentifier.newInstance();
 
 		FhirTerser terser = theFhirContext.newTerser();
@@ -175,7 +178,7 @@ public final class TerserUtil {
 	 * @param theField Field name to be copied
 	 */
 	public static void cloneCompositeField(
-			FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo, String theField) {
+		FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo, String theField) {
 		FhirTerser terser = theFhirContext.newTerser();
 
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
@@ -242,7 +245,7 @@ public final class TerserUtil {
 				return (Boolean) theMethod.invoke(theItem1, theItem2);
 			} catch (Exception e) {
 				throw new RuntimeException(
-						Msg.code(1746) + String.format("Unable to compare equality via %s", EQUALS_DEEP), e);
+					Msg.code(1746) + String.format("Unable to compare equality via %s", EQUALS_DEEP), e);
 			}
 		}
 		return theItem1.equals(theItem2);
@@ -275,12 +278,12 @@ public final class TerserUtil {
 	 * @param theFieldNameInclusion Inclusion strategy that checks if a given field should be replaced
 	 */
 	public static void replaceFields(
-			FhirContext theFhirContext,
-			IBaseResource theFrom,
-			IBaseResource theTo,
-			Predicate<String> theFieldNameInclusion) {
+		FhirContext theFhirContext,
+		IBaseResource theFrom,
+		IBaseResource theTo,
+		Predicate<String> theFieldNameInclusion) {
 		Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> predicate =
-				(t) -> theFieldNameInclusion.test(t.getLeft().getElementName());
+			(t) -> theFieldNameInclusion.test(t.getLeft().getElementName());
 		replaceFieldsByPredicate(theFhirContext, theFrom, theTo, predicate);
 	}
 
@@ -294,10 +297,10 @@ public final class TerserUtil {
 	 * @param thePredicate   Predicate that checks if a given field should be replaced
 	 */
 	public static void replaceFieldsByPredicate(
-			FhirContext theFhirContext,
-			IBaseResource theFrom,
-			IBaseResource theTo,
-			Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> thePredicate) {
+		FhirContext theFhirContext,
+		IBaseResource theFrom,
+		IBaseResource theTo,
+		Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> thePredicate) {
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
 		FhirTerser terser = theFhirContext.newTerser();
 		for (BaseRuntimeChildDefinition childDefinition : definition.getChildrenAndExtension()) {
@@ -328,14 +331,14 @@ public final class TerserUtil {
 	 * @param theTo          The resource to replace the field on
 	 */
 	public static void replaceField(
-			FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
+		FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
 		Validate.notNull(definition);
 		replaceField(
-				theFhirContext.newTerser(),
-				theFrom,
-				theTo,
-				theFhirContext.getResourceDefinition(theFrom).getChildByName(theFieldName));
+			theFhirContext.newTerser(),
+			theFrom,
+			theTo,
+			theFhirContext.getResourceDefinition(theFrom).getChildByName(theFieldName));
 	}
 
 	/**
@@ -347,14 +350,25 @@ public final class TerserUtil {
 	 */
 	public static void clearField(FhirContext theFhirContext, IBaseResource theResource, String theFieldName) {
 		BaseRuntimeChildDefinition childDefinition =
-				getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
+			getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
 		clear(childDefinition.getAccessor().getValues(theResource));
 	}
 
+	public static void clearFieldByFhirPath(
+		FhirContext theFhirContext, IBaseResource theResource, String theFhirPath) {
 
-	public static void clearFieldByFhirPath(FhirContext theFhirContext, IBaseResource theResource, String theFhirPath) {
+		if (theFhirPath.contains(".")) {
+			String parentPath = theFhirPath.substring(0, theFhirPath.lastIndexOf("."));
+			String fieldName = theFhirPath.substring(theFhirPath.lastIndexOf(".") + 1);
+			FhirTerser terser = theFhirContext.newTerser();
+			List<IBase> parents = terser.getValues(theResource, parentPath);
+			for (IBase parent : parents) {
+				clearField(theFhirContext, fieldName, parent);
+			}
+		} else {
+			clearField(theFhirContext, theResource, theFhirPath);
+		}
 	}
-
 
 	/**
 	 * Clears the specified field on the element provided
@@ -381,7 +395,7 @@ public final class TerserUtil {
 	 * @param theValues      The values to set on the resource child field name
 	 */
 	public static void setField(
-			FhirContext theFhirContext, String theFieldName, IBaseResource theResource, IBase... theValues) {
+		FhirContext theFhirContext, String theFieldName, IBaseResource theResource, IBase... theValues) {
 		setField(theFhirContext, theFhirContext.newTerser(), theFieldName, theResource, theValues);
 	}
 
@@ -397,13 +411,13 @@ public final class TerserUtil {
 	 * @param theValues      The values to set on the resource child field name
 	 */
 	public static void setField(
-			FhirContext theFhirContext,
-			FhirTerser theTerser,
-			String theFieldName,
-			IBaseResource theResource,
-			IBase... theValues) {
+		FhirContext theFhirContext,
+		FhirTerser theTerser,
+		String theFieldName,
+		IBaseResource theResource,
+		IBase... theValues) {
 		BaseRuntimeChildDefinition childDefinition =
-				getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
+			getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
 		List<IBase> theFromFieldValues = childDefinition.getAccessor().getValues(theResource);
 		if (theFromFieldValues.isEmpty()) {
 			for (IBase value : theValues) {
@@ -411,9 +425,9 @@ public final class TerserUtil {
 					childDefinition.getMutator().addValue(theResource, value);
 				} catch (UnsupportedOperationException e) {
 					ourLog.warn(
-							"Resource {} does not support multiple values, but an attempt to set {} was made. Setting the first item only",
-							theResource,
-							theValues);
+						"Resource {} does not support multiple values, but an attempt to set {} was made. Setting the first item only",
+						theResource,
+						theValues);
 					childDefinition.getMutator().setValue(theResource, value);
 					break;
 				}
@@ -433,7 +447,7 @@ public final class TerserUtil {
 	 * @param theValue    The value to set
 	 */
 	public static void setFieldByFhirPath(
-			FhirTerser theTerser, String theFhirPath, IBaseResource theResource, IBase theValue) {
+		FhirTerser theTerser, String theFhirPath, IBaseResource theResource, IBase theValue) {
 		List<IBase> theFromFieldValues = theTerser.getValues(theResource, theFhirPath, true, false);
 		for (IBase theFromFieldValue : theFromFieldValues) {
 			theTerser.cloneInto(theValue, theFromFieldValue, true);
@@ -449,7 +463,7 @@ public final class TerserUtil {
 	 * @param theValue       The value to set
 	 */
 	public static void setFieldByFhirPath(
-			FhirContext theFhirContext, String theFhirPath, IBaseResource theResource, IBase theValue) {
+		FhirContext theFhirContext, String theFhirPath, IBaseResource theResource, IBase theValue) {
 		setFieldByFhirPath(theFhirContext.newTerser(), theFhirPath, theResource, theValue);
 	}
 
@@ -482,10 +496,10 @@ public final class TerserUtil {
 	}
 
 	private static void replaceField(
-			FhirTerser theTerser,
-			IBaseResource theFrom,
-			IBaseResource theTo,
-			BaseRuntimeChildDefinition childDefinition) {
+		FhirTerser theTerser,
+		IBaseResource theFrom,
+		IBaseResource theTo,
+		BaseRuntimeChildDefinition childDefinition) {
 		List<IBase> fromValues = childDefinition.getAccessor().getValues(theFrom);
 		List<IBase> toValues = childDefinition.getAccessor().getValues(theTo);
 
@@ -508,7 +522,7 @@ public final class TerserUtil {
 	 * @param theTo          Resource to merge the specified field into
 	 */
 	public static void mergeFieldsExceptIdAndMeta(
-			FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo) {
+		FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo) {
 		mergeFields(theFhirContext, theFrom, theTo, EXCLUDE_IDS_AND_META);
 	}
 
@@ -522,10 +536,10 @@ public final class TerserUtil {
 	 * @param inclusionStrategy Predicate to test which fields should be merged
 	 */
 	public static void mergeFields(
-			FhirContext theFhirContext,
-			IBaseResource theFrom,
-			IBaseResource theTo,
-			Predicate<String> inclusionStrategy) {
+		FhirContext theFhirContext,
+		IBaseResource theFrom,
+		IBaseResource theTo,
+		Predicate<String> inclusionStrategy) {
 		FhirTerser terser = theFhirContext.newTerser();
 
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
@@ -551,7 +565,7 @@ public final class TerserUtil {
 	 * @param theTo          Resource to merge the specified field into
 	 */
 	public static void mergeField(
-			FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
+		FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
 		mergeField(theFhirContext, theFhirContext.newTerser(), theFieldName, theFrom, theTo);
 	}
 
@@ -566,13 +580,13 @@ public final class TerserUtil {
 	 * @param theTo          Resource to merge the specified field into
 	 */
 	public static void mergeField(
-			FhirContext theFhirContext,
-			FhirTerser theTerser,
-			String theFieldName,
-			IBaseResource theFrom,
-			IBaseResource theTo) {
+		FhirContext theFhirContext,
+		FhirTerser theTerser,
+		String theFieldName,
+		IBaseResource theFrom,
+		IBaseResource theTo) {
 		BaseRuntimeChildDefinition childDefinition =
-				getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theFrom);
+			getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theFrom);
 
 		List<IBase> theFromFieldValues = childDefinition.getAccessor().getValues(theFrom);
 		List<IBase> theToFieldValues = childDefinition.getAccessor().getValues(theTo);
@@ -581,7 +595,7 @@ public final class TerserUtil {
 	}
 
 	private static BaseRuntimeChildDefinition getBaseRuntimeChildDefinition(
-			FhirContext theFhirContext, String theFieldName, IBaseResource theFrom) {
+		FhirContext theFhirContext, String theFieldName, IBaseResource theFrom) {
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
 		BaseRuntimeChildDefinition childDefinition = definition.getChildByName(theFieldName);
 		Validate.notNull(childDefinition);
@@ -599,14 +613,14 @@ public final class TerserUtil {
 	 * @return Returns the new element with the given value if configured
 	 */
 	private static IBase newElement(
-			FhirTerser theFhirTerser,
-			BaseRuntimeChildDefinition theChildDefinition,
-			IBase theFromFieldValue,
-			Object theConstructorParam) {
+		FhirTerser theFhirTerser,
+		BaseRuntimeChildDefinition theChildDefinition,
+		IBase theFromFieldValue,
+		Object theConstructorParam) {
 		BaseRuntimeElementDefinition runtimeElementDefinition;
 		if (theChildDefinition instanceof RuntimeChildChoiceDefinition) {
 			runtimeElementDefinition =
-					theChildDefinition.getChildElementDefinitionByDatatype(theFromFieldValue.getClass());
+				theChildDefinition.getChildElementDefinitionByDatatype(theFromFieldValue.getClass());
 		} else {
 			runtimeElementDefinition = theChildDefinition.getChildByName(theChildDefinition.getElementName());
 		}
@@ -621,11 +635,11 @@ public final class TerserUtil {
 	}
 
 	private static void mergeFields(
-			FhirTerser theTerser,
-			IBaseResource theTo,
-			BaseRuntimeChildDefinition childDefinition,
-			List<IBase> theFromFieldValues,
-			List<IBase> theToFieldValues) {
+		FhirTerser theTerser,
+		IBaseResource theTo,
+		BaseRuntimeChildDefinition childDefinition,
+		List<IBase> theFromFieldValues,
+		List<IBase> theToFieldValues) {
 		for (IBase theFromFieldValue : theFromFieldValues) {
 			if (contains(theFromFieldValue, theToFieldValues)) {
 				continue;
@@ -636,11 +650,11 @@ public final class TerserUtil {
 				try {
 					Method copyMethod = getMethod(theFromFieldValue, "copy");
 					if (copyMethod != null) {
-						newFieldValue = (IBase) copyMethod.invoke(theFromFieldValue, new Object[] {});
+						newFieldValue = (IBase) copyMethod.invoke(theFromFieldValue, new Object[]{});
 					}
 				} catch (Throwable t) {
 					((IPrimitiveType) newFieldValue)
-							.setValueAsString(((IPrimitiveType) theFromFieldValue).getValueAsString());
+						.setValueAsString(((IPrimitiveType) theFromFieldValue).getValueAsString());
 				}
 			} else {
 				theTerser.cloneInto(theFromFieldValue, newFieldValue, true);
@@ -695,7 +709,7 @@ public final class TerserUtil {
 	 * @return Returns a new instance of the element with the specified initial value
 	 */
 	public static <T extends IBase> T newElement(
-			FhirContext theFhirContext, String theElementType, Object theConstructorParam) {
+		FhirContext theFhirContext, String theElementType, Object theConstructorParam) {
 		BaseRuntimeElementDefinition def = theFhirContext.getElementDefinition(theElementType);
 		Validate.notNull(def);
 		return (T) def.newInstance(theConstructorParam);
@@ -724,7 +738,7 @@ public final class TerserUtil {
 	 * @return Returns a new instance of the resource
 	 */
 	public static <T extends IBase> T newResource(
-			FhirContext theFhirContext, String theResourceName, Object theConstructorParam) {
+		FhirContext theFhirContext, String theResourceName, Object theConstructorParam) {
 		RuntimeResourceDefinition def = theFhirContext.getResourceDefinition(theResourceName);
 		return (T) def.newInstance(theConstructorParam);
 	}
@@ -738,12 +752,12 @@ public final class TerserUtil {
 	 * @return Returns a new instance of the element
 	 */
 	public static IBaseBackboneElement instantiateBackboneElement(
-			FhirContext theFhirContext, String theTargetResourceName, String theTargetFieldName) {
+		FhirContext theFhirContext, String theTargetResourceName, String theTargetFieldName) {
 		BaseRuntimeElementDefinition<?> targetParentElementDefinition =
-				theFhirContext.getResourceDefinition(theTargetResourceName);
+			theFhirContext.getResourceDefinition(theTargetResourceName);
 		BaseRuntimeChildDefinition childDefinition = targetParentElementDefinition.getChildByName(theTargetFieldName);
 		return (IBaseBackboneElement)
-				childDefinition.getChildByName(theTargetFieldName).newInstance();
+			childDefinition.getChildByName(theTargetFieldName).newInstance();
 	}
 
 	private static void clear(List<IBase> values) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -385,7 +385,15 @@ public final class TerserUtil {
 		BaseRuntimeElementDefinition definition = theFhirContext.getElementDefinition(theBase.getClass());
 		BaseRuntimeChildDefinition childDefinition = definition.getChildByName(theFieldName);
 		Validate.notNull(childDefinition);
-		clear(childDefinition.getAccessor().getValues(theBase));
+		BaseRuntimeChildDefinition.IAccessor accessor = childDefinition.getAccessor();
+		clear(accessor.getValues(theBase));
+		List<IBase> newValue = accessor.getValues(theBase);
+
+		if (newValue != null && !newValue.isEmpty()) {
+			// Our clear failed, probably because it was an immutable SingletonList returned by a FieldPlainAccessor that cannot be cleared.
+			// Let's just null it out instead.
+			childDefinition.getMutator().setValue(theBase, null);
+		}
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -351,6 +351,11 @@ public final class TerserUtil {
 		clear(childDefinition.getAccessor().getValues(theResource));
 	}
 
+
+	public static void clearFieldByFhirPath(FhirContext theFhirContext, IBaseResource theResource, String theFhirPath) {
+	}
+
+
 	/**
 	 * Clears the specified field on the element provided
 	 *

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -26,7 +26,6 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeChildChoiceDefinition;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
-import ca.uhn.fhir.model.api.annotation.Child;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -36,7 +35,6 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.slf4j.Logger;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -54,7 +52,7 @@ public final class TerserUtil {
 	 * Exclude for id, identifier and meta fields of a resource.
 	 */
 	public static final Collection<String> IDS_AND_META_EXCLUDES =
-		Collections.unmodifiableSet(Stream.of("id", "identifier", "meta").collect(Collectors.toSet()));
+			Collections.unmodifiableSet(Stream.of("id", "identifier", "meta").collect(Collectors.toSet()));
 	/**
 	 * Exclusion predicate for id, identifier, meta fields.
 	 */
@@ -69,20 +67,20 @@ public final class TerserUtil {
 	 * empty source fields will not results in erasure of target fields.
 	 */
 	public static final Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> EXCLUDE_IDS_META_AND_EMPTY =
-		new Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>>() {
-			@Override
-			public boolean test(Triple<BaseRuntimeChildDefinition, IBase, IBase> theTriple) {
-				if (!EXCLUDE_IDS_AND_META.test(theTriple.getLeft().getElementName())) {
-					return false;
+			new Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>>() {
+				@Override
+				public boolean test(Triple<BaseRuntimeChildDefinition, IBase, IBase> theTriple) {
+					if (!EXCLUDE_IDS_AND_META.test(theTriple.getLeft().getElementName())) {
+						return false;
+					}
+					BaseRuntimeChildDefinition childDefinition = theTriple.getLeft();
+					boolean isSourceFieldEmpty = childDefinition
+							.getAccessor()
+							.getValues(theTriple.getMiddle())
+							.isEmpty();
+					return !isSourceFieldEmpty;
 				}
-				BaseRuntimeChildDefinition childDefinition = theTriple.getLeft();
-				boolean isSourceFieldEmpty = childDefinition
-					.getAccessor()
-					.getValues(theTriple.getMiddle())
-					.isEmpty();
-				return !isSourceFieldEmpty;
-			}
-		};
+			};
 	/**
 	 * Exclusion predicate for keeping all fields.
 	 */
@@ -96,20 +94,19 @@ public final class TerserUtil {
 	private static final Logger ourLog = getLogger(TerserUtil.class);
 	private static final String EQUALS_DEEP = "equalsDeep";
 
-	private TerserUtil() {
-	}
+	private TerserUtil() {}
 
 	/**
 	 * Given an Child Definition of `identifier`, a R4/DSTU3 EID Identifier, and a new resource, clone the EID into that resources' identifier list.
 	 */
 	public static void cloneEidIntoResource(
-		FhirContext theFhirContext,
-		BaseRuntimeChildDefinition theIdentifierDefinition,
-		IBase theEid,
-		IBase theResourceToCloneEidInto) {
+			FhirContext theFhirContext,
+			BaseRuntimeChildDefinition theIdentifierDefinition,
+			IBase theEid,
+			IBase theResourceToCloneEidInto) {
 		// FHIR choice types - fields within fhir where we have a choice of ids
 		BaseRuntimeElementCompositeDefinition<?> childIdentifier = (BaseRuntimeElementCompositeDefinition<?>)
-			theIdentifierDefinition.getChildByName(FIELD_NAME_IDENTIFIER);
+				theIdentifierDefinition.getChildByName(FIELD_NAME_IDENTIFIER);
 		IBase resourceNewIdentifier = childIdentifier.newInstance();
 
 		FhirTerser terser = theFhirContext.newTerser();
@@ -178,7 +175,7 @@ public final class TerserUtil {
 	 * @param theField Field name to be copied
 	 */
 	public static void cloneCompositeField(
-		FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo, String theField) {
+			FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo, String theField) {
 		FhirTerser terser = theFhirContext.newTerser();
 
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
@@ -245,7 +242,7 @@ public final class TerserUtil {
 				return (Boolean) theMethod.invoke(theItem1, theItem2);
 			} catch (Exception e) {
 				throw new RuntimeException(
-					Msg.code(1746) + String.format("Unable to compare equality via %s", EQUALS_DEEP), e);
+						Msg.code(1746) + String.format("Unable to compare equality via %s", EQUALS_DEEP), e);
 			}
 		}
 		return theItem1.equals(theItem2);
@@ -278,12 +275,12 @@ public final class TerserUtil {
 	 * @param theFieldNameInclusion Inclusion strategy that checks if a given field should be replaced
 	 */
 	public static void replaceFields(
-		FhirContext theFhirContext,
-		IBaseResource theFrom,
-		IBaseResource theTo,
-		Predicate<String> theFieldNameInclusion) {
+			FhirContext theFhirContext,
+			IBaseResource theFrom,
+			IBaseResource theTo,
+			Predicate<String> theFieldNameInclusion) {
 		Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> predicate =
-			(t) -> theFieldNameInclusion.test(t.getLeft().getElementName());
+				(t) -> theFieldNameInclusion.test(t.getLeft().getElementName());
 		replaceFieldsByPredicate(theFhirContext, theFrom, theTo, predicate);
 	}
 
@@ -297,10 +294,10 @@ public final class TerserUtil {
 	 * @param thePredicate   Predicate that checks if a given field should be replaced
 	 */
 	public static void replaceFieldsByPredicate(
-		FhirContext theFhirContext,
-		IBaseResource theFrom,
-		IBaseResource theTo,
-		Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> thePredicate) {
+			FhirContext theFhirContext,
+			IBaseResource theFrom,
+			IBaseResource theTo,
+			Predicate<Triple<BaseRuntimeChildDefinition, IBase, IBase>> thePredicate) {
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
 		FhirTerser terser = theFhirContext.newTerser();
 		for (BaseRuntimeChildDefinition childDefinition : definition.getChildrenAndExtension()) {
@@ -331,14 +328,14 @@ public final class TerserUtil {
 	 * @param theTo          The resource to replace the field on
 	 */
 	public static void replaceField(
-		FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
+			FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
 		Validate.notNull(definition);
 		replaceField(
-			theFhirContext.newTerser(),
-			theFrom,
-			theTo,
-			theFhirContext.getResourceDefinition(theFrom).getChildByName(theFieldName));
+				theFhirContext.newTerser(),
+				theFrom,
+				theTo,
+				theFhirContext.getResourceDefinition(theFrom).getChildByName(theFieldName));
 	}
 
 	/**
@@ -350,12 +347,11 @@ public final class TerserUtil {
 	 */
 	public static void clearField(FhirContext theFhirContext, IBaseResource theResource, String theFieldName) {
 		BaseRuntimeChildDefinition childDefinition =
-			getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
+				getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
 		clear(childDefinition.getAccessor().getValues(theResource));
 	}
 
-	public static void clearFieldByFhirPath(
-		FhirContext theFhirContext, IBaseResource theResource, String theFhirPath) {
+	public static void clearFieldByFhirPath(FhirContext theFhirContext, IBaseResource theResource, String theFhirPath) {
 
 		if (theFhirPath.contains(".")) {
 			String parentPath = theFhirPath.substring(0, theFhirPath.lastIndexOf("."));
@@ -395,7 +391,7 @@ public final class TerserUtil {
 	 * @param theValues      The values to set on the resource child field name
 	 */
 	public static void setField(
-		FhirContext theFhirContext, String theFieldName, IBaseResource theResource, IBase... theValues) {
+			FhirContext theFhirContext, String theFieldName, IBaseResource theResource, IBase... theValues) {
 		setField(theFhirContext, theFhirContext.newTerser(), theFieldName, theResource, theValues);
 	}
 
@@ -411,13 +407,13 @@ public final class TerserUtil {
 	 * @param theValues      The values to set on the resource child field name
 	 */
 	public static void setField(
-		FhirContext theFhirContext,
-		FhirTerser theTerser,
-		String theFieldName,
-		IBaseResource theResource,
-		IBase... theValues) {
+			FhirContext theFhirContext,
+			FhirTerser theTerser,
+			String theFieldName,
+			IBaseResource theResource,
+			IBase... theValues) {
 		BaseRuntimeChildDefinition childDefinition =
-			getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
+				getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theResource);
 		List<IBase> theFromFieldValues = childDefinition.getAccessor().getValues(theResource);
 		if (theFromFieldValues.isEmpty()) {
 			for (IBase value : theValues) {
@@ -425,9 +421,9 @@ public final class TerserUtil {
 					childDefinition.getMutator().addValue(theResource, value);
 				} catch (UnsupportedOperationException e) {
 					ourLog.warn(
-						"Resource {} does not support multiple values, but an attempt to set {} was made. Setting the first item only",
-						theResource,
-						theValues);
+							"Resource {} does not support multiple values, but an attempt to set {} was made. Setting the first item only",
+							theResource,
+							theValues);
 					childDefinition.getMutator().setValue(theResource, value);
 					break;
 				}
@@ -447,7 +443,7 @@ public final class TerserUtil {
 	 * @param theValue    The value to set
 	 */
 	public static void setFieldByFhirPath(
-		FhirTerser theTerser, String theFhirPath, IBaseResource theResource, IBase theValue) {
+			FhirTerser theTerser, String theFhirPath, IBaseResource theResource, IBase theValue) {
 		List<IBase> theFromFieldValues = theTerser.getValues(theResource, theFhirPath, true, false);
 		for (IBase theFromFieldValue : theFromFieldValues) {
 			theTerser.cloneInto(theValue, theFromFieldValue, true);
@@ -463,7 +459,7 @@ public final class TerserUtil {
 	 * @param theValue       The value to set
 	 */
 	public static void setFieldByFhirPath(
-		FhirContext theFhirContext, String theFhirPath, IBaseResource theResource, IBase theValue) {
+			FhirContext theFhirContext, String theFhirPath, IBaseResource theResource, IBase theValue) {
 		setFieldByFhirPath(theFhirContext.newTerser(), theFhirPath, theResource, theValue);
 	}
 
@@ -496,10 +492,10 @@ public final class TerserUtil {
 	}
 
 	private static void replaceField(
-		FhirTerser theTerser,
-		IBaseResource theFrom,
-		IBaseResource theTo,
-		BaseRuntimeChildDefinition childDefinition) {
+			FhirTerser theTerser,
+			IBaseResource theFrom,
+			IBaseResource theTo,
+			BaseRuntimeChildDefinition childDefinition) {
 		List<IBase> fromValues = childDefinition.getAccessor().getValues(theFrom);
 		List<IBase> toValues = childDefinition.getAccessor().getValues(theTo);
 
@@ -522,7 +518,7 @@ public final class TerserUtil {
 	 * @param theTo          Resource to merge the specified field into
 	 */
 	public static void mergeFieldsExceptIdAndMeta(
-		FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo) {
+			FhirContext theFhirContext, IBaseResource theFrom, IBaseResource theTo) {
 		mergeFields(theFhirContext, theFrom, theTo, EXCLUDE_IDS_AND_META);
 	}
 
@@ -536,10 +532,10 @@ public final class TerserUtil {
 	 * @param inclusionStrategy Predicate to test which fields should be merged
 	 */
 	public static void mergeFields(
-		FhirContext theFhirContext,
-		IBaseResource theFrom,
-		IBaseResource theTo,
-		Predicate<String> inclusionStrategy) {
+			FhirContext theFhirContext,
+			IBaseResource theFrom,
+			IBaseResource theTo,
+			Predicate<String> inclusionStrategy) {
 		FhirTerser terser = theFhirContext.newTerser();
 
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
@@ -565,7 +561,7 @@ public final class TerserUtil {
 	 * @param theTo          Resource to merge the specified field into
 	 */
 	public static void mergeField(
-		FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
+			FhirContext theFhirContext, String theFieldName, IBaseResource theFrom, IBaseResource theTo) {
 		mergeField(theFhirContext, theFhirContext.newTerser(), theFieldName, theFrom, theTo);
 	}
 
@@ -580,13 +576,13 @@ public final class TerserUtil {
 	 * @param theTo          Resource to merge the specified field into
 	 */
 	public static void mergeField(
-		FhirContext theFhirContext,
-		FhirTerser theTerser,
-		String theFieldName,
-		IBaseResource theFrom,
-		IBaseResource theTo) {
+			FhirContext theFhirContext,
+			FhirTerser theTerser,
+			String theFieldName,
+			IBaseResource theFrom,
+			IBaseResource theTo) {
 		BaseRuntimeChildDefinition childDefinition =
-			getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theFrom);
+				getBaseRuntimeChildDefinition(theFhirContext, theFieldName, theFrom);
 
 		List<IBase> theFromFieldValues = childDefinition.getAccessor().getValues(theFrom);
 		List<IBase> theToFieldValues = childDefinition.getAccessor().getValues(theTo);
@@ -595,7 +591,7 @@ public final class TerserUtil {
 	}
 
 	private static BaseRuntimeChildDefinition getBaseRuntimeChildDefinition(
-		FhirContext theFhirContext, String theFieldName, IBaseResource theFrom) {
+			FhirContext theFhirContext, String theFieldName, IBaseResource theFrom) {
 		RuntimeResourceDefinition definition = theFhirContext.getResourceDefinition(theFrom);
 		BaseRuntimeChildDefinition childDefinition = definition.getChildByName(theFieldName);
 		Validate.notNull(childDefinition);
@@ -613,14 +609,14 @@ public final class TerserUtil {
 	 * @return Returns the new element with the given value if configured
 	 */
 	private static IBase newElement(
-		FhirTerser theFhirTerser,
-		BaseRuntimeChildDefinition theChildDefinition,
-		IBase theFromFieldValue,
-		Object theConstructorParam) {
+			FhirTerser theFhirTerser,
+			BaseRuntimeChildDefinition theChildDefinition,
+			IBase theFromFieldValue,
+			Object theConstructorParam) {
 		BaseRuntimeElementDefinition runtimeElementDefinition;
 		if (theChildDefinition instanceof RuntimeChildChoiceDefinition) {
 			runtimeElementDefinition =
-				theChildDefinition.getChildElementDefinitionByDatatype(theFromFieldValue.getClass());
+					theChildDefinition.getChildElementDefinitionByDatatype(theFromFieldValue.getClass());
 		} else {
 			runtimeElementDefinition = theChildDefinition.getChildByName(theChildDefinition.getElementName());
 		}
@@ -635,11 +631,11 @@ public final class TerserUtil {
 	}
 
 	private static void mergeFields(
-		FhirTerser theTerser,
-		IBaseResource theTo,
-		BaseRuntimeChildDefinition childDefinition,
-		List<IBase> theFromFieldValues,
-		List<IBase> theToFieldValues) {
+			FhirTerser theTerser,
+			IBaseResource theTo,
+			BaseRuntimeChildDefinition childDefinition,
+			List<IBase> theFromFieldValues,
+			List<IBase> theToFieldValues) {
 		for (IBase theFromFieldValue : theFromFieldValues) {
 			if (contains(theFromFieldValue, theToFieldValues)) {
 				continue;
@@ -650,11 +646,11 @@ public final class TerserUtil {
 				try {
 					Method copyMethod = getMethod(theFromFieldValue, "copy");
 					if (copyMethod != null) {
-						newFieldValue = (IBase) copyMethod.invoke(theFromFieldValue, new Object[]{});
+						newFieldValue = (IBase) copyMethod.invoke(theFromFieldValue, new Object[] {});
 					}
 				} catch (Throwable t) {
 					((IPrimitiveType) newFieldValue)
-						.setValueAsString(((IPrimitiveType) theFromFieldValue).getValueAsString());
+							.setValueAsString(((IPrimitiveType) theFromFieldValue).getValueAsString());
 				}
 			} else {
 				theTerser.cloneInto(theFromFieldValue, newFieldValue, true);
@@ -709,7 +705,7 @@ public final class TerserUtil {
 	 * @return Returns a new instance of the element with the specified initial value
 	 */
 	public static <T extends IBase> T newElement(
-		FhirContext theFhirContext, String theElementType, Object theConstructorParam) {
+			FhirContext theFhirContext, String theElementType, Object theConstructorParam) {
 		BaseRuntimeElementDefinition def = theFhirContext.getElementDefinition(theElementType);
 		Validate.notNull(def);
 		return (T) def.newInstance(theConstructorParam);
@@ -738,7 +734,7 @@ public final class TerserUtil {
 	 * @return Returns a new instance of the resource
 	 */
 	public static <T extends IBase> T newResource(
-		FhirContext theFhirContext, String theResourceName, Object theConstructorParam) {
+			FhirContext theFhirContext, String theResourceName, Object theConstructorParam) {
 		RuntimeResourceDefinition def = theFhirContext.getResourceDefinition(theResourceName);
 		return (T) def.newInstance(theConstructorParam);
 	}
@@ -752,12 +748,12 @@ public final class TerserUtil {
 	 * @return Returns a new instance of the element
 	 */
 	public static IBaseBackboneElement instantiateBackboneElement(
-		FhirContext theFhirContext, String theTargetResourceName, String theTargetFieldName) {
+			FhirContext theFhirContext, String theTargetResourceName, String theTargetFieldName) {
 		BaseRuntimeElementDefinition<?> targetParentElementDefinition =
-			theFhirContext.getResourceDefinition(theTargetResourceName);
+				theFhirContext.getResourceDefinition(theTargetResourceName);
 		BaseRuntimeChildDefinition childDefinition = targetParentElementDefinition.getChildByName(theTargetFieldName);
 		return (IBaseBackboneElement)
-			childDefinition.getChildByName(theTargetFieldName).newInstance();
+				childDefinition.getChildByName(theTargetFieldName).newInstance();
 	}
 
 	private static void clear(List<IBase> values) {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5401-terserutil-clear.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5401-terserutil-clear.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 5401
+title: "Previously, it was only possible to clear a top-level field on a resource using TerserUtil.  A new method has been added
+to TerserUtil to support clearing a value by FhirPath."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
@@ -31,88 +31,88 @@ class TerserUtilTest {
 
 	private FhirContext ourFhirContext = FhirContext.forR4();
 	private static final String SAMPLE_PERSON =
-		"""
-			{
-			      "resourceType": "Patient",
-			      "extension": [
-			        {
-			          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
-			          "valueCoding": {
-			            "system": "MyInternalRace",
-			            "code": "X",
-			            "display": "Eks"
+		 """
+			  {
+			        "resourceType": "Patient",
+			        "extension": [
+			          {
+			            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+			            "valueCoding": {
+			              "system": "MyInternalRace",
+			              "code": "X",
+			              "display": "Eks"
+			            }
+			          },
+			          {
+			            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'",
+			            "valueCoding": {
+			              "system": "MyInternalEthnicity",
+			              "display": "NNN"
+			            }
 			          }
-			        },
-			        {
-			          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'",
-			          "valueCoding": {
-			            "system": "MyInternalEthnicity",
-			            "display": "NNN"
+			        ],
+			        "identifier": [
+			          {
+			            "system": "http://example.org/member_id",
+			            "value": "123123"
+			          },
+			          {
+			            "system": "http://example.org/medicaid_id",
+			            "value": "12312323123Z"
+			          },
+			          {
+			            "system": "http://example.org/CDNS_id",
+			            "value": "123123123E"
+			          },
+			          {
+			            "system": "http://example.org/SSN"
 			          }
-			        }
-			      ],
-			      "identifier": [
-			        {
-			          "system": "http://example.org/member_id",
-			          "value": "123123"
-			        },
-			        {
-			          "system": "http://example.org/medicaid_id",
-			          "value": "12312323123Z"
-			        },
-			        {
-			          "system": "http://example.org/CDNS_id",
-			          "value": "123123123E"
-			        },
-			        {
-			          "system": "http://example.org/SSN"
-			        }
-			      ],
-			      "active": true,
-			      "name": [
-			        {
-			          "family": "TestFamily",
-			          "given": [
-			            "Given"
-			          ]
-			        }
-			      ],
-			      "telecom": [
-			        {
-			          "system": "email",
-			          "value": "email@email.io"
-			        },
-			        {
-			          "system": "phone",
-			          "value": "123123231"
-			        },
-			        {
-			          "system": "phone",
-			          "value": "1231232312"
-			        },
-			        {
-			          "system": "phone",
-			          "value": "1231232314"
-			        }
-			      ],
-			      "gender": "male",
-			      "birthDate": "1900-01-01",
-			      "deceasedBoolean": true,
-			       "contained": [
-			              {
-			                  "id": "1",
-			                  "identifier": [
-			                      {
-			                          "system": "urn:hssc:srhs:contact:organizationId",
-			                          "value": "1000"
-			                      }
-			                  ],
-			                  "name": "BUILDERS FIRST SOURCE",
-			                  "resourceType": "Organization"
-			              }
-			          ]
-			    }
-				""";
+			        ],
+			        "active": true,
+			        "name": [
+			          {
+			            "family": "TestFamily",
+			            "given": [
+			              "Given"
+			            ]
+			          }
+			        ],
+			        "telecom": [
+			          {
+			            "system": "email",
+			            "value": "email@email.io"
+			          },
+			          {
+			            "system": "phone",
+			            "value": "123123231"
+			          },
+			          {
+			            "system": "phone",
+			            "value": "1231232312"
+			          },
+			          {
+			            "system": "phone",
+			            "value": "1231232314"
+			          }
+			        ],
+			        "gender": "male",
+			        "birthDate": "1900-01-01",
+			        "deceasedBoolean": true,
+			         "contained": [
+			                {
+			                    "id": "1",
+			                    "identifier": [
+			                        {
+			                            "system": "urn:hssc:srhs:contact:organizationId",
+			                            "value": "1000"
+			                        }
+			                    ],
+			                    "name": "BUILDERS FIRST SOURCE",
+			                    "resourceType": "Organization"
+			                }
+			            ]
+			      }
+			  	""";
 
 	@Test
 	void testCloneEidIntoResource() {
@@ -181,7 +181,7 @@ class TerserUtilTest {
 		RuntimeResourceDefinition definition = p1Helper.getResourceDefinition();
 
 		TerserUtil.cloneEidIntoResource(ourFhirContext, definition.getChildByName("identifier"),
-			p1.getIdentifier().get(0), p2Helper.getResource());
+			 p1.getIdentifier().get(0), p2Helper.getResource());
 
 		assertEquals(1, p2Helper.getFieldValues("identifier").size());
 
@@ -292,12 +292,12 @@ class TerserUtilTest {
 
 		Patient p1 = new Patient();
 		p1.addAddress()
-			.addLine("10 Main Street")
-			.setCity("Hamilton")
-			.setState("ON")
-			.setPostalCode("Z0Z0Z0")
-			.setCountry("Canada")
-			.addExtension(ext);
+			 .addLine("10 Main Street")
+			 .setCity("Hamilton")
+			 .setState("ON")
+			 .setPostalCode("Z0Z0Z0")
+			 .setCountry("Canada")
+			 .addExtension(ext);
 
 		Patient p2 = new Patient();
 		p2.addAddress().addLine("10 Lenin Street").setCity("Severodvinsk").setCountry("Russia");
@@ -329,12 +329,12 @@ class TerserUtilTest {
 
 		Patient p1 = new Patient();
 		p1.addAddress()
-			.addLine("10 Main Street")
-			.setCity("Hamilton")
-			.setState("ON")
-			.setPostalCode("Z0Z0Z0")
-			.setCountry("Canada")
-			.addExtension(ext);
+			 .addLine("10 Main Street")
+			 .setCity("Hamilton")
+			 .setState("ON")
+			 .setPostalCode("Z0Z0Z0")
+			 .setCountry("Canada")
+			 .addExtension(ext);
 
 		Patient p2 = new Patient();
 		p2.addAddress().addLine("10 Lenin Street").setCity("Severodvinsk").setCountry("Russia");
@@ -354,21 +354,21 @@ class TerserUtilTest {
 
 		Patient p1 = new Patient();
 		p1.addAddress()
-			.addLine("10 Main Street")
-			.setCity("Hamilton")
-			.setState("ON")
-			.setPostalCode("Z0Z0Z0")
-			.setCountry("Canada")
-			.addExtension(ext);
+			 .addLine("10 Main Street")
+			 .setCity("Hamilton")
+			 .setState("ON")
+			 .setPostalCode("Z0Z0Z0")
+			 .setCountry("Canada")
+			 .addExtension(ext);
 
 		Patient p2 = new Patient();
 		p2.addAddress()
-			.addLine("10 Main Street")
-			.setCity("Hamilton")
-			.setState("ON")
-			.setPostalCode("Z0Z0Z1")
-			.setCountry("Canada")
-			.addExtension(ext);
+			 .addLine("10 Main Street")
+			 .setCity("Hamilton")
+			 .setState("ON")
+			 .setPostalCode("Z0Z0Z1")
+			 .setCountry("Canada")
+			 .addExtension(ext);
 
 		TerserUtil.mergeField(ourFhirContext, "address", p1, p2);
 
@@ -470,7 +470,8 @@ class TerserUtilTest {
 		assertEquals(1, p2.getName().size());
 		assertEquals("Doe", p2.getName().get(0).getFamily());
 	}
-		@Test
+
+	@Test
 	public void testReplaceFieldByEmptyValue() {
 		Patient p1 = new Patient();
 		Patient p2 = new Patient();
@@ -530,24 +531,34 @@ class TerserUtilTest {
 
 	@Test
 	public void testClearFieldByFhirPath() {
-			Patient p1 = new Patient();
-			p1.addName().setFamily("Doe");
-			assertEquals(1, p1.getName().size());
+		Patient p1 = new Patient();
+		p1.addName().setFamily("Doe");
+		assertEquals(1, p1.getName().size());
 
-			TerserUtil.clearFieldByFhirPath(ourFhirContext, p1, "name");
+		TerserUtil.clearFieldByFhirPath(ourFhirContext, p1, "name");
 
-			assertEquals(0, p1.getName().size());
+		assertEquals(0, p1.getName().size());
 
-			Address a1 = new Address();
-			a1.addLine("Line 1");
-			a1.addLine("Line 2");
-			assertEquals(2, a1.getLine().size());
-			a1.setCity("Test");
-			p1.addAddress(a1);
-			TerserUtil.clearFieldByFhirPath(ourFhirContext, p1,"address.line");
+		Address a1 = new Address();
+		a1.addLine("Line 1");
+		a1.addLine("Line 2");
+		assertEquals(2, a1.getLine().size());
+		a1.setCity("Test");
+		p1.addAddress(a1);
 
-			assertEquals(0, p1.getAddressFirstRep().getLine().size());
-			assertEquals("Test", p1.getAddressFirstRep().getCity());
+		Address a2 = new Address();
+		a2.addLine("Line 1");
+		a2.addLine("Line 2");
+		a2.setCity("Test");
+		p1.addAddress(a2);
+
+		TerserUtil.clearFieldByFhirPath(ourFhirContext, p1, "address.line");
+
+		assertEquals(2, p1.getAddress().size());
+		assertEquals(0, p1.getAddress().get(0).getLine().size());
+		assertEquals(0, p1.getAddress().get(1).getLine().size());
+		assertEquals("Test", p1.getAddress().get(0).getCity());
+		assertEquals("Test", p1.getAddress().get(1).getCity());
 	}
 
 	@Test

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
@@ -13,6 +13,7 @@ import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.PrimitiveType;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
@@ -570,6 +571,16 @@ class TerserUtilTest {
 		address.setCity("CITY");
 
 		TerserUtil.setFieldByFhirPath(ourFhirContext, "address", p1, address);
+
+		assertEquals(1, p1.getAddress().size());
+		assertEquals("CITY", p1.getAddress().get(0).getCity());
+	}
+
+	@Test
+	public void testSetFieldByCompositeFhirPath() {
+		Patient p1 = new Patient();
+
+		TerserUtil.setFieldByFhirPath(ourFhirContext, "address.city", p1, new StringType("CITY"));
 
 		assertEquals(1, p1.getAddress().size());
 		assertEquals("CITY", p1.getAddress().get(0).getCity());

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
@@ -544,15 +544,24 @@ class TerserUtilTest {
 		a1.addLine("Line 2");
 		assertEquals(2, a1.getLine().size());
 		a1.setCity("Test");
+		a1.getPeriod().setStartElement(new DateTimeType("2021-01-01"));
 		p1.addAddress(a1);
+
+		assertEquals("2021-01-01", p1.getAddress().get(0).getPeriod().getStartElement().toHumanDisplay());
+		assertNotNull(p1.getAddress().get(0).getPeriod().getStart());
 
 		Address a2 = new Address();
 		a2.addLine("Line 1");
 		a2.addLine("Line 2");
 		a2.setCity("Test");
+		a2.getPeriod().setStartElement(new DateTimeType("2021-01-01"));
 		p1.addAddress(a2);
 
+
 		TerserUtil.clearFieldByFhirPath(ourFhirContext, p1, "address.line");
+		TerserUtil.clearFieldByFhirPath(ourFhirContext, p1, "address.period.start");
+
+		assertNull(p1.getAddress().get(0).getPeriod().getStart());
 
 		assertEquals(2, p1.getAddress().size());
 		assertEquals(0, p1.getAddress().get(0).getLine().size());

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/TerserUtilTest.java
@@ -507,6 +507,7 @@ class TerserUtilTest {
 		{
 			Patient p1 = new Patient();
 			p1.addName().setFamily("Doe");
+			assertEquals(1, p1.getName().size());
 
 			TerserUtil.clearField(ourFhirContext, p1, "name");
 
@@ -517,12 +518,35 @@ class TerserUtilTest {
 			Address a1 = new Address();
 			a1.addLine("Line 1");
 			a1.addLine("Line 2");
+			assertEquals(2, a1.getLine().size());
 			a1.setCity("Test");
 			TerserUtil.clearField(ourFhirContext, "line", a1);
 
 			assertEquals(0, a1.getLine().size());
 			assertEquals("Test", a1.getCity());
 		}
+	}
+
+	@Test
+	public void testClearFieldByFhirPath() {
+			Patient p1 = new Patient();
+			p1.addName().setFamily("Doe");
+			assertEquals(1, p1.getName().size());
+
+			TerserUtil.clearFieldByFhirPath(ourFhirContext, p1, "name");
+
+			assertEquals(0, p1.getName().size());
+
+			Address a1 = new Address();
+			a1.addLine("Line 1");
+			a1.addLine("Line 2");
+			assertEquals(2, a1.getLine().size());
+			a1.setCity("Test");
+			p1.addAddress(a1);
+			TerserUtil.clearFieldByFhirPath(ourFhirContext, p1,"address.line");
+
+			assertEquals(0, p1.getAddressFirstRep().getLine().size());
+			assertEquals("Test", p1.getAddressFirstRep().getCity());
 	}
 
 	@Test


### PR DESCRIPTION
Previously, it was only possible to clear a top-level field on a resource using TerserUtil.  A new method has been added
to TerserUtil to support clearing a value by FhirPath.