### PR TITLE
Transaction fails if SearchNarrowingInterceptor is registered and Partitioning Enabled - fix cross-tenant requests failure

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategy.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategy.java
@@ -69,7 +69,7 @@ public class UrlBaseTenantIdentificationStrategy implements ITenantIdentificatio
 			tenantId = defaultIfBlank(theUrlPathTokenizer.peek(), null);
 
 			// If it's "metadata" or starts with "$", use DEFAULT partition and don't consume this token:
-			if (tenantId != null && (tenantId.equals("metadata") || tenantId.startsWith("$"))) {
+			if (tenantId != null && (tenantId.equals("metadata") || isOperation(tenantId))) {
 				tenantId = "DEFAULT";
 				theRequestDetails.setTenantId(tenantId);
 				ourLog.trace("No tenant ID found for metadata or system request; using DEFAULT.");
@@ -94,6 +94,10 @@ public class UrlBaseTenantIdentificationStrategy implements ITenantIdentificatio
 		}
 	}
 
+	private boolean isOperation(String theToken) {
+		return theToken.startsWith("$");
+	}
+
 	@Override
 	public String massageServerBaseUrl(String theFhirServerBase, RequestDetails theRequestDetails) {
 		String result = theFhirServerBase;
@@ -116,8 +120,8 @@ public class UrlBaseTenantIdentificationStrategy implements ITenantIdentificatio
 			return theRelativeUrl;
 		}
 
-		// token is Resource type - adding tenant ID from parent request details
-		if (isResourceType(nextToken, theRequestDetails)) {
+		// token is Resource type or operation - adding tenant ID from parent request details
+		if (isResourceType(nextToken, theRequestDetails) || isOperation(nextToken)) {
 			return theRequestDetails.getTenantId() + "/" + theRelativeUrl;
 		} else {
 			return theRelativeUrl;

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
@@ -75,21 +75,24 @@ public class UrlBaseTenantIdentificationStrategyTest {
 	}
 
 	@CsvSource(value = {
-			" , ", // empty URL - return input URL
-			"TENANT1/Patient/123, TENANT1/Patient/123", // tenant ID already exists - return input URL
-			"TENANT2/Patient/123, TENANT2/Patient/123", // requestDetails contains different tenant ID - return input URL
-			"Patient/123		, TENANT1/Patient/123", // url starts with resource type - add tenant ID to URL
-			"$export			, TENANT1/$export" // url starts with operation - add tenant ID to URL
+			"						, 							, empty input url - empty URL should be returned",
+			"TENANT1/Patient/123	, TENANT1/Patient/123		, tenant ID already exists - input URL should be returned",
+			"TENANT1/Patient/$export, TENANT1/Patient/$export	, tenant ID already exists - input URL should be returned",
+			"TENANT2/Patient/123	, TENANT2/Patient/123		, requestDetails contains different tenant ID - input URL should be returned",
+			"TENANT2/$export		, TENANT2/$export			, requestDetails contains different tenant ID - input URL should be returned",
+			"Patient/123			, TENANT1/Patient/123		, url starts with resource type - tenant ID should be added to URL",
+			"Patient/$export		, TENANT1/Patient/$export	, url starts with resource type - tenant ID should be added to URL",
+			"$export				, TENANT1/$export			, url starts with operation name - tenant ID should be added to URL",
 	})
 	@ParameterizedTest
-	void resolveRelativeUrl_urlStartsWithOperation_tenantIdIsAddedToUrl(String theInputUrl, String theExpectedResolvedUrl) {
+	void resolveRelativeUrl_returnsCorrectlyResolvedUrl(String theInputUrl, String theExpectedResolvedUrl, String theMessage) {
 		lenient().when(myRequestDetails.getTenantId()).thenReturn("TENANT1");
 		lenient().when(myFHIRContext.getResourceTypes()).thenReturn(Collections.singleton("Patient"));
 		lenient().when(myRequestDetails.getFhirContext()).thenReturn(myFHIRContext);
 
 		String actual = ourTenantStrategy.resolveRelativeUrl(theInputUrl, myRequestDetails);
 
-		assertEquals(theExpectedResolvedUrl, actual);
+		assertEquals(theExpectedResolvedUrl, actual, theMessage);
 	}
 
 	@Test

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/rest/server/tenant/UrlBaseTenantIdentificationStrategyTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,6 +69,55 @@ public class UrlBaseTenantIdentificationStrategyTest {
 
 		//then nothing should happen
 		assertEquals(BASE_URL, actual);
+	}
+
+	@Test
+	void resolveRelativeUrl_withEmptyUrl_returnEmptyString() {
+		String actual = ourTenantStrategy.resolveRelativeUrl("", myRequestDetails);
+
+		assertEquals("", actual);
+	}
+
+	@Test
+	void resolveRelativeUrl_withNoTenantIdInRequestDetails_returnsInputUrl() {
+		String inputUrl = "Patient/123";
+		String actual = ourTenantStrategy.resolveRelativeUrl(inputUrl, myRequestDetails);
+
+		assertEquals(inputUrl, actual);
+	}
+
+	@Test
+	void resolveRelativeUrl_urlAlreadyContainsTenantId_returnsInputUrl() {
+		when(myRequestDetails.getTenantId()).thenReturn("TENANT1");
+
+		String inputUrl = "TENANT1/Patient/123";
+		String actual = ourTenantStrategy.resolveRelativeUrl(inputUrl, myRequestDetails);
+
+		assertEquals(inputUrl, actual);
+	}
+
+	@Test
+	void resolveRelativeUrl_urlAlreadyContainsDifferentTenantId_returnsInputUrl() {
+		when(myRequestDetails.getTenantId()).thenReturn("TENANT1");
+		when(myFHIRContext.getResourceTypes()).thenReturn(Collections.singleton("Patient"));
+		when(myRequestDetails.getFhirContext()).thenReturn(myFHIRContext);
+
+		String inputUrl = "TENANT2/Patient/123";
+		String actual = ourTenantStrategy.resolveRelativeUrl(inputUrl, myRequestDetails);
+
+		assertEquals(inputUrl, actual);
+	}
+
+	@Test
+	void resolveRelativeUrl_urlStartsWithResourceType_tenantIdIsAddedToUrl() {
+		when(myRequestDetails.getTenantId()).thenReturn("TENANT1");
+		when(myFHIRContext.getResourceTypes()).thenReturn(Collections.singleton("Patient"));
+		when(myRequestDetails.getFhirContext()).thenReturn(myFHIRContext);
+
+		String inputUrl = "Patient/123";
+		String actual = ourTenantStrategy.resolveRelativeUrl(inputUrl, myRequestDetails);
+
+		assertEquals("TENANT1/" + inputUrl, actual);
 	}
 
 	@Test


### PR DESCRIPTION
Part of the fix for issue #5388 
Includes fix for cross-tenant request failure