### PR TITLE
Resolve We don't have guaranteed subscription delivery if a resource is too large

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5407-we-dont-have-guaranteed-subscription-delivery-if-a-resource-is-too-large.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5407-we-dont-have-guaranteed-subscription-delivery-if-a-resource-is-too-large.yaml
@@ -1,5 +1,5 @@
 ---
-type: change
+type: add
 issue: 5407
 title: "Previously, when the payload of a subscription message exceeds the broker maximum message size, exception would 
 be thrown and retry will be performed indefinitely until the maximum message size is adjusted. Now, the message will be

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5407-we-dont-have-guaranteed-subscription-delivery-if-a-resource-is-too-large.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5407-we-dont-have-guaranteed-subscription-delivery-if-a-resource-is-too-large.yaml
@@ -1,0 +1,7 @@
+---
+type: change
+issue: 5407
+title: "Previously, when the payload of a subscription message exceeds the broker maximum message size, exception would 
+be thrown and retry will be performed indefinitely until the maximum message size is adjusted. Now, the message will be
+successfully delivered for rest-hook and email subscriptions, while message subscriptions remains the same behavior as
+before."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
-import org.hl7.fhir.r5.model.IdType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,10 +112,7 @@ public class ResourceModifiedMessagePersistenceSvcImpl implements IResourceModif
 					theResourceModifiedMessage.getPayloadId(),
 					theResourceModifiedMessage.getPayloadVersion());
 
-			ourLog.warn(
-					"Scheduled submission will be ignored since resource {} cannot be found",
-					idDt.getIdPart(),
-					e);
+			ourLog.warn("Scheduled submission will be ignored since resource {} cannot be found", idDt.getIdPart(), e);
 		} catch (Exception ex) {
 			ourLog.error("Unknown error encountered on inflation of resources.", ex);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
@@ -108,14 +108,14 @@ public class ResourceModifiedMessagePersistenceSvcImpl implements IResourceModif
 		try {
 			inflatedResourceModifiedMessage = inflatePersistedResourceModifiedMessage(theResourceModifiedMessage);
 		} catch (ResourceNotFoundException e) {
-			IdType idType = new IdType(
+			IdDt idDt = new IdDt(
 					theResourceModifiedMessage.getPayloadType(myFhirContext),
 					theResourceModifiedMessage.getPayloadId(),
 					theResourceModifiedMessage.getPayloadVersion());
 
 			ourLog.warn(
 					"Scheduled submission will be ignored since resource {} cannot be found",
-					idType.asStringValue(),
+					idDt.getIdPart(),
 					e);
 		} catch (Exception ex) {
 			ourLog.error("Unknown error encountered on inflation of resources.", ex);

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/config/SubscriptionProcessorConfig.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/config/SubscriptionProcessorConfig.java
@@ -61,9 +61,8 @@ import org.springframework.context.annotation.Scope;
 public class SubscriptionProcessorConfig {
 
 	@Bean
-	public SubscriptionMatchingSubscriber subscriptionMatchingSubscriber(
-			IResourceModifiedMessagePersistenceSvc theResourceModifiedMessagePersistenceSvc) {
-		return new SubscriptionMatchingSubscriber(theResourceModifiedMessagePersistenceSvc);
+	public SubscriptionMatchingSubscriber subscriptionMatchingSubscriber() {
+		return new SubscriptionMatchingSubscriber();
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/config/SubscriptionProcessorConfig.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/config/SubscriptionProcessorConfig.java
@@ -45,6 +45,7 @@ import ca.uhn.fhir.jpa.subscription.model.config.SubscriptionModelConfig;
 import ca.uhn.fhir.jpa.topic.SubscriptionTopicDispatcher;
 import ca.uhn.fhir.jpa.topic.SubscriptionTopicPayloadBuilder;
 import ca.uhn.fhir.jpa.topic.filter.InMemoryTopicFilterMatcher;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -60,8 +61,9 @@ import org.springframework.context.annotation.Scope;
 public class SubscriptionProcessorConfig {
 
 	@Bean
-	public SubscriptionMatchingSubscriber subscriptionMatchingSubscriber() {
-		return new SubscriptionMatchingSubscriber();
+	public SubscriptionMatchingSubscriber subscriptionMatchingSubscriber(
+			IResourceModifiedMessagePersistenceSvc theResourceModifiedMessagePersistenceSvc) {
+		return new SubscriptionMatchingSubscriber(theResourceModifiedMessagePersistenceSvc);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/config/SubscriptionProcessorConfig.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/config/SubscriptionProcessorConfig.java
@@ -45,7 +45,6 @@ import ca.uhn.fhir.jpa.subscription.model.config.SubscriptionModelConfig;
 import ca.uhn.fhir.jpa.topic.SubscriptionTopicDispatcher;
 import ca.uhn.fhir.jpa.topic.SubscriptionTopicPayloadBuilder;
 import ca.uhn.fhir.jpa.topic.filter.InMemoryTopicFilterMatcher;
-import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
@@ -33,6 +33,7 @@ import ca.uhn.fhir.jpa.subscription.match.registry.ActiveSubscription;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionRegistry;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
+import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import ca.uhn.fhir.util.BundleBuilder;
@@ -151,6 +152,13 @@ public abstract class BaseSubscriptionDeliverySubscriber implements MessageHandl
 			builder.addTransactionUpdateEntry(next);
 		}
 		return builder.getBundle();
+	}
+
+	protected ResourceModifiedMessage inflateResourceModifiedMessageFromDeliveryMessage(
+			ResourceDeliveryMessage theMsg) {
+		ResourceModifiedMessage payloadLess =
+				new ResourceModifiedMessage(theMsg.getPayloadId(myFhirContext), theMsg.getOperationType());
+		return myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(payloadLess);
 	}
 
 	@VisibleForTesting

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
@@ -50,6 +50,7 @@ import org.springframework.messaging.MessagingException;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static ca.uhn.fhir.jpa.subscription.util.SubscriptionUtil.createRequestDetailForPartitionedRequest;
 
@@ -154,11 +155,11 @@ public abstract class BaseSubscriptionDeliverySubscriber implements MessageHandl
 		return builder.getBundle();
 	}
 
-	protected ResourceModifiedMessage inflateResourceModifiedMessageFromDeliveryMessage(
+	protected Optional<ResourceModifiedMessage> inflateResourceModifiedMessageFromDeliveryMessage(
 			ResourceDeliveryMessage theMsg) {
 		ResourceModifiedMessage payloadLess =
 				new ResourceModifiedMessage(theMsg.getPayloadId(myFhirContext), theMsg.getOperationType());
-		return myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(payloadLess);
+		return myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(payloadLess);
 	}
 
 	@VisibleForTesting

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
@@ -187,6 +187,12 @@ public abstract class BaseSubscriptionDeliverySubscriber implements MessageHandl
 		myMatchUrlService = theMatchUrlService;
 	}
 
+	@VisibleForTesting
+	public void setResourceModifiedMessagePersistenceSvcForUnitTest(
+			IResourceModifiedMessagePersistenceSvc theResourceModifiedMessagePersistenceSvc) {
+		myResourceModifiedMessagePersistenceSvc = theResourceModifiedMessagePersistenceSvc;
+	}
+
 	public IInterceptorBroadcaster getInterceptorBroadcaster() {
 		return myInterceptorBroadcaster;
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriber.java
@@ -34,6 +34,7 @@ import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionRegistry;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import ca.uhn.fhir.util.BundleBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.text.StringSubstitutor;
@@ -59,6 +60,9 @@ public abstract class BaseSubscriptionDeliverySubscriber implements MessageHandl
 
 	@Autowired
 	protected SubscriptionRegistry mySubscriptionRegistry;
+
+	@Autowired
+	protected IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
 
 	@Autowired
 	private IInterceptorBroadcaster myInterceptorBroadcaster;

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/email/SubscriptionDeliveringEmailSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/email/SubscriptionDeliveringEmailSubscriber.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.swing.text.html.Option;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -126,8 +125,9 @@ public class SubscriptionDeliveringEmailSubscriber extends BaseSubscriptionDeliv
 			return payload;
 		}
 
-		Optional<ResourceModifiedMessage> inflatedMessage = inflateResourceModifiedMessageFromDeliveryMessage(theMessage);
-		if (inflatedMessage.isEmpty()){
+		Optional<ResourceModifiedMessage> inflatedMessage =
+				inflateResourceModifiedMessageFromDeliveryMessage(theMessage);
+		if (inflatedMessage.isEmpty()) {
 			return "";
 		}
 

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/email/SubscriptionDeliveringEmailSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/email/SubscriptionDeliveringEmailSubscriber.java
@@ -73,7 +73,7 @@ public class SubscriptionDeliveringEmailSubscriber extends BaseSubscriptionDeliv
 		if (isNotBlank(subscription.getPayloadString())) {
 			EncodingEnum encoding = EncodingEnum.forContentType(subscription.getPayloadString());
 			if (encoding != null) {
-				payload = theMessage.getPayloadString();
+				payload = getPayloadStringFromMessage(theMessage);
 			}
 		}
 
@@ -111,5 +111,19 @@ public class SubscriptionDeliveringEmailSubscriber extends BaseSubscriptionDeliv
 	@VisibleForTesting
 	public IEmailSender getEmailSender() {
 		return myEmailSender;
+	}
+
+	/**
+	 * Get the payload string, fetch it from the DB when the payload is null.
+	 */
+	private String getPayloadStringFromMessage(ResourceDeliveryMessage theMessage) {
+		String payload = theMessage.getPayloadString();
+
+		if (payload != null) {
+			return payload;
+		}
+
+		payload = inflateResourceModifiedMessageFromDeliveryMessage(theMessage).getPayloadString();
+		return payload;
 	}
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/email/SubscriptionDeliveringEmailSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/email/SubscriptionDeliveringEmailSubscriber.java
@@ -121,7 +121,7 @@ public class SubscriptionDeliveringEmailSubscriber extends BaseSubscriptionDeliv
 	private String getPayloadStringFromMessageOrEmptyString(ResourceDeliveryMessage theMessage) {
 		String payload = theMessage.getPayloadString();
 
-		if (payload != null) {
+		if (theMessage.getPayload(myCtx) != null) {
 			return payload;
 		}
 

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -30,7 +30,9 @@ import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
+import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,8 +86,14 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 
 	private ResourceModifiedJsonMessage convertDeliveryMessageToResourceModifiedMessage(
 			ResourceDeliveryMessage theMsg, IBaseResource thePayloadResource) {
-		ResourceModifiedMessage payload =
-				new ResourceModifiedMessage(myFhirContext, thePayloadResource, theMsg.getOperationType());
+		ResourceModifiedMessage payload;
+		if (thePayloadResource == null) {
+			ResourceModifiedMessage payloadLess = new ResourceModifiedMessage(theMsg.getPayloadId(myFhirContext), theMsg.getOperationType());
+			payload = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(payloadLess);
+		} else {
+			payload = new ResourceModifiedMessage(myFhirContext, thePayloadResource, theMsg.getOperationType());
+		}
+
 		payload.setMessageKey(theMsg.getMessageKeyOrDefault());
 		payload.setTransactionId(theMsg.getTransactionId());
 		payload.setPartitionId(theMsg.getRequestPartitionId());

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -103,6 +103,7 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 			if (inflatedMsg.isEmpty()) {
 				return;
 			}
+			payloadResource = inflatedMsg.get().getPayload(myFhirContext);
 		}
 
 		ResourceModifiedJsonMessage messageWrapperToSend =

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/message/SubscriptionDeliveringMessageSubscriber.java
@@ -86,7 +86,7 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 	private ResourceModifiedJsonMessage convertDeliveryMessageToResourceModifiedJsonMessage(
 			ResourceDeliveryMessage theMsg, IBaseResource thePayloadResource) {
 		ResourceModifiedMessage payload =
-			new ResourceModifiedMessage(myFhirContext, thePayloadResource, theMsg.getOperationType());
+				new ResourceModifiedMessage(myFhirContext, thePayloadResource, theMsg.getOperationType());
 		payload.setMessageKey(theMsg.getMessageKeyOrDefault());
 		payload.setTransactionId(theMsg.getTransactionId());
 		payload.setPartitionId(theMsg.getRequestPartitionId());
@@ -97,9 +97,10 @@ public class SubscriptionDeliveringMessageSubscriber extends BaseSubscriptionDel
 	public void handleMessage(ResourceDeliveryMessage theMessage) throws MessagingException, URISyntaxException {
 		CanonicalSubscription subscription = theMessage.getSubscription();
 		IBaseResource payloadResource = theMessage.getPayload(myFhirContext);
-		if (payloadResource == null){
-			Optional<ResourceModifiedMessage> inflatedMsg = inflateResourceModifiedMessageFromDeliveryMessage(theMessage);
-			if (inflatedMsg.isEmpty()){
+		if (payloadResource == null) {
+			Optional<ResourceModifiedMessage> inflatedMsg =
+					inflateResourceModifiedMessageFromDeliveryMessage(theMessage);
+			if (inflatedMsg.isEmpty()) {
 				return;
 			}
 		}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionActivatingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionActivatingSubscriber.java
@@ -31,6 +31,7 @@ import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import ca.uhn.fhir.util.SubscriptionUtil;
 import org.hl7.fhir.dstu2.model.Subscription;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -64,6 +65,8 @@ public class SubscriptionActivatingSubscriber implements MessageHandler {
 	@Autowired
 	private StorageSettings myStorageSettings;
 
+	@Autowired
+	private IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
 	/**
 	 * Constructor
 	 */
@@ -86,6 +89,7 @@ public class SubscriptionActivatingSubscriber implements MessageHandler {
 		switch (payload.getOperationType()) {
 			case CREATE:
 			case UPDATE:
+				payload = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(payload);
 				activateSubscriptionIfRequired(payload.getNewPayload(myFhirContext));
 				break;
 			case TRANSACTION:

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionActivatingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionActivatingSubscriber.java
@@ -90,9 +90,10 @@ public class SubscriptionActivatingSubscriber implements MessageHandler {
 		switch (payload.getOperationType()) {
 			case CREATE:
 			case UPDATE:
-				if (payload.getPayload(myFhirContext) == null){
+				if (payload.getPayload(myFhirContext) == null) {
 					Optional<ResourceModifiedMessage> inflatedMsg =
-						myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(payload);
+							myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(
+									payload);
 					if (inflatedMsg.isEmpty()) {
 						return;
 					}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionActivatingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionActivatingSubscriber.java
@@ -90,12 +90,15 @@ public class SubscriptionActivatingSubscriber implements MessageHandler {
 		switch (payload.getOperationType()) {
 			case CREATE:
 			case UPDATE:
-				Optional<ResourceModifiedMessage> inflatedMsg =
+				if (payload.getPayload(myFhirContext) == null){
+					Optional<ResourceModifiedMessage> inflatedMsg =
 						myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(payload);
-				if (inflatedMsg.isEmpty()) {
-					return;
+					if (inflatedMsg.isEmpty()) {
+						return;
+					}
+					payload = inflatedMsg.get();
 				}
-				payload = inflatedMsg.get();
+
 				activateSubscriptionIfRequired(payload.getNewPayload(myFhirContext));
 				break;
 			case TRANSACTION:

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchDeliverer.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchDeliverer.java
@@ -37,7 +37,6 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageDeliveryException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -158,9 +157,9 @@ public class SubscriptionMatchDeliverer {
 				ourLog.warn("Failed to send message to Delivery Channel.");
 			}
 		} catch (RuntimeException e) {
-			if (e.getCause() instanceof PayloadTooLargeException){
-				ourLog.warn("Failed to send message to Delivery Channel because the payload size is larger than broker " +
-						"max message size. Retry is about to be performed without payload");
+			if (e.getCause() instanceof PayloadTooLargeException) {
+				ourLog.warn("Failed to send message to Delivery Channel because the payload size is larger than broker "
+						+ "max message size. Retry is about to be performed without payload.");
 				ResourceDeliveryJsonMessage msgPayloadLess = nullOutPayload(theWrappedMsg);
 				trySendToDeliveryChannel(msgPayloadLess, theDeliveryChannel);
 			} else {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchDeliverer.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchDeliverer.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.searchparam.matcher.InMemoryMatchResult;
+import ca.uhn.fhir.jpa.subscription.channel.api.PayloadTooLargeException;
 import ca.uhn.fhir.jpa.subscription.channel.subscription.SubscriptionChannelRegistry;
 import ca.uhn.fhir.jpa.subscription.match.registry.ActiveSubscription;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
@@ -36,6 +37,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -156,8 +158,21 @@ public class SubscriptionMatchDeliverer {
 				ourLog.warn("Failed to send message to Delivery Channel.");
 			}
 		} catch (RuntimeException e) {
-			ourLog.error("Failed to send message to Delivery Channel", e);
-			throw new RuntimeException(Msg.code(7) + "Failed to send message to Delivery Channel", e);
+			if (e.getCause() instanceof PayloadTooLargeException){
+				ourLog.warn("Failed to send message to Delivery Channel because the payload size is larger than broker " +
+						"max message size. Retry is about to be performed without payload");
+				ResourceDeliveryJsonMessage msgPayloadLess = nullOutPayload(theWrappedMsg);
+				trySendToDeliveryChannel(msgPayloadLess, theDeliveryChannel);
+			} else {
+				ourLog.error("Failed to send message to Delivery Channel", e);
+				throw new RuntimeException(Msg.code(7) + "Failed to send message to Delivery Channel", e);
+			}
 		}
+	}
+
+	private ResourceDeliveryJsonMessage nullOutPayload(ResourceDeliveryJsonMessage theWrappedMsg) {
+		ResourceDeliveryMessage resourceDeliveryMessage = theWrappedMsg.getPayload();
+		resourceDeliveryMessage.setPayloadToNull();
+		return new ResourceDeliveryJsonMessage(resourceDeliveryMessage);
 	}
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -102,10 +102,10 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 				return;
 		}
 
-		if (theMsg.getPayload(myFhirContext) == null){
+		if (theMsg.getPayload(myFhirContext) == null) {
 			// inflate the message and ignore any resource that cannot be found.
 			Optional<ResourceModifiedMessage> inflatedMsg =
-				myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(theMsg);
+					myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(theMsg);
 			if (inflatedMsg.isEmpty()) {
 				return;
 			}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -66,15 +66,14 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 	@Autowired
 	private SubscriptionMatchDeliverer mySubscriptionMatchDeliverer;
 
+	@Autowired
 	private IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
 
 	/**
 	 * Constructor
 	 */
-	public SubscriptionMatchingSubscriber(
-			IResourceModifiedMessagePersistenceSvc theResourceModifiedMessagePersistenceSvc) {
+	public SubscriptionMatchingSubscriber() {
 		super();
-		myResourceModifiedMessagePersistenceSvc = theResourceModifiedMessagePersistenceSvc;
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -102,13 +102,15 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 				return;
 		}
 
-		// inflate the message and ignore any resource that cannot be found.
-		Optional<ResourceModifiedMessage> inflatedMsg =
+		if (theMsg.getPayload(myFhirContext) == null){
+			// inflate the message and ignore any resource that cannot be found.
+			Optional<ResourceModifiedMessage> inflatedMsg =
 				myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(theMsg);
-		if (inflatedMsg.isEmpty()) {
-			return;
+			if (inflatedMsg.isEmpty()) {
+				return;
+			}
+			theMsg = inflatedMsg.get();
 		}
-		theMsg = inflatedMsg.get();
 
 		// Interceptor call: SUBSCRIPTION_BEFORE_PERSISTED_RESOURCE_CHECKED
 		HookParams params = new HookParams().add(ResourceModifiedMessage.class, theMsg);

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
@@ -20,9 +20,11 @@
 package ca.uhn.fhir.jpa.subscription.submit.interceptor;
 
 import ca.uhn.fhir.jpa.subscription.async.AsyncResourceModifiedProcessingSchedulerSvc;
+import ca.uhn.fhir.jpa.subscription.channel.api.PayloadTooLargeException;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.IResourceModifiedConsumer;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -49,11 +51,33 @@ public class SynchronousSubscriptionMatcherInterceptor extends SubscriptionMatch
 
 				@Override
 				public void afterCommit() {
-					myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
+					doSubmitResourceModified(theResourceModifiedMessage);
 				}
 			});
 		} else {
+			doSubmitResourceModified(theResourceModifiedMessage);
+		}
+	}
+
+	/**
+	 * Submit the message through the broker channel to the matcher.
+	 *
+	 * Note: most of our integrated tests for subscription assume we can successfully inflate the message and therefore
+	 * does not run with an actual database to persist the data. In these cases, submitting the complete message (i.e.
+	 * with payload) is OK. However, there are a few tests that do not assume it and do run with an actual DB. For them,
+	 * we should null out the payload body before submitting. This try-catch block only covers the case where the
+	 * payload is too large, which is enough for now. However, for better practice we might want to consider splitting
+	 * this interceptor into two, each for tests with/without DB connection.
+	 * @param theResourceModifiedMessage
+	 */
+	private void doSubmitResourceModified(ResourceModifiedMessage theResourceModifiedMessage) {
+		try {
 			myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
+		} catch (MessageDeliveryException e) {
+			if (e.getCause() instanceof PayloadTooLargeException) {
+				theResourceModifiedMessage.setPayloadToNull();
+				myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
+			}
 		}
 	}
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
@@ -49,10 +49,12 @@ public class SynchronousSubscriptionMatcherInterceptor extends SubscriptionMatch
 
 				@Override
 				public void afterCommit() {
+					theResourceModifiedMessage.setPayloadToNull();
 					myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
 				}
 			});
 		} else {
+			theResourceModifiedMessage.setPayloadToNull();
 			myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
 		}
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
@@ -49,12 +49,10 @@ public class SynchronousSubscriptionMatcherInterceptor extends SubscriptionMatch
 
 				@Override
 				public void afterCommit() {
-//					theResourceModifiedMessage.setPayloadToNull();
 					myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
 				}
 			});
 		} else {
-//			theResourceModifiedMessage.setPayloadToNull();
 			myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
 		}
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SynchronousSubscriptionMatcherInterceptor.java
@@ -49,12 +49,12 @@ public class SynchronousSubscriptionMatcherInterceptor extends SubscriptionMatch
 
 				@Override
 				public void afterCommit() {
-					theResourceModifiedMessage.setPayloadToNull();
+//					theResourceModifiedMessage.setPayloadToNull();
 					myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
 				}
 			});
 		} else {
-			theResourceModifiedMessage.setPayloadToNull();
+//			theResourceModifiedMessage.setPayloadToNull();
 			myResourceModifiedConsumer.submitResourceModified(theResourceModifiedMessage);
 		}
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/svc/ResourceModifiedSubmitterSvc.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/svc/ResourceModifiedSubmitterSvc.java
@@ -148,16 +148,7 @@ public class ResourceModifiedSubmitterSvc implements IResourceModifiedConsumer, 
 				boolean wasDeleted = deletePersistedResourceModifiedMessage(
 						thePersistedResourceModifiedMessage.getPersistedResourceModifiedMessagePk());
 
-				//				Optional<ResourceModifiedMessage> optionalResourceModifiedMessage =
-				//						inflatePersistedResourceMessage(thePersistedResourceModifiedMessage);
-				//
-				//				if (wasDeleted && optionalResourceModifiedMessage.isPresent()) {
-				//					// the PK did exist and we were able to deleted it, ie, we are the only one processing the
-				// message
-				//					resourceModifiedMessage = optionalResourceModifiedMessage.get();
-				//					submitResourceModified(resourceModifiedMessage);
-				//				}
-
+				// submit the resource modified message with empty payload, actual inflation is done by the matcher.
 				resourceModifiedMessage =
 						createResourceModifiedMessageWithoutInflation(thePersistedResourceModifiedMessage);
 
@@ -190,34 +181,6 @@ public class ResourceModifiedSubmitterSvc implements IResourceModifiedConsumer, 
 			return processed;
 		};
 	}
-
-	//	private Optional<ResourceModifiedMessage> inflatePersistedResourceMessage(
-	//			IPersistedResourceModifiedMessage thePersistedResourceModifiedMessage) {
-	//		ResourceModifiedMessage resourceModifiedMessage = null;
-	//
-	//		try {
-	//			resourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(
-	//					thePersistedResourceModifiedMessage);
-	//
-	//		} catch (ResourceNotFoundException e) {
-	//			IPersistedResourceModifiedMessagePK persistedResourceModifiedMessagePk =
-	//					thePersistedResourceModifiedMessage.getPersistedResourceModifiedMessagePk();
-	//
-	//			IdType idType = new IdType(
-	//					thePersistedResourceModifiedMessage.getResourceType(),
-	//					persistedResourceModifiedMessagePk.getResourcePid(),
-	//					persistedResourceModifiedMessagePk.getResourceVersion());
-	//
-	//			ourLog.warn(
-	//					"Scheduled submission will be ignored since resource {} cannot be found",
-	//					idType.asStringValue(),
-	//					e);
-	//		} catch (Exception ex) {
-	//			ourLog.error("Unknown error encountered on inflation of resources.", ex);
-	//		}
-	//
-	//		return Optional.ofNullable(resourceModifiedMessage);
-	//	}
 
 	private ResourceModifiedMessage createResourceModifiedMessageWithoutInflation(
 			IPersistedResourceModifiedMessage thePersistedResourceModifiedMessage) {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/deliver/BaseSubscriptionDeliverySubscriberTest.java
@@ -8,10 +8,13 @@ import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.subscription.channel.api.IChannelFactory;
 import ca.uhn.fhir.jpa.subscription.channel.api.IChannelProducer;
+import ca.uhn.fhir.jpa.subscription.match.deliver.email.IEmailSender;
+import ca.uhn.fhir.jpa.subscription.match.deliver.email.SubscriptionDeliveringEmailSubscriber;
 import ca.uhn.fhir.jpa.subscription.match.deliver.message.SubscriptionDeliveringMessageSubscriber;
 import ca.uhn.fhir.jpa.subscription.match.deliver.resthook.SubscriptionDeliveringRestHookSubscriber;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionRegistry;
@@ -26,6 +29,7 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
@@ -33,6 +37,8 @@ import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -57,6 +63,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -71,6 +78,7 @@ public class BaseSubscriptionDeliverySubscriberTest {
 
 	private SubscriptionDeliveringRestHookSubscriber mySubscriber;
 	private SubscriptionDeliveringMessageSubscriber myMessageSubscriber;
+	private SubscriptionDeliveringEmailSubscriber myEmailSubscriber;
 	private final FhirContext myCtx = FhirContext.forR4();
 
 	@Mock
@@ -96,6 +104,12 @@ public class BaseSubscriptionDeliverySubscriberTest {
 	@Mock
 	private MatchUrlService myMatchUrlService;
 
+	@Mock
+	private IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
+
+	@Mock
+	private IEmailSender myEmailSender;
+
 	@BeforeEach
 	public void before() {
 		mySubscriber = new SubscriptionDeliveringRestHookSubscriber();
@@ -109,8 +123,15 @@ public class BaseSubscriptionDeliverySubscriberTest {
 		myMessageSubscriber.setSubscriptionRegistryForUnitTest(mySubscriptionRegistry);
 		myMessageSubscriber.setDaoRegistryForUnitTest(myDaoRegistry);
 		myMessageSubscriber.setMatchUrlServiceForUnitTest(myMatchUrlService);
+		myMessageSubscriber.setResourceModifiedMessagePersistenceSvcForUnitTest(myResourceModifiedMessagePersistenceSvc);
 		myCtx.setRestfulClientFactory(myRestfulClientFactory);
 		when(myRestfulClientFactory.newGenericClient(any())).thenReturn(myGenericClient);
+
+		myEmailSubscriber = new SubscriptionDeliveringEmailSubscriber(myEmailSender);
+		myEmailSubscriber.setFhirContextForUnitTest(myCtx);
+		myEmailSubscriber.setInterceptorBroadcasterForUnitTest(myInterceptorBroadcaster);
+		myEmailSubscriber.setSubscriptionRegistryForUnitTest(mySubscriptionRegistry);
+		myEmailSubscriber.setResourceModifiedMessagePersistenceSvcForUnitTest(myResourceModifiedMessagePersistenceSvc);
 	}
 
 	@Test
@@ -398,6 +419,38 @@ public class BaseSubscriptionDeliverySubscriberTest {
 			String messageExceptionAsString = e.toString();
 			assertFalse(messageExceptionAsString.contains(familyName));
 		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"message", "email"})
+	public void testMessageAndEmailSubscriber_whenPayloadIsNull_shouldTryInflateMessage(String theSubscriber) {
+		// setup
+		when(myInterceptorBroadcaster.callHooks(any(), any())).thenReturn(true);
+
+		Patient patient = generatePatient();
+
+		CanonicalSubscription subscription = generateSubscription();
+
+		ResourceDeliveryMessage payload = new ResourceDeliveryMessage();
+		payload.setSubscription(subscription);
+		payload.setPayload(myCtx, patient, EncodingEnum.JSON);
+		payload.setOperationType(ResourceModifiedMessage.OperationTypeEnum.CREATE);
+
+		// mock the inflated message
+		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(any())).thenReturn(any());
+
+		// this will null out the payload but keep the resource id and version.
+		payload.setPayloadToNull();
+
+		// execute & verify
+        switch (theSubscriber) {
+            case "message" ->
+                    assertThrows(MessagingException.class, () -> myMessageSubscriber.handleMessage(new ResourceDeliveryJsonMessage(payload)));
+            case "email" ->
+                    assertThrows(MessagingException.class, () -> myEmailSubscriber.handleMessage(new ResourceDeliveryJsonMessage(payload)));
+        }
+
+		verify(myResourceModifiedMessagePersistenceSvc, times(1)).inflatePersistedResourceModifiedMessageOrNull(any());
 	}
 
 	@Nonnull

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/matcher/matching/DaoSubscriptionMatcherTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/matcher/matching/DaoSubscriptionMatcherTest.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.jpa.subscription.match.config.SubscriptionProcessorConfig;
 import ca.uhn.fhir.jpa.subscription.match.deliver.email.IEmailSender;
 import ca.uhn.fhir.jpa.subscription.submit.config.SubscriptionSubmitterConfig;
 import ca.uhn.fhir.jpa.subscription.submit.interceptor.SubscriptionQueryValidator;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,6 +90,11 @@ public class DaoSubscriptionMatcherTest {
 		@Bean
 		public IEmailSender emailSender(){
 			return mock(IEmailSender.class);
+		}
+
+		@Bean
+		public IResourceModifiedMessagePersistenceSvc resourceModifiedMessagePersistenceSvc() {
+			return mock(IResourceModifiedMessagePersistenceSvc.class);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/cache/SubscriptionRegistrySharedTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/cache/SubscriptionRegistrySharedTest.java
@@ -2,8 +2,10 @@ package ca.uhn.fhir.jpa.subscription.module.cache;
 
 import ca.uhn.fhir.jpa.subscription.channel.subscription.ISubscriptionDeliveryChannelNamer;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import org.hl7.fhir.dstu3.model.Subscription;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -20,6 +22,9 @@ import static org.mockito.Mockito.when;
 public class SubscriptionRegistrySharedTest extends BaseSubscriptionRegistryTest {
 
 	private static final String OTHER_ID = "OTHER_ID";
+
+	@Autowired
+	private IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
 
 	@Configuration
 	public static class SpringConfig {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/cache/SubscriptionRegistrySharedTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/cache/SubscriptionRegistrySharedTest.java
@@ -10,6 +10,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @ContextConfiguration(classes = {
 	SubscriptionRegistrySharedTest.SpringConfig.class

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/cache/SubscriptionRegistrySharedTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/cache/SubscriptionRegistrySharedTest.java
@@ -12,9 +12,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @ContextConfiguration(classes = {
 	SubscriptionRegistrySharedTest.SpringConfig.class

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/config/TestSubscriptionDstu3Config.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/config/TestSubscriptionDstu3Config.java
@@ -6,6 +6,9 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.model.sched.ISchedulerService;
 import ca.uhn.fhir.jpa.searchparam.registry.ISearchParamProvider;
+import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
+import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import com.google.common.collect.Lists;
 import org.hl7.fhir.dstu3.model.Subscription;
 import org.slf4j.Logger;
@@ -60,6 +63,11 @@ public class TestSubscriptionDstu3Config {
 		IFhirResourceDao mock = mock(IFhirResourceDao.class);
 		when(mock.getResourceType()).thenReturn(Subscription.class);
 		return mock;
+	}
+
+	@Bean
+	public IResourceModifiedMessagePersistenceSvc resourceModifiedMessagePersistenceSvc() {
+		return mock(IResourceModifiedMessagePersistenceSvc.class);
 	}
 
 }

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/config/TestSubscriptionDstu3Config.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/config/TestSubscriptionDstu3Config.java
@@ -6,8 +6,6 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.model.sched.ISchedulerService;
 import ca.uhn.fhir.jpa.searchparam.registry.ISearchParamProvider;
-import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
-import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import com.google.common.collect.Lists;
 import org.hl7.fhir.dstu3.model.Subscription;

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/standalone/BaseBlockingQueueSubscribableChannelDstu3Test.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/standalone/BaseBlockingQueueSubscribableChannelDstu3Test.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import ca.uhn.fhir.test.utilities.JettyUtil;
 import ca.uhn.test.concurrency.IPointcutLatch;
 import ca.uhn.test.concurrency.PointcutLatch;
@@ -54,6 +55,10 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 public abstract class BaseBlockingQueueSubscribableChannelDstu3Test extends BaseSubscriptionDstu3Test {
 	public static final ChannelConsumerSettings CONSUMER_OPTIONS = new ChannelConsumerSettings().setConcurrentConsumers(1);
@@ -100,6 +105,8 @@ public abstract class BaseBlockingQueueSubscribableChannelDstu3Test extends Base
 	IInterceptorService myInterceptorRegistry;
 	@Autowired
 	private ISubscriptionDeliveryChannelNamer mySubscriptionDeliveryChannelNamer;
+	@Autowired
+	private IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
 
 	@BeforeEach
 	public void beforeReset() {
@@ -140,6 +147,8 @@ public abstract class BaseBlockingQueueSubscribableChannelDstu3Test extends Base
 	public <T extends IBaseResource> T sendResource(T theResource, RequestPartitionId theRequestPartitionId) throws InterruptedException {
 		ResourceModifiedMessage msg = new ResourceModifiedMessage(myFhirContext, theResource, ResourceModifiedMessage.OperationTypeEnum.CREATE, null, theRequestPartitionId);
 		ResourceModifiedJsonMessage message = new ResourceModifiedJsonMessage(msg);
+		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(any())).thenReturn(Optional.of(msg));
+
 		mySubscriptionMatchingPost.setExpectedCount(1);
 		ourSubscribableChannel.send(message);
 		mySubscriptionMatchingPost.awaitExpected();

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriberTest.java
@@ -17,6 +17,7 @@ import ca.uhn.fhir.jpa.subscription.module.standalone.BaseBlockingQueueSubscriba
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.server.messaging.BaseResourceModifiedMessage;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.google.common.collect.Lists;
 import org.hl7.fhir.dstu3.model.BooleanType;
@@ -33,6 +34,7 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static ca.uhn.fhir.jpa.subscription.match.matcher.subscriber.SubscriptionCriteriaParser.TypeEnum.STARTYPE_EXPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -434,6 +436,8 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 		SubscriptionCriteriaParser.SubscriptionCriteria mySubscriptionCriteria;
 		@Mock
 		SubscriptionMatchDeliverer mySubscriptionMatchDeliverer;
+		@Mock
+		IResourceModifiedMessagePersistenceSvc myResourceModifiedMessagePersistenceSvc;
 		@InjectMocks
 		SubscriptionMatchingSubscriber subscriber;
 
@@ -445,6 +449,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 			when(myInterceptorBroadcaster.callHooks(
 				eq(Pointcut.SUBSCRIPTION_BEFORE_PERSISTED_RESOURCE_CHECKED), any(HookParams.class))).thenReturn(true);
 			when(mySubscriptionRegistry.getAll()).thenReturn(Collections.emptyList());
+			when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(any())).thenReturn(Optional.ofNullable(message));
 
 			subscriber.matchActiveSubscriptionsAndDeliver(message);
 
@@ -465,6 +470,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 			when(myActiveSubscription.getCriteria()).thenReturn(mySubscriptionCriteria);
 			when(myActiveSubscription.getId()).thenReturn("Patient/123");
 			when(mySubscriptionCriteria.getType()).thenReturn(STARTYPE_EXPRESSION);
+			when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(any())).thenReturn(Optional.ofNullable(message));
 
 			subscriber.matchActiveSubscriptionsAndDeliver(message);
 
@@ -486,6 +492,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 			when(myNonDeleteSubscription.getCriteria()).thenReturn(mySubscriptionCriteria);
 			when(myNonDeleteSubscription.getId()).thenReturn("Patient/123");
 			when(mySubscriptionCriteria.getType()).thenReturn(STARTYPE_EXPRESSION);
+			when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(any())).thenReturn(Optional.ofNullable(message));
 
 			subscriber.matchActiveSubscriptionsAndDeliver(message);
 
@@ -505,6 +512,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 			when(myActiveSubscription.getId()).thenReturn("Patient/123");
 			when(mySubscriptionCriteria.getType()).thenReturn(STARTYPE_EXPRESSION);
 			when(myCanonicalSubscription.getSendDeleteMessages()).thenReturn(true);
+			when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessageOrNull(any())).thenReturn(Optional.ofNullable(message));
 
 			subscriber.matchActiveSubscriptionsAndDeliver(message);
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/websocket/WebsocketConnectionValidatorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/websocket/WebsocketConnectionValidatorTest.java
@@ -20,6 +20,7 @@ import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionRegistry;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscriptionChannelType;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
+import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import org.hl7.fhir.r4.model.IdType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,6 +145,11 @@ public class WebsocketConnectionValidatorTest {
 		@Bean
 		public IEmailSender emailSender(){
 			return mock(IEmailSender.class);
+		}
+
+		@Bean
+		public IResourceModifiedMessagePersistenceSvc resourceModifiedMessagePersistenceSvc(){
+			return mock(IResourceModifiedMessagePersistenceSvc.class);
 		}
 
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
@@ -252,31 +252,6 @@ public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
 		assertThat(wasDeleted, is(Boolean.FALSE));
 	}
 
-//	@Test
-//	public void testPersistedResourceModifiedMessage_whenFetchFromDb_willEqualOriginalMessage() throws JsonProcessingException {
-//		mySubscriptionTestUtil.unregisterSubscriptionInterceptor();
-//		// given
-//		TransactionTemplate transactionTemplate = new TransactionTemplate(myTxManager);
-//		Observation obs = sendObservation("zoop", "SNOMED-CT", "theExplicitSource", "theRequestId");
-//
-//		ResourceModifiedMessage originalResourceModifiedMessage = createResourceModifiedMessage(obs);
-//
-//		transactionTemplate.execute(tx -> {
-//
-//				IPersistedResourceModifiedMessage persistedResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.persist(originalResourceModifiedMessage);
-//
-//				// when
-//				ResourceModifiedMessage restoredResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(persistedResourceModifiedMessage);
-//
-//				// then
-//				assertEquals(toJson(originalResourceModifiedMessage), toJson(restoredResourceModifiedMessage));
-//				assertEquals(originalResourceModifiedMessage, restoredResourceModifiedMessage);
-//
-//				return null;
-//		});
-//
-//	}
-
 	@Test
 	public void testMethodInflatePersistedResourceModifiedMessage_whenGivenResourceModifiedMessageWithEmptyPayload_willEqualOriginalMessage() {
 		mySubscriptionTestUtil.unregisterSubscriptionInterceptor();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
@@ -252,27 +252,54 @@ public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
 		assertThat(wasDeleted, is(Boolean.FALSE));
 	}
 
+//	@Test
+//	public void testPersistedResourceModifiedMessage_whenFetchFromDb_willEqualOriginalMessage() throws JsonProcessingException {
+//		mySubscriptionTestUtil.unregisterSubscriptionInterceptor();
+//		// given
+//		TransactionTemplate transactionTemplate = new TransactionTemplate(myTxManager);
+//		Observation obs = sendObservation("zoop", "SNOMED-CT", "theExplicitSource", "theRequestId");
+//
+//		ResourceModifiedMessage originalResourceModifiedMessage = createResourceModifiedMessage(obs);
+//
+//		transactionTemplate.execute(tx -> {
+//
+//				IPersistedResourceModifiedMessage persistedResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.persist(originalResourceModifiedMessage);
+//
+//				// when
+//				ResourceModifiedMessage restoredResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(persistedResourceModifiedMessage);
+//
+//				// then
+//				assertEquals(toJson(originalResourceModifiedMessage), toJson(restoredResourceModifiedMessage));
+//				assertEquals(originalResourceModifiedMessage, restoredResourceModifiedMessage);
+//
+//				return null;
+//		});
+//
+//	}
+
 	@Test
-	public void testPersistedResourceModifiedMessage_whenFetchFromDb_willEqualOriginalMessage() throws JsonProcessingException {
+	public void testMethodInflatePersistedResourceModifiedMessage_whenGivenResourceModifiedMessageWithEmptyPayload_willEqualOriginalMessage() {
 		mySubscriptionTestUtil.unregisterSubscriptionInterceptor();
-		// given
+		// setup
 		TransactionTemplate transactionTemplate = new TransactionTemplate(myTxManager);
 		Observation obs = sendObservation("zoop", "SNOMED-CT", "theExplicitSource", "theRequestId");
 
 		ResourceModifiedMessage originalResourceModifiedMessage = createResourceModifiedMessage(obs);
+		ResourceModifiedMessage resourceModifiedMessageWithEmptyPayload = createResourceModifiedMessage(obs);
+		resourceModifiedMessageWithEmptyPayload.setPayloadToNull();
 
 		transactionTemplate.execute(tx -> {
 
-				IPersistedResourceModifiedMessage persistedResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.persist(originalResourceModifiedMessage);
+			myResourceModifiedMessagePersistenceSvc.persist(originalResourceModifiedMessage);
 
-				// when
-				ResourceModifiedMessage restoredResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(persistedResourceModifiedMessage);
+			// execute
+			ResourceModifiedMessage restoredResourceModifiedMessage = myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(resourceModifiedMessageWithEmptyPayload);
 
-				// then
-				assertEquals(toJson(originalResourceModifiedMessage), toJson(restoredResourceModifiedMessage));
-				assertEquals(originalResourceModifiedMessage, restoredResourceModifiedMessage);
+			// verify
+			assertEquals(toJson(originalResourceModifiedMessage), toJson(restoredResourceModifiedMessage));
+			assertEquals(originalResourceModifiedMessage, restoredResourceModifiedMessage);
 
-				return null;
+			return null;
 		});
 
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/svc/ResourceModifiedSubmitterSvcTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/svc/ResourceModifiedSubmitterSvcTest.java
@@ -105,7 +105,7 @@ public class ResourceModifiedSubmitterSvcTest {
 		// given
 		// a successful deletion implies that the message did exist.
 		when(myResourceModifiedMessagePersistenceSvc.deleteByPK(any())).thenReturn(true);
-		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(any())).thenReturn(new ResourceModifiedMessage());
+		when(myResourceModifiedMessagePersistenceSvc.createResourceModifiedMessageFromEntityWithoutInflation(any())).thenReturn(new ResourceModifiedMessage());
 
 		// when
 		boolean wasProcessed = myResourceModifiedSubmitterSvc.submitPersisedResourceModifiedMessage(new ResourceModifiedEntity());
@@ -134,7 +134,7 @@ public class ResourceModifiedSubmitterSvcTest {
 		// when
 		when(myResourceModifiedMessagePersistenceSvc.deleteByPK(any()))
 			.thenThrow(new RuntimeException(deleteExMsg));
-		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(any()))
+		when(myResourceModifiedMessagePersistenceSvc.createResourceModifiedMessageFromEntityWithoutInflation(any()))
 			.thenThrow(new RuntimeException(inflationExMsg));
 
 		// test
@@ -180,7 +180,7 @@ public class ResourceModifiedSubmitterSvcTest {
 		// when
 		when(myResourceModifiedMessagePersistenceSvc.deleteByPK(any()))
 			.thenReturn(true);
-		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(any()))
+		when(myResourceModifiedMessagePersistenceSvc.createResourceModifiedMessageFromEntityWithoutInflation(any()))
 			.thenReturn(msg);
 		when(myChannelProducer.send(any()))
 			.thenThrow(new RuntimeException(exceptionString));
@@ -206,7 +206,7 @@ public class ResourceModifiedSubmitterSvcTest {
 		// given
 		// deletion fails, someone else was faster and processed the message
 		when(myResourceModifiedMessagePersistenceSvc.deleteByPK(any())).thenReturn(false);
-		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(any())).thenReturn(new ResourceModifiedMessage());
+		when(myResourceModifiedMessagePersistenceSvc.createResourceModifiedMessageFromEntityWithoutInflation(any())).thenReturn(new ResourceModifiedMessage());
 
 		// when
 		boolean wasProcessed = myResourceModifiedSubmitterSvc.submitPersisedResourceModifiedMessage(new ResourceModifiedEntity());
@@ -223,7 +223,7 @@ public class ResourceModifiedSubmitterSvcTest {
 	public void testSubmitPersistedResourceModifiedMessage_whitErrorOnSending_willRollbackDeletion(){
 		// given
 		when(myResourceModifiedMessagePersistenceSvc.deleteByPK(any())).thenReturn(true);
-		when(myResourceModifiedMessagePersistenceSvc.inflatePersistedResourceModifiedMessage(any())).thenReturn(new ResourceModifiedMessage());
+		when(myResourceModifiedMessagePersistenceSvc.createResourceModifiedMessageFromEntityWithoutInflation(any())).thenReturn(new ResourceModifiedMessage());
 
 		// simulate failure writing to the channel
 		when(myChannelProducer.send(any())).thenThrow(new MessageDeliveryException("sendingError"));

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/BaseResourceModifiedMessage.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/BaseResourceModifiedMessage.java
@@ -68,6 +68,12 @@ public abstract class BaseResourceModifiedMessage extends BaseResourceMessage im
 		super();
 	}
 
+	public BaseResourceModifiedMessage(IIdType theIdType, OperationTypeEnum theOperationType) {
+		this();
+		setOperationType(theOperationType);
+		setPayloadId(theIdType);
+	}
+
 	public BaseResourceModifiedMessage(
 			FhirContext theFhirContext, IBaseResource theResource, OperationTypeEnum theOperationType) {
 		this();

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/BaseResourceModifiedMessage.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/BaseResourceModifiedMessage.java
@@ -52,14 +52,14 @@ public abstract class BaseResourceModifiedMessage extends BaseResourceMessage im
 	@JsonProperty(value = "partitionId")
 	protected RequestPartitionId myPartitionId;
 
+	@JsonProperty(value = "payloadVersion")
+	protected String myPayloadVersion;
+
 	@JsonIgnore
 	protected transient IBaseResource myPayloadDecoded;
 
 	@JsonIgnore
 	protected transient String myPayloadType;
-
-	@JsonIgnore
-	protected String myPayloadVersion;
 
 	/**
 	 * Constructor

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/PayloadTooLargeException.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/PayloadTooLargeException.java
@@ -6,11 +6,11 @@ package ca.uhn.fhir.jpa.subscription.channel.api;
  */
 public class PayloadTooLargeException extends RuntimeException {
 
-    public PayloadTooLargeException(String theMessage){
-        super(theMessage);
-    }
+	public PayloadTooLargeException(String theMessage) {
+		super(theMessage);
+	}
 
-    public PayloadTooLargeException(String theMessage, Throwable theThrowable) {
-        super(theMessage, theThrowable);
-    }
+	public PayloadTooLargeException(String theMessage, Throwable theThrowable) {
+		super(theMessage, theThrowable);
+	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/PayloadTooLargeException.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/channel/api/PayloadTooLargeException.java
@@ -1,0 +1,16 @@
+package ca.uhn.fhir.jpa.subscription.channel.api;
+
+/**
+ * This exception represents the message payload exceeded the maximum message size of the broker. Used as a wrapper of
+ * similar exceptions specific to different message brokers, e.g. kafka.common.errors.RecordTooLargeException.
+ */
+public class PayloadTooLargeException extends RuntimeException {
+
+    public PayloadTooLargeException(String theMessage){
+        super(theMessage);
+    }
+
+    public PayloadTooLargeException(String theMessage, Throwable theThrowable) {
+        super(theMessage, theThrowable);
+    }
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceDeliveryMessage.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceDeliveryMessage.java
@@ -108,6 +108,10 @@ public class ResourceDeliveryMessage extends BaseResourceMessage implements IRes
 		myPayloadId = thePayload.getIdElement().toUnqualifiedVersionless().getValue();
 	}
 
+	public void setPayloadToNull() {
+		myPayloadString = null;
+	}
+
 	@Override
 	public String getPayloadId() {
 		return myPayloadId;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceModifiedMessage.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceModifiedMessage.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.rest.server.messaging.BaseResourceModifiedMessage;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 
 /**
  * Most of this class has been moved to ResourceModifiedMessage in the hapi-fhir-server project, for a reusable channel ResourceModifiedMessage
@@ -45,6 +46,11 @@ public class ResourceModifiedMessage extends BaseResourceModifiedMessage {
 	 */
 	public ResourceModifiedMessage() {
 		super();
+	}
+
+	public ResourceModifiedMessage(IIdType theIdType, OperationTypeEnum theOperationType) {
+		super(theIdType, theOperationType);
+		setPartitionId(RequestPartitionId.defaultPartition());
 	}
 
 	public ResourceModifiedMessage(
@@ -77,6 +83,10 @@ public class ResourceModifiedMessage extends BaseResourceModifiedMessage {
 
 	public void setSubscriptionId(String theSubscriptionId) {
 		mySubscriptionId = theSubscriptionId;
+	}
+
+	public void setPayloadToNull() {
+		myPayload = null;
 	}
 
 	@Override

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/subscription/api/IResourceModifiedMessagePersistenceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/subscription/api/IResourceModifiedMessagePersistenceSvc.java
@@ -58,13 +58,32 @@ public interface IResourceModifiedMessagePersistenceSvc {
 	 */
 	IPersistedResourceModifiedMessage persist(ResourceModifiedMessage theMsg);
 
+//		/**
+//		 * Restore a resourceModifiedMessage to its pre persistence representation.
+//		 *
+//		 * @param thePersistedResourceModifiedMessage The message needing restoration.
+//		 * @return The resourceModifiedMessage in its pre persistence form.
+//		 */
+//		ResourceModifiedMessage inflatePersistedResourceModifiedMessage(
+//				IPersistedResourceModifiedMessage thePersistedResourceModifiedMessage);
+
 	/**
 	 * Restore a resourceModifiedMessage to its pre persistence representation.
 	 *
-	 * @param thePersistedResourceModifiedMessage The message needing restoration.
+	 * @param theResourceModifiedMessage The message needing restoration.
 	 * @return The resourceModifiedMessage in its pre persistence form.
 	 */
 	ResourceModifiedMessage inflatePersistedResourceModifiedMessage(
+			ResourceModifiedMessage theResourceModifiedMessage);
+
+	/**
+	 * Create a ResourceModifiedMessage without its pre persistence representation, i.e. without the resource body in
+	 * payload
+	 *
+	 * @param thePersistedResourceModifiedMessage The message needing creation
+	 * @return The resourceModifiedMessage without its pre persistence form
+	 */
+	ResourceModifiedMessage createResourceModifiedMessageFromEntityWithoutInflation(
 			IPersistedResourceModifiedMessage thePersistedResourceModifiedMessage);
 
 	/**

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/subscription/api/IResourceModifiedMessagePersistenceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/subscription/api/IResourceModifiedMessagePersistenceSvc.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.model.entity.IPersistedResourceModifiedMessagePK;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * An implementer of this interface will provide {@link ResourceModifiedMessage} persistence services.
@@ -58,22 +59,22 @@ public interface IResourceModifiedMessagePersistenceSvc {
 	 */
 	IPersistedResourceModifiedMessage persist(ResourceModifiedMessage theMsg);
 
-//		/**
-//		 * Restore a resourceModifiedMessage to its pre persistence representation.
-//		 *
-//		 * @param thePersistedResourceModifiedMessage The message needing restoration.
-//		 * @return The resourceModifiedMessage in its pre persistence form.
-//		 */
-//		ResourceModifiedMessage inflatePersistedResourceModifiedMessage(
-//				IPersistedResourceModifiedMessage thePersistedResourceModifiedMessage);
-
 	/**
 	 * Restore a resourceModifiedMessage to its pre persistence representation.
 	 *
 	 * @param theResourceModifiedMessage The message needing restoration.
 	 * @return The resourceModifiedMessage in its pre persistence form.
 	 */
-	ResourceModifiedMessage inflatePersistedResourceModifiedMessage(
+	ResourceModifiedMessage inflatePersistedResourceModifiedMessage(ResourceModifiedMessage theResourceModifiedMessage);
+
+	/**
+	 * Restore a resourceModifiedMessage to its pre persistence representation or null if the resource does not exist.
+	 *
+	 * @param theResourceModifiedMessage
+	 * @return An Optional containing The resourceModifiedMessage in its pre persistence form or null when the resource
+	 * does not exist
+	 */
+	Optional<ResourceModifiedMessage> inflatePersistedResourceModifiedMessageOrNull(
 			ResourceModifiedMessage theResourceModifiedMessage);
 
 	/**


### PR DESCRIPTION
What was done:
1. Moved the inflation of the resource from before the matching queue to the matcher. Now, the payload of all messages going into the matching queue from `ResourceModifiedSubmitterSvc` would be null, and the `SubscriptionMatchingSubscriber` will inflate them using their id and version.
2. In `SubscriptionMatchDeliverer`, added the ability to handle `PayloadTooLargeException`. When encountering this exception, the deliverer will retry sending the message without payload, as in `ResourceModifiedSubmitterSvc`.
3. Added the ability to inflate messages in SubscriptionDeliveringMessageSubscriber and SubscriptionDeliveringEmailSubscriber in response to the changes in 2. (SubscriptionDeliveringRestHookSubscriber already have this ability, see [line 216](https://github.com/hapifhir/hapi-fhir/blob/52f3ef599271e47e3856151104649711d505c4aa/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/deliver/resthook/SubscriptionDeliveringRestHookSubscriber.java#L216))
4. Added/modified corresponding tests and changelog.