### PR TITLE
If AutoInflateBinaries is enabled, binaries are created on the disk only for the first resource entry of the bundle

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5419-binaries-created-only-for-the-first-resource-entry-of-the-bundle.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5419-binaries-created-only-for-the-first-resource-entry-of-the-bundle.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5419
+title: "Previously, when `AllowAutoInflateBinaries` was enabled in `JpaStorageSettings` and bundles with multiple 
+resources were submitted, binaries were created on the disk only for the first resource entry of the bundle. 
+This has been fixed."


### PR DESCRIPTION
Previously, when `AllowAutoInflateBinaries` was enabled in `JpaStorageSettings` and bundles with multiple 
resources were submitted, binaries were created on the disk only for the first resource entry of the bundle. 
This has been fixed.