### PR TITLE
Bump core to 6.1.2.1

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/changes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/changes.yaml
@@ -11,5 +11,5 @@
         <li>Thymeleaf (Testpage Overlay): 3.0.14.RELEASE -&gt; 3.1.2.RELEASE</li>
         <li>xpp3 (All): 1.1.4c.0 -&gt; 1.1.6</li>
         <li>HtmlUnit (All): 2.67.0 -&gt; 2.70.0</li>
-        <li>org.hl7.fhir.core (All): 6.0.22.2 -&gt; 6.1.2</li>
+        <li>org.hl7.fhir.core (All): 6.0.22.2 -&gt; 6.1.2.1</li>
    </ul>"

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.1.2</fhir_core_version>
+		<fhir_core_version>6.1.2.1</fhir_core_version>
 		<spotless_version>2.37.0</spotless_version>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>
 


### PR DESCRIPTION
Patch release that uses https for primary org.hl7.fhir.core package server