### PR TITLE
Fix VersionCanonicalizer conversion from R5 into DSTU2 for CapabilityStatement, Parameters and StructuredDefinition

### DIFF
--- a/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
+++ b/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
@@ -65,11 +65,11 @@ import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.StructureDefinition;
 
+import javax.annotation.Nonnull;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -458,7 +458,7 @@ public class VersionCanonicalizer {
 		@Override
 		public IBaseParameters parametersFromCanonical(Parameters theParameters) {
 			Resource converted = VersionConvertorFactory_10_40.convertResource(theParameters, ADVISOR_10_40);
-			return (IBaseParameters) reencodeToHl7Org(converted);
+			return (IBaseParameters) reencodeFromHl7Org(converted);
 		}
 
 		@Override
@@ -470,7 +470,7 @@ public class VersionCanonicalizer {
 		@Override
 		public IBaseResource structureDefinitionFromCanonical(StructureDefinition theResource) {
 			Resource converted = VersionConvertorFactory_10_50.convertResource(theResource, ADVISOR_10_50);
-			return reencodeToHl7Org(converted);
+			return reencodeFromHl7Org(converted);
 		}
 
 		@Override
@@ -514,7 +514,7 @@ public class VersionCanonicalizer {
 		@Override
 		public IBaseConformance capabilityStatementFromCanonical(CapabilityStatement theResource) {
 			Resource converted = VersionConvertorFactory_10_50.convertResource(theResource, ADVISOR_10_50);
-			return (IBaseConformance) reencodeToHl7Org(converted);
+			return (IBaseConformance) reencodeFromHl7Org(converted);
 		}
 
 		private Resource reencodeToHl7Org(IBaseResource theInput) {

--- a/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
+++ b/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
@@ -65,11 +65,11 @@ import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.StructureDefinition;
 
-import javax.annotation.Nonnull;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 

--- a/hapi-fhir-converter/src/test/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizerTest.java
+++ b/hapi-fhir-converter/src/test/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizerTest.java
@@ -2,22 +2,19 @@ package ca.uhn.hapi.converters.canonical;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.model.dstu2.composite.CodingDt;
+import ca.uhn.fhir.model.dstu2.resource.Conformance;
 import ca.uhn.fhir.util.HapiExtensions;
-import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
-import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r5.model.CapabilityStatement;
 import org.hl7.fhir.r5.model.Enumeration;
 import org.hl7.fhir.r5.model.SearchParameter;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.util.ExtensionUtil.getExtensionPrimitiveValues;
@@ -25,73 +22,100 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class VersionCanonicalizerTest {
+	@Nested
+	class VersionCanonicalizerR4 {
 
-	@Test
-	public void testToCanonicalCoding() {
-		VersionCanonicalizer canonicalizer = new VersionCanonicalizer(FhirVersionEnum.DSTU2);
-		IBaseCoding coding = new CodingDt("dstuSystem", "dstuCode");
-		Coding convertedCoding = canonicalizer.codingToCanonical(coding);
-		assertEquals("dstuCode", convertedCoding.getCode());
-		assertEquals("dstuSystem", convertedCoding.getSystem());
+		private static final FhirVersionEnum FHIR_VERSION = FhirVersionEnum.R4;
+		private static final VersionCanonicalizer ourCanonicalizer = new VersionCanonicalizer(FHIR_VERSION);
+		@Test
+		public void testToCanonical_SearchParameterNoCustomResourceType_ConvertedCorrectly() {
+			org.hl7.fhir.r4.model.SearchParameter input = new org.hl7.fhir.r4.model.SearchParameter();
+			input.addBase("Patient");
+			input.addBase("Observation");
+			input.addTarget("Organization");
+
+			// Test
+			org.hl7.fhir.r5.model.SearchParameter actual = ourCanonicalizer.searchParameterToCanonical(input);
+
+			// Verify
+			assertThat(actual.getBase().stream().map(Enumeration::getCode).collect(Collectors.toList()), contains("Patient", "Observation"));
+			assertThat(actual.getTarget().stream().map(Enumeration::getCode).collect(Collectors.toList()), contains("Organization"));
+			assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE), empty());
+			assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE), empty());
+
+		}
+
+		@Test
+		public void testToCanonical_SearchParameterWithCustomResourceType__ConvertedCorrectly() {
+			// Setup
+			org.hl7.fhir.r4.model.SearchParameter input = new org.hl7.fhir.r4.model.SearchParameter();
+			input.addBase("Base1");
+			input.addBase("Base2");
+			input.addTarget("Target1");
+			input.addTarget("Target2");
+
+			// Test
+			org.hl7.fhir.r5.model.SearchParameter actual = ourCanonicalizer.searchParameterToCanonical(input);
+
+			// Verify
+			assertThat(actual.getBase().stream().map(Enumeration::getCode).collect(Collectors.toList()), empty());
+			assertThat(actual.getTarget().stream().map(Enumeration::getCode).collect(Collectors.toList()), empty());
+			assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE), contains("Base1", "Base2"));
+			assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE), contains("Target1", "Target2"));
+			// Original shouldn't be modified
+			assertThat(input.getBase().stream().map(CodeType::getCode).toList(), contains("Base1", "Base2"));
+			assertThat(input.getTarget().stream().map(CodeType::getCode).toList(), contains("Target1", "Target2"));
+
+		}
 	}
 
-	@Test
-	public void testFromCanonicalSearchParameter() {
-		VersionCanonicalizer canonicalizer = new VersionCanonicalizer(FhirVersionEnum.DSTU2);
+	@Nested
+	class VersionCanonicalizerDstu2 {
+		private static final FhirVersionEnum FHIR_VERSION = FhirVersionEnum.DSTU2;
+		private static final VersionCanonicalizer ourCanonicalizer = new VersionCanonicalizer(FHIR_VERSION);
 
-		SearchParameter inputR5 = new SearchParameter();
-		inputR5.setUrl("http://foo");
-		ca.uhn.fhir.model.dstu2.resource.SearchParameter outputDstu2 = (ca.uhn.fhir.model.dstu2.resource.SearchParameter) canonicalizer.searchParameterFromCanonical(inputR5);
-		assertEquals("http://foo", outputDstu2.getUrl());
+		@Test
+		public void testToCanonical_Coding_ConvertSuccessful() {
+			IBaseCoding coding = new CodingDt("dstuSystem", "dstuCode");
+			Coding convertedCoding = ourCanonicalizer.codingToCanonical(coding);
+			assertEquals("dstuCode", convertedCoding.getCode());
+			assertEquals("dstuSystem", convertedCoding.getSystem());
+		}
+
+		@Test
+		public void testFromCanonical_SearchParameter_ConvertSuccessful() {
+			SearchParameter inputR5 = new SearchParameter();
+			inputR5.setUrl("http://foo");
+			ca.uhn.fhir.model.dstu2.resource.SearchParameter outputDstu2 = (ca.uhn.fhir.model.dstu2.resource.SearchParameter) ourCanonicalizer.searchParameterFromCanonical(inputR5);
+			assertEquals("http://foo", outputDstu2.getUrl());
+		}
+
+		@Test
+		public void testFromCanonical_CapabilityStatement_ConvertSuccessful() {
+			CapabilityStatement inputR5 = new CapabilityStatement();
+			inputR5.setUrl("http://foo");
+			Conformance conformance = (Conformance) ourCanonicalizer.capabilityStatementFromCanonical(inputR5);
+			assertEquals("http://foo", conformance.getUrl());
+		}
+
+		@Test
+		public void testFromCanonical_StructureDefinition_ConvertSuccessful() {
+			StructureDefinition inputR5 = new StructureDefinition();
+			inputR5.setId("123");
+			ca.uhn.fhir.model.dstu2.resource.StructureDefinition structureDefinition = (ca.uhn.fhir.model.dstu2.resource.StructureDefinition) ourCanonicalizer.structureDefinitionFromCanonical(inputR5);
+			assertEquals("StructureDefinition/123", structureDefinition.getId().getValue());
+		}
+
+		@Test
+		public void testFromCanonical_Parameters_ConvertSuccessful() {
+			org.hl7.fhir.r4.model.Parameters inputR4 = new Parameters();
+			inputR4.setParameter("paramA", "1");
+			ca.uhn.fhir.model.dstu2.resource.Parameters parameters = (ca.uhn.fhir.model.dstu2.resource.Parameters) ourCanonicalizer.parametersFromCanonical(inputR4);
+			assertNotNull(parameters.getParameter());
+			assertEquals("paramA", parameters.getParameter().get(0).getName());
+		}
 	}
-
-	@Test
-	public void testToCanonicalSearchParameter_NoCustomResourceType() {
-		// Setup
-		VersionCanonicalizer canonicalizer = new VersionCanonicalizer(FhirVersionEnum.R4);
-
-		org.hl7.fhir.r4.model.SearchParameter input = new org.hl7.fhir.r4.model.SearchParameter();
-		input.addBase("Patient");
-		input.addBase("Observation");
-		input.addTarget("Organization");
-
-		// Test
-		org.hl7.fhir.r5.model.SearchParameter actual = canonicalizer.searchParameterToCanonical(input);
-
-		// Verify
-		assertThat(actual.getBase().stream().map(Enumeration::getCode).collect(Collectors.toList()), contains("Patient", "Observation"));
-		assertThat(actual.getTarget().stream().map(Enumeration::getCode).collect(Collectors.toList()), contains("Organization"));
-		assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE), empty());
-		assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE), empty());
-
-	}
-
-	@Test
-	public void testToCanonicalSearchParameter_WithCustomResourceType() {
-		// Setup
-		VersionCanonicalizer canonicalizer = new VersionCanonicalizer(FhirVersionEnum.R4);
-
-		org.hl7.fhir.r4.model.SearchParameter input = new org.hl7.fhir.r4.model.SearchParameter();
-		input.addBase("Base1");
-		input.addBase("Base2");
-		input.addTarget("Target1");
-		input.addTarget("Target2");
-
-		// Test
-		org.hl7.fhir.r5.model.SearchParameter actual = canonicalizer.searchParameterToCanonical(input);
-
-		// Verify
-		assertThat(actual.getBase().stream().map(Enumeration::getCode).collect(Collectors.toList()), empty());
-		assertThat(actual.getTarget().stream().map(Enumeration::getCode).collect(Collectors.toList()), empty());
-		assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_BASE_RESOURCE), contains("Base1", "Base2"));
-		assertThat(getExtensionPrimitiveValues(actual, HapiExtensions.EXTENSION_SEARCHPARAM_CUSTOM_TARGET_RESOURCE), contains("Target1", "Target2"));
-		// Original shouldn't be modified
-		assertThat(input.getBase().stream().map(CodeType::getCode).toList(), contains("Base1", "Base2"));
-		assertThat(input.getTarget().stream().map(CodeType::getCode).toList(), contains("Target1", "Target2"));
-
-	}
-
-
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5431-version_canonicalizer_fails_capabilitystatement_dstu2.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/6_10_0/5431-version_canonicalizer_fails_capabilitystatement_dstu2.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5431
+jira: SMILE-5306
+title: "Previously, using VersionCanonicalizer to convert a CapabilityStatement from R5 to DSTU2 would fail. This is now fixed."


### PR DESCRIPTION
There was a likely typo when this code was written, using **to** instead of **from** helper methods.