### PR TITLE
Resolve 5445-adding-extra-logs-to-mdm-candidate-search-parameter

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5445-adding-extra-logs-to-mdm-candidate-search-parameter.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5445-adding-extra-logs-to-mdm-candidate-search-parameter.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5445
+title: "Added warnings when MDM candidate search parameters are not defined and candidate search limit is exceeded."

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/broker/MdmMessageHandler.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/broker/MdmMessageHandler.java
@@ -87,9 +87,6 @@ public class MdmMessageHandler implements MessageHandler {
 			if (toProcess) {
 				matchMdmAndUpdateLinks(sourceResource, msg);
 			}
-		} catch (TooManyCandidatesException e) {
-			ourLog.error(e.getMessage(), e);
-			// skip this one with an error message and continue processing
 		} catch (Exception e) {
 			ourLog.error("Failed to handle MDM Matching Resource:", e);
 			throw e;
@@ -123,6 +120,12 @@ public class MdmMessageHandler implements MessageHandler {
 					ourLog.trace("Not processing modified message for {}", theMsg.getOperationType());
 			}
 		} catch (Exception e) {
+			if (e instanceof TooManyCandidatesException) {
+				ourLog.debug(
+						"Failed to handle MDM Matching for resource: {} since candidate matches exceeded the "
+								+ "candidate search limit",
+						theSourceResource.getIdElement());
+			}
 			log(mdmContext, "Failure during MDM processing: " + e.getMessage(), e);
 			mdmContext.addTransactionLogMessage(e.getMessage());
 		} finally {

--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/candidate/MdmCandidateSearchSvc.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/candidate/MdmCandidateSearchSvc.java
@@ -159,7 +159,8 @@ public class MdmCandidateSearchSvc {
 				myCandidateSearcher.search(theResourceType, resourceCriteria, theRequestPartitionId);
 		if (!bundleProvider.isPresent()) {
 			throw new TooManyCandidatesException(Msg.code(762) + "More than " + myMdmSettings.getCandidateSearchLimit()
-					+ " candidate matches found for " + resourceCriteria + ".  Aborting mdm matching.");
+					+ " candidate matches found for " + resourceCriteria + ".  Aborting mdm matching. Updating the "
+					+ "candidate search parameters is strongly recommended for better performance of MDM.");
 		}
 		List<IBaseResource> resources = bundleProvider.get().getAllResources();
 

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmCandidateSearchSvcIT.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/svc/MdmCandidateSearchSvcIT.java
@@ -149,7 +149,7 @@ public class MdmCandidateSearchSvcIT extends BaseMdmR4Test {
 			myMdmCandidateSearchSvc.findCandidates("Patient", newJane, RequestPartitionId.allPartitions());
 			fail();
 		} catch (TooManyCandidatesException e) {
-			assertEquals("HAPI-0762: More than 3 candidate matches found for Patient?identifier=http%3A%2F%2Fa.tv%2F%7CID.JANE.123&active=true.  Aborting mdm matching.", e.getMessage());
+			assertEquals("HAPI-0762: More than 3 candidate matches found for Patient?identifier=http%3A%2F%2Fa.tv%2F%7CID.JANE.123&active=true.  Aborting mdm matching. Updating the candidate search parameters is strongly recommended for better performance of MDM.", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/config/MdmRuleValidator.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/config/MdmRuleValidator.java
@@ -136,7 +136,10 @@ public class MdmRuleValidator implements IMdmRuleValidator {
 
 	private void validateSearchParams(MdmRulesJson theMdmRulesJson) {
 		ourLog.info("Validating search parameters {}", theMdmRulesJson.getCandidateSearchParams());
-
+		if (theMdmRulesJson.getCandidateSearchParams().isEmpty()) {
+			ourLog.warn("No candidate search parameter was found. Defining candidate search parameter is strongly "
+					+ "recommended for better performance of MDM");
+		}
 		for (MdmResourceSearchParamJson searchParams : theMdmRulesJson.getCandidateSearchParams()) {
 			searchParams
 					.iterator()


### PR DESCRIPTION
- Added logs when MDM candidate search parameters are not defined and candidate search limit is exceeded.
- modified corresponding tests and added changelog