### PR TITLE
remove requirement to have 'missing' idxs enabled for patient bulk export

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
@@ -163,13 +163,6 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 			throws IOException {
 		LinkedHashSet<JpaPid> pids = new LinkedHashSet<>();
 		// Patient
-		if (myStorageSettings.getIndexMissingFields() == JpaStorageSettings.IndexEnabledEnum.DISABLED) {
-			String errorMessage =
-					"You attempted to start a Patient Bulk Export, but the system has `Index Missing Fields` disabled. It must be enabled for Patient Bulk Export";
-			ourLog.error(errorMessage);
-			throw new IllegalStateException(Msg.code(797) + errorMessage);
-		}
-
 		Set<String> patientSearchParams =
 				SearchParameterUtil.getPatientSearchParamsForResourceType(myContext, theParams.getResourceType());
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
@@ -203,8 +203,6 @@ public class JpaBulkExportProcessorTest {
 		ISearchBuilder<JpaPid> searchBuilder = mock(ISearchBuilder.class);
 
 		// when
-		when(myStorageSettings.getIndexMissingFields())
-			.thenReturn(JpaStorageSettings.IndexEnabledEnum.ENABLED);
 		when(myBulkExportHelperService.createSearchParameterMapsForResourceType(any(RuntimeResourceDefinition.class), eq(parameters), any(boolean.class)))
 			.thenReturn(maps);
 		// from getSearchBuilderForLocalResourceType
@@ -245,26 +243,7 @@ public class JpaBulkExportProcessorTest {
 			return RequestPartitionId.allPartitions();
 		}
 	}
-
-	@Test
-	public void getResourcePidIterator_patientStyleWithIndexMissingFieldsDisabled_throws() {
-		// setup
-		ExportPIDIteratorParameters parameters = createExportParameters(BulkExportJobParameters.ExportStyle.PATIENT);
-		parameters.setResourceType("Patient");
-
-		// when
-		when(myStorageSettings.getIndexMissingFields())
-			.thenReturn(JpaStorageSettings.IndexEnabledEnum.DISABLED);
-
-		// test
-		try {
-			myProcessor.getResourcePidIterator(parameters);
-			fail();
-		} catch (InternalErrorException ex) {
-			assertThat(ex.getMessage(), containsString("You attempted to start a Patient Bulk Export,"));
-		}
-	}
-
+	
 	@ParameterizedTest
 	@CsvSource({"false, false", "false, true", "true, true", "true, false"})
 	public void getResourcePidIterator_groupExportStyleWithPatientResource_returnsIterator(boolean theMdm, boolean thePartitioned) {


### PR DESCRIPTION
TBH, I'm not clear why missing indexes were required for patient bulk export in the first place. So I'm not certain if this PR is "safe". But submitting for review in the hopes it was some old holdover that is no longer necessary. 