### PR TITLE
Resolve 5452-mdm-query-link-returns-scientific-notation-in-linkcreated-and-linkupdated

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
@@ -403,8 +403,15 @@ public class ParametersUtil {
 	public static void addPartDecimal(FhirContext theContext, IBase theParameter, String theName, Double theValue) {
 		IPrimitiveType<BigDecimal> value = (IPrimitiveType<BigDecimal>)
 				theContext.getElementDefinition("decimal").newInstance();
-		value.setValue(theValue == null ? null : BigDecimal.valueOf(theValue).setScale(0));
-
+		if (theValue == null) {
+			value.setValue(null);
+		} else {
+			BigDecimal decimalValue = BigDecimal.valueOf(theValue);
+			if (decimalValue.scale() < 0) {
+				decimalValue = decimalValue.setScale(0);
+			}
+			value.setValue(decimalValue);
+		}
 		addPart(theContext, theParameter, theName, value);
 	}
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
@@ -403,7 +403,7 @@ public class ParametersUtil {
 	public static void addPartDecimal(FhirContext theContext, IBase theParameter, String theName, Double theValue) {
 		IPrimitiveType<BigDecimal> value = (IPrimitiveType<BigDecimal>)
 				theContext.getElementDefinition("decimal").newInstance();
-		value.setValue(theValue == null ? null : BigDecimal.valueOf(theValue));
+		value.setValue(theValue == null ? null : BigDecimal.valueOf(theValue).setScale(0));
 
 		addPart(theContext, theParameter, theName, value);
 	}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5452-mdm-query-link-returns-scientific-notation-in-linkCreated-and-linkUpdated.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5452-mdm-query-link-returns-scientific-notation-in-linkCreated-and-linkUpdated.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5452
+title: "Previously, the $mdm-query-link operation would return values of field linkCreated and linkUpdated in scientific
+notation when the last digits are 0. This is now fixed and always returns in standard notation."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/ParametersUtilR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/ParametersUtilR4Test.java
@@ -9,6 +9,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,5 +79,21 @@ public class ParametersUtilR4Test {
 		assertThat(values.get(0), is(TEST_PERSON_ID));
 		assertThat(values.get(1), is(TEST_PERSON_ID));
 		assertThat(values.get(2), is(TEST_PERSON_ID));
+	}
+
+	@Test
+	public void testAddPartDecimalNoScientificNotation() {
+		// setup
+		Double decimalValue = Double.valueOf("10000000");
+		IBaseParameters parameters = ParametersUtil.newInstance(ourFhirContext);
+		IBase resultPart = ParametersUtil.addParameterToParameters(ourFhirContext, parameters, "link");
+
+		// execute
+		ParametersUtil.addPartDecimal(ourFhirContext, resultPart, "linkCreated", decimalValue);
+
+		// verify
+		String expected = BigDecimal.valueOf(decimalValue).toPlainString();
+		List<String> results = ParametersUtil.getNamedParameterPartAsString(ourFhirContext, parameters, "link", "linkCreated");
+		assertEquals(expected, results.get(0));
 	}
 }


### PR DESCRIPTION
What was done:
- set negative scale to 0 when converting double to BigDecimal