### PR TITLE
Fix broken links for us core ig and supported hibernate databases in documentation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/architecture.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/architecture.md
@@ -14,7 +14,7 @@ The HAPI JPA Server has the following components:
 
 * **Hibernate:** The HAPI JPA Server uses the JPA library, implemented by Hibernate. No Hibernate specific features are used, so the library should also work with other providers (e.g. Eclipselink) but it is not tested regularly with them.
 
-* **Database:** The RESTful server uses an embedded Derby database, but can be configured to talk to [any database supported by Hibernate](https://developer.jboss.org/wiki/SupportedDatabases2?_sscc=t).
+* **Database:** The RESTful server uses an embedded Derby database, but can be configured to talk to [any database supported by Hibernate](https://github.com/hibernate/hibernate-orm/blob/main/dialects.adoc).
 
 # Schema
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/validation/introduction.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/validation/introduction.md
@@ -8,6 +8,6 @@ This section contains details on several strategies for validating resources:
 
 * **[Instance Validator](./instance_validator.html)** is validation of the raw or parsed resource against the official FHIR validation rules (ie. the official FHIR definitions, expressed as profile resources such as [StructureDefinition](http://hl7.org/fhir/structuredefinition.html) and [ValueSet](http://hl7.org/fhir/valueset.html).
 
-  The Instance Validator can also be used to validate resources against individual Implementation Guides which derive from the core specification (e.g. the [US Core](http://hl7.com/uscore) implementation guide).
+  The Instance Validator can also be used to validate resources against individual Implementation Guides which derive from the core specification (e.g. the [US Core](https://build.fhir.org/ig/HL7/US-Core/) implementation guide).
   
 * **[Schema/Schematron Validation](./schema_validator.html)** is validation using XSD/SCH validation files provided by FHIR. This validator performs well but produces less usable error messages than Profile Validation. It is considered a legacy feature, as the Instance Validator is now mature and preferred.


### PR DESCRIPTION
The previous US Core IG guide link was broken and redirected me to hl7.com (which doesn't exist). The previous hibernate supported databases link was also broken and resulted in a 404 error.