### PR TITLE
Remove mandatory caffeine dependency

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5472-remove-mandatory-caffeine-dependency-in-validator-module.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5472-remove-mandatory-caffeine-dependency-in-validator-module.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+title: "The hapi-fhir-validation module inadvertently included a mandatory dependency on the Caffeine 
+  caching library instead of leaving it to implementors to choose which module to pick. This has been
+  corrected."

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -160,6 +160,12 @@
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-commons</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-caching-caffeine</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 	<build>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -26,15 +26,9 @@
 			<artifactId>hapi-fhir-converter</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-caching-caffeine</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -82,16 +76,13 @@
 
 			</exclusions>
 		</dependency>
-
-
-
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.utilities</artifactId>
 			<version>${fhir_core_version}</version>
 		</dependency>
 
-        <dependency>
+      <dependency>
             <groupId>org.fhir</groupId>
             <artifactId>ucum</artifactId>
 			  <exclusions>
@@ -101,11 +92,6 @@
 				  </exclusion>
 			  </exclusions>
         </dependency>
-
-        <dependency>
-			<groupId>com.github.ben-manes.caffeine</groupId>
-			<artifactId>caffeine</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
@@ -351,6 +337,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 	  </dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-caching-caffeine</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Remove non-optional dependency on Caffeine cache in the validation module as requested in #3977