### PR TITLE
Resolve 5480 Update member-match signature to match the spec

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>6.11.1-SNAPSHOT</version>
+		 <version>6.11.2-SNAPSHOT</version>
 
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
@@ -227,8 +227,8 @@ public class Constants {
 
 	public static final String PARAM_MEMBER_IDENTIFIER = "MemberIdentifier";
 
-	public static final String PARAM_OLD_COVERAGE = "OldCoverage";
-	public static final String PARAM_NEW_COVERAGE = "NewCoverage";
+	public static final String COVERAGE_TO_MATCH = "CoverageToMatch";
+	public static final String COVERAGE_TO_LINK = "CoverageToLink";
 	public static final String PARAM_CONSENT = "Consent";
 	public static final String PARAM_MEMBER_PATIENT_NAME = PARAM_MEMBER_PATIENT + " Name";
 	public static final String PARAM_MEMBER_PATIENT_BIRTHDATE = PARAM_MEMBER_PATIENT + " Birthdate";

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>6.11.1-SNAPSHOT</version>
+	<version>6.11.2-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5480-update-member-match-signature-to-match-the-spec.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5480-update-member-match-signature-to-match-the-spec.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 5480
+title: "Updated $member-match operation signature to match the latest specification."

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatchR4ResourceProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatchR4ResourceProvider.java
@@ -59,18 +59,18 @@ public class MemberMatchR4ResourceProvider {
 			returnParameters = {@OperationParam(name = "MemberIdentifier", typeName = "string")})
 	public Parameters patientMemberMatch(
 			javax.servlet.http.HttpServletRequest theServletRequest,
-			@Description(
-							shortDefinition =
-									"The target of the operation. Will be returned with Identifier for matched coverage added.")
+			@Description(shortDefinition = "The target of the operation. Contain member Patient demographics.")
 					@OperationParam(name = Constants.PARAM_MEMBER_PATIENT, min = 1, max = 1)
 					Patient theMemberPatient,
-			@Description(shortDefinition = "Old coverage information as extracted from beneficiary's card.")
-					@OperationParam(name = Constants.PARAM_OLD_COVERAGE, min = 1, max = 1)
+			@Description(
+							shortDefinition =
+									"Old coverage information as extracted from beneficiary's card. Identifies the coverage to be matched by the receiving payer.")
+					@OperationParam(name = Constants.COVERAGE_TO_MATCH, min = 1, max = 1)
 					Coverage oldCoverage,
 			@Description(
 							shortDefinition =
-									"New Coverage information. Provided as a reference. Optionally returned unmodified.")
-					@OperationParam(name = Constants.PARAM_NEW_COVERAGE, min = 1, max = 1)
+									"New Coverage information. Identifies the coverage information of the member as they are known by the requesting payer. Provided as a reference.")
+					@OperationParam(name = Constants.COVERAGE_TO_LINK, min = 1, max = 1)
 					Coverage newCoverage,
 			@Description(
 							shortDefinition =
@@ -129,14 +129,14 @@ public class MemberMatchR4ResourceProvider {
 
 		myMemberMatcherR4Helper.addMemberIdentifierToMemberPatient(theMemberPatient, patient.getIdentifierFirstRep());
 		myMemberMatcherR4Helper.updateConsentForMemberMatch(theConsent, patient, theMemberPatient, theRequestDetails);
-		return myMemberMatcherR4Helper.buildSuccessReturnParameters(theMemberPatient, theCoverageToLink, theConsent);
+		return myMemberMatcherR4Helper.buildSuccessReturnParameters(patient);
 	}
 
 	private void validateParams(
 			Patient theMemberPatient, Coverage theOldCoverage, Coverage theNewCoverage, Consent theConsent) {
 		validateParam(theMemberPatient, Constants.PARAM_MEMBER_PATIENT);
-		validateParam(theOldCoverage, Constants.PARAM_OLD_COVERAGE);
-		validateParam(theNewCoverage, Constants.PARAM_NEW_COVERAGE);
+		validateParam(theOldCoverage, Constants.COVERAGE_TO_MATCH);
+		validateParam(theNewCoverage, Constants.COVERAGE_TO_LINK);
 		validateParam(theConsent, Constants.PARAM_CONSENT);
 		validateMemberPatientParam(theMemberPatient);
 		validateConsentParam(theConsent);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4Helper.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4Helper.java
@@ -51,10 +51,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
-import static ca.uhn.fhir.rest.api.Constants.PARAM_CONSENT;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_IDENTIFIER;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_NEW_COVERAGE;
 
 public class MemberMatcherR4Helper {
 	static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(MemberMatcherR4Helper.class);
@@ -144,13 +141,13 @@ public class MemberMatcherR4Helper {
 		myConsentDao.create(theConsent, theRequestDetails);
 	}
 
-	public Parameters buildSuccessReturnParameters(Patient theMemberPatient, Coverage theCoverage, Consent theConsent) {
+	public Parameters buildSuccessReturnParameters(Patient thePatient) {
 		IBaseParameters parameters = ParametersUtil.newInstance(myFhirContext);
-		ParametersUtil.addParameterToParameters(myFhirContext, parameters, PARAM_MEMBER_PATIENT, theMemberPatient);
-		ParametersUtil.addParameterToParameters(myFhirContext, parameters, PARAM_NEW_COVERAGE, theCoverage);
-		ParametersUtil.addParameterToParameters(myFhirContext, parameters, PARAM_CONSENT, theConsent);
 		ParametersUtil.addParameterToParameters(
-				myFhirContext, parameters, PARAM_MEMBER_IDENTIFIER, getIdentifier(theMemberPatient));
+				myFhirContext,
+				parameters,
+				PARAM_MEMBER_IDENTIFIER,
+				thePatient.getIdElement().toUnqualifiedVersionless());
 		return (Parameters) parameters;
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4HelperTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4HelperTest.java
@@ -1,7 +1,6 @@
 package ca.uhn.fhir.jpa.provider.r4;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.model.api.IQueryParameterType;
@@ -20,6 +19,7 @@ import org.hl7.fhir.r4.model.Consent;
 import org.hl7.fhir.r4.model.Coverage;
 import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
@@ -40,13 +40,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static ca.uhn.fhir.rest.api.Constants.PARAM_CONSENT;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_IDENTIFIER;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_NEW_COVERAGE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -162,38 +158,13 @@ public class MemberMatcherR4HelperTest {
 		identifierType.addCoding(new Coding("", "MB", ""));
 		identifier.setType(identifierType);
 		Patient patient = new Patient();
-		Coverage coverage = new Coverage();
-		Consent consent = new Consent();
+		patient.setId("testPatient");
 		patient.addIdentifier(identifier);
 
-		Parameters result = myHelper.buildSuccessReturnParameters(patient, coverage, consent);
+		Parameters result = myHelper.buildSuccessReturnParameters(patient);
 
-		assertEquals(PARAM_MEMBER_PATIENT, result.getParameter().get(0).getName());
-		assertEquals(patient, result.getParameter().get(0).getResource());
-
-		assertEquals(PARAM_NEW_COVERAGE, result.getParameter().get(1).getName());
-		assertEquals(coverage, result.getParameter().get(1).getResource());
-
-		assertEquals(PARAM_CONSENT, result.getParameter().get(2).getName());
-		assertEquals(consent, result.getParameter().get(2).getResource());
-
-		assertEquals(PARAM_MEMBER_IDENTIFIER, result.getParameter().get(3).getName());
-		assertEquals(identifier, result.getParameter().get(3).getValue());
-	}
-
-	@Test
-	void buildNotSuccessReturnParameters_IncorrectPatientIdentifier() {
-		Identifier identifier = new Identifier();
-		Patient patient = new Patient();
-		Coverage coverage = new Coverage();
-		Consent consent = new Consent();
-		patient.addIdentifier(identifier);
-
-		try {
-			myHelper.buildSuccessReturnParameters(patient, coverage, consent);
-		} catch (Exception e) {
-			assertThat(e.getMessage(), startsWith(Msg.code(2219)));
-		}
+		assertEquals(PARAM_MEMBER_IDENTIFIER, result.getParameter().get(0).getName());
+		assertEquals(patient.getId(), ((IdType)(result.getParameter().get(0).getValue())).getValue());
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4HelperTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/MemberMatcherR4HelperTest.java
@@ -158,7 +158,7 @@ public class MemberMatcherR4HelperTest {
 		identifierType.addCoding(new Coding("", "MB", ""));
 		identifier.setType(identifierType);
 		Patient patient = new Patient();
-		patient.setId("testPatient");
+		patient.setId("Patient/test123");
 		patient.addIdentifier(identifier);
 
 		Parameters result = myHelper.buildSuccessReturnParameters(patient);

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-ips/pom.xml
+++ b/hapi-fhir-jpaserver-ips/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-dstu2/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-dstu3/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu3/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
@@ -258,9 +258,9 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	/**
 	 * validates that the returned patient ID is correct
 	 */
-	private void validateMemberIdentifier(Parameters response){
-		assertTrue(response.hasParameter(PARAM_MEMBER_IDENTIFIER));
-		Optional<IBase> memberIdentifierOptional = ParametersUtil.getNamedParameter(this.getFhirContext(), response, PARAM_MEMBER_IDENTIFIER);
+	private void validateMemberIdentifier(Parameters theResponse){
+		assertTrue(theResponse.hasParameter(PARAM_MEMBER_IDENTIFIER));
+		Optional<IBase> memberIdentifierOptional = ParametersUtil.getNamedParameter(this.getFhirContext(), theResponse, PARAM_MEMBER_IDENTIFIER);
 		assertTrue(memberIdentifierOptional.isPresent());
 		IdType memberIdentifier = (IdType) ((Parameters.ParametersParameterComponent) memberIdentifierOptional.get()).getValue();
 		assertEquals(PATIENT_ID, memberIdentifier.getValue());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
@@ -12,17 +12,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Consent;
-import org.hl7.fhir.r4.model.Coverage;
-import org.hl7.fhir.r4.model.DateType;
-import org.hl7.fhir.r4.model.Enumerations;
-import org.hl7.fhir.r4.model.HumanName;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -32,26 +22,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
-import static ca.uhn.fhir.rest.api.Constants.PARAM_CONSENT;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_CONSENT_PATIENT_REFERENCE;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_CONSENT_PERFORMER_REFERENCE;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT_BIRTHDATE;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT_NAME;
-import static ca.uhn.fhir.rest.api.Constants.COVERAGE_TO_LINK;
-import static ca.uhn.fhir.rest.api.Constants.COVERAGE_TO_MATCH;
+import static ca.uhn.fhir.rest.api.Constants.*;
+import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_IDENTIFIER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("Duplicates")
 public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Test {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(PatientMemberMatchOperationR4Test.class);
 
 	private static final String ourQuery = "/Patient/$member-match?_format=json";
+	private static final String PATIENT_ID = "Patient/A123";
 	private static final String EXISTING_COVERAGE_ID = "cov-id-123";
 	private static final String EXISTING_COVERAGE_IDENT_SYSTEM = "http://centene.com/insurancePlanIds";
 	private static final String EXISTING_COVERAGE_IDENT_VALUE = "U1234567890";
@@ -62,8 +47,8 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 
 	private Identifier ourExistingCoverageIdentifier;
 	private Patient myPatient;
-	private Coverage oldCoverage; // Old Coverage (must match field)
-	private Coverage newCoverage; // New Coverage (must return unchanged)
+	private Coverage coverageToMatch; // Old Coverage (must match field)
+	private Coverage coverageToLink;
 	private Consent myConsent;
 
 	@Autowired
@@ -96,14 +81,14 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		myPatient = (Patient) new Patient().setName(Lists.newArrayList(new HumanName()
 				.setUse(HumanName.NameUse.OFFICIAL).setFamily("Person")))
 			.setBirthDateElement(new DateType("2020-01-01"))
-			.setId("Patient/A123");
+			.setId(PATIENT_ID);
 
 		// Old Coverage (must match field)
-		oldCoverage = (Coverage) new Coverage()
+		coverageToMatch = (Coverage) new Coverage()
 			.setId(EXISTING_COVERAGE_ID);
 
 		// New Coverage (must return unchanged)
-		newCoverage = (Coverage) new Coverage()
+		coverageToLink = (Coverage) new Coverage()
 			.setIdentifier(Lists.newArrayList(new Identifier().setSystem("http://newealthplan.example.com").setValue("234567")))
 			.setId("AA87654");
 
@@ -111,8 +96,8 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 			.setStatus(Consent.ConsentState.ACTIVE)
 			.setScope(new CodeableConcept().addCoding(new Coding("http://terminology.hl7.org/CodeSystem/consentscope", "patient-privacy", null)))
 			.addPolicy(new Consent.ConsentPolicyComponent().setUri(CONSENT_POLICY_SENSITIVE_DATA_URI))
-			.setPatient(new Reference("Patient/A123"))
-			.addPerformer(new Reference("Patient/A123"));
+			.setPatient(new Reference(PATIENT_ID))
+			.addPerformer(new Reference(PATIENT_ID));
 		myServer.getRestfulServer().registerProvider(theMemberMatchR4ResourceProvider);
 		myMemberMatcherR4Helper.setRegularFilterSupported(false);
 	}
@@ -126,7 +111,7 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 			member.setName(Lists.newArrayList(new HumanName()
 				.setUse(HumanName.NameUse.OFFICIAL).setFamily("Person")))
 				.setBirthDateElement(new DateType("2020-01-01"))
-				.setId("Patient/A123");
+				.setId(PATIENT_ID);
 			if (includeBeneficiaryIdentifier) {
 				member.setIdentifier(Collections.singletonList(new Identifier()
 					.setSystem(EXISTING_COVERAGE_PATIENT_IDENT_SYSTEM).setValue(EXISTING_COVERAGE_PATIENT_IDENT_VALUE)));
@@ -151,23 +136,10 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	}
 
 	@Test
-	public void testMemberMatchByCoverageId() throws Exception {
-		createCoverageWithBeneficiary(true, true);
-
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
-		Parameters parametersResponse = performOperation(myServerBase + ourQuery,
-			EncodingEnum.JSON, inputParameters);
-
-		validateMemberPatient(parametersResponse);
-		validateNewCoverage(parametersResponse, newCoverage);
-	}
-
-
-	@Test
 	public void testCoverageNoBeneficiaryReturns422() throws Exception {
 		createCoverageWithBeneficiary(false, false);
 
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
 			"Could not find beneficiary for coverage.");
 	}
@@ -176,7 +148,7 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	public void testCoverageBeneficiaryNoIdentifierReturns422() throws Exception {
 		createCoverageWithBeneficiary(true, false);
 
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
 			"Coverage beneficiary does not have an identifier.");
 	}
@@ -186,7 +158,7 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		createCoverageWithBeneficiary(true, true);
 
 		myPatient.setName(Lists.newArrayList(new HumanName().setUse(HumanName.NameUse.OFFICIAL).setFamily("Smith")));
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
 			"Could not find matching patient for coverage.");
 	}
@@ -196,7 +168,7 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		createCoverageWithBeneficiary(true, false);
 
 		myPatient.setBirthDateElement(new DateType("2000-01-01"));
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
 			"Could not find matching patient for coverage.");
 	}
@@ -205,7 +177,7 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	public void testRegularContentProfileAccessWithRegularNotAllowedReturns422() throws Exception {
 		createCoverageWithBeneficiary(true, true);
 		myConsent.getPolicy().get(0).setUri(CONSENT_POLICY_REGULAR_DATA_URI);
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
 			"Consent policy does not match the data release segmentation capabilities.");
 	}
@@ -213,12 +185,12 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	@Test
 	public void testSensitiveContentProfileAccessWithRegularNotAllowed() throws Exception {
 		createCoverageWithBeneficiary(true, true);
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		Parameters parametersResponse = performOperation(myServerBase + ourQuery,
 			EncodingEnum.JSON, inputParameters);
 
-		validateMemberPatient(parametersResponse);
-		validateNewCoverage(parametersResponse, newCoverage);
+		validateMemberIdentifier(parametersResponse);
 	}
 
 	@Test
@@ -226,37 +198,11 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		createCoverageWithBeneficiary(true, true);
 		myConsent.getPolicy().get(0).setUri(CONSENT_POLICY_REGULAR_DATA_URI);
 		myMemberMatcherR4Helper.setRegularFilterSupported(true);
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
 		Parameters parametersResponse = performOperation(myServerBase + ourQuery,
 			EncodingEnum.JSON, inputParameters);
 
-		validateMemberPatient(parametersResponse);
-		validateNewCoverage(parametersResponse, newCoverage);
-	}
-
-	@Test
-	public void testConsentReturns() throws Exception {
-		createCoverageWithBeneficiary(true, true);
-		myConsent.getPolicy().get(0).setUri(CONSENT_POLICY_REGULAR_DATA_URI);
-		myMemberMatcherR4Helper.setRegularFilterSupported(true);
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
-		Parameters parametersResponse = performOperation(myServerBase + ourQuery,
-			EncodingEnum.JSON, inputParameters);
-
-		validateMemberPatient(parametersResponse);
-		validateNewCoverage(parametersResponse, newCoverage);
-		validateResponseConsent(parametersResponse, myConsent);
-	}
-
-	@Test
-	public void testMemberMatchByCoverageIdentifier() throws Exception {
-		createCoverageWithBeneficiary(true, true);
-
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
-		Parameters parametersResponse = performOperation(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters);
-
-		validateMemberPatient(parametersResponse);
-		validateNewCoverage(parametersResponse, newCoverage);
+		validateMemberIdentifier(parametersResponse);
 	}
 
 	/**
@@ -309,22 +255,22 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		assertEquals(EXISTING_COVERAGE_PATIENT_IDENT_VALUE, addedIdentifier.getValue());
 	}
 
-	@Test
-	public void testNoCoverageMatchFound() throws Exception {
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
-		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
-			"Could not find coverage for member");
+	/**
+	 * validates that the returned patient ID is correct
+	 */
+	private void validateMemberIdentifier(Parameters response){
+		assertTrue(response.hasParameter(PARAM_MEMBER_IDENTIFIER));
+		Optional<IBase> memberIdentifierOptional = ParametersUtil.getNamedParameter(this.getFhirContext(), response, PARAM_MEMBER_IDENTIFIER);
+		assertTrue(memberIdentifierOptional.isPresent());
+		IdType memberIdentifier = (IdType) ((Parameters.ParametersParameterComponent) memberIdentifierOptional.get()).getValue();
+		assertEquals(PATIENT_ID, memberIdentifier.getValue());
 	}
 
 	@Test
-	public void testConsentUpdatePatientAndPerformer() throws Exception {
-		createCoverageWithBeneficiary(true, true);
-		Parameters inputParameters = buildInputParameters(myPatient, oldCoverage, newCoverage, myConsent);
-		Parameters parametersResponse = performOperation(myServerBase + ourQuery,
-			EncodingEnum.JSON, inputParameters);
-
-		Consent respConsent = validateResponseConsent(parametersResponse, myConsent);
-		validateConsentPatientAndPerformerRef(myPatient, respConsent);
+	public void testNoCoverageMatchFound() throws Exception {
+		Parameters inputParameters = buildInputParameters(myPatient, coverageToMatch, coverageToLink, myConsent);
+		performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
+			"Could not find coverage for member");
 	}
 
 	private Parameters buildInputParameters(Patient thePatient, Coverage theOldCoverage, Coverage theNewCoverage, Consent theConsent) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMemberMatchOperationR4Test.java
@@ -39,8 +39,8 @@ import static ca.uhn.fhir.rest.api.Constants.PARAM_CONSENT_PERFORMER_REFERENCE;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT_BIRTHDATE;
 import static ca.uhn.fhir.rest.api.Constants.PARAM_MEMBER_PATIENT_NAME;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_NEW_COVERAGE;
-import static ca.uhn.fhir.rest.api.Constants.PARAM_OLD_COVERAGE;
+import static ca.uhn.fhir.rest.api.Constants.COVERAGE_TO_LINK;
+import static ca.uhn.fhir.rest.api.Constants.COVERAGE_TO_MATCH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -263,7 +263,7 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	 * Validates that second resource from the response is same as the received coverage
 	 */
 	private void validateNewCoverage(Parameters theResponse, Coverage theOriginalCoverage) {
-		List<IBase> patientList = ParametersUtil.getNamedParameters(this.getFhirContext(), theResponse, PARAM_NEW_COVERAGE);
+		List<IBase> patientList = ParametersUtil.getNamedParameters(this.getFhirContext(), theResponse, COVERAGE_TO_LINK);
 		assertEquals(1, patientList.size());
 		Coverage respCoverage = (Coverage) theResponse.getParameter().get(1).getResource();
 
@@ -330,8 +330,8 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 	private Parameters buildInputParameters(Patient thePatient, Coverage theOldCoverage, Coverage theNewCoverage, Consent theConsent) {
 		Parameters p = new Parameters();
 		ParametersUtil.addParameterToParameters(this.getFhirContext(), p, PARAM_MEMBER_PATIENT, thePatient);
-		ParametersUtil.addParameterToParameters(this.getFhirContext(), p, PARAM_OLD_COVERAGE, theOldCoverage);
-		ParametersUtil.addParameterToParameters(this.getFhirContext(), p, PARAM_NEW_COVERAGE, theNewCoverage);
+		ParametersUtil.addParameterToParameters(this.getFhirContext(), p, COVERAGE_TO_MATCH, theOldCoverage);
+		ParametersUtil.addParameterToParameters(this.getFhirContext(), p, COVERAGE_TO_LINK, theNewCoverage);
 		ParametersUtil.addParameterToParameters(this.getFhirContext(), p, PARAM_CONSENT, theConsent);
 		return p;
 	}
@@ -434,14 +434,14 @@ public class PatientMemberMatchOperationR4Test extends BaseResourceProviderR4Tes
 		public void testInvalidOldCoverage() throws Exception {
 			Parameters inputParameters = buildInputParameters(ourPatient, new Coverage(), ourNewCoverage, ourConsent);
 			performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
-				"Parameter \\\"" + PARAM_OLD_COVERAGE + "\\\" is required.");
+				"Parameter \\\"" + COVERAGE_TO_MATCH + "\\\" is required.");
 		}
 
 		@Test
 		public void testInvalidNewCoverage() throws Exception {
 			Parameters inputParameters = buildInputParameters(ourPatient, ourOldCoverage, new Coverage(), ourConsent);
 			performOperationExpecting422(myServerBase + ourQuery, EncodingEnum.JSON, inputParameters,
-				"Parameter \\\"" + PARAM_NEW_COVERAGE + "\\\" is required.");
+				"Parameter \\\"" + COVERAGE_TO_LINK + "\\\" is required.");
 		}
 
 		@Test

--- a/hapi-fhir-jpaserver-test-r4b/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/pom.xml
+++ b/hapi-fhir-jpaserver-test-r5/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>6.11.1-SNAPSHOT</version>
+			<version>6.11.2-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>6.11.1-SNAPSHOT</version>
+      <version>6.11.2-SNAPSHOT</version>
 
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/pom.xml
+++ b/hapi-fhir-storage-batch2-test-utilities/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4b/pom.xml
+++ b/hapi-fhir-validation-resources-r4b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>6.11.1-SNAPSHOT</version>
+	<version>6.11.2-SNAPSHOT</version>
 
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.11.2-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>


### PR DESCRIPTION
What was done: 
- Changed member-match function param names, and return value, now returns:
```
{
    "resourceType": "Parameters",
    "parameter": [
        {
            "name": "MemberIdentifier",
            "valueId": "Patient/1329"
        }
    ]
}
```
- modified existing tests to accomodate for the change
- added changelog
