### PR TITLE
CLI tool command migrate-database executing in dry-run mode insert entries into table FLY_HFJ_MIGRATION

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/HapiFlywayMigrateDatabaseCommandTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/HapiFlywayMigrateDatabaseCommandTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 import ca.uhn.fhir.jpa.migrate.JdbcUtils;
 import ca.uhn.fhir.jpa.migrate.SchemaMigrator;
 import ca.uhn.fhir.jpa.migrate.dao.HapiMigrationDao;
+import ca.uhn.fhir.jpa.migrate.entity.HapiMigrationEntity;
 import ca.uhn.fhir.system.HapiSystemProperties;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.FileUtils;
@@ -25,6 +26,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -163,7 +165,7 @@ public class HapiFlywayMigrateDatabaseCommandTest {
 		// Verify that foreign key FK_SEARCHRES_RES on HFJ_SEARCH_RESULT exists
 		foreignKeys = JdbcUtils.getForeignKeys(connectionProperties, "HFJ_RESOURCE", "HFJ_SEARCH_RESULT");
 		assertTrue(foreignKeys.contains("FK_SEARCHRES_RES"));
-		assertFalse(JdbcUtils.getTableNames(connectionProperties).contains(SchemaMigrator.HAPI_FHIR_MIGRATION_TABLENAME));
+		int expectedMigrationEntities = hapiMigrationDao.findAll().size();
 
 		App.main(args);
 
@@ -185,7 +187,8 @@ public class HapiFlywayMigrateDatabaseCommandTest {
 		// Verify that foreign key FK_SEARCHRES_RES on HFJ_SEARCH_RESULT still exists
 		foreignKeys = JdbcUtils.getForeignKeys(connectionProperties, "HFJ_RESOURCE", "HFJ_SEARCH_RESULT");
 		assertTrue(foreignKeys.contains("FK_SEARCHRES_RES"));
-		assertTrue(hapiMigrationDao.findAll().isEmpty());
+		assertTrue(expectedMigrationEntities == hapiMigrationDao.findAll().size());
+
 	}
 
 	@Test
@@ -332,9 +335,59 @@ public class HapiFlywayMigrateDatabaseCommandTest {
 				}
 			);
 
+			jdbcTemplate.execute(
+				"insert into FLY_HFJ_MIGRATION (\"installed_rank\", \"version\", \"description\", \"type\", \"script\", \"checksum\", \"installed_by\", \"installed_on\", \"execution_time\", \"success\") values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				new AbstractLobCreatingPreparedStatementCallback(new DefaultLobHandler()) {
+					@Override
+					protected void setValues(PreparedStatement thePs, LobCreator theLobCreator) throws SQLException {
+						thePs.setInt(1, -1);
+						thePs.setNull(2, Types.VARCHAR);
+						thePs.setString(3, "<< HAPI FHIR Schema History table created >>");
+						thePs.setString(4, "TABLE");
+						thePs.setString(5, "HAPI FHIR");
+						thePs.setNull(6, Types.INTEGER);
+						thePs.setString(7, "V7_0_0");
+						thePs.setTimestamp(8, new Timestamp(System.currentTimeMillis()));
+						thePs.setInt(9, 0);
+						thePs.setBoolean(10, true);
+					}
+				}
+			);
+
+			jdbcTemplate.execute(
+				"insert into FLY_HFJ_MIGRATION (\"installed_rank\", \"version\", \"description\", \"type\", \"script\", \"checksum\", \"installed_by\", \"installed_on\", \"execution_time\", \"success\") values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				new AbstractLobCreatingPreparedStatementCallback(new DefaultLobHandler()) {
+					@Override
+					protected void setValues(PreparedStatement thePs, LobCreator theLobCreator) throws SQLException {
+						thePs.setInt(1, 1);
+						thePs.setString(2, "3.4.0.20180401.1");
+						thePs.setString(3, "Drop index IDX_CSV_RESOURCEPID_AND_VER from table TRM_CODESYSTEM_VER");
+						thePs.setString(4, "JDBC");
+						thePs.setString(5, "HAPI FHIR");
+						thePs.setInt(6, -725398508);
+						thePs.setString(7, "V7_0_0");
+						thePs.setTimestamp(8, new Timestamp(System.currentTimeMillis()));
+						thePs.setInt(9, 4);
+						thePs.setBoolean(10, true);
+					}
+				}
+			);
+
 			return null;
 		});
 
+	}
+
+	private List<HapiMigrationEntity> getMigrationEntities(DriverTypeEnum.ConnectionProperties theConnectionProperties){
+
+		List<HapiMigrationEntity> entities = theConnectionProperties.getTxTemplate().execute(t -> {
+
+			List<HapiMigrationEntity> hapiMigrationEntities = theConnectionProperties.newJdbcTemplate().query("SELECT * FROM FLY_HFJ_MIGRATION", HapiMigrationEntity.rowMapper());
+
+			return hapiMigrationEntities;
+		});
+
+		return entities;
 	}
 
 	private void executeSqlStatements(DriverTypeEnum.ConnectionProperties theConnectionProperties, String theInitSql) throws

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/resources/persistence_create_h2_340.sql
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/resources/persistence_create_h2_340.sql
@@ -29,7 +29,6 @@ create sequence SEQ_SPIDX_TOKEN start with 1 increment by 50;
 create sequence SEQ_SPIDX_URI start with 1 increment by 50;
 create sequence SEQ_SUBSCRIPTION_ID start with 1 increment by 50;
 create sequence SEQ_TAGDEF_ID start with 1 increment by 50;
-create sequence SEQ_FLY_HFJ_MIGRATION start with 1 increment by 50;
 create table HFJ_FORCED_ID (PID bigint not null, FORCED_ID varchar(100) not null, RESOURCE_PID bigint not null, RESOURCE_TYPE varchar(100) default '', primary key (PID));
 create table HFJ_HISTORY_TAG (PID bigint not null, TAG_ID bigint, RES_ID bigint not null, RES_TYPE varchar(30) not null, RES_VER_PID bigint not null, primary key (PID));
 create table HFJ_IDX_CMP_STRING_UNIQ (PID bigint not null, IDX_STRING varchar(150) not null, RES_ID bigint, primary key (PID));
@@ -61,8 +60,6 @@ create table TRM_CONCEPT_MAP_GRP_ELEMENT (PID bigint not null, SOURCE_CODE varch
 create table TRM_CONCEPT_MAP_GRP_ELM_TGT (PID bigint not null, TARGET_CODE varchar(50) not null, myConceptMapUrl varchar(255), TARGET_DISPLAY varchar(400), TARGET_EQUIVALENCE varchar(50), mySystem varchar(255), mySystemVersion varchar(255), myValueSet varchar(255), CONCEPT_MAP_GRP_ELM_PID bigint not null, primary key (PID));
 create table TRM_CONCEPT_PC_LINK (PID bigint not null, CHILD_PID bigint, PARENT_PID bigint, REL_TYPE integer, CODESYSTEM_PID bigint not null, primary key (PID));
 create table TRM_CONCEPT_PROPERTY (PID bigint not null, PROP_CODESYSTEM varchar(500), PROP_DISPLAY varchar(500), PROP_KEY varchar(500) not null, PROP_TYPE integer not null, PROP_VAL varchar(500), CONCEPT_PID bigint, primary key (PID));
-CREATE TABLE "FLY_HFJ_MIGRATION" ("installed_rank" INTEGER NOT NULL,"version" VARCHAR(50),"description" VARCHAR(200) NOT NULL,"type" VARCHAR(20) NOT NULL,"script" VARCHAR(1000) NOT NULL,"checksum" INTEGER,"installed_by" VARCHAR(100) NOT NULL,"installed_on" DATE NOT NULL,"execution_time" INTEGER NOT NULL,"success" boolean NOT NULL)
-CREATE UNIQUE INDEX FLY_HFJ_MIGRATION_PK_INDEX ON "FLY_HFJ_MIGRATION" ("installed_rank")
 create index IDX_FORCEDID_TYPE_FORCEDID on HFJ_FORCED_ID (RESOURCE_TYPE, FORCED_ID);
 create unique index IDX_FORCEDID_RESID on HFJ_FORCED_ID (RESOURCE_PID);
 create unique index IDX_FORCEDID_TYPE_RESID on HFJ_FORCED_ID (RESOURCE_TYPE, RESOURCE_PID);

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/resources/persistence_create_h2_340.sql
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/resources/persistence_create_h2_340.sql
@@ -29,6 +29,7 @@ create sequence SEQ_SPIDX_TOKEN start with 1 increment by 50;
 create sequence SEQ_SPIDX_URI start with 1 increment by 50;
 create sequence SEQ_SUBSCRIPTION_ID start with 1 increment by 50;
 create sequence SEQ_TAGDEF_ID start with 1 increment by 50;
+create sequence SEQ_FLY_HFJ_MIGRATION start with 1 increment by 50;
 create table HFJ_FORCED_ID (PID bigint not null, FORCED_ID varchar(100) not null, RESOURCE_PID bigint not null, RESOURCE_TYPE varchar(100) default '', primary key (PID));
 create table HFJ_HISTORY_TAG (PID bigint not null, TAG_ID bigint, RES_ID bigint not null, RES_TYPE varchar(30) not null, RES_VER_PID bigint not null, primary key (PID));
 create table HFJ_IDX_CMP_STRING_UNIQ (PID bigint not null, IDX_STRING varchar(150) not null, RES_ID bigint, primary key (PID));
@@ -60,6 +61,8 @@ create table TRM_CONCEPT_MAP_GRP_ELEMENT (PID bigint not null, SOURCE_CODE varch
 create table TRM_CONCEPT_MAP_GRP_ELM_TGT (PID bigint not null, TARGET_CODE varchar(50) not null, myConceptMapUrl varchar(255), TARGET_DISPLAY varchar(400), TARGET_EQUIVALENCE varchar(50), mySystem varchar(255), mySystemVersion varchar(255), myValueSet varchar(255), CONCEPT_MAP_GRP_ELM_PID bigint not null, primary key (PID));
 create table TRM_CONCEPT_PC_LINK (PID bigint not null, CHILD_PID bigint, PARENT_PID bigint, REL_TYPE integer, CODESYSTEM_PID bigint not null, primary key (PID));
 create table TRM_CONCEPT_PROPERTY (PID bigint not null, PROP_CODESYSTEM varchar(500), PROP_DISPLAY varchar(500), PROP_KEY varchar(500) not null, PROP_TYPE integer not null, PROP_VAL varchar(500), CONCEPT_PID bigint, primary key (PID));
+CREATE TABLE "FLY_HFJ_MIGRATION" ("installed_rank" INTEGER NOT NULL,"version" VARCHAR(50),"description" VARCHAR(200) NOT NULL,"type" VARCHAR(20) NOT NULL,"script" VARCHAR(1000) NOT NULL,"checksum" INTEGER,"installed_by" VARCHAR(100) NOT NULL,"installed_on" DATE NOT NULL,"execution_time" INTEGER NOT NULL,"success" boolean NOT NULL)
+CREATE UNIQUE INDEX FLY_HFJ_MIGRATION_PK_INDEX ON "FLY_HFJ_MIGRATION" ("installed_rank")
 create index IDX_FORCEDID_TYPE_FORCEDID on HFJ_FORCED_ID (RESOURCE_TYPE, FORCED_ID);
 create unique index IDX_FORCEDID_RESID on HFJ_FORCED_ID (RESOURCE_PID);
 create unique index IDX_FORCEDID_TYPE_RESID on HFJ_FORCED_ID (RESOURCE_TYPE, RESOURCE_PID);

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5486-cli-migrate-database-in-dry-run-modifies-db.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5486-cli-migrate-database-in-dry-run-modifies-db.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5486
+jira: SMILE-7457
+title: "Previously, testing database migration with cli migrate-database command in dry-run mode would insert in the
+migration task table.  The issue has been fixed."

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/HapiMigrator.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/HapiMigrator.java
@@ -221,6 +221,8 @@ public class HapiMigrator {
 	}
 
 	public void createMigrationTableIfRequired() {
-		myHapiMigrationStorageSvc.createMigrationTableIfRequired();
+		if (!myDryRun) {
+			myHapiMigrationStorageSvc.createMigrationTableIfRequired();
+		}
 	}
 }

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/HapiMigrator.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/HapiMigrator.java
@@ -30,12 +30,12 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -188,7 +188,7 @@ public class HapiMigrator {
 	}
 
 	private void postExecute(BaseTask theNext, StopWatch theStopWatch, boolean theSuccess) {
-		if(!theNext.isDryRun()){
+		if (!theNext.isDryRun()) {
 			myHapiMigrationStorageSvc.saveTask(theNext, Math.toIntExact(theStopWatch.getMillis()), theSuccess);
 		}
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/HapiMigrator.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/HapiMigrator.java
@@ -30,12 +30,12 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.sql.DataSource;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -188,7 +188,9 @@ public class HapiMigrator {
 	}
 
 	private void postExecute(BaseTask theNext, StopWatch theStopWatch, boolean theSuccess) {
-		myHapiMigrationStorageSvc.saveTask(theNext, Math.toIntExact(theStopWatch.getMillis()), theSuccess);
+		if(!theNext.isDryRun()){
+			myHapiMigrationStorageSvc.saveTask(theNext, Math.toIntExact(theStopWatch.getMillis()), theSuccess);
+		}
 	}
 
 	public void addTasks(Iterable<BaseTask> theMigrationTasks) {


### PR DESCRIPTION
**Background:**
when testing database migration with the cli tool migrate-database command executing in dry-run mode, entries are added to table FLY_HFJ_MIGRATION.

**What was done:**
- added test;
- preventing inserts to the migration table when the executing task is operating in dry-run mode;
- added changelog;