### PR TITLE
Add a new field to the CLIENT_RESPONSE pointcut in order to allow clients to mutate an HTTP response from the BaseClient.

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>6.11.2-SNAPSHOT</version>
+		 <version>6.11.3-SNAPSHOT</version>
 
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -101,7 +101,8 @@ public enum Pointcut implements IPointcut {
 			void.class,
 			"ca.uhn.fhir.rest.client.api.IHttpRequest",
 			"ca.uhn.fhir.rest.client.api.IHttpResponse",
-			"ca.uhn.fhir.rest.client.api.IRestfulClient"),
+			"ca.uhn.fhir.rest.client.api.IRestfulClient",
+			"ca.uhn.fhir.rest.client.api.ClientResponseContext"),
 
 	/**
 	 * <b>Server Hook:</b>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -93,6 +93,10 @@ public enum Pointcut implements IPointcut {
 	 * <li>
 	 *    ca.uhn.fhir.rest.client.api.IRestfulClient - The client object making the request
 	 * </li>
+	 * <li>
+	 *    ca.uhn.fhir.rest.client.api.ClientResponseContext - Contains an IHttpRequest, an IHttpResponse, and an IRestfulClient
+	 *    and also allows the client to mutate the contained IHttpResponse
+	 * </li>
 	 * </ul>
 	 * </p>
 	 * Hook methods must return <code>void</code>.

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.rest.client.api;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -33,16 +34,19 @@ public class ClientResponseContext {
 	private IHttpResponse myHttpResponse;
 	private final IRestfulClient myRestfulClient;
 	private final FhirContext myFhirContext;
+	private final Class<? extends IBaseResource> myReturnType;
 
 	public ClientResponseContext(
 			IHttpRequest myHttpRequest,
 			IHttpResponse theHttpResponse,
 			IRestfulClient myRestfulClient,
-			FhirContext theFhirContext) {
+			FhirContext theFhirContext,
+			Class<? extends IBaseResource> theReturnType) {
 		this.myHttpRequest = myHttpRequest;
 		this.myHttpResponse = theHttpResponse;
 		this.myRestfulClient = myRestfulClient;
 		this.myFhirContext = theFhirContext;
+		this.myReturnType = theReturnType;
 	}
 
 	public IHttpRequest getHttpRequest() {
@@ -59,6 +63,10 @@ public class ClientResponseContext {
 
 	public FhirContext getFhirContext() {
 		return myFhirContext;
+	}
+
+	public Class<? extends IBaseResource> getReturnType() {
+		return myReturnType;
 	}
 
 	public void setHttpResponse(IHttpResponse theHttpResponse) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.rest.client.api;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -78,24 +78,23 @@ public class ClientResponseContext {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		ClientResponseContext that = (ClientResponseContext) o;
-		return Objects.equals(myHttpRequest, that.myHttpRequest)
-				&& Objects.equals(myHttpResponse, that.myHttpResponse)
-				&& Objects.equals(myRestfulClient, that.myRestfulClient)
-				&& Objects.equals(myFhirContext, that.myFhirContext);
+		return Objects.equals(myHttpRequest, that.myHttpRequest) && Objects.equals(myHttpResponse, that.myHttpResponse) && Objects.equals(myRestfulClient, that.myRestfulClient) && Objects.equals(myFhirContext, that.myFhirContext) && Objects.equals(myReturnType, that.myReturnType);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(myHttpRequest, myHttpResponse, myRestfulClient, myFhirContext);
+		return Objects.hash(myHttpRequest, myHttpResponse, myRestfulClient, myFhirContext, myReturnType);
 	}
 
 	@Override
-	public String toString() {
+	public String
+	toString() {
 		return new StringJoiner(", ", ClientResponseContext.class.getSimpleName() + "[", "]")
-				.add("myHttpRequest=" + myHttpRequest)
-				.add("myHttpResponse=" + myHttpResponse)
-				.add("myRestfulClient=" + myRestfulClient)
-				.add("myFhirContext=" + myFhirContext)
-				.toString();
+			.add("myHttpRequest=" + myHttpRequest)
+			.add("myHttpResponse=" + myHttpResponse)
+			.add("myRestfulClient=" + myRestfulClient)
+			.add("myFhirContext=" + myFhirContext)
+			.add("myReturnType=" + myReturnType)
+			.toString();
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -1,0 +1,61 @@
+package ca.uhn.fhir.rest.client.api;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+// LUKETODO:  javadoc
+public class ClientResponseContext {
+	private final IHttpRequest myHttpRequest;
+	private IHttpResponse myHttpResponse;
+	private final IRestfulClient myRestfulClient;
+
+	public ClientResponseContext(IHttpRequest myHttpRequest, IHttpResponse theHttpResponse, IRestfulClient myRestfulClient) {
+		this.myHttpRequest = myHttpRequest;
+		this.myHttpResponse = theHttpResponse;
+		this.myRestfulClient = myRestfulClient;
+	}
+
+	public IHttpRequest getMyHttpRequest() {
+		return myHttpRequest;
+	}
+
+	public IHttpResponse getMyHttpResponse() {
+		return myHttpResponse;
+	}
+
+	public IRestfulClient getMyRestfulClient() {
+		return myRestfulClient;
+	}
+
+	public IHttpResponse getHttpResponse() {
+		return myHttpResponse;
+	}
+
+	public void setHttpResponse(IHttpResponse theHttpResponse) {
+		this.myHttpResponse = theHttpResponse;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ClientResponseContext that = (ClientResponseContext) o;
+		return Objects.equals(myHttpRequest, that.myHttpRequest) && Objects.equals(myHttpResponse, that.myHttpResponse) && Objects.equals(myRestfulClient, that.myRestfulClient);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(myHttpRequest, myHttpResponse, myRestfulClient);
+	}
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", ClientResponseContext.class.getSimpleName() + "[", "]")
+			.add("myHttpResponse=" + myHttpResponse)
+			.toString();
+	}
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -1,11 +1,14 @@
 package ca.uhn.fhir.rest.client.api;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.api.Pointcut;
 
 import java.util.Objects;
 import java.util.StringJoiner;
 
-// LUKETODO:  javadoc
+/**
+ * Used to pass context to {@link Pointcut#CLIENT_RESPONSE}, including a mutable {@link IHttpResponse}
+ */
 public class ClientResponseContext {
 	private final IHttpRequest myHttpRequest;
 	private IHttpResponse myHttpResponse;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -1,5 +1,7 @@
 package ca.uhn.fhir.rest.client.api;
 
+import ca.uhn.fhir.context.FhirContext;
+
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -8,27 +10,29 @@ public class ClientResponseContext {
 	private final IHttpRequest myHttpRequest;
 	private IHttpResponse myHttpResponse;
 	private final IRestfulClient myRestfulClient;
+	private final FhirContext myFhirContext;
 
-	public ClientResponseContext(IHttpRequest myHttpRequest, IHttpResponse theHttpResponse, IRestfulClient myRestfulClient) {
+	public ClientResponseContext(IHttpRequest myHttpRequest, IHttpResponse theHttpResponse, IRestfulClient myRestfulClient, FhirContext theFhirContext) {
 		this.myHttpRequest = myHttpRequest;
 		this.myHttpResponse = theHttpResponse;
 		this.myRestfulClient = myRestfulClient;
+		this.myFhirContext = theFhirContext;
 	}
 
-	public IHttpRequest getMyHttpRequest() {
+	public IHttpRequest getHttpRequest() {
 		return myHttpRequest;
-	}
-
-	public IHttpResponse getMyHttpResponse() {
-		return myHttpResponse;
-	}
-
-	public IRestfulClient getMyRestfulClient() {
-		return myRestfulClient;
 	}
 
 	public IHttpResponse getHttpResponse() {
 		return myHttpResponse;
+	}
+
+	public IRestfulClient getRestfulClient() {
+		return myRestfulClient;
+	}
+
+	public FhirContext getFhirContext() {
+		return myFhirContext;
 	}
 
 	public void setHttpResponse(IHttpResponse theHttpResponse) {
@@ -37,25 +41,24 @@ public class ClientResponseContext {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 		ClientResponseContext that = (ClientResponseContext) o;
-		return Objects.equals(myHttpRequest, that.myHttpRequest) && Objects.equals(myHttpResponse, that.myHttpResponse) && Objects.equals(myRestfulClient, that.myRestfulClient);
+		return Objects.equals(myHttpRequest, that.myHttpRequest) && Objects.equals(myHttpResponse, that.myHttpResponse) && Objects.equals(myRestfulClient, that.myRestfulClient) && Objects.equals(myFhirContext, that.myFhirContext);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(myHttpRequest, myHttpResponse, myRestfulClient);
+		return Objects.hash(myHttpRequest, myHttpResponse, myRestfulClient, myFhirContext);
 	}
 
 	@Override
 	public String toString() {
 		return new StringJoiner(", ", ClientResponseContext.class.getSimpleName() + "[", "]")
+			.add("myHttpRequest=" + myHttpRequest)
 			.add("myHttpResponse=" + myHttpResponse)
+			.add("myRestfulClient=" + myRestfulClient)
+			.add("myFhirContext=" + myFhirContext)
 			.toString();
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -12,7 +12,11 @@ public class ClientResponseContext {
 	private final IRestfulClient myRestfulClient;
 	private final FhirContext myFhirContext;
 
-	public ClientResponseContext(IHttpRequest myHttpRequest, IHttpResponse theHttpResponse, IRestfulClient myRestfulClient, FhirContext theFhirContext) {
+	public ClientResponseContext(
+			IHttpRequest myHttpRequest,
+			IHttpResponse theHttpResponse,
+			IRestfulClient myRestfulClient,
+			FhirContext theFhirContext) {
 		this.myHttpRequest = myHttpRequest;
 		this.myHttpResponse = theHttpResponse;
 		this.myRestfulClient = myRestfulClient;
@@ -44,7 +48,10 @@ public class ClientResponseContext {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		ClientResponseContext that = (ClientResponseContext) o;
-		return Objects.equals(myHttpRequest, that.myHttpRequest) && Objects.equals(myHttpResponse, that.myHttpResponse) && Objects.equals(myRestfulClient, that.myRestfulClient) && Objects.equals(myFhirContext, that.myFhirContext);
+		return Objects.equals(myHttpRequest, that.myHttpRequest)
+				&& Objects.equals(myHttpResponse, that.myHttpResponse)
+				&& Objects.equals(myRestfulClient, that.myRestfulClient)
+				&& Objects.equals(myFhirContext, that.myFhirContext);
 	}
 
 	@Override
@@ -55,10 +62,10 @@ public class ClientResponseContext {
 	@Override
 	public String toString() {
 		return new StringJoiner(", ", ClientResponseContext.class.getSimpleName() + "[", "]")
-			.add("myHttpRequest=" + myHttpRequest)
-			.add("myHttpResponse=" + myHttpResponse)
-			.add("myRestfulClient=" + myRestfulClient)
-			.add("myFhirContext=" + myFhirContext)
-			.toString();
+				.add("myHttpRequest=" + myHttpRequest)
+				.add("myHttpResponse=" + myHttpResponse)
+				.add("myRestfulClient=" + myRestfulClient)
+				.add("myFhirContext=" + myFhirContext)
+				.toString();
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/api/ClientResponseContext.java
@@ -78,7 +78,11 @@ public class ClientResponseContext {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		ClientResponseContext that = (ClientResponseContext) o;
-		return Objects.equals(myHttpRequest, that.myHttpRequest) && Objects.equals(myHttpResponse, that.myHttpResponse) && Objects.equals(myRestfulClient, that.myRestfulClient) && Objects.equals(myFhirContext, that.myFhirContext) && Objects.equals(myReturnType, that.myReturnType);
+		return Objects.equals(myHttpRequest, that.myHttpRequest)
+				&& Objects.equals(myHttpResponse, that.myHttpResponse)
+				&& Objects.equals(myRestfulClient, that.myRestfulClient)
+				&& Objects.equals(myFhirContext, that.myFhirContext)
+				&& Objects.equals(myReturnType, that.myReturnType);
 	}
 
 	@Override
@@ -87,14 +91,13 @@ public class ClientResponseContext {
 	}
 
 	@Override
-	public String
-	toString() {
+	public String toString() {
 		return new StringJoiner(", ", ClientResponseContext.class.getSimpleName() + "[", "]")
-			.add("myHttpRequest=" + myHttpRequest)
-			.add("myHttpResponse=" + myHttpResponse)
-			.add("myRestfulClient=" + myRestfulClient)
-			.add("myFhirContext=" + myFhirContext)
-			.add("myReturnType=" + myReturnType)
-			.toString();
+				.add("myHttpRequest=" + myHttpRequest)
+				.add("myHttpResponse=" + myHttpResponse)
+				.add("myRestfulClient=" + myRestfulClient)
+				.add("myFhirContext=" + myFhirContext)
+				.add("myReturnType=" + myReturnType)
+				.toString();
 	}
 }

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>6.11.2-SNAPSHOT</version>
+	<version>6.11.3-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ModifiedStringApacheHttpResponse.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ModifiedStringApacheHttpResponse.java
@@ -66,8 +66,8 @@ public class ModifiedStringApacheHttpResponse extends BaseHttpResponse implement
 				this.myEntityBuffered = true;
 				try {
 					this.myEntityBytes = IOUtils.toByteArray(respEntity);
-				} catch (IllegalStateException e) {
-					throw new InternalErrorException(Msg.code(1478) + e);
+				} catch (IllegalStateException exception) {
+					throw new InternalErrorException(Msg.code(2447) + exception);
 				}
 			}
 		}
@@ -78,8 +78,8 @@ public class ModifiedStringApacheHttpResponse extends BaseHttpResponse implement
 		if (myOrigHttpResponse instanceof CloseableHttpResponse) {
 			try {
 				((CloseableHttpResponse) myOrigHttpResponse).close();
-			} catch (IOException e) {
-				ourLog.debug("Failed to close response", e);
+			} catch (IOException exception) {
+				ourLog.debug("Failed to close response", exception);
 			}
 		}
 	}

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ModifiedStringApacheHttpResponse.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ModifiedStringApacheHttpResponse.java
@@ -63,12 +63,12 @@ public class ModifiedStringApacheHttpResponse extends BaseHttpResponse implement
 		}
 		try (InputStream respEntity = readEntity()) {
 			if (respEntity != null) {
-				this.myEntityBuffered = true;
 				try {
-					this.myEntityBytes = IOUtils.toByteArray(respEntity);
+					myEntityBytes = IOUtils.toByteArray(respEntity);
 				} catch (IllegalStateException exception) {
 					throw new InternalErrorException(Msg.code(2447) + exception);
 				}
+				myEntityBuffered = true;
 			}
 		}
 	}
@@ -126,7 +126,7 @@ public class ModifiedStringApacheHttpResponse extends BaseHttpResponse implement
 
 	@Override
 	public InputStream readEntity() {
-		if (this.myEntityBuffered) {
+		if (myEntityBuffered) {
 			return new ByteArrayInputStream(myEntityBytes);
 		} else {
 			return new ByteArrayInputStream(myNewContent.getBytes());

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ModifiedStringApacheHttpResponse.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ModifiedStringApacheHttpResponse.java
@@ -1,0 +1,135 @@
+/*
+ * #%L
+ * HAPI FHIR - Client Framework
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.rest.client.apache;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+import ca.uhn.fhir.rest.client.impl.BaseHttpResponse;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.util.StopWatch;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Process a modified copy of an existing {@link IHttpResponse} with a String containing new content.
+ * <p/>
+ * Meant to be used with custom interceptors that need to hijack an existing IHttpResponse with new content.
+ */
+public class ModifiedStringApacheHttpResponse extends BaseHttpResponse implements IHttpResponse {
+	private static final org.slf4j.Logger ourLog =
+			org.slf4j.LoggerFactory.getLogger(ModifiedStringApacheHttpResponse.class);
+	private boolean myEntityBuffered = false;
+	private final String myNewContent;
+	private final IHttpResponse myOrigHttpResponse;
+	private byte[] myEntityBytes = null;
+
+	public ModifiedStringApacheHttpResponse(
+			IHttpResponse theOrigHttpResponse, String theNewContent, StopWatch theResponseStopWatch) {
+		super(theResponseStopWatch);
+		myOrigHttpResponse = theOrigHttpResponse;
+		myNewContent = theNewContent;
+	}
+
+	@Override
+	public void bufferEntity() throws IOException {
+		if (myEntityBuffered) {
+			return;
+		}
+		try (InputStream respEntity = readEntity()) {
+			if (respEntity != null) {
+				this.myEntityBuffered = true;
+				try {
+					this.myEntityBytes = IOUtils.toByteArray(respEntity);
+				} catch (IllegalStateException e) {
+					throw new InternalErrorException(Msg.code(1478) + e);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		if (myOrigHttpResponse instanceof CloseableHttpResponse) {
+			try {
+				((CloseableHttpResponse) myOrigHttpResponse).close();
+			} catch (IOException e) {
+				ourLog.debug("Failed to close response", e);
+			}
+		}
+	}
+
+	@Override
+	public Reader createReader() throws IOException {
+		return new InputStreamReader(readEntity(), StandardCharsets.UTF_8);
+	}
+
+	@Override
+	public Map<String, List<String>> getAllHeaders() {
+		return myOrigHttpResponse.getAllHeaders();
+	}
+
+	@Override
+	public List<String> getHeaders(String theName) {
+		return myOrigHttpResponse.getHeaders(theName);
+	}
+
+	@Override
+	public String getMimeType() {
+		return myOrigHttpResponse.getMimeType();
+	}
+
+	@Override
+	public StopWatch getRequestStopWatch() {
+		return myOrigHttpResponse.getRequestStopWatch();
+	}
+
+	@Override
+	public Object getResponse() {
+		return null;
+	}
+
+	@Override
+	public int getStatus() {
+		return myOrigHttpResponse.getStatus();
+	}
+
+	@Override
+	public String getStatusInfo() {
+		return myOrigHttpResponse.getStatusInfo();
+	}
+
+	@Override
+	public InputStream readEntity() {
+		if (this.myEntityBuffered) {
+			return new ByteArrayInputStream(myEntityBytes);
+		} else {
+			return new ByteArrayInputStream(myNewContent.getBytes());
+		}
+	}
+}

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -353,9 +353,8 @@ public abstract class BaseClient implements IRestfulClient {
 
 			response = httpRequest.execute();
 
-            final Class<? extends IBaseResource> returnType =
-				(binding instanceof ResourceResponseHandler)
-					? ((ResourceResponseHandler<? extends IBaseResource>)binding).getReturnType()
+			final Class<? extends IBaseResource> returnType = (binding instanceof ResourceResponseHandler)
+					? ((ResourceResponseHandler<? extends IBaseResource>) binding).getReturnType()
 					: null;
 
 			final ClientResponseContext clientResponseContext =

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -353,17 +353,16 @@ public abstract class BaseClient implements IRestfulClient {
 
 			response = httpRequest.execute();
 
-			final ClientResponseContext clientResponseContext = new ClientResponseContext(httpRequest, response, this, getFhirContext());
+			final ClientResponseContext clientResponseContext =
+					new ClientResponseContext(httpRequest, response, this, getFhirContext());
 			HookParams responseParams = new HookParams();
 			responseParams.add(IHttpRequest.class, httpRequest);
 			responseParams.add(IHttpResponse.class, response);
 			responseParams.add(IRestfulClient.class, this);
 			responseParams.add(ClientResponseContext.class, clientResponseContext);
-			// LUKETODO:  add new holder object with client, response, and request
-			// keep the old params but add the new
-			// holder object would allow  them to mutate the holder with a new response
+
 			getInterceptorService().callHooks(Pointcut.CLIENT_RESPONSE, responseParams);
-			// replace the local response variable with the holder's mutated response
+
 			// LUKETODO:  documentation to the buffer the inputstream
 			// LUKETODO:  documentation DO NOT CHAIN THESE HOOKS!!!!
 			response = clientResponseContext.getHttpResponse();
@@ -390,6 +389,7 @@ public abstract class BaseClient implements IRestfulClient {
 				if (Constants.CT_TEXT.equals(mimeType)) {
 					message = message + ": " + body;
 				} else {
+					// LUKETODO:  this is where the pattern comes from
 					EncodingEnum enc = EncodingEnum.forContentType(mimeType);
 					if (enc != null) {
 						IParser p = enc.newParser(theContext);

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -353,8 +353,13 @@ public abstract class BaseClient implements IRestfulClient {
 
 			response = httpRequest.execute();
 
+            final Class<? extends IBaseResource> returnType =
+				(binding instanceof ResourceResponseHandler)
+					? ((ResourceResponseHandler<? extends IBaseResource>)binding).getReturnType()
+					: null;
+
 			final ClientResponseContext clientResponseContext =
-					new ClientResponseContext(httpRequest, response, this, getFhirContext());
+					new ClientResponseContext(httpRequest, response, this, getFhirContext(), returnType);
 			HookParams responseParams = new HookParams();
 			responseParams.add(IHttpRequest.class, httpRequest);
 			responseParams.add(IHttpResponse.class, response);
@@ -652,6 +657,10 @@ public abstract class BaseClient implements IRestfulClient {
 			myId = theId;
 			myPreferResponseTypes = thePreferResponseTypes;
 			myAllowHtmlResponse = theAllowHtmlResponse;
+		}
+
+		public Class<T> getReturnType() {
+			return myReturnType;
 		}
 
 		@Override

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -363,7 +363,8 @@ public abstract class BaseClient implements IRestfulClient {
 
 			getInterceptorService().callHooks(Pointcut.CLIENT_RESPONSE, responseParams);
 
-			// Replace the contents of the response with whatever the hook returned, or the same response as before if it no-op'd
+			// Replace the contents of the response with whatever the hook returned, or the same response as before if
+			// it no-op'd
 			response = clientResponseContext.getHttpResponse();
 
 			String mimeType;

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -363,8 +363,7 @@ public abstract class BaseClient implements IRestfulClient {
 
 			getInterceptorService().callHooks(Pointcut.CLIENT_RESPONSE, responseParams);
 
-			// LUKETODO:  documentation to the buffer the inputstream
-			// LUKETODO:  documentation DO NOT CHAIN THESE HOOKS!!!!
+			// Replace the contents of the response with whatever the hook returned, or the same response as before if it no-op'd
 			response = clientResponseContext.getHttpResponse();
 
 			String mimeType;
@@ -389,7 +388,6 @@ public abstract class BaseClient implements IRestfulClient {
 				if (Constants.CT_TEXT.equals(mimeType)) {
 					message = message + ": " + body;
 				} else {
-					// LUKETODO:  this is where the pattern comes from
 					EncodingEnum enc = EncodingEnum.forContentType(mimeType);
 					if (enc != null) {
 						IParser p = enc.newParser(theContext);

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -353,7 +353,7 @@ public abstract class BaseClient implements IRestfulClient {
 
 			response = httpRequest.execute();
 
-			final ClientResponseContext clientResponseContext = new ClientResponseContext(httpRequest, response, this);
+			final ClientResponseContext clientResponseContext = new ClientResponseContext(httpRequest, response, this, getFhirContext());
 			HookParams responseParams = new HookParams();
 			responseParams.add(IHttpRequest.class, httpRequest);
 			responseParams.add(IHttpResponse.class, response);

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5502-base-client-client-response-pointcut-mutate-response.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5502-base-client-client-response-pointcut-mutate-response.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 5502
+jira: SMILE-7262
+title: "It is now possible to mutate an HTTP response from the CLIENT_RESPONSE Pointcut, and pass this mutated response
+        to downstream processing."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/9999-base-client-client-response-pointcut-mutate-response.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/9999-base-client-client-response-pointcut-mutate-response.yaml
@@ -1,4 +1,0 @@
----
-type: fix
-issue: 9999
-title: "Something something"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/9999-base-client-client-response-pointcut-mutate-response.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/9999-base-client-client-response-pointcut-mutate-response.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 9999
+title: "Something something"

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-ips/pom.xml
+++ b/hapi-fhir-jpaserver-ips/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-dstu2/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-dstu3/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu3/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4b/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/pom.xml
+++ b/hapi-fhir-jpaserver-test-r5/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>6.11.2-SNAPSHOT</version>
+			<version>6.11.3-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>6.11.2-SNAPSHOT</version>
+      <version>6.11.3-SNAPSHOT</version>
 
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/pom.xml
+++ b/hapi-fhir-storage-batch2-test-utilities/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-cr/pom.xml
+++ b/hapi-fhir-storage-cr/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4b/pom.xml
+++ b/hapi-fhir-validation-resources-r4b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>6.11.2-SNAPSHOT</version>
+	<version>6.11.3-SNAPSHOT</version>
 
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>6.11.2-SNAPSHOT</version>
+		<version>6.11.3-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>


### PR DESCRIPTION
- Add a new ClientResponseContext wrapper to capture all params for the CLIENT_RESPONSE Pointcut, allowing callers to mutate the HTTP response
- Introduce a new ModifiedStringApacheHttpResponse similar to ApacheHttpResponse but one that takes a String with new contents to serve to callers of IHttpResponse
- Ensure BaseClient overrides the previous HTTP response with the one mutated by the interceptor, or keeps the original if the pointcut doesn't modify it.

Closes https://github.com/hapifhir/hapi-fhir/issues/5502