### PR TITLE
Bump setup-java action to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
 
     - name: Setup java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
          distribution: zulu
          java-version: 17


### PR DESCRIPTION
This should remove warnings regarding node12 deprecation

Anyone reviewing should check https://github.com/hapifhir/hapi-fhir/actions/runs/6982883082 and other checks; they should no longer be reporting: `The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-java@v2`

