### PR TITLE
Allow chained searches in Bundles where the fullUrl is fully qualified

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5529-allow-chained-search-in-bundle-where-fullurl-is-qualified.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5529-allow-chained-search-in-bundle-where-fullurl-is-qualified.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5529
+title: "When using a chained SearchParameter to search within a Bundle as [described here](https://smilecdr.com/docs/fhir_storage_relational/chained_searches_and_sorts.html#document-and-message-search-parameters), if the `Bundle.entry.fullUrl` was fully qualified but the reference was not, the search did not work. This has been corrected."

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -2018,7 +2018,8 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 				unqualifiedVersionlessReference = null;
 			} else {
 				isPlaceholderReference = false;
-				unqualifiedVersionlessReference = new IdType(theUrl).toUnqualifiedVersionless().getValue();
+				unqualifiedVersionlessReference =
+						new IdType(theUrl).toUnqualifiedVersionless().getValue();
 			}
 
 			List<BundleEntryParts> entries = BundleUtil.toListOfEntries(getContext(), (IBaseBundle) theAppContext);
@@ -2031,7 +2032,10 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 							return (T) next.getResource();
 						}
 					} else {
-						if (unqualifiedVersionlessReference.equals(next.getResource().getIdElement().toUnqualifiedVersionless().getValue())) {
+						if (unqualifiedVersionlessReference.equals(next.getResource()
+								.getIdElement()
+								.toUnqualifiedVersionless()
+								.getValue())) {
 							return (T) next.getResource();
 						}
 					}


### PR DESCRIPTION
When using a chained SearchParameter to search within a Bundle as [described here](https://smilecdr.com/docs/fhir_storage_relational/chained_searches_and_sorts.html#document-and-message-search-parameters), if the `Bundle.entry.fullUrl` was fully qualified but the reference was not, the search did not work.