### PR TITLE
SQL Migration:  Support lowercase for SQL columns and overridden column type/driver type SQL type string rules

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5536-sql-migration-lowercase-and-custom-column-type-sql.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5536-sql-migration-lowercase-and-custom-column-type-sql.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 5536
+title: "In code: Support lowercase for SQL columns and overridden column type/driver type SQL type string rules"

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -36,6 +36,10 @@
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>jakarta.transaction</groupId>
 			<artifactId>jakarta.transaction-api</artifactId>
 		</dependency>

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTask.java
@@ -31,6 +31,10 @@ public class AddColumnTask extends BaseTableColumnTypeTask {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(AddColumnTask.class);
 
+	public static AddColumnTask lowerCase() {
+		return new AddColumnTask(null, null, ColumnNameCase.ALL_LOWER);
+	}
+
 	public AddColumnTask() {
 		this(null, null);
 		setDryRun(true);
@@ -39,6 +43,10 @@ public class AddColumnTask extends BaseTableColumnTypeTask {
 
 	public AddColumnTask(String theProductVersion, String theSchemaVersion) {
 		super(theProductVersion, theSchemaVersion);
+	}
+
+	private AddColumnTask(String theProductVersion, String theSchemaVersion, ColumnNameCase theColumnNameCase) {
+		super(theProductVersion, theSchemaVersion, theColumnNameCase);
 	}
 
 	@Override

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTask.java
@@ -31,8 +31,8 @@ public class AddColumnTask extends BaseTableColumnTypeTask {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(AddColumnTask.class);
 
-	public static AddColumnTask lowerCase() {
-		return new AddColumnTask(null, null, ColumnNameCase.ALL_LOWER);
+	public static AddColumnTask lowerCase(Set<ColumnDriverMappingOverride> theColumnDriverMappingOverrides) {
+		return new AddColumnTask(null, null, ColumnNameCase.ALL_LOWER, theColumnDriverMappingOverrides);
 	}
 
 	public AddColumnTask() {
@@ -45,8 +45,12 @@ public class AddColumnTask extends BaseTableColumnTypeTask {
 		super(theProductVersion, theSchemaVersion);
 	}
 
-	private AddColumnTask(String theProductVersion, String theSchemaVersion, ColumnNameCase theColumnNameCase) {
-		super(theProductVersion, theSchemaVersion, theColumnNameCase);
+	private AddColumnTask(
+			String theProductVersion,
+			String theSchemaVersion,
+			ColumnNameCase theColumnNameCase,
+			Set<ColumnDriverMappingOverride> theColumnDriverMappingOverrides) {
+		super(theProductVersion, theSchemaVersion, theColumnNameCase, theColumnDriverMappingOverrides);
 	}
 
 	@Override

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
@@ -42,8 +42,6 @@ public class AddTableByColumnTask extends BaseTableTask {
 	private final List<ForeignKeyContainer> myFKColumns = new ArrayList<>();
 	private final Comparator<AddColumnTask> myColumnSortingRules;
 
-	// LUKETODO:  deprecation message
-	@Deprecated
 	public AddTableByColumnTask() {
 		this(null);
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
@@ -41,6 +41,12 @@ public class AddTableByColumnTask extends BaseTableTask {
 	private final List<ForeignKeyContainer> myFKColumns = new ArrayList<>();
 	private final Comparator<AddColumnTask> myColumnSortingRules;
 
+	// LUKETODO:  deprecation message
+	@Deprecated
+	public AddTableByColumnTask() {
+		this(null);
+	}
+
 	public AddTableByColumnTask(Comparator<AddColumnTask> theColumnSortingRules) {
 		this(null, null, theColumnSortingRules);
 		setDryRun(true);

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
@@ -31,6 +31,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class AddTableByColumnTask extends BaseTableTask {
 
@@ -214,6 +215,6 @@ public class AddTableByColumnTask extends BaseTableTask {
 			return myAddColumnTasks;
 		}
 
-		return myAddColumnTasks.stream().sorted(myColumnSortingRules).toList();
+		return myAddColumnTasks.stream().sorted(myColumnSortingRules).collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
@@ -55,7 +55,8 @@ public class AddTableByColumnTask extends BaseTableTask {
 		this(theProductVersion, theSchemaVersion, null);
 	}
 
-	private AddTableByColumnTask(String theProductVersion, String theSchemaVersion, Comparator<AddColumnTask> theColumnSortingRules) {
+	private AddTableByColumnTask(
+			String theProductVersion, String theSchemaVersion, Comparator<AddColumnTask> theColumnSortingRules) {
 		super(theProductVersion, theSchemaVersion);
 		myColumnSortingRules = theColumnSortingRules;
 	}
@@ -211,8 +212,6 @@ public class AddTableByColumnTask extends BaseTableTask {
 			return myAddColumnTasks;
 		}
 
-		return myAddColumnTasks.stream()
-			.sorted(myColumnSortingRules)
-			.toList();
+		return myAddColumnTasks.stream().sorted(myColumnSortingRules).toList();
 	}
 }

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTask.java
@@ -41,12 +41,8 @@ public class AddTableByColumnTask extends BaseTableTask {
 	private final List<ForeignKeyContainer> myFKColumns = new ArrayList<>();
 	private final Comparator<AddColumnTask> myColumnSortingRules;
 
-	public static AddTableByColumnTask withCustomColumnSortingRules(Comparator<AddColumnTask> theColumnSortingRules) {
-		return new AddTableByColumnTask(null, null, theColumnSortingRules);
-	}
-
-	public AddTableByColumnTask() {
-		this(null, null, null);
+	public AddTableByColumnTask(Comparator<AddColumnTask> theColumnSortingRules) {
+		this(null, null, theColumnSortingRules);
 		setDryRun(true);
 		myCheckForExistingTables = false;
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
@@ -66,8 +66,8 @@ public abstract class BaseTableColumnTask extends BaseTableTask {
 				myColumnName = theColumnName.toLowerCase();
 				break;
 			default:
-				// LUKETODO:  reserve message code
-				throw new IllegalArgumentException(Msg.code(9999) + " Unknown ColumnNameCase: " + myColumnNameCase);
+				throw new IllegalArgumentException(Msg.code(2448)
+						+ " Unknown ColumnNameCase was passed when setting column name case: " + myColumnNameCase);
 		}
 		return this;
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
@@ -35,8 +35,15 @@ public abstract class BaseTableColumnTask extends BaseTableTask {
 	// If a concrete class decides to, they can define a custom WHERE clause for the task.
 	protected String myWhereClause;
 
+	private final ColumnNameCase myColumnNameCase;
+
 	public BaseTableColumnTask(String theProductVersion, String theSchemaVersion) {
+		this(theProductVersion, theSchemaVersion, ColumnNameCase.ALL_UPPER);
+	}
+
+	BaseTableColumnTask(String theProductVersion, String theSchemaVersion, ColumnNameCase theColumnNameCase) {
 		super(theProductVersion, theSchemaVersion);
+		myColumnNameCase = theColumnNameCase;
 	}
 
 	public String getColumnName() {
@@ -44,7 +51,16 @@ public abstract class BaseTableColumnTask extends BaseTableTask {
 	}
 
 	public BaseTableColumnTask setColumnName(String theColumnName) {
-		myColumnName = theColumnName.toUpperCase();
+		switch (myColumnNameCase) {
+			case ALL_UPPER:
+				 myColumnName = theColumnName.toUpperCase();
+				break;
+			case ALL_LOWER:
+				myColumnName = theColumnName.toLowerCase();
+				break;
+			default:
+				throw new IllegalArgumentException("Unknown ColumnNameCase: " + myColumnNameCase);
+		}
 		return this;
 	}
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
@@ -53,7 +53,7 @@ public abstract class BaseTableColumnTask extends BaseTableTask {
 	public BaseTableColumnTask setColumnName(String theColumnName) {
 		switch (myColumnNameCase) {
 			case ALL_UPPER:
-				 myColumnName = theColumnName.toUpperCase();
+				myColumnName = theColumnName.toUpperCase();
 				break;
 			case ALL_LOWER:
 				myColumnName = theColumnName.toLowerCase();

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
@@ -24,8 +24,10 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 public abstract class BaseTableColumnTask extends BaseTableTask {
@@ -39,11 +41,15 @@ public abstract class BaseTableColumnTask extends BaseTableTask {
 	private final ColumnNameCase myColumnNameCase;
 
 	public BaseTableColumnTask(String theProductVersion, String theSchemaVersion) {
-		this(theProductVersion, theSchemaVersion, ColumnNameCase.ALL_UPPER);
+		this(theProductVersion, theSchemaVersion, ColumnNameCase.ALL_UPPER, Collections.emptySet());
 	}
 
-	BaseTableColumnTask(String theProductVersion, String theSchemaVersion, ColumnNameCase theColumnNameCase) {
-		super(theProductVersion, theSchemaVersion);
+	BaseTableColumnTask(
+			String theProductVersion,
+			String theSchemaVersion,
+			ColumnNameCase theColumnNameCase,
+			Set<ColumnDriverMappingOverride> theColumnDriverMappingOverrides) {
+		super(theProductVersion, theSchemaVersion, theColumnDriverMappingOverrides);
 		myColumnNameCase = theColumnNameCase;
 	}
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTask.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.migrate.taskdef;
 
+import ca.uhn.fhir.i18n.Msg;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -59,7 +60,8 @@ public abstract class BaseTableColumnTask extends BaseTableTask {
 				myColumnName = theColumnName.toLowerCase();
 				break;
 			default:
-				throw new IllegalArgumentException("Unknown ColumnNameCase: " + myColumnNameCase);
+				// LUKETODO:  reserve message code
+				throw new IllegalArgumentException(Msg.code(9999) + " Unknown ColumnNameCase: " + myColumnNameCase);
 		}
 		return this;
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
@@ -19,12 +19,12 @@
  */
 package ca.uhn.fhir.jpa.migrate.taskdef;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Set;
-import jakarta.annotation.Nullable;
 
 public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 	private ColumnTypeEnum myColumnType;

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
@@ -37,6 +37,10 @@ public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 		super(theProductVersion, theSchemaVersion);
 	}
 
+	BaseTableColumnTypeTask(String theProductVersion, String theSchemaVersion, ColumnNameCase theColumnNameCase) {
+		super(theProductVersion, theSchemaVersion, theColumnNameCase);
+	}
+
 	public ColumnTypeEnum getColumnType() {
 		return myColumnType;
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Set;
 import javax.annotation.Nullable;
 
 public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
@@ -37,8 +38,12 @@ public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 		super(theProductVersion, theSchemaVersion);
 	}
 
-	BaseTableColumnTypeTask(String theProductVersion, String theSchemaVersion, ColumnNameCase theColumnNameCase) {
-		super(theProductVersion, theSchemaVersion, theColumnNameCase);
+	BaseTableColumnTypeTask(
+			String theProductVersion,
+			String theSchemaVersion,
+			ColumnNameCase theColumnNameCase,
+			Set<ColumnDriverMappingOverride> theColumnDriverMappingOverrides) {
+		super(theProductVersion, theSchemaVersion, theColumnNameCase, theColumnDriverMappingOverrides);
 	}
 
 	public ColumnTypeEnum getColumnType() {

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Set;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 	private ColumnTypeEnum myColumnType;

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.migrate.taskdef;
 
+import ca.uhn.fhir.i18n.Msg;
 import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -102,6 +103,10 @@ public abstract class BaseTableTask extends BaseTask {
 
 		if (eligibleOverrides.size() == 1) {
 			return eligibleOverrides.get(0).getColumnTypeSql();
+		}
+
+		if (! ColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType().containsKey(theColumnType)) {
+			throw new IllegalArgumentException(Msg.code(2448) + "Column type does not exist: " + theColumnType);
 		}
 
 		return ColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType()

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
@@ -107,7 +107,7 @@ public abstract class BaseTableTask extends BaseTask {
 
 		if (!ColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType()
 				.containsKey(theColumnType)) {
-			throw new IllegalArgumentException(Msg.code(2448) + "Column type does not exist: " + theColumnType);
+			throw new IllegalArgumentException(Msg.code(2449) + "Column type does not exist: " + theColumnType);
 		}
 
 		return ColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType()

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
@@ -105,7 +105,8 @@ public abstract class BaseTableTask extends BaseTask {
 			return eligibleOverrides.get(0).getColumnTypeSql();
 		}
 
-		if (! ColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType().containsKey(theColumnType)) {
+		if (!ColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType()
+				.containsKey(theColumnType)) {
 			throw new IllegalArgumentException(Msg.code(2448) + "Column type does not exist: " + theColumnType);
 		}
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.migrate.taskdef;
 
+import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import jakarta.annotation.Nonnull;
 
 public abstract class BaseTableTask extends BaseTask {
 	private static final Logger ourLog = LoggerFactory.getLogger(BaseTableTask.class);

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public abstract class BaseTableTask extends BaseTask {
 	private static final Logger ourLog = LoggerFactory.getLogger(BaseTableTask.class);

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnDriverMappingOverride.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnDriverMappingOverride.java
@@ -1,0 +1,85 @@
+/*-
+ * #%L
+ * HAPI FHIR Server - SQL Migration
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Capture a single SQL column type text override to the logic in {@link ColumnDriverMappingOverride}, namely,
+ * by column type and driver type.
+ * <p/>
+ * Several overrides can be passed down together at the same time to override said logic.
+ */
+public class ColumnDriverMappingOverride {
+	private final ColumnTypeEnum myColumnType;
+	private final DriverTypeEnum myDriverType;
+
+	private final String myColumnTypeSql;
+
+	public ColumnDriverMappingOverride(
+			ColumnTypeEnum theColumnType, DriverTypeEnum theDriverType, String theColumnTypeSql) {
+		myColumnType = theColumnType;
+		myDriverType = theDriverType;
+		myColumnTypeSql = theColumnTypeSql;
+	}
+
+	ColumnTypeEnum getColumnType() {
+		return myColumnType;
+	}
+
+	DriverTypeEnum getDriverType() {
+		return myDriverType;
+	}
+
+	String getColumnTypeSql() {
+		return myColumnTypeSql;
+	}
+
+	@Override
+	public boolean equals(Object theO) {
+		if (this == theO) {
+			return true;
+		}
+		if (theO == null || getClass() != theO.getClass()) {
+			return false;
+		}
+		ColumnDriverMappingOverride that = (ColumnDriverMappingOverride) theO;
+		return myColumnType == that.myColumnType
+				&& myDriverType == that.myDriverType
+				&& Objects.equals(myColumnTypeSql, that.myColumnTypeSql);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(myColumnType, myDriverType, myColumnTypeSql);
+	}
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", ColumnDriverMappingOverride.class.getSimpleName() + "[", "]")
+				.add("myColumnType=" + myColumnType)
+				.add("myDriverType=" + myDriverType)
+				.add("myColumnTypeSql='" + myColumnTypeSql + "'")
+				.toString();
+	}
+}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnDriverMappingOverride.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnDriverMappingOverride.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.annotation.Nonnull;
 
 /**
  * Capture a single SQL column type text override to the logic in {@link ColumnDriverMappingOverride}, namely,
@@ -37,7 +38,9 @@ public class ColumnDriverMappingOverride {
 	private final String myColumnTypeSql;
 
 	public ColumnDriverMappingOverride(
-			ColumnTypeEnum theColumnType, DriverTypeEnum theDriverType, String theColumnTypeSql) {
+			@Nonnull ColumnTypeEnum theColumnType,
+			@Nonnull DriverTypeEnum theDriverType,
+			@Nonnull String theColumnTypeSql) {
 		myColumnType = theColumnType;
 		myDriverType = theDriverType;
 		myColumnTypeSql = theColumnTypeSql;

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnDriverMappingOverride.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnDriverMappingOverride.java
@@ -46,15 +46,15 @@ public class ColumnDriverMappingOverride {
 		myColumnTypeSql = theColumnTypeSql;
 	}
 
-	ColumnTypeEnum getColumnType() {
+	public ColumnTypeEnum getColumnType() {
 		return myColumnType;
 	}
 
-	DriverTypeEnum getDriverType() {
+	public DriverTypeEnum getDriverType() {
 		return myDriverType;
 	}
 
-	String getColumnTypeSql() {
+	public String getColumnTypeSql() {
 		return myColumnTypeSql;
 	}
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnNameCase.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnNameCase.java
@@ -1,0 +1,7 @@
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+// LUKETODO:  javadoc
+public enum ColumnNameCase {
+	ALL_UPPER,
+	ALL_LOWER
+}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnNameCase.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnNameCase.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR Server - SQL Migration
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.migrate.taskdef;
 
 // LUKETODO:  javadoc

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnNameCase.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnNameCase.java
@@ -19,7 +19,9 @@
  */
 package ca.uhn.fhir.jpa.migrate.taskdef;
 
-// LUKETODO:  javadoc
+/**
+ * Determine whether to display column names in upper case, lower case, or eventually some form of mixed case.
+ */
 public enum ColumnNameCase {
 	ALL_UPPER,
 	ALL_LOWER

--- a/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTest.java
@@ -93,7 +93,7 @@ public class AddColumnTest extends BaseTest {
 			getMigrator().migrate();
 			fail();
 		} catch (HapiMigrationException e) {
-			assertThat(e.getMessage(), startsWith("HAPI-0047: Failure executing task \"Add column foo_column on table FOO_TABLE\", aborting! Cause: ca.uhn.fhir.jpa.migrate.HapiMigrationException: HAPI-0061: Failed during task 4.0.0.2001.01: "));
+			assertThat(e.getMessage(), startsWith("HAPI-0047: Failure executing task \"Add column FOO_COLUMN on table FOO_TABLE\", aborting! Cause: ca.uhn.fhir.jpa.migrate.HapiMigrationException: HAPI-0061: Failed during task 4.0.0.2001.01: "));
 		}
 	}
 


### PR DESCRIPTION
- Allow callers to choose uppercase or lowercase column names.  Default uppercase.
- Allow callers to pass custom sorting rules:  Default no special sorting.
- In both cases, set the defaults to pre-existing behaviour, namely, uppercase and no overrides
- Fix unrelated unit test that's broken in master
- Add a new test

Closes https://github.com/hapifhir/hapi-fhir/issues/5536