### PR TITLE
Migration:  Add new indexes to hfj_spidx_string and hfj_spidx_uri if collation is NOT 'C'

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5547-postgres-collation-utf8-migration-detect-add-index.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5547-postgres-collation-utf8-migration-detect-add-index.yaml
@@ -2,6 +2,6 @@
 type: fix
 issue: 5547
 title: "Previously LIKE queries against resources would perform poorly on PostgreSQL if the database locale/collation was not 'C'.
-        This has been resolving by checking hfj_spidx_string.sp_value_normalized and hfj_spidx_uri.sp_uri column
+        This has been resolved by checking hfj_spidx_string.sp_value_normalized and hfj_spidx_uri.sp_uri column
         collations during migration and if either or both are non C, create a new btree varchar_pattern_ops on the
         hash values.  If both column collations are 'C', do not create any new indexes."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5547-postgres-collation-utf8-migration-detect-add-index.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5547-postgres-collation-utf8-migration-detect-add-index.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 5547
+title: "Previously LIKE queries against resources would perform poorly on PostgreSQL if the database locale/collation was not 'C'.
+        This has been resolving by checking hfj_spidx_string.sp_value_normalized and hfj_spidx_uri.sp_uri column
+        collations during migration and if either or both are non C, create a new btree varchar_pattern_ops on the
+        hash values.  If both column collations are 'C', do not create any new indexes."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/upgrade.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/upgrade.md
@@ -1,0 +1,16 @@
+## Possible New Indexes on PostgresSQL
+
+* This affects only clients running PostgreSQL who have a locale/collation that is NOT 'C'
+* For those clients, the migration will detect this condition and add new indexes to:
+    * hfj_spidx_string
+    * hfj_spidx_uri
+* This is meant to address performance issues for these clients on GET queries whose resulting SQL uses "LIKE" clauses
+
+These are the new indexes that will be created:
+
+```sql
+CREATE INDEX idx_sp_string_hash_nrm_pattern_ops ON public.hfj_spidx_string USING btree (hash_norm_prefix, sp_value_normalized varchar_pattern_ops, res_id, partition_id);
+```
+```sql
+CREATE UNIQUE INDEX idx_sp_uri_hash_identity_pattern_ops ON public.hfj_spidx_uri USING btree (hash_identity, sp_uri varchar_pattern_ops, res_id, partition_id);
+```

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -143,7 +143,6 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		batch2JobInstanceTable.addColumn("20231128.2", "CLIENT_ID").nullable().type(ColumnTypeEnum.STRING, 200);
 
 		{
-			// LUKETODO: why am I getting more than one result?
 			final String queryForColumnCollationTemplate = "WITH defcoll AS (\n"
 					+ "	SELECT datcollate AS coll\n"
 					+ "	FROM pg_database\n"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -97,8 +97,6 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		init700();
 	}
 
-	// LUKETODO: ConditionalTaskWrapper: compose the underlying task
-
 	protected void init700() {
 		/* ************************************************
 		 * Start of 6.10 migrations
@@ -120,7 +118,6 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 		// Move forced_id constraints to hfj_resource and the new fhir_id column
 		// Note: we leave the HFJ_FORCED_ID.IDX_FORCEDID_TYPE_FID index in place to support old writers for a while.
-		// LUKETODO:
 		version.addTask(new ForceIdMigrationCopyTask(version.getRelease(), "20231018.1"));
 
 		Builder.BuilderWithTableName hfjResource = version.onTable("HFJ_RESOURCE");
@@ -146,7 +143,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		batch2JobInstanceTable.addColumn("20231128.2", "CLIENT_ID").nullable().type(ColumnTypeEnum.STRING, 200);
 
 		{
-			final String queryForColumnCollationTemplate = "WITH defcoll AS (\n" + "	SELECT datcollate AS coll\n"
+			// LUKETODO: why am I getting more than one result?
+			final String queryForColumnCollationTemplate = "WITH defcoll AS (\n"
+					+ "	SELECT datcollate AS coll\n"
 					+ "	FROM pg_database\n"
 					+ "	WHERE datname = current_database())\n"
 					+ ", collation_by_column AS (\n"
@@ -170,116 +169,29 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 			version.executeRawSql(
 							"20231212.1",
-					"CREATE INDEX idx_sp_string_hash_nrm_pattern_ops ON public.hfj_spidx_string USING btree (hash_norm_prefix, sp_value_normalized varchar_pattern_ops, res_id, partition_id)")
+							"CREATE INDEX idx_sp_string_hash_nrm_pattern_ops ON public.hfj_spidx_string USING btree (hash_norm_prefix, sp_value_normalized varchar_pattern_ops, res_id, partition_id)")
 					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4)
-					.onlyIf(String.format(
-							queryForColumnCollationTemplate, "HFJ_SPIDX_STRING".toLowerCase(), "SP_VALUE_NORMALIZED".toLowerCase(), "C"));
+					.onlyIf(
+							String.format(
+									queryForColumnCollationTemplate,
+									"HFJ_SPIDX_STRING".toLowerCase(),
+									"SP_VALUE_NORMALIZED".toLowerCase(),
+									"C"),
+							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
 
 			version.executeRawSql(
 							"20231212.2",
-					  "CREATE UNIQUE INDEX idx_sp_uri_hash_identity_pattern_ops ON public.hfj_spidx_uri USING btree (hash_identity, sp_uri varchar_pattern_ops, res_id, partition_id)")
+							"CREATE UNIQUE INDEX idx_sp_uri_hash_identity_pattern_ops ON public.hfj_spidx_uri USING btree (hash_identity, sp_uri varchar_pattern_ops, res_id, partition_id)")
 					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4)
-					.onlyIf(String.format(queryForColumnCollationTemplate, "HFJ_SPIDX_URI".toLowerCase(), "SP_URI".toLowerCase(), "C"));
+					.onlyIf(
+							String.format(
+									queryForColumnCollationTemplate,
+									"HFJ_SPIDX_URI".toLowerCase(),
+									"SP_URI".toLowerCase(),
+									"C"),
+							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
 		}
-
-		//		{
-		//			if (1 != 1) {
-		//				version.onTable("HFJ_SPIDX_STRING")
-		//					.addIndex("20231211.1", "HFJ_SPIDX_STRING_PTRN_OPS")
-		//					.unique(false)
-		//					.withColumns("SP_VALUE_NORMALIZED")
-		//					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4);
-		//
-		//				final Builder.BuilderWithTableName hfjSpidxString = version.onTable("HFJ_SPIDX_STRING");
-		//
-		//				// LUKETODO: conditional logic to decide whether or not the column is the correct collation
-		//
-		/*
-		* 1. For Postgres and possibly MSSQL and Oracle
-		* 2. Detect if the column is utf8
-		* 3. If so, add a new index
-		*
-		* CREATE INDEX idx_sp_string_hash_nrm_v3 ON public.hfj_spidx_string USING btree (hash_norm_prefix, sp_value_normalized varchar_pattern_ops, res_id, partition_id);
-		* CREATE UNIQUE INDEX idx_sp_uri_hash_identity_v3 ON public.hfj_spidx_uri USING btree (hash_identity, sp_uri varchar_pattern_ops, res_id, partition_id);
-		*
-		* Detect column:
-		* WITH defcoll AS (
-			SELECT datcollate AS coll
-			FROM pg_database
-			WHERE datname = current_database()
-		)
-		SELECT a.attname,
-				CASE WHEN c.collname = 'default'
-							THEN defcoll.coll
-						ELSE c.collname
-					END AS collation
-		FROM pg_attribute AS a
-					CROSS JOIN defcoll
-					LEFT JOIN pg_collation AS c ON a.attcollation = c.oid
-		WHERE a.attrelid = 'hfj_spidx_string'::regclass
-		AND a.attnum > 0
-		ORDER BY attnum;
-		*/
-
-		//				final Map<DriverTypeEnum, String> fixCollationSpidxString = new HashMap<>();
-		//				fixCollationSpidxString.put(
-		//					DriverTypeEnum.POSTGRES_9_4,
-		//					"ALTER TABLE HFJ_SPIDX_STRING ALTER COLUMN SP_VALUE_NORMALIZED SET DATA TYPE character varying(255)
-		// COLLATE \"C\"");
-		//
-		//				version.executeRawSql("20231211.1", fixCollationSpidxString);
-		//
-		//				final Map<DriverTypeEnum, String> rebuildIndexSpidxString = new HashMap<>();
-		//				rebuildIndexSpidxString.put(
-		//					DriverTypeEnum.POSTGRES_9_4,
-		//					"REINDEX INDEX IDX_SP_STRING_HASH_NRM_V2");
-		//
-		//				final String x = "CREATE INDEX CONCURRENTLY HFJ_SPIDX_STRING_PTRN_OPS ON HFJ_SPIDX_STRING
-		// (SP_VALUE_NORMALIZED varchar_pattern_ops)";
-		//				final String y = "CREATE INDEX CONCURRENTLY HFJ_SPIDX_URI_PTRN_OPS ON HFJ_SPIDX_URI (SP_URI
-		// varchar_pattern_ops)";
-		//
-		//				version.executeRawSql("20231211.2", rebuildIndexSpidxString);
-		//
-		//				final 	Builder.BuilderWithTableName hfjSpidxUri = version.onTable("HFJ_SPIDX_URI");
-		//
-		//				final Map<DriverTypeEnum, String> fixCollationSpidxUri = new HashMap<>();
-		//				fixCollationSpidxUri.put(
-		//					DriverTypeEnum.POSTGRES_9_4,
-		//					"ALTER TABLE HFJ_SPIDX_URI ALTER COLUMN SP_URI SET DATA TYPE character varying(255) COLLATE \"C\"");
-		//
-		//				version.executeRawSql("20231211.3", fixCollationSpidxUri);
-		//
-		//				final Map<DriverTypeEnum, String> rebuildIndexSpidxUri = new HashMap<>();
-		//				rebuildIndexSpidxUri.put(
-		//					DriverTypeEnum.POSTGRES_9_4,
-		//					"REINDEX INDEX IDX_SP_URI_HASH_IDENTITY_V2");
-		//
-		//				version.executeRawSql("20231211.4", rebuildIndexSpidxUri);
-
-		// LUKETODO:  consider logic like this:
-
-		// add res_id, and partition_id so queries are covered without row-reads.
-		//			tokenTable
-		//				.addIndex("20220428.1", "IDX_SP_STRING_HASH_NRM_V2")
-		//				.unique(false)
-		//				.online(true)
-		//				.withColumns("HASH_NORM_PREFIX", "SP_VALUE_NORMALIZED", "RES_ID", "PARTITION_ID");
-		//			tokenTable.dropIndexOnline("20220428.2", "IDX_SP_STRING_HASH_NRM");
-
-		//			}
-		//		}
 	}
-
-	//	private void doExecute() throws SQLException {
-	//		// LUKETODO: respect dryRun settings
-	//		// LUKETODO: take into consideration DBRMS (ex Postgres)
-	//		// LUKETO
-	//		BaseTask child  = null;
-	//		if (1 ==1 ) {
-	//			child.execute();
-	//		}
-	//	}
 
 	protected void init680() {
 		Builder version = forVersion(VersionEnum.V6_8_0);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -171,7 +171,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4)
 					.onlyIf(
 							String.format(
-								QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
+									QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
 									"HFJ_SPIDX_STRING".toLowerCase(),
 									"SP_VALUE_NORMALIZED".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
@@ -182,7 +182,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4)
 					.onlyIf(
 							String.format(
-								QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
+									QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
 									"HFJ_SPIDX_URI".toLowerCase(),
 									"SP_URI".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -62,6 +62,28 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 	// H2, Derby, MariaDB, and MySql automatically add indexes to foreign keys
 	public static final DriverTypeEnum[] NON_AUTOMATIC_FK_INDEX_PLATFORMS =
 			new DriverTypeEnum[] {DriverTypeEnum.POSTGRES_9_4, DriverTypeEnum.ORACLE_12C, DriverTypeEnum.MSSQL_2012};
+	private static final String QUERY_FOR_COLUMN_COLLATION_TEMPLATE = "WITH defcoll AS (\n"
+			+ "	SELECT datcollate AS coll\n"
+			+ "	FROM pg_database\n"
+			+ "	WHERE datname = current_database())\n"
+			+ ", collation_by_column AS (\n"
+			+ "	SELECT a.attname,\n"
+			+ "		CASE WHEN c.collname = 'default'\n"
+			+ "			THEN defcoll.coll\n"
+			+ "			ELSE c.collname\n"
+			+ "		END AS my_collation\n"
+			+ "	FROM pg_attribute AS a\n"
+			+ "		CROSS JOIN defcoll\n"
+			+ "		LEFT JOIN pg_collation AS c ON a.attcollation = c.oid\n"
+			+ "	WHERE a.attrelid = '%s'::regclass\n"
+			+ "		AND a.attnum > 0\n"
+			+ "		AND attname = '%s'\n"
+			+ ")\n"
+			+ "SELECT TRUE as result\n"
+			+ "FROM collation_by_column\n"
+			+ "WHERE EXISTS (SELECT 1\n"
+			+ "	FROM collation_by_column\n"
+			+ "	WHERE my_collation != 'C')";
 	private final Set<FlagEnum> myFlags;
 
 	/**
@@ -143,39 +165,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		batch2JobInstanceTable.addColumn("20231128.2", "CLIENT_ID").nullable().type(ColumnTypeEnum.STRING, 200);
 
 		{
-			final String queryForColumnCollationTemplate = "WITH defcoll AS (\n"
-					+ "	SELECT datcollate AS coll\n"
-					+ "	FROM pg_database\n"
-					+ "	WHERE datname = current_database())\n"
-					+ ", collation_by_column AS (\n"
-					+ "	SELECT a.attname,\n"
-					+ "		CASE WHEN c.collname = 'default'\n"
-					+ "			THEN defcoll.coll\n"
-					+ "			ELSE c.collname\n"
-					+ "		END AS my_collation\n"
-					+ "	FROM pg_attribute AS a\n"
-					+ "		CROSS JOIN defcoll\n"
-					+ "		LEFT JOIN pg_collation AS c ON a.attcollation = c.oid\n"
-					+ "	WHERE a.attrelid = '%s'::regclass\n"
-					+ "		AND a.attnum > 0\n"
-					+ "		AND attname = '%s'\n"
-					+ ")\n"
-					+ "SELECT TRUE as result\n"
-					+ "FROM collation_by_column\n"
-					+ "WHERE EXISTS (SELECT 1\n"
-					+ "	FROM collation_by_column\n"
-					+ "	WHERE my_collation != '%s')";
-
 			version.executeRawSql(
 							"20231212.1",
 							"CREATE INDEX idx_sp_string_hash_nrm_pattern_ops ON public.hfj_spidx_string USING btree (hash_norm_prefix, sp_value_normalized varchar_pattern_ops, res_id, partition_id)")
 					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4)
 					.onlyIf(
 							String.format(
-									queryForColumnCollationTemplate,
+								QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
 									"HFJ_SPIDX_STRING".toLowerCase(),
-									"SP_VALUE_NORMALIZED".toLowerCase(),
-									"C"),
+									"SP_VALUE_NORMALIZED".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
 
 			version.executeRawSql(
@@ -184,10 +182,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 					.onlyAppliesToPlatforms(DriverTypeEnum.POSTGRES_9_4)
 					.onlyIf(
 							String.format(
-									queryForColumnCollationTemplate,
+								QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
 									"HFJ_SPIDX_URI".toLowerCase(),
-									"SP_URI".toLowerCase(),
-									"C"),
+									"SP_URI".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
 		}
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
@@ -34,10 +34,10 @@ import java.util.Optional;
 public class MigrationJdbcUtils {
 	private static final Logger ourLog = LoggerFactory.getLogger(MigrationJdbcUtils.class);
 
-	public static boolean queryForSingleBooleanResultMultipleThrowsException(String theSql, JdbcTemplate theJdbcTemplate) {
+	public static boolean queryForSingleBooleanResultMultipleThrowsException(
+			String theSql, JdbcTemplate theJdbcTemplate) {
 		final RowMapper<Boolean> booleanRowMapper = (theResultSet, theRowNumber) -> theResultSet.getBoolean(1);
-		return queryForSingle(theSql, theJdbcTemplate, booleanRowMapper)
-			.orElse(false);
+		return queryForSingle(theSql, theJdbcTemplate, booleanRowMapper).orElse(false);
 	}
 
 	private static <T> Optional<T> queryForSingle(
@@ -51,7 +51,9 @@ public class MigrationJdbcUtils {
 		if (results.size() > 1) {
 			// Presumably other callers may want different behaviour but in this case more than one result should be
 			// considered a hard failure distinct from an empty result, which is one expected outcome.
-			throw new IllegalArgumentException(Msg.code(2474)+String.format("Failure due to query returning more than one result: %s for SQL: [%s].", results, theSql));
+			throw new IllegalArgumentException(Msg.code(2474)
+					+ String.format(
+							"Failure due to query returning more than one result: %s for SQL: [%s].", results, theSql));
 		}
 
 		return Optional.ofNullable(results.get(0));

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
@@ -46,7 +46,7 @@ public class MigrationJdbcUtils {
 			return Optional.empty();
 		}
 
-		if (results.size() == 1) {
+		if (results.size() > 1) {
 			ourLog.warn(
 					"Query returned more than one result: {} for SQL: {}.  Returning the first result",
 					results,

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
@@ -1,0 +1,65 @@
+/*-
+ * #%L
+ * HAPI FHIR Server - SQL Migration
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.migrate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Utility methods to be used by migrator functionality that needs to invoke JDBC directly.
+ */
+public class MigrationJdbcUtils {
+	private static final Logger ourLog = LoggerFactory.getLogger(MigrationJdbcUtils.class);
+
+	public static boolean queryForSingleBooleanResult(String theSql, JdbcTemplate theJdbcTemplate) {
+		final RowMapper<Boolean> booleanRowMapper = (theResultSet, theRowNumber) -> theResultSet.getBoolean(1);
+		return queryForSingle(theSql, theJdbcTemplate, booleanRowMapper).orElse(false);
+	}
+
+	private static <T> Optional<T> queryForSingle(
+			String theSql, JdbcTemplate theJdbcTemplate, RowMapper<T> theRowMapper) {
+		final List<T> results = queryForMultiple(theSql, theJdbcTemplate, theRowMapper);
+
+		ourLog.info("5258: result: {}", results);
+
+		if (results.isEmpty()) {
+			return Optional.empty();
+		}
+
+		if (results.size() == 1) {
+			ourLog.warn(
+					"5258: Query returned more than one result: {} for SQL: {}.  Returning the first result",
+					results,
+					theSql);
+		}
+
+		return Optional.ofNullable(results.get(0));
+	}
+
+	private static <T> List<T> queryForMultiple(
+			String theSql, JdbcTemplate theJdbcTemplate, RowMapper<T> theRowMapper) {
+		return theJdbcTemplate.query(theSql, theRowMapper);
+	}
+}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/MigrationJdbcUtils.java
@@ -42,15 +42,13 @@ public class MigrationJdbcUtils {
 			String theSql, JdbcTemplate theJdbcTemplate, RowMapper<T> theRowMapper) {
 		final List<T> results = queryForMultiple(theSql, theJdbcTemplate, theRowMapper);
 
-		ourLog.info("5258: result: {}", results);
-
 		if (results.isEmpty()) {
 			return Optional.empty();
 		}
 
 		if (results.size() == 1) {
 			ourLog.warn(
-					"5258: Query returned more than one result: {} for SQL: {}.  Returning the first result",
+					"Query returned more than one result: {} for SQL: {}.  Returning the first result",
 					results,
 					theSql);
 		}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
@@ -265,7 +265,7 @@ public abstract class BaseTask {
 		}
 
 		for (ExecuteTaskPrecondition precondition : myPreconditions) {
-			ourLog.info("5258:  precondition: {}", precondition);
+			ourLog.debug("precondition to evaluate: {}", precondition);
 			if (!precondition.getPreconditionRunner().get()) {
 				ourLog.info(
 						"Skipping task since one of the preconditions was not met: {}",
@@ -273,7 +273,6 @@ public abstract class BaseTask {
 				return;
 			}
 		}
-
 		doExecute();
 	}
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
@@ -267,7 +267,6 @@ public abstract class BaseTask {
 		for (ExecuteTaskPrecondition precondition : myPreconditions) {
 			ourLog.info("5258:  precondition: {}", precondition);
 			if (!precondition.getPreconditionRunner().get()) {
-				// LUKETODO:  add a reason to the precondition
 				ourLog.info(
 						"Skipping task since one of the preconditions was not met: {}",
 						precondition.getPreconditionReason());

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTask.java
@@ -26,14 +26,11 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.jdbc.core.PreparedStatementSetter;
-import org.springframework.jdbc.core.ResultSetExtractor;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import static org.apache.commons.lang3.StringUtils.trim;
 
@@ -42,8 +39,6 @@ public class ExecuteRawSqlTask extends BaseTask {
 	private static final Logger ourLog = LoggerFactory.getLogger(ExecuteRawSqlTask.class);
 	private Map<DriverTypeEnum, List<String>> myDriverToSqls = new HashMap<>();
 	private List<String> myDriverNeutralSqls = new ArrayList<>();
-	// LUKETODO:  consider getting rid of this
-	private List<Supplier<Boolean>> myExecuteConditions = new ArrayList<>();
 
 	public ExecuteRawSqlTask(String theProductVersion, String theSchemaVersion) {
 		super(theProductVersion, theSchemaVersion);
@@ -73,38 +68,6 @@ public class ExecuteRawSqlTask extends BaseTask {
 		return this;
 	}
 
-	String queryForColumnCollationTemplate = "WITH defcoll AS (\n" + "	SELECT datcollate AS coll\n"
-			+ "	FROM pg_database\n"
-			+ "	WHERE datname = current_database()\n"
-			+ ")\n"
-			+ "SELECT a.attname,\n"
-			+ "	CASE WHEN c.collname = 'default'\n"
-			+ "		THEN defcoll.coll\n"
-			+ "		ELSE c.collname\n"
-			+ "	END AS collation\n"
-			+ "FROM pg_attribute AS a\n"
-			+ "	CROSS JOIN defcoll\n"
-			+ "	LEFT JOIN pg_collation AS c ON a.attcollation = c.oid\n"
-			+ "WHERE a.attrelid = '?'::regclass\n"
-			+ "	AND a.attnum > 0\n"
-			+ "ORDER BY attnum";
-
-	// LUKETODO:  assume Boolean here?
-	public ExecuteRawSqlTask onlyIf(String sql, Object[] theParams) {
-		myExecuteConditions.add(() -> {
-			final ResultSetExtractor<Boolean> rowCallbackHandler = theResultSet -> theResultSet.getBoolean(1);
-			final PreparedStatementSetter preparedStatementSetter = thePreparedStatement -> {
-				for (int index = 0; index < theParams.length; index++) {
-					thePreparedStatement.setObject(index + 1, theParams[index]);
-				}
-			};
-
-			return newJdbcTemplate().query(sql, preparedStatementSetter, rowCallbackHandler);
-		});
-
-		return this;
-	}
-
 	@Override
 	public void validate() {
 		// nothing
@@ -114,19 +77,6 @@ public class ExecuteRawSqlTask extends BaseTask {
 	public void doExecute() {
 		List<String> sqlStatements = myDriverToSqls.computeIfAbsent(getDriverType(), t -> new ArrayList<>());
 		sqlStatements.addAll(myDriverNeutralSqls);
-
-		ourLog.info("Evaluating Preconditions for executing SQL, if any exist");
-
-		// LUKETODO: figure out how to unit test this
-		// LUKETODO: consider adding a reason to this result
-		for (Supplier<Boolean> executeCondition : myExecuteConditions) {
-			final Boolean evalResult = executeCondition.get();
-
-			if (!evalResult) {
-				ourLog.info("Evaluation test is false.  Not executing SQL statements");
-				return;
-			}
-		}
 
 		logInfo(ourLog, "Going to execute {} SQL statements", sqlStatements.size());
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteTaskPrecondition.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteTaskPrecondition.java
@@ -1,0 +1,69 @@
+/*-
+ * #%L
+ * HAPI FHIR Server - SQL Migration
+ * %%
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+
+// LUKETODO: javadoc
+public class ExecuteTaskPrecondition {
+	private final Supplier<Boolean> myPreconditionRunner;
+	private final String myPreconditionReason;
+
+	public ExecuteTaskPrecondition(Supplier<Boolean> thePreconditionRunner, String thePreconditionReason) {
+		myPreconditionRunner = thePreconditionRunner;
+		myPreconditionReason = thePreconditionReason;
+	}
+
+	public Supplier<Boolean> getPreconditionRunner() {
+		return myPreconditionRunner;
+	}
+
+	public String getPreconditionReason() {
+		return myPreconditionReason;
+	}
+
+	@Override
+	public boolean equals(Object theO) {
+		if (this == theO) {
+			return true;
+		}
+		if (theO == null || getClass() != theO.getClass()) {
+			return false;
+		}
+		ExecuteTaskPrecondition that = (ExecuteTaskPrecondition) theO;
+		return Objects.equals(myPreconditionRunner, that.myPreconditionRunner)
+				&& Objects.equals(myPreconditionReason, that.myPreconditionReason);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(myPreconditionRunner, myPreconditionReason);
+	}
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", ExecuteTaskPrecondition.class.getSimpleName() + "[", "]")
+				.add("myPreconditionRunner=" + myPreconditionRunner)
+				.add("myPreconditionReason='" + myPreconditionReason + "'")
+				.toString();
+	}
+}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteTaskPrecondition.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteTaskPrecondition.java
@@ -23,7 +23,12 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Supplier;
 
-// LUKETODO: javadoc
+/**
+ * Contains a pre-built precondition to evaluate once {@link BaseTask#execute()} is called.
+ * <p/>
+ * Includes both a {@link Supplier} containing the logic to determine if the precondition evaluates to true or false and
+ * a reason String to output to the logs if the precondition evaluates to false and halts execution of the task.
+ */
 public class ExecuteTaskPrecondition {
 	private final Supplier<Boolean> myPreconditionRunner;
 	private final String myPreconditionReason;

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -592,15 +592,12 @@ public class Builder {
 		 * @return The BuilderCompleteTask in order to chain further method calls on this builder.
 		 */
 		public BuilderCompleteTask onlyIf(@Language("SQL") String theSql, String reason) {
-			if (theSql.toUpperCase().startsWith("WITH") && theSql.toUpperCase().startsWith("SELECT")) {
-				// LUKETODO: new Msg.code()
-				throw new IllegalArgumentException(Msg.code(9999)
-						+ "Only SELECT statements (including CTEs) are allowed here.  Please check your SQL: "
-						+ theSql);
+			if (! theSql.toUpperCase().startsWith("WITH") && ! theSql.toUpperCase().startsWith("SELECT")) {
+				throw new IllegalArgumentException(Msg.code(2455)
+						+ String.format("Only SELECT statements (including CTEs) are allowed here.  Please check your SQL: [%s]", theSql));
 			}
 
-			// LUKETODO:  changelog
-			ourLog.info("5258: Evaluating onlyIf for SQL: {}", theSql);
+			ourLog.info("Evaluating onlyIf for SQL: {}", theSql);
 
 			myTask.addPrecondition(new ExecuteTaskPrecondition(
 					() -> MigrationJdbcUtils.queryForSingleBooleanResult(theSql, myTask.newJdbcTemplate()), reason));
@@ -626,18 +623,12 @@ public class Builder {
 				return false;
 			}
 
-			if (results.size() == 1) {
+			if (results.size() > 1) {
 				ourLog.warn(
 						"5258: Query returned more than one result for SQL: {}.  Returning the first result", theSql);
 			}
 
 			return results.get(0);
-			//					final ResultSetExtractor<Boolean> rowCallbackHandler = theResultSet ->
-			// theResultSet.getBoolean(1);
-			//
-			//					return myTask.newJdbcTemplate()
-			//						.query(theSql, rowCallbackHandler);
-
 		}
 	}
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -602,7 +602,7 @@ public class Builder {
 			myTask.addPrecondition(new ExecuteTaskPrecondition(
 					() -> {
 						ourLog.info("Checking precondition for SQL: {}", theSql);
-						return MigrationJdbcUtils.queryForSingleBooleanResult(theSql, myTask.newJdbcTemplate());
+						return MigrationJdbcUtils.queryForSingleBooleanResultMultipleThrowsException(theSql, myTask.newJdbcTemplate());
 					},
 					reason));
 

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -602,7 +602,8 @@ public class Builder {
 			myTask.addPrecondition(new ExecuteTaskPrecondition(
 					() -> {
 						ourLog.info("Checking precondition for SQL: {}", theSql);
-						return MigrationJdbcUtils.queryForSingleBooleanResultMultipleThrowsException(theSql, myTask.newJdbcTemplate());
+						return MigrationJdbcUtils.queryForSingleBooleanResultMultipleThrowsException(
+								theSql, myTask.newJdbcTemplate());
 					},
 					reason));
 

--- a/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTest.java
@@ -81,12 +81,16 @@ public abstract class BaseTest {
 	protected HapiMigrationDao myHapiMigrationDao;
 	protected HapiMigrationStorageSvc myHapiMigrationStorageSvc;
 
-	public static Stream<Arguments> dataWithEvaluationResult() {
+	public static Stream<Arguments> dataWithEvaluationResults() {
 		return Stream.of(
-			Arguments.of(TEST_DATABASE_DETAILS_H2_SUPPLIER, true),
-			Arguments.of(TEST_DATABASE_DETAILS_H2_SUPPLIER, false),
-			Arguments.of(TEST_DATABASE_DETAILS_DERBY_SUPPLIER, true),
-			Arguments.of(TEST_DATABASE_DETAILS_DERBY_SUPPLIER, false)
+			Arguments.of(TEST_DATABASE_DETAILS_H2_SUPPLIER, List.of(true, true), true),
+			Arguments.of(TEST_DATABASE_DETAILS_H2_SUPPLIER, List.of(false, true), false),
+			Arguments.of(TEST_DATABASE_DETAILS_H2_SUPPLIER, List.of(true, false), false),
+			Arguments.of(TEST_DATABASE_DETAILS_H2_SUPPLIER, List.of(false, false), false),
+			Arguments.of(TEST_DATABASE_DETAILS_DERBY_SUPPLIER, List.of(true, true), true),
+			Arguments.of(TEST_DATABASE_DETAILS_DERBY_SUPPLIER, List.of(false, true), false),
+			Arguments.of(TEST_DATABASE_DETAILS_DERBY_SUPPLIER, List.of(true, false), false),
+			Arguments.of(TEST_DATABASE_DETAILS_DERBY_SUPPLIER, List.of(false, false), false)
 		);
 	}
 

--- a/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTaskTest.java
+++ b/hapi-fhir-sql-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ExecuteRawSqlTaskTest.java
@@ -2,7 +2,6 @@ package ca.uhn.fhir.jpa.migrate.taskdef;
 
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 import ca.uhn.fhir.jpa.migrate.tasks.api.BaseMigrationTasks;
-import ca.uhn.fhir.jpa.migrate.tasks.api.Builder;
 import ca.uhn.fhir.util.VersionEnum;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
- Introduce a new preconditions mechanism to BaseTask:  Pass in a single boolean result SQL to be run before a particular task is executed
- It's possible to chain multiple preconditions, with the first false result halting the execution of the task
- More tests
- Leverage this new mechanism to check both hfj_spidx_string.sp_string_normalized and hfj_spidx_uri.sp_uri columns to see if the collations are not 'C'
- If either or both is not 'C', add one or both new indexes to them.
- Add to upgrade document for 7.0 release.

Closes https://github.com/hapifhir/hapi-fhir/issues/5547