### PR TITLE
Fix fhirpath expression evaluation with _fhirpath parameter when resolve() references resources within a Bundle

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleUtil.java
@@ -646,7 +646,7 @@ public class BundleUtil {
 	}
 
 	public static IBase getReferenceInBundle(
-		@Nonnull FhirContext theFhirContext, @Nonnull String theUrl, @Nullable Object theAppContext) {
+			@Nonnull FhirContext theFhirContext, @Nonnull String theUrl, @Nullable Object theAppContext) {
 		if (!(theAppContext instanceof IBaseBundle) || isBlank(theUrl) || theUrl.startsWith("#")) {
 			return null;
 		}
@@ -658,7 +658,7 @@ public class BundleUtil {
 
 		final boolean isPlaceholderReference = theUrl.startsWith("urn:");
 		final String unqualifiedVersionlessReference =
-			new IdDt(theUrl).toUnqualifiedVersionless().getValue();
+				new IdDt(theUrl).toUnqualifiedVersionless().getValue();
 
 		for (BundleEntryParts next : BundleUtil.toListOfEntries(theFhirContext, bundle)) {
 			IBaseResource nextResource = next.getResource();
@@ -667,14 +667,12 @@ public class BundleUtil {
 			}
 			if (isPlaceholderReference) {
 				if (theUrl.equals(next.getUrl())
-					|| theUrl.equals(nextResource.getIdElement().getValue())) {
+						|| theUrl.equals(nextResource.getIdElement().getValue())) {
 					return nextResource;
 				}
 			} else {
-				if (unqualifiedVersionlessReference.equals(nextResource
-					.getIdElement()
-					.toUnqualifiedVersionless()
-					.getValue())) {
+				if (unqualifiedVersionlessReference.equals(
+						nextResource.getIdElement().toUnqualifiedVersionless().getValue())) {
 					return nextResource;
 				}
 			}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5564-fhirpath-expression-with-resolve-doesnt-work-for-bundle.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5564-fhirpath-expression-with-resolve-doesnt-work-for-bundle.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5564
+title: "Previously, FHIRPath expression evaluation when using the `_fhirpath` parameter would not work on chained 
+use of 'resolve()'. This was most notable when using `_fhirpath` with FHIR Documents (i.e. 'Bundle' of type 'document' 
+where 'entry[0]' is a 'Composition'). This has now been fixed."

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -41,12 +41,10 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
-import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.FhirTerser;
 import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.StringUtil;
 import ca.uhn.fhir.util.UrlUtil;
-import ca.uhn.fhir.util.bundle.BundleEntryParts;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import jakarta.annotation.Nonnull;
@@ -59,14 +57,12 @@ import org.apache.commons.text.StringTokenizer;
 import org.fhir.ucum.Pair;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseEnumeration;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.hl7.fhir.r4.model.IdType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
@@ -2002,47 +1998,6 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 			myCodeableReferenceConcept = codeableReferenceDef.getChildByName("concept");
 			myCodeableReferenceReference = codeableReferenceDef.getChildByName("reference");
 		}
-	}
-
-	@SuppressWarnings("unchecked")
-	protected final <T extends IBase> T resolveResourceInBundleWithPlaceholderId(Object theAppContext, String theUrl) {
-		/*
-		 * If this is a reference that is a UUID, we must be looking for local
-		 * references within a Bundle
-		 */
-		if (theAppContext instanceof IBaseBundle && isNotBlank(theUrl) && !theUrl.startsWith("#")) {
-			String unqualifiedVersionlessReference;
-			boolean isPlaceholderReference;
-			if (theUrl.startsWith("urn:")) {
-				isPlaceholderReference = true;
-				unqualifiedVersionlessReference = null;
-			} else {
-				isPlaceholderReference = false;
-				unqualifiedVersionlessReference =
-						new IdType(theUrl).toUnqualifiedVersionless().getValue();
-			}
-
-			List<BundleEntryParts> entries = BundleUtil.toListOfEntries(getContext(), (IBaseBundle) theAppContext);
-			for (BundleEntryParts next : entries) {
-				if (next.getResource() != null) {
-					if (isPlaceholderReference) {
-						if (theUrl.equals(next.getUrl())
-								|| theUrl.equals(
-										next.getResource().getIdElement().getValue())) {
-							return (T) next.getResource();
-						}
-					} else {
-						if (unqualifiedVersionlessReference.equals(next.getResource()
-								.getIdElement()
-								.toUnqualifiedVersionless()
-								.getValue())) {
-							return (T) next.getResource();
-						}
-					}
-				}
-			}
-		}
-		return null;
 	}
 
 	@FunctionalInterface

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4.java
@@ -140,12 +140,9 @@ public class SearchParamExtractorR4 extends BaseSearchParamExtractor implements 
 
 		@Override
 		public Base resolveReference(Object theAppContext, String theUrl, Base theRefContext) throws FHIRException {
-			Base retVal = null;
-			if (theAppContext instanceof IBase) {
-				retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, (IBase) theAppContext);
-				if (retVal != null) {
-					return retVal;
-				}
+			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, theAppContext);
+			if (retVal != null) {
+				return retVal;
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4.java
@@ -140,9 +140,12 @@ public class SearchParamExtractorR4 extends BaseSearchParamExtractor implements 
 
 		@Override
 		public Base resolveReference(Object theAppContext, String theUrl, Base theRefContext) throws FHIRException {
-			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, theRefContext);
-			if (retVal != null) {
-				return retVal;
+			Base retVal = null;
+			if (theAppContext instanceof IBase) {
+				retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, (IBase) theAppContext);
+				if (retVal != null) {
+					return retVal;
+				}
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.sl.cache.Cache;
 import ca.uhn.fhir.sl.cache.CacheFactory;
+import ca.uhn.fhir.util.BundleUtil;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.PostConstruct;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -139,7 +140,7 @@ public class SearchParamExtractorR4 extends BaseSearchParamExtractor implements 
 
 		@Override
 		public Base resolveReference(Object theAppContext, String theUrl, Base theRefContext) throws FHIRException {
-			Base retVal = resolveResourceInBundleWithPlaceholderId(theAppContext, theUrl);
+			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, theRefContext);
 			if (retVal != null) {
 				return retVal;
 			}

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4B.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4B.java
@@ -140,9 +140,12 @@ public class SearchParamExtractorR4B extends BaseSearchParamExtractor implements
 
 		@Override
 		public Base resolveReference(Object theAppContext, String theUrl, Base refContext) throws FHIRException {
-			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, refContext);
-			if (retVal != null) {
-				return retVal;
+			Base retVal = null;
+			if (theAppContext instanceof IBase) {
+				retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, (IBase) theAppContext);
+				if (retVal != null) {
+					return retVal;
+				}
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4B.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4B.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.sl.cache.Cache;
 import ca.uhn.fhir.sl.cache.CacheFactory;
+import ca.uhn.fhir.util.BundleUtil;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.PostConstruct;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -139,7 +140,7 @@ public class SearchParamExtractorR4B extends BaseSearchParamExtractor implements
 
 		@Override
 		public Base resolveReference(Object theAppContext, String theUrl, Base refContext) throws FHIRException {
-			Base retVal = resolveResourceInBundleWithPlaceholderId(theAppContext, theUrl);
+			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, refContext);
 			if (retVal != null) {
 				return retVal;
 			}

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4B.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR4B.java
@@ -140,12 +140,9 @@ public class SearchParamExtractorR4B extends BaseSearchParamExtractor implements
 
 		@Override
 		public Base resolveReference(Object theAppContext, String theUrl, Base refContext) throws FHIRException {
-			Base retVal = null;
-			if (theAppContext instanceof IBase) {
-				retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, (IBase) theAppContext);
-				if (retVal != null) {
-					return retVal;
-				}
+			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, theAppContext);
+			if (retVal != null) {
+				return retVal;
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR5.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR5.java
@@ -137,12 +137,9 @@ public class SearchParamExtractorR5 extends BaseSearchParamExtractor implements 
 
 		@Override
 		public Base resolveReference(Object appContext, String theUrl, Base refContext) throws FHIRException {
-			Base retVal = null;
-			if (appContext instanceof IBase) {
-				retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, (IBase) appContext);
-				if (retVal != null) {
-					return retVal;
-				}
+			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, appContext);
+			if (retVal != null) {
+				return retVal;
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR5.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR5.java
@@ -137,9 +137,12 @@ public class SearchParamExtractorR5 extends BaseSearchParamExtractor implements 
 
 		@Override
 		public Base resolveReference(Object appContext, String theUrl, Base refContext) throws FHIRException {
-			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, refContext);
-			if (retVal != null) {
-				return retVal;
+			Base retVal = null;
+			if (appContext instanceof IBase) {
+				retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, (IBase) appContext);
+				if (retVal != null) {
+					return retVal;
+				}
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR5.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorR5.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.sl.cache.Cache;
 import ca.uhn.fhir.sl.cache.CacheFactory;
+import ca.uhn.fhir.util.BundleUtil;
 import jakarta.annotation.PostConstruct;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.PathEngineException;
@@ -136,7 +137,7 @@ public class SearchParamExtractorR5 extends BaseSearchParamExtractor implements 
 
 		@Override
 		public Base resolveReference(Object appContext, String theUrl, Base refContext) throws FHIRException {
-			Base retVal = resolveResourceInBundleWithPlaceholderId(appContext, theUrl);
+			Base retVal = (Base) BundleUtil.getReferenceInBundle(getContext(), theUrl, refContext);
 			if (retVal != null) {
 				return retVal;
 			}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/FhirPathFilterInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/FhirPathFilterInterceptor.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.rest.server.interceptor;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.fhirpath.FhirPathExecutionException;
 import ca.uhn.fhir.fhirpath.IFhirPath;
+import ca.uhn.fhir.fhirpath.IFhirPathEvaluationContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
@@ -29,10 +30,14 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.ResponseDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.ParametersUtil;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 
 import java.util.List;
 
@@ -65,6 +70,12 @@ public class FhirPathFilterInterceptor {
 						ParametersUtil.addPartString(ctx, resultPart, "expression", expression);
 
 						IFhirPath fhirPath = ctx.newFhirPath();
+						fhirPath.setEvaluationContext(new IFhirPathEvaluationContext() {
+							@Override
+							public IBase resolveReference(@Nonnull IIdType theReference, @Nullable IBase theContext) {
+								return BundleUtil.getReferenceInBundle(ctx, theReference.getValue(), responseResource);
+							}
+						});
 						List<IBase> outputs;
 						try {
 							outputs = fhirPath.evaluate(responseResource, expression, IBase.class);

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/interceptor/FhirPathFilterInterceptorR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/interceptor/FhirPathFilterInterceptorR4Test.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -19,6 +20,7 @@ import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Composition;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.MedicationAdministration;
+import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Reference;
@@ -39,6 +41,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FhirPathFilterInterceptorR4Test {
 
@@ -210,8 +214,15 @@ public class FhirPathFilterInterceptorR4Test {
 		try (CloseableHttpResponse response = myHttpClient.execute(request)) {
 			String responseText = IOUtils.toString(response.getEntity().getContent(), Charsets.UTF_8);
 			ourLog.info("Response:\n{}", responseText);
-			assertThat(responseText, containsString("      \"name\": \"result\",\n" +
-					"      \"" + expectedResult + "\""));
+			IBaseResource resource = ourCtx.newJsonParser().parseResource(responseText);
+			assertTrue(resource instanceof Parameters);
+			Parameters parameters = (Parameters)resource;
+			Parameters.ParametersParameterComponent parameterComponent = parameters.getParameter("result");
+			assertNotNull(parameterComponent);
+			assertEquals(2, parameterComponent.getPart().size());
+			Parameters.ParametersParameterComponent resultComponent = parameterComponent.getPart().get(1);
+			assertEquals("result", resultComponent.getName());
+			assertThat(responseText, containsString(expectedResult));
 		}
 
 	}


### PR DESCRIPTION
#5564

General idea with the fix.

I reused some logic that was previously in method `resolveResourceInBundleWithPlaceholderId` which resolved references for `SearchParameter` evaluation and moved it to the BundleUtil class. I then reused in the the interceptor for `_fhirpath` search parameter.