### PR TITLE
Remove duplicate indexes on update

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IParam.java
@@ -28,8 +28,8 @@ public interface IParam {
 
 	/**
 	 * Sets the <code>:missing</code> qualifier for this parameter. Set this to <code>true</code>
-	 * to indicate that the server should return resources with this value <p>populated</p>. Set this to
-	 * <code>false</code> to indicate that the server should return resources with this value <b>missing</b>.
+	 * to indicate that the server should return resources with this value <p>missing</p>. Set this to
+	 * <code>false</code> to indicate that the server should return resources with this value <b>populated</b>.
 	 */
 	ICriterion<?> isMissing(boolean theMissing);
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5567-remove-duplicate-rows-in-indexes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5567-remove-duplicate-rows-in-indexes.yaml
@@ -1,6 +1,7 @@
 ---
 type: fix
 issue: 5567
+jira: SMILE-7819
 title: "Whem updating or reindexing a resource in the JPA server, if duplicate rows are
    present in the indexing tables, the duplicate rows may fail to be removed. Duplicates
    are not typically present in these tables, but can happen if an indexing job fails in

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5567-remove-duplicate-rows-in-indexes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5567-remove-duplicate-rows-in-indexes.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 5567
+title: "Whem updating or reindexing a resource in the JPA server, if duplicate rows are
+   present in the indexing tables, the duplicate rows may fail to be removed. Duplicates
+   are not typically present in these tables, but can happen if an indexing job fails in
+   some circumstances. The impact of these rows not being cleaned up is that resources
+   may appear in search results that they should no longer appear in."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -1083,7 +1083,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 							() -> new IdentityHashMap<>());
 			existingParams = existingSearchParams.get(entity);
 			if (existingParams == null) {
-				existingParams = new ResourceIndexedSearchParams(entity);
+				existingParams = ResourceIndexedSearchParams.withLists(entity);
 				/*
 				 * If we have lots of resource links, this proactively fetches the targets so
 				 * that we don't look them up one-by-one when comparing the new set to the
@@ -1105,7 +1105,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			// TODO: is this IF statement always true? Try removing it
 			if (thePerformIndexing || theEntity.getVersion() == 1) {
 
-				newParams = new ResourceIndexedSearchParams();
+				newParams = ResourceIndexedSearchParams.withSets();
 
 				RequestPartitionId requestPartitionId;
 				if (!myPartitionSettings.isPartitioningEnabled()) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizer.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizer.java
@@ -98,13 +98,13 @@ public class DaoSearchParamSynchronizer {
 		 * remove them.
 		 */
 		Set<T> existingParamsAsSet = new HashSet<>(theExistingParams.size());
-        for (Iterator<T> iterator = theExistingParams.iterator(); iterator.hasNext(); ) {
-            T next = iterator.next();
-            if (!existingParamsAsSet.add(next)) {
+		for (Iterator<T> iterator = theExistingParams.iterator(); iterator.hasNext(); ) {
+			T next = iterator.next();
+			if (!existingParamsAsSet.add(next)) {
 				iterator.remove();
 				myEntityManager.remove(next);
-            }
-        }
+			}
+		}
 
 		/*
 		 * HashCodes may have changed as a result of setting the partition ID, so

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizer.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizer.java
@@ -34,7 +34,9 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class DaoSearchParamSynchronizer {
@@ -81,6 +83,28 @@ public class DaoSearchParamSynchronizer {
 			next.setPartitionId(theEntity.getPartitionId());
 			next.calculateHashes();
 		}
+
+		/*
+		 * It's technically possible that the existing index collection
+		 * contains duplicates. Duplicates don't actually cause any
+		 * issues for searching since we always deduplicate the PIDs we
+		 * get back from the search, but they are wasteful. We don't
+		 * enforce uniqueness in the DB for the index tables for
+		 * performance reasons (no sense adding a constraint that slows
+		 * down writes when dupes don't actually hurt anything other than
+		 * a bit of wasted space).
+		 *
+		 * So we check if there are any dupes, and if we find any we
+		 * remove them.
+		 */
+		Set<T> existingParamsAsSet = new HashSet<>(theExistingParams.size());
+        for (Iterator<T> iterator = theExistingParams.iterator(); iterator.hasNext(); ) {
+            T next = iterator.next();
+            if (!existingParamsAsSet.add(next)) {
+				iterator.remove();
+				myEntityManager.remove(next);
+            }
+        }
 
 		/*
 		 * HashCodes may have changed as a result of setting the partition ID, so

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/SearchParamWithInlineReferencesExtractor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/SearchParamWithInlineReferencesExtractor.java
@@ -28,7 +28,6 @@ import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.BaseResourceIndexedSearchParam;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedComboStringUnique;
-import ca.uhn.fhir.jpa.model.entity.ResourceLink;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.searchparam.extractor.BaseSearchParamWithInlineReferencesExtractor;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
@@ -50,7 +49,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.stream.Collectors;
 
 @Service
@@ -122,15 +120,15 @@ public class SearchParamWithInlineReferencesExtractor extends BaseSearchParamWit
 		 * If the existing resource already has links and those match links we still want, use them instead of removing them and re adding them
 		 */
 		// FIXME: remove
-//		for (Iterator<ResourceLink> existingLinkIter =
-//						theExistingParams.getResourceLinks().iterator();
-//				existingLinkIter.hasNext(); ) {
-//			ResourceLink nextExisting = existingLinkIter.next();
-//			if (theParams.myLinks.remove(nextExisting)) {
-//				existingLinkIter.remove();
-//				theParams.myLinks.add(nextExisting);
-//			}
-//		}
+		//		for (Iterator<ResourceLink> existingLinkIter =
+		//						theExistingParams.getResourceLinks().iterator();
+		//				existingLinkIter.hasNext(); ) {
+		//			ResourceLink nextExisting = existingLinkIter.next();
+		//			if (theParams.myLinks.remove(nextExisting)) {
+		//				existingLinkIter.remove();
+		//				theParams.myLinks.add(nextExisting);
+		//			}
+		//		}
 	}
 
 	@Nullable

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/SearchParamWithInlineReferencesExtractor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/SearchParamWithInlineReferencesExtractor.java
@@ -115,20 +115,6 @@ public class SearchParamWithInlineReferencesExtractor extends BaseSearchParamWit
 				theTransactionDetails,
 				thePerformIndexing,
 				ISearchParamExtractor.ALL_PARAMS);
-
-		/*
-		 * If the existing resource already has links and those match links we still want, use them instead of removing them and re adding them
-		 */
-		// FIXME: remove
-		//		for (Iterator<ResourceLink> existingLinkIter =
-		//						theExistingParams.getResourceLinks().iterator();
-		//				existingLinkIter.hasNext(); ) {
-		//			ResourceLink nextExisting = existingLinkIter.next();
-		//			if (theParams.myLinks.remove(nextExisting)) {
-		//				existingLinkIter.remove();
-		//				theParams.myLinks.add(nextExisting);
-		//			}
-		//		}
 	}
 
 	@Nullable

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/SearchParamWithInlineReferencesExtractor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/SearchParamWithInlineReferencesExtractor.java
@@ -121,15 +121,16 @@ public class SearchParamWithInlineReferencesExtractor extends BaseSearchParamWit
 		/*
 		 * If the existing resource already has links and those match links we still want, use them instead of removing them and re adding them
 		 */
-		for (Iterator<ResourceLink> existingLinkIter =
-						theExistingParams.getResourceLinks().iterator();
-				existingLinkIter.hasNext(); ) {
-			ResourceLink nextExisting = existingLinkIter.next();
-			if (theParams.myLinks.remove(nextExisting)) {
-				existingLinkIter.remove();
-				theParams.myLinks.add(nextExisting);
-			}
-		}
+		// FIXME: remove
+//		for (Iterator<ResourceLink> existingLinkIter =
+//						theExistingParams.getResourceLinks().iterator();
+//				existingLinkIter.hasNext(); ) {
+//			ResourceLink nextExisting = existingLinkIter.next();
+//			if (theParams.myLinks.remove(nextExisting)) {
+//				existingLinkIter.remove();
+//				theParams.myLinks.add(nextExisting);
+//			}
+//		}
 	}
 
 	@Nullable

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/reindex/InstanceReindexServiceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/reindex/InstanceReindexServiceImpl.java
@@ -160,7 +160,7 @@ public class InstanceReindexServiceImpl implements IInstanceReindexService {
 				myInterceptorService, theRequestDetails, theResourceId, resource);
 		BaseHapiFhirResourceDao.invokeStoragePreShowResources(myInterceptorService, theRequestDetails, resource);
 
-		ResourceIndexedSearchParams existingParamsToPopulate = new ResourceIndexedSearchParams(entity);
+		ResourceIndexedSearchParams existingParamsToPopulate = ResourceIndexedSearchParams.withLists(entity);
 		existingParamsToPopulate.mySearchParamPresentEntities.addAll(entity.getSearchParamPresents());
 
 		List<String> messages = new ArrayList<>();
@@ -173,7 +173,7 @@ public class InstanceReindexServiceImpl implements IInstanceReindexService {
 			messages.add("WARNING: " + next);
 		}
 
-		ResourceIndexedSearchParams newParamsToPopulate = new ResourceIndexedSearchParams(entity);
+		ResourceIndexedSearchParams newParamsToPopulate = ResourceIndexedSearchParams.withLists(entity);
 		newParamsToPopulate.mySearchParamPresentEntities.addAll(entity.getSearchParamPresents());
 
 		return buildIndexResponse(existingParamsToPopulate, newParamsToPopulate, true, messages);
@@ -205,12 +205,12 @@ public class InstanceReindexServiceImpl implements IInstanceReindexService {
 					.collect(Collectors.toSet());
 		}
 
-		ResourceIndexedSearchParams newParamsToPopulate = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams newParamsToPopulate = ResourceIndexedSearchParams.withSets();
 		mySearchParamExtractorService.extractFromResource(
 				theRequestPartitionId,
 				theRequestDetails,
 				newParamsToPopulate,
-				new ResourceIndexedSearchParams(),
+				ResourceIndexedSearchParams.empty(),
 				entity,
 				resource,
 				theTransactionDetails,
@@ -220,13 +220,13 @@ public class InstanceReindexServiceImpl implements IInstanceReindexService {
 		ResourceIndexedSearchParams existingParamsToPopulate;
 		boolean showAction;
 		if (theParameters == null) {
-			existingParamsToPopulate = new ResourceIndexedSearchParams(entity);
+			existingParamsToPopulate = ResourceIndexedSearchParams.withLists(entity);
 			existingParamsToPopulate.mySearchParamPresentEntities.addAll(entity.getSearchParamPresents());
 			fillInParamNames(
 					entity, existingParamsToPopulate.mySearchParamPresentEntities, theResourceId.getResourceType());
 			showAction = true;
 		} else {
-			existingParamsToPopulate = new ResourceIndexedSearchParams();
+			existingParamsToPopulate = ResourceIndexedSearchParams.withSets();
 			showAction = false;
 		}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizerTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizerTest.java
@@ -53,8 +53,8 @@ public class DaoSearchParamSynchronizerTest {
 		when(existingEntity.isParamsNumberPopulated()).thenReturn(true);
 		when(existingEntity.getParamsNumber()).thenReturn(List.of(EXISTING_SEARCH_PARAM_NUMBER));
 
-		theParams = new ResourceIndexedSearchParams(theEntity);
-		existingParams = new ResourceIndexedSearchParams(existingEntity);
+		theParams = ResourceIndexedSearchParams.withLists(theEntity);
+		existingParams = ResourceIndexedSearchParams.withLists(existingEntity);
 
 		final ResourceTable resourceTable = new ResourceTable();
 		resourceTable.setId(1L);

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
@@ -205,9 +205,9 @@ public final class ResourceIndexedSearchParams {
 	}
 
 	private void updateSpnamePrefixForIndexOnUpliftedChain(
-		String theContainingType,
-		Collection<? extends BaseResourceIndexedSearchParam> theParams,
-		@Nonnull String theSpnamePrefix) {
+			String theContainingType,
+			Collection<? extends BaseResourceIndexedSearchParam> theParams,
+			@Nonnull String theSpnamePrefix) {
 
 		for (BaseResourceIndexedSearchParam param : theParams) {
 			param.setResourceType(theContainingType);
@@ -223,11 +223,11 @@ public final class ResourceIndexedSearchParams {
 	}
 
 	public boolean matchParam(
-		StorageSettings theStorageSettings,
-		String theResourceName,
-		String theParamName,
-		RuntimeSearchParam theParamDef,
-		IQueryParameterType theValue) {
+			StorageSettings theStorageSettings,
+			String theResourceName,
+			String theParamName,
+			RuntimeSearchParam theParamDef,
+			IQueryParameterType theValue) {
 
 		if (theParamDef == null) {
 			return false;
@@ -240,8 +240,8 @@ public final class ResourceIndexedSearchParams {
 				break;
 			case QUANTITY:
 				if (theStorageSettings
-					.getNormalizedQuantitySearchLevel()
-					.equals(NormalizedQuantitySearchLevel.NORMALIZED_QUANTITY_SEARCH_SUPPORTED)) {
+						.getNormalizedQuantitySearchLevel()
+						.equals(NormalizedQuantitySearchLevel.NORMALIZED_QUANTITY_SEARCH_SUPPORTED)) {
 					QuantityParam quantity = QuantityParam.toQuantityParam(theValue);
 					QuantityParam normalized = UcumServiceUtil.toCanonicalQuantityOrNull(quantity);
 					if (normalized != null) {
@@ -268,11 +268,11 @@ public final class ResourceIndexedSearchParams {
 				break;
 			case REFERENCE:
 				return matchResourceLinks(
-					theStorageSettings,
-					theResourceName,
-					theParamName,
-					value,
-					theParamDef.getPathsSplitForResourceType(theResourceName));
+						theStorageSettings,
+						theResourceName,
+						theParamName,
+						value,
+						theParamDef.getPathsSplitForResourceType(theResourceName));
 			case COMPOSITE:
 			case HAS:
 			case SPECIAL:
@@ -300,16 +300,16 @@ public final class ResourceIndexedSearchParams {
 	// KHS This needs to be public as libraries outside of hapi call it directly
 	@Deprecated
 	public boolean matchResourceLinks(
-		String theResourceName, String theParamName, IQueryParameterType theParam, String theParamPath) {
+			String theResourceName, String theParamName, IQueryParameterType theParam, String theParamPath) {
 		return matchResourceLinks(new StorageSettings(), theResourceName, theParamName, theParam, theParamPath);
 	}
 
 	public boolean matchResourceLinks(
-		StorageSettings theStorageSettings,
-		String theResourceName,
-		String theParamName,
-		IQueryParameterType theParam,
-		List<String> theParamPaths) {
+			StorageSettings theStorageSettings,
+			String theResourceName,
+			String theParamName,
+			IQueryParameterType theParam,
+			List<String> theParamPaths) {
 		for (String nextPath : theParamPaths) {
 			if (matchResourceLinks(theStorageSettings, theResourceName, theParamName, theParam, nextPath)) {
 				return true;
@@ -320,22 +320,22 @@ public final class ResourceIndexedSearchParams {
 
 	// KHS This needs to be public as libraries outside of hapi call it directly
 	public boolean matchResourceLinks(
-		StorageSettings theStorageSettings,
-		String theResourceName,
-		String theParamName,
-		IQueryParameterType theParam,
-		String theParamPath) {
+			StorageSettings theStorageSettings,
+			String theResourceName,
+			String theParamName,
+			IQueryParameterType theParam,
+			String theParamPath) {
 		ReferenceParam reference = (ReferenceParam) theParam;
 
 		Predicate<ResourceLink> namedParamPredicate =
-			resourceLink -> searchParameterPathMatches(theResourceName, resourceLink, theParamName, theParamPath)
-				&& resourceIdMatches(theStorageSettings, resourceLink, reference);
+				resourceLink -> searchParameterPathMatches(theResourceName, resourceLink, theParamName, theParamPath)
+						&& resourceIdMatches(theStorageSettings, resourceLink, reference);
 
 		return myLinks.stream().anyMatch(namedParamPredicate);
 	}
 
 	private boolean resourceIdMatches(
-		StorageSettings theStorageSettings, ResourceLink theResourceLink, ReferenceParam theReference) {
+			StorageSettings theStorageSettings, ResourceLink theResourceLink, ReferenceParam theReference) {
 		String baseUrl = theReference.getBaseUrl();
 		if (isNotBlank(baseUrl)) {
 			if (!theStorageSettings.getTreatBaseUrlsAsLocal().contains(baseUrl)) {
@@ -363,7 +363,7 @@ public final class ResourceIndexedSearchParams {
 	}
 
 	private boolean searchParameterPathMatches(
-		String theResourceName, ResourceLink theResourceLink, String theParamName, String theParamPath) {
+			String theResourceName, ResourceLink theResourceLink, String theParamName, String theParamPath) {
 		String sourcePath = theResourceLink.getSourcePath();
 		return sourcePath.equalsIgnoreCase(theParamPath);
 	}
@@ -371,83 +371,83 @@ public final class ResourceIndexedSearchParams {
 	@Override
 	public String toString() {
 		return "ResourceIndexedSearchParams{" + "stringParams="
-			+ myStringParams + ", tokenParams="
-			+ myTokenParams + ", numberParams="
-			+ myNumberParams + ", quantityParams="
-			+ myQuantityParams + ", quantityNormalizedParams="
-			+ myQuantityNormalizedParams + ", dateParams="
-			+ myDateParams + ", uriParams="
-			+ myUriParams + ", coordsParams="
-			+ myCoordsParams + ", comboStringUniques="
-			+ myComboStringUniques + ", comboTokenNonUniques="
-			+ myComboTokenNonUnique + ", links="
-			+ myLinks + '}';
+				+ myStringParams + ", tokenParams="
+				+ myTokenParams + ", numberParams="
+				+ myNumberParams + ", quantityParams="
+				+ myQuantityParams + ", quantityNormalizedParams="
+				+ myQuantityNormalizedParams + ", dateParams="
+				+ myDateParams + ", uriParams="
+				+ myUriParams + ", coordsParams="
+				+ myCoordsParams + ", comboStringUniques="
+				+ myComboStringUniques + ", comboTokenNonUniques="
+				+ myComboTokenNonUnique + ", links="
+				+ myLinks + '}';
 	}
 
 	public void findMissingSearchParams(
-		PartitionSettings thePartitionSettings,
-		StorageSettings theStorageSettings,
-		ResourceTable theEntity,
-		ResourceSearchParams theActiveSearchParams) {
+			PartitionSettings thePartitionSettings,
+			StorageSettings theStorageSettings,
+			ResourceTable theEntity,
+			ResourceSearchParams theActiveSearchParams) {
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.STRING,
-			myStringParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.STRING,
+				myStringParams);
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.NUMBER,
-			myNumberParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.NUMBER,
+				myNumberParams);
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.QUANTITY,
-			myQuantityParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.QUANTITY,
+				myQuantityParams);
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.DATE,
-			myDateParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.DATE,
+				myDateParams);
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.URI,
-			myUriParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.URI,
+				myUriParams);
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.TOKEN,
-			myTokenParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.TOKEN,
+				myTokenParams);
 		findMissingSearchParams(
-			thePartitionSettings,
-			theStorageSettings,
-			theEntity,
-			theActiveSearchParams,
-			RestSearchParameterTypeEnum.SPECIAL,
-			myCoordsParams);
+				thePartitionSettings,
+				theStorageSettings,
+				theEntity,
+				theActiveSearchParams,
+				RestSearchParameterTypeEnum.SPECIAL,
+				myCoordsParams);
 	}
 
 	@SuppressWarnings("unchecked")
 	private <RT extends BaseResourceIndexedSearchParam> void findMissingSearchParams(
-		PartitionSettings thePartitionSettings,
-		StorageSettings theStorageSettings,
-		ResourceTable theEntity,
-		ResourceSearchParams activeSearchParams,
-		RestSearchParameterTypeEnum type,
-		Collection<RT> paramCollection) {
+			PartitionSettings thePartitionSettings,
+			StorageSettings theStorageSettings,
+			ResourceTable theEntity,
+			ResourceSearchParams activeSearchParams,
+			RestSearchParameterTypeEnum type,
+			Collection<RT> paramCollection) {
 		for (String nextParamName : activeSearchParams.getSearchParamNames()) {
 			if (nextParamName == null || myIgnoredParams.contains(nextParamName)) {
 				continue;
@@ -536,7 +536,7 @@ public final class ResourceIndexedSearchParams {
 	 * @param thePartsChoices E.g. <code>[[gender=male], [name=SMITH, name=JOHN]]</code>
 	 */
 	public static Set<String> extractCompositeStringUniquesValueChains(
-		String theResourceType, List<List<String>> thePartsChoices) {
+			String theResourceType, List<List<String>> thePartsChoices) {
 
 		for (List<String> next : thePartsChoices) {
 			next.removeIf(StringUtils::isBlank);
@@ -571,20 +571,20 @@ public final class ResourceIndexedSearchParams {
 	}
 
 	private static void extractCompositeStringUniquesValueChains(
-		String theResourceType,
-		List<List<String>> thePartsChoices,
-		List<String> theValues,
-		Set<String> theQueryStringsToPopulate) {
+			String theResourceType,
+			List<List<String>> thePartsChoices,
+			List<String> theValues,
+			Set<String> theQueryStringsToPopulate) {
 		if (thePartsChoices.size() > 0) {
 			List<String> nextList = thePartsChoices.get(0);
 			Collections.sort(nextList);
 			for (String nextChoice : nextList) {
 				theValues.add(nextChoice);
 				extractCompositeStringUniquesValueChains(
-					theResourceType,
-					thePartsChoices.subList(1, thePartsChoices.size()),
-					theValues,
-					theQueryStringsToPopulate);
+						theResourceType,
+						thePartsChoices.subList(1, thePartsChoices.size()),
+						theValues,
+						theQueryStringsToPopulate);
 				theValues.remove(theValues.size() - 1);
 			}
 		} else {
@@ -649,5 +649,4 @@ public final class ResourceIndexedSearchParams {
 
 		public abstract <T> Collection<T> newCollection();
 	}
-
 }

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
@@ -77,6 +77,16 @@ public final class ResourceIndexedSearchParams {
 	public final Collection<ResourceIndexedSearchParamComposite> myCompositeParams;
 	public final Set<String> myPopulatedResourceLinkParameters = new HashSet<>();
 
+	/**
+	 * TODO: Remove this - Currently used by CDR though
+	 *
+	 * @deprecated Use a factory constructor instead
+	 */
+	@Deprecated
+	public ResourceIndexedSearchParams() {
+		this(Mode.SET);
+	}
+
 	private ResourceIndexedSearchParams(Mode theMode) {
 		myStringParams = theMode.newCollection();
 		myTokenParams = theMode.newCollection();

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
@@ -627,7 +627,7 @@ public final class ResourceIndexedSearchParams {
 		return new ResourceIndexedSearchParams(theResourceTable, Mode.LIST);
 	}
 
-	public enum Mode {
+	private enum Mode {
 		LIST {
 			@Override
 			public <T> Collection<T> newCollection() {

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorService.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorService.java
@@ -124,7 +124,7 @@ public class SearchParamExtractorService {
 				theRequestPartitionId,
 				theRequestDetails,
 				theParams,
-				new ResourceIndexedSearchParams(),
+				ResourceIndexedSearchParams.withSets(),
 				theEntity,
 				theResource,
 				theTransactionDetails,
@@ -149,7 +149,7 @@ public class SearchParamExtractorService {
 			boolean theFailOnInvalidReference,
 			@Nonnull ISearchParamExtractor.ISearchParamFilter theSearchParamFilter) {
 		// All search parameter types except Reference
-		ResourceIndexedSearchParams normalParams = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams normalParams = ResourceIndexedSearchParams.withSets();
 		extractSearchIndexParameters(theRequestDetails, normalParams, theResource, theSearchParamFilter);
 		mergeParams(normalParams, theNewParams);
 
@@ -159,14 +159,14 @@ public class SearchParamExtractorService {
 		SearchParamExtractorService.handleWarnings(theRequestDetails, myInterceptorBroadcaster, indexedReferences);
 
 		if (indexOnContainedResources) {
-			ResourceIndexedSearchParams containedParams = new ResourceIndexedSearchParams();
+			ResourceIndexedSearchParams containedParams = ResourceIndexedSearchParams.withSets();
 			extractSearchIndexParametersForContainedResources(
 					theRequestDetails, containedParams, theResource, theEntity, indexedReferences);
 			mergeParams(containedParams, theNewParams);
 		}
 
 		if (myStorageSettings.isIndexOnUpliftedRefchains()) {
-			ResourceIndexedSearchParams containedParams = new ResourceIndexedSearchParams();
+			ResourceIndexedSearchParams containedParams = ResourceIndexedSearchParams.withSets();
 			extractSearchIndexParametersForUpliftedRefchains(
 					theRequestDetails,
 					containedParams,
@@ -427,7 +427,7 @@ public class SearchParamExtractorService {
 				continue;
 			}
 
-			ResourceIndexedSearchParams currParams = new ResourceIndexedSearchParams();
+			ResourceIndexedSearchParams currParams = ResourceIndexedSearchParams.withSets();
 
 			// 3.3 create indexes for the current contained resource
 			extractSearchIndexParameters(theRequestDetails, currParams, targetResource, searchParamsToIndex);
@@ -599,7 +599,7 @@ public class SearchParamExtractorService {
 			ISearchParamExtractor.SearchParamSet<PathAndRef> theIndexedReferences) {
 		extractResourceLinks(
 				theRequestPartitionId,
-				new ResourceIndexedSearchParams(),
+				ResourceIndexedSearchParams.withSets(),
 				theParams,
 				theEntity,
 				theResource,
@@ -937,7 +937,7 @@ public class SearchParamExtractorService {
 				continue;
 			}
 
-			currParams = new ResourceIndexedSearchParams();
+			currParams = ResourceIndexedSearchParams.withSets();
 
 			// 3.3 create indexes for the current contained resource
 			ISearchParamExtractor.SearchParamSet<PathAndRef> indexedReferences =

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/IndexedSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/IndexedSearchParamExtractor.java
@@ -50,12 +50,12 @@ public class IndexedSearchParamExtractor {
 		TransactionDetails transactionDetails = new TransactionDetails();
 		String resourceType = myContext.getResourceType(theResource);
 		entity.setResourceType(resourceType);
-		ResourceIndexedSearchParams resourceIndexedSearchParams = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams resourceIndexedSearchParams = ResourceIndexedSearchParams.withSets();
 		mySearchParamExtractorService.extractFromResource(
 				null,
 				theRequest,
 				resourceIndexedSearchParams,
-				new ResourceIndexedSearchParams(),
+				ResourceIndexedSearchParams.empty(),
 				entity,
 				theResource,
 				transactionDetails,

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
@@ -31,7 +31,7 @@ public class ResourceIndexedSearchParamsTest {
 		mySource = new ResourceTable();
 		mySource.setResourceType("Patient");
 
-		myParams = new ResourceIndexedSearchParams(mySource);
+		myParams = ResourceIndexedSearchParams.withLists(mySource);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherConfigurationR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherConfigurationR5Test.java
@@ -103,7 +103,7 @@ public class InMemoryResourceMatcherConfigurationR5Test {
 	}
 
 	private ResourceIndexedSearchParams extractSearchParams(Observation theObservation) {
-		ResourceIndexedSearchParams retval = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams retval = ResourceIndexedSearchParams.withSets();
 		retval.myTokenParams.add(extractCodeTokenParam(theObservation));
 		return retval;
 	}

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
@@ -166,7 +166,7 @@ public class InMemoryResourceMatcherR5Test {
 	public void testMatch_sourceWithModifiers_matchesSuccessfully(String theSourceValue, String theSearchCriteria, boolean theShouldMatch) {
 		myObservation.getMeta().setSource(theSourceValue);
 
-		ResourceIndexedSearchParams searchParams = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams searchParams = ResourceIndexedSearchParams.withSets();
 		searchParams.myUriParams.add(extractSourceUriParam(myObservation));
 
 		InMemoryMatchResult resultInsidePeriod = myInMemoryResourceMatcher.match(theSearchCriteria, myObservation, searchParams, newRequest());
@@ -408,7 +408,7 @@ public class InMemoryResourceMatcherR5Test {
 
 
 	private ResourceIndexedSearchParams extractSearchParams(Observation theObservation) {
-		ResourceIndexedSearchParams retval = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams retval = ResourceIndexedSearchParams.withSets();
 		retval.myDateParams.add(extractEffectiveDateParam(theObservation));
 		retval.myTokenParams.add(extractCodeTokenParam(theObservation));
 		return retval;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4UpdateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4UpdateTest.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTable;
+import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.entity.TagDefinition;
 import ca.uhn.fhir.jpa.model.entity.TagTypeEnum;

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/BaseJpaR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/BaseJpaR5Test.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.dao.r5;
 
+import ca.uhn.fhir.batch2.api.IJobCoordinator;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.interceptor.api.IInterceptorService;
@@ -144,6 +145,8 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {TestR5Config.class})
 public abstract class BaseJpaR5Test extends BaseJpaTest implements ITestDataBuilder {
+	@Autowired
+	protected IJobCoordinator myJobCoordinator;
 	@Autowired
 	protected PartitionSettings myPartitionSettings;
 	@Autowired

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DuplicateIndexR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DuplicateIndexR5Test.java
@@ -1,0 +1,312 @@
+package ca.uhn.fhir.jpa.dao.r5;
+
+import ca.uhn.fhir.batch2.jobs.reindex.ReindexAppCtx;
+import ca.uhn.fhir.batch2.jobs.reindex.ReindexJobParameters;
+import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
+import ca.uhn.fhir.jpa.batch.models.Batch2JobStartResponse;
+import ca.uhn.fhir.jpa.model.entity.ResourceIndexedComboTokenNonUnique;
+import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamString;
+import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
+import ca.uhn.fhir.jpa.model.entity.ResourceLink;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.util.HapiExtensions;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r5.model.BooleanType;
+import org.hl7.fhir.r5.model.Enumerations;
+import org.hl7.fhir.r5.model.SearchParameter;
+import org.hl7.fhir.r5.model.Patient;
+import org.hl7.fhir.r5.model.Reference;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DuplicateIndexR5Test extends BaseJpaR5Test {
+
+	@Test
+	public void testDuplicateTokensClearedOnUpdate() {
+		// Setup
+		IIdType id = createPatientWithDuplicateTokens();
+		assertEquals(3, runInTransaction(()->myResourceIndexedSearchParamTokenDao.findAll().stream().filter(t->t.getParamName().equals("identifier")).count()));
+
+		// Test
+		Patient pt = new Patient();
+		pt.setId(id);
+		pt.addIdentifier().setSystem("http://foo").setValue("bar22");
+		myPatientDao.update(pt, mySrd);
+
+		// Verify
+		logAllTokenIndexes();
+		assertEquals(1, runInTransaction(()->myResourceIndexedSearchParamTokenDao.findAll().stream().filter(t->t.getParamName().equals("identifier")).count()));
+	}
+
+	@Test
+	public void testDuplicateTokensClearedOnReindex() {
+		// Setup
+		createPatientWithDuplicateTokens();
+
+		// Test
+		reindexAllPatients();
+
+		// Verify
+		logAllTokenIndexes();
+		assertEquals(1, runInTransaction(()->myResourceIndexedSearchParamTokenDao.findAll().stream().filter(t->t.getParamName().equals("identifier")).count()));
+	}
+
+	@Test
+	public void testDuplicateStringsClearedOnUpdate() {
+		// Setup
+        IIdType id = createPatientWithDuplicateStrings();
+		assertEquals(3, runInTransaction(()->myResourceIndexedSearchParamStringDao.findAll().stream().filter(t->t.getParamName().equals("family")).count()));
+
+		// Test
+		Patient pt = new Patient();
+		pt.setId(id);
+		pt.getNameFirstRep().setFamily("FAMILY2");
+		myPatientDao.update(pt, mySrd);
+
+		// Verify
+		logAllTokenIndexes();
+		assertEquals(1, runInTransaction(()->myResourceIndexedSearchParamStringDao.findAll().stream().filter(t->t.getParamName().equals("family")).count()));
+	}
+
+	@Test
+	public void testDuplicateStringsClearedOnReindex() {
+		// Setup
+		createPatientWithDuplicateStrings();
+		assertEquals(3, runInTransaction(()->myResourceIndexedSearchParamStringDao.findAll().stream().filter(t->t.getParamName().equals("family")).count()));
+
+		// Test
+		reindexAllPatients();
+
+		// Verify
+		logAllTokenIndexes();
+		assertEquals(1, runInTransaction(()->myResourceIndexedSearchParamStringDao.findAll().stream().filter(t->t.getParamName().equals("family")).count()));
+	}
+
+	@Test
+	public void testDuplicateResourceLinksClearedOnUpdate() {
+		// Setup
+        IIdType id = createPatientWithDuplicateResourceLinks();
+		assertEquals(3, runInTransaction(()->myResourceLinkDao.findAll().stream().filter(t->t.getSourcePath().equals("Patient.managingOrganization")).count()));
+
+		// Test
+		IIdType orgId = createOrganization(withName("MY ORG 2"));
+		Patient pt = new Patient();
+		pt.setId(id);
+		pt.setManagingOrganization(new Reference(orgId));
+		myPatientDao.update(pt, mySrd);
+
+		// Verify
+		assertEquals(1, runInTransaction(()->myResourceLinkDao.findAll().stream().filter(t->t.getSourcePath().equals("Patient.managingOrganization")).count()));
+	}
+
+	@Test
+	public void testDuplicateResourceLinksClearedOnReindex() {
+		// Setup
+		createPatientWithDuplicateResourceLinks();
+
+		// Test
+		reindexAllPatients();
+
+		// Verify
+		assertEquals(1, runInTransaction(()->myResourceLinkDao.findAll().stream().filter(t->t.getSourcePath().equals("Patient.managingOrganization")).count()));
+	}
+
+	@Test
+	public void testDuplicateComboParamsClearedOnUpdate() {
+		// Setup
+        IIdType id = createPatientWithDuplicateNonUniqueComboParams();
+		assertEquals(3, runInTransaction(()->myResourceIndexedComboTokensNonUniqueDao.count()));
+
+		// Test
+		Patient pt = new Patient();
+		pt.setId(id);
+		pt.getNameFirstRep().setFamily("FAMILY2");
+		myPatientDao.update(pt, mySrd);
+
+		// Verify
+		assertEquals(1, runInTransaction(()->myResourceIndexedComboTokensNonUniqueDao.count()));
+	}
+
+	@Test
+	public void testDuplicateComboParamsClearedOnReindex() {
+		// Setup
+		createPatientWithDuplicateNonUniqueComboParams();
+		assertEquals(3, runInTransaction(()->myResourceIndexedComboTokensNonUniqueDao.count()));
+
+		// Test
+		reindexAllPatients();
+
+		// Verify
+		assertEquals(1, runInTransaction(()->myResourceIndexedComboTokensNonUniqueDao.count()));
+	}
+
+	private void reindexAllPatients() {
+		ReindexJobParameters parameters = new ReindexJobParameters();
+		parameters.addUrl("Patient?");
+		JobInstanceStartRequest startRequest = new JobInstanceStartRequest();
+		startRequest.setJobDefinitionId(ReindexAppCtx.JOB_REINDEX);
+		startRequest.setParameters(parameters);
+		Batch2JobStartResponse res = myJobCoordinator.startInstance(mySrd, startRequest);
+		// FIXME: remove 9999
+		myBatch2JobHelper.awaitJobCompletion(res.getInstanceId(), 9999);
+	}
+
+	private IIdType createPatientWithDuplicateNonUniqueComboParams() {
+		createNamesAndGenderSp();
+		IIdType id1 = createPatient(withFamily("FAMILY"), withGiven("GIVEN"), withGender("male"));
+		runInTransaction(()->{
+			assertEquals(2, myResourceTableDao.count());
+			ResourceTable table = myResourceTableDao.findAll().stream().filter(t1 -> t1.getResourceType().equals("Patient")).findFirst().orElseThrow();
+			assertEquals(1, table.getmyParamsComboTokensNonUnique().size());
+			ResourceIndexedComboTokenNonUnique param = table.getmyParamsComboTokensNonUnique().iterator().next();
+
+			// Create a dupe
+			ResourceIndexedComboTokenNonUnique dupe0 = new ResourceIndexedComboTokenNonUnique();
+			dupe0.setPartitionSettings(param.getPartitionSettings());
+			dupe0.setResource(param.getResource());
+			dupe0.setHashComplete(param.getHashComplete());
+			dupe0.setIndexString(param.getIndexString());
+			dupe0.setSearchParameterId(param.getSearchParameterId());
+			dupe0.calculateHashes();
+			myResourceIndexedComboTokensNonUniqueDao.save(dupe0);
+
+			// Create a second dupe
+			ResourceIndexedComboTokenNonUnique dupe1 = new ResourceIndexedComboTokenNonUnique();
+			dupe1.setPartitionSettings(param.getPartitionSettings());
+			dupe1.setResource(param.getResource());
+			dupe1.setHashComplete(param.getHashComplete());
+			dupe1.setIndexString(param.getIndexString());
+			dupe1.setSearchParameterId(param.getSearchParameterId());
+			dupe1.calculateHashes();
+			myResourceIndexedComboTokensNonUniqueDao.save(dupe1);
+		});
+		return id1;
+	}
+
+	private IIdType createPatientWithDuplicateResourceLinks() {
+		IIdType orgId = createOrganization(withName("MY ORG"));
+		IIdType id1 = createPatient(withOrganization(orgId));
+		runInTransaction(()->{
+			assertEquals(2, myResourceTableDao.count());
+			ResourceTable table = myResourceTableDao.findAll().stream().filter(t->t.getResourceType().equals("Patient")).findFirst().orElseThrow();
+			assertEquals(1, table.getResourceLinks().size());
+			ResourceLink existingLink = table.getResourceLinks().iterator().next();
+
+			// Create a dupe
+			ResourceLink dupe0 = new ResourceLink();
+			dupe0.setSourceResource(existingLink.getSourceResource());
+			dupe0.setUpdated(existingLink.getUpdated());
+			dupe0.setSourcePath(existingLink.getSourcePath());
+			dupe0.setTargetResource(existingLink.getTargetResourceType(), existingLink.getTargetResourcePid(), existingLink.getTargetResourceId());
+			dupe0.setTargetResourceVersion(existingLink.getTargetResourceVersion());
+			dupe0.calculateHashes();
+			myResourceLinkDao.save(dupe0);
+
+			// Create a second dupe
+			ResourceLink dupe1 = new ResourceLink();
+			dupe1.setSourceResource(existingLink.getSourceResource());
+			dupe1.setUpdated(existingLink.getUpdated());
+			dupe1.setSourcePath(existingLink.getSourcePath());
+			dupe1.setTargetResource(existingLink.getTargetResourceType(), existingLink.getTargetResourcePid(), existingLink.getTargetResourceId());
+			dupe1.setTargetResourceVersion(existingLink.getTargetResourceVersion());
+			dupe1.calculateHashes();
+			myResourceLinkDao.save(dupe1);
+		});
+		return id1;
+	}
+
+	private IIdType createPatientWithDuplicateStrings() {
+		IIdType id1 = createPatient(withFamily("FAMILY"));
+		runInTransaction(()->{
+			assertEquals(1, myResourceTableDao.count());
+			ResourceTable table = myResourceTableDao.findAll().get(0);
+
+			// Create a dupe
+			ResourceIndexedSearchParamString dupe0 = new ResourceIndexedSearchParamString(myPartitionSettings, myStorageSettings, "Patient", "family", "FAMILY", "FAMILY");
+			dupe0.setResource(table);
+			dupe0.calculateHashes();
+			myResourceIndexedSearchParamStringDao.save(dupe0);
+
+			// Create a second dupe
+			ResourceIndexedSearchParamString dupe1 = new ResourceIndexedSearchParamString(myPartitionSettings, myStorageSettings, "Patient", "family", "FAMILY", "FAMILY");
+			dupe1.setResource(table);
+			dupe1.calculateHashes();
+			myResourceIndexedSearchParamStringDao.save(dupe1);
+		});
+		return id1;
+	}
+
+	private IIdType createPatientWithDuplicateTokens() {
+		IIdType id = createPatient(withIdentifier("http://foo", "bar"));
+		runInTransaction(()->{
+			assertEquals(1, myResourceTableDao.count());
+			ResourceTable table = myResourceTableDao.findAll().get(0);
+
+			// Create a dupe
+			ResourceIndexedSearchParamToken dupe0 = new ResourceIndexedSearchParamToken(myPartitionSettings, "Patient", "identifier", "http://foo", "bar");
+			dupe0.setResource(table);
+			dupe0.calculateHashes();
+			myResourceIndexedSearchParamTokenDao.save(dupe0);
+
+			// Create a second dupe
+			ResourceIndexedSearchParamToken dupe1 = new ResourceIndexedSearchParamToken(myPartitionSettings, "Patient", "identifier", "http://foo", "bar");
+			dupe1.setResource(table);
+			dupe1.calculateHashes();
+			myResourceIndexedSearchParamTokenDao.save(dupe1);
+		});
+		return id;
+	}
+
+
+	private void createNamesAndGenderSp() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-family");
+		sp.setType(Enumerations.SearchParamType.STRING);
+		sp.setCode("family");
+		sp.setExpression("Patient.name.family + '|'");
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.addBase(Enumerations.VersionIndependentResourceTypesAll.PATIENT);
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-given");
+		sp.setType(Enumerations.SearchParamType.STRING);
+		sp.setCode("given");
+		sp.setExpression("Patient.name.given");
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.addBase(Enumerations.VersionIndependentResourceTypesAll.PATIENT);
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-gender");
+		sp.setType(Enumerations.SearchParamType.TOKEN);
+		sp.setCode("gender");
+		sp.setExpression("Patient.gender");
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.addBase(Enumerations.VersionIndependentResourceTypesAll.PATIENT);
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-names-and-gender");
+		sp.setType(Enumerations.SearchParamType.COMPOSITE);
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.addBase(Enumerations.VersionIndependentResourceTypesAll.PATIENT);
+		sp.addComponent()
+			.setExpression("Patient")
+			.setDefinition("SearchParameter/patient-family");
+		sp.addComponent()
+			.setExpression("Patient")
+			.setDefinition("SearchParameter/patient-given");
+		sp.addComponent()
+			.setExpression("Patient")
+			.setDefinition("SearchParameter/patient-gender");
+		sp.addExtension()
+			.setUrl(HapiExtensions.EXT_SP_UNIQUE)
+			.setValue(new BooleanType(false));
+		mySearchParameterDao.update(sp, mySrd);
+
+		mySearchParamRegistry.forceRefresh();
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DuplicateIndexR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DuplicateIndexR5Test.java
@@ -121,7 +121,8 @@ public class DuplicateIndexR5Test extends BaseJpaR5Test {
 		// Test
 		Patient pt = new Patient();
 		pt.setId(id);
-		pt.getNameFirstRep().setFamily("FAMILY2");
+		pt.getNameFirstRep().setFamily("FAMILY2").addGiven("GIVEN");
+		pt.setGender(Enumerations.AdministrativeGender.MALE);
 		myPatientDao.update(pt, mySrd);
 
 		// Verify
@@ -156,7 +157,7 @@ public class DuplicateIndexR5Test extends BaseJpaR5Test {
 		createNamesAndGenderSp();
 		IIdType id1 = createPatient(withFamily("FAMILY"), withGiven("GIVEN"), withGender("male"));
 		runInTransaction(()->{
-			assertEquals(2, myResourceTableDao.count());
+			assertEquals(5, myResourceTableDao.count());
 			ResourceTable table = myResourceTableDao.findAll().stream().filter(t1 -> t1.getResourceType().equals("Patient")).findFirst().orElseThrow();
 			assertEquals(1, table.getmyParamsComboTokensNonUnique().size());
 			ResourceIndexedComboTokenNonUnique param = table.getmyParamsComboTokensNonUnique().iterator().next();

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DuplicateIndexR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DuplicateIndexR5Test.java
@@ -149,8 +149,7 @@ public class DuplicateIndexR5Test extends BaseJpaR5Test {
 		startRequest.setJobDefinitionId(ReindexAppCtx.JOB_REINDEX);
 		startRequest.setParameters(parameters);
 		Batch2JobStartResponse res = myJobCoordinator.startInstance(mySrd, startRequest);
-		// FIXME: remove 9999
-		myBatch2JobHelper.awaitJobCompletion(res.getInstanceId(), 9999);
+		myBatch2JobHelper.awaitJobCompletion(res.getInstanceId());
 	}
 
 	private IIdType createPatientWithDuplicateNonUniqueComboParams() {

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/search/reindex/InstanceReindexServiceImplNarrativeR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/search/reindex/InstanceReindexServiceImplNarrativeR5Test.java
@@ -307,7 +307,7 @@ public class InstanceReindexServiceImplNarrativeR5Test {
 
 	@Nonnull
 	private static ResourceIndexedSearchParams newParams() {
-		return new ResourceIndexedSearchParams();
+		return ResourceIndexedSearchParams.withSets();
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/search/ExtendedHSearchIndexExtractorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/search/ExtendedHSearchIndexExtractorTest.java
@@ -48,7 +48,7 @@ class ExtendedHSearchIndexExtractorTest implements ITestDataBuilder.WithSupport 
 		valueParams.add(new ResourceIndexedSearchParamToken(new PartitionSettings(), "Observation", "component-value-concept", "https://example.com", "some_other_value"));
 		composite.addComponentIndexedSearchParams("component-value-concept", RestSearchParameterTypeEnum.TOKEN, valueParams);
 
-		ResourceIndexedSearchParams extractedParams = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams extractedParams = ResourceIndexedSearchParams.withSets();
 		extractedParams.myCompositeParams.add(composite);
 
 		// run: now translate to HSearch
@@ -65,7 +65,7 @@ class ExtendedHSearchIndexExtractorTest implements ITestDataBuilder.WithSupport 
 	@Test
 	void testExtract_withParamMarkedAsMissing_willBeIgnored() {
 		//setup
-		ResourceIndexedSearchParams searchParams = new ResourceIndexedSearchParams();
+		ResourceIndexedSearchParams searchParams = ResourceIndexedSearchParams.withSets();
 		ResourceIndexedSearchParamDate searchParamDate = new ResourceIndexedSearchParamDate(new PartitionSettings(), "SearchParameter", "Date", null, null, null, null, null);
 		searchParamDate.setMissing(true);
 		searchParams.myDateParams.add(searchParamDate);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -1836,7 +1836,7 @@ public abstract class BaseTransactionProcessor {
 				.filter(t -> t.getEntity().getDeleted() == null)
 				.filter(t -> t.getResource() != null)
 				.forEach(t -> resourceToIndexedParams.put(
-						t.getResource(), new ResourceIndexedSearchParams((ResourceTable) t.getEntity())));
+						t.getResource(), ResourceIndexedSearchParams.withLists((ResourceTable) t.getEntity())));
 
 		for (Map.Entry<String, Class<? extends IBaseResource>> nextEntry : conditionalRequestUrls.entrySet()) {
 			String matchUrl = nextEntry.getKey();


### PR DESCRIPTION
Duplicate rows in the index tables are not removed when resources are updated or reindexed. This patch fixes that.