### PR TITLE
New extension for auto versioning references of the resource

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -42,9 +42,8 @@ import ca.uhn.fhir.parser.path.EncodeContextPath;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.BundleUtil;
-import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.FhirTerser;
-import ca.uhn.fhir.util.HapiExtensions;
+import ca.uhn.fhir.util.MetaUtil;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.base.Charsets;
 import jakarta.annotation.Nullable;
@@ -616,14 +615,11 @@ public abstract class BaseParser implements IParser {
 	private boolean isStripVersionsFromReferences(
 			CompositeChildElement theCompositeChildElement, IBaseResource theResource) {
 
-		Set<String> autoVersionReferencesAtPathFromExtensions = ExtensionUtil.getExtensionPrimitiveValues(
-						theResource.getMeta(), HapiExtensions.EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH)
-				.stream()
-				.map(path -> String.format("%s.%s", myContext.getResourceType(theResource), path))
-				.collect(Collectors.toSet());
+		Set<String> autoVersionReferencesAtPathExtensions =
+				MetaUtil.getAutoVersionReferencesAtPath(theResource.getMeta(), myContext.getResourceType(theResource));
 
-		if (!autoVersionReferencesAtPathFromExtensions.isEmpty()
-				&& theCompositeChildElement.anyPathMatches(autoVersionReferencesAtPathFromExtensions)) {
+		if (!autoVersionReferencesAtPathExtensions.isEmpty()
+				&& theCompositeChildElement.anyPathMatches(autoVersionReferencesAtPathExtensions)) {
 			return false;
 		}
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ExtensionUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ExtensionUtil.java
@@ -30,6 +30,7 @@ import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -177,15 +178,18 @@ public class ExtensionUtil {
 	 * pulls out any extensions that have the given theExtensionUrl and a primitive value type,
 	 * and returns a list of the string version of the extension values.
 	 */
-	public static List<String> getExtensionPrimitiveValues(IBaseHasExtensions theBase, String theExtensionUrl) {
-		List<String> values = theBase.getExtension().stream()
-				.filter(t -> theExtensionUrl.equals(t.getUrl()))
-				.filter(t -> t.getValue() instanceof IPrimitiveType<?>)
-				.map(t -> (IPrimitiveType<?>) t.getValue())
-				.map(IPrimitiveType::getValueAsString)
-				.filter(StringUtils::isNotBlank)
-				.collect(Collectors.toList());
-		return values;
+	public static List<String> getExtensionPrimitiveValues(IBase theBase, String theExtensionUrl) {
+		if (theBase instanceof IBaseHasExtensions) {
+			return ((IBaseHasExtensions) theBase)
+					.getExtension().stream()
+							.filter(t -> theExtensionUrl.equals(t.getUrl()))
+							.filter(t -> t.getValue() instanceof IPrimitiveType<?>)
+							.map(t -> (IPrimitiveType<?>) t.getValue())
+							.map(IPrimitiveType::getValueAsString)
+							.filter(StringUtils::isNotBlank)
+							.collect(Collectors.toList());
+		}
+		return Collections.emptyList();
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -163,11 +163,14 @@ public class HapiExtensions {
 	public static final String EXTENSION_SEARCHPARAM_UPLIFT_REFCHAIN =
 			"https://smilecdr.com/fhir/ns/StructureDefinition/searchparameter-uplift-refchain";
 
-	public static final String EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH_LIST =
-			"https://smilecdr.com/fhir/ns/StructureDefinition/auto-version-references-at-path-list";
-
+	/**
+	 * This extension is used to enable auto version references at path for resource instances.
+	 * This extension should be of type <code>string</code> and should be
+	 * placed on the <code>Resource.meta</code> element.
+	 * It is allowed to add multiple extensions with different paths.
+	 */
 	public static final String EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH =
-			"https://smilecdr.com/fhir/ns/StructureDefinition/auto-version-references-at-path";
+			"http://hapifhir.io/fhir/StructureDefinition/auto-version-references-at-path";
 
 	/**
 	 * This extension is used for "uplifted refchains" on search parameters. See the

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -162,6 +162,13 @@ public class HapiExtensions {
 	 */
 	public static final String EXTENSION_SEARCHPARAM_UPLIFT_REFCHAIN =
 			"https://smilecdr.com/fhir/ns/StructureDefinition/searchparameter-uplift-refchain";
+
+	public static final String EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH_LIST =
+			"https://smilecdr.com/fhir/ns/StructureDefinition/auto-version-references-at-path-list";
+
+	public static final String EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH =
+			"https://smilecdr.com/fhir/ns/StructureDefinition/auto-version-references-at-path";
+
 	/**
 	 * This extension is used for "uplifted refchains" on search parameters. See the
 	 * HAPI FHIR documentation for an explanation of how these work.

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/MetaUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/MetaUtil.java
@@ -35,6 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -143,5 +145,13 @@ public class MetaUtil {
 			sourceChild.getMutator().setValue(theMeta, sourceElement);
 		}
 		sourceElement.setValueAsString(theValue);
+	}
+
+	public static Set<String> getAutoVersionReferencesAtPath(IBaseMetaType theMeta, String theResourceType) {
+		return ExtensionUtil.getExtensionPrimitiveValues(
+						theMeta, HapiExtensions.EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH)
+				.stream()
+				.map(path -> String.format("%s.%s", theResourceType, path))
+				.collect(Collectors.toSet());
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5588-add-extension-to-auto-version-references-at-path.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5588-add-extension-to-auto-version-references-at-path.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 5588
+title: "Added `auto-version-references-at-path` extension that allows to 
+enable auto versioning references at specified paths of resource instances."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/references.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/references.md
@@ -166,3 +166,22 @@ You can also configure HAPI to not strip versions only on certain fields. This i
 ```java
 {{snippet:classpath:/ca/uhn/hapi/fhir/docs/Parser.java|disableStripVersionsField}}
 ``` 
+
+# Automatically Versioned References
+
+It is possible to configure HAPI to automatically version references for desired resource instances by proving `auto-version-references-at-path` extension in `Resource.meta` element:
+
+```json
+"meta": {
+   "extension":[
+      {
+         "url":"http://hapifhir.io/fhir/StructureDefinition/auto-version-references-at-path",
+         "valueString":"focus"
+      }
+   ]
+}
+```
+
+It is allowed to add multiple extensions with different paths. When a resource is stored, any references found at the specified paths will have the current version of the target appended, if a version is not already present.
+
+Parser will not strip versions from references at paths provided by `auto-version-references-at-path` extension.

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/references.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/references.md
@@ -169,7 +169,7 @@ You can also configure HAPI to not strip versions only on certain fields. This i
 
 # Automatically Versioned References
 
-It is possible to configure HAPI to automatically version references for desired resource instances by proving `auto-version-references-at-path` extension in `Resource.meta` element:
+It is possible to configure HAPI to automatically version references for desired resource instances by providing the `auto-version-references-at-path` extension in the `Resource.meta` element:
 
 ```json
 "meta": {
@@ -184,4 +184,4 @@ It is possible to configure HAPI to automatically version references for desired
 
 It is allowed to add multiple extensions with different paths. When a resource is stored, any references found at the specified paths will have the current version of the target appended, if a version is not already present.
 
-Parser will not strip versions from references at paths provided by `auto-version-references-at-path` extension.
+Parser will not strip versions from references at paths provided by the `auto-version-references-at-path` extension.

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
@@ -407,7 +407,17 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		myStorageSettings.setDeleteEnabled(false);
 		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
 
-		createAndUpdatePatient("PATIENT");
+		{
+			// Create patient
+			Patient patient = new Patient();
+			patient.setId("PATIENT");
+			patient.setActive(true);
+			myPatientDao.update(patient).getId();
+
+			// Update patient to make a second version
+			patient.setActive(false);
+			myPatientDao.update(patient);
+		}
 
 		BundleBuilder builder = new BundleBuilder(myFhirContext);
 
@@ -506,9 +516,7 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		// create MessageHeader
 		MessageHeader messageHeader = new MessageHeader();
 		// add extension to MessageHeader.meta
-		Extension autoVersionExtension = new Extension(HapiExtensions.EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH_LIST);
-		autoVersionExtension.addExtension(EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH, new StringType("focus"));
-		messageHeader.getMeta().setExtension(List.of(autoVersionExtension));
+		messageHeader.getMeta().addExtension(EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH, new StringType("focus"));
 		// add references
 		messageHeader.addFocus().setReference(patient.getIdElement().toVersionless().getValue());
 		messageHeader.addFocus().setReference(encounter.getId());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
@@ -122,7 +122,7 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		protected List<Extension> messageHeaderAutoVersionExtension = Collections.emptyList();
 
 		@Test
-		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToUpsertWithNop() {
+		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToUpsertWithNoOp() {
 			// We'll submit the same bundle twice. It has an UPSERT (with no changes
 			// the second time) on a Patient, and a CREATE on an ExplanationOfBenefit
 			// referencing that Patient.
@@ -163,7 +163,7 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		}
 
 		@Test
-		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToVersionedReferenceToUpsertWithNop() {
+		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToVersionedReferenceToUpsertWithNoOp() {
 			// We'll submit the same bundle twice. It has an UPSERT (with no changes
 			// the second time) on a Patient, and a CREATE on an ExplanationOfBenefit
 			// referencing that Patient.
@@ -346,7 +346,7 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 
 
 		@Test
-		public void testInsertVersionedReferenceAtPath_InTransaction_TargetConditionalCreatedNop() {
+		public void testInsertVersionedReferenceAtPath_InTransaction_TargetConditionalCreatedNoOp() {
 			{
 				// Create patient
 				createAndUpdatePatient(IdType.newRandomUuid().getId());
@@ -487,7 +487,7 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 
 		@Test
 		@DisplayName("Bundle transaction with AutoVersionReferenceAtPath on and with existing Patient resource should create")
-		public void bundleTransaction_autoreferenceAtPathWithPreexistingPatientReference_shouldCreate() {
+		public void bundleTransaction_autoVersionReferenceAtPathWithPreexistingPatientReference_shouldCreate() {
 			String patientId = "Patient/RED";
 			IIdType idType = new IdDt(patientId);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
@@ -2,16 +2,15 @@ package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
-import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.util.BundleBuilder;
-import ca.uhn.fhir.util.HapiExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.BooleanType;
@@ -21,7 +20,6 @@ import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.MessageHeader;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Organization;
@@ -29,14 +27,19 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Task;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.annotation.Testable;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -66,164 +69,525 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		myStorageSettings.setAutoVersionReferenceAtPaths(new JpaStorageSettings().getAutoVersionReferenceAtPaths());
 	}
 
-	@Test
-	public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToUpsertWithNop() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths("ExplanationOfBenefit.patient");
-
-		// We'll submit the same bundle twice. It has an UPSERT (with no changes
-		// the second time) on a Patient, and a CREATE on an ExplanationOfBenefit
-		// referencing that Patient.
-		Supplier<Bundle> supplier = () -> {
-			BundleBuilder bb = new BundleBuilder(myFhirContext);
-
-			Patient patient = new Patient();
-			patient.setId("Patient/A");
-			patient.setActive(true);
-			bb.addTransactionUpdateEntry(patient);
-
-			ExplanationOfBenefit eob = new ExplanationOfBenefit();
-			eob.setId(IdType.newRandomUuid());
-			eob.setPatient(new Reference("Patient/A"));
-			bb.addTransactionCreateEntry(eob);
-
-			return (Bundle) bb.getBundle();
-		};
-
-		// Send it the first time
-		Bundle outcome1 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
-		assertEquals("Patient/A/_history/1", outcome1.getEntry().get(0).getResponse().getLocation());
-		String eobId1 = outcome1.getEntry().get(1).getResponse().getLocation();
-		assertThat(eobId1, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
-
-		ExplanationOfBenefit eob1 = myExplanationOfBenefitDao.read(new IdType(eobId1), new SystemRequestDetails());
-		assertEquals("Patient/A/_history/1", eob1.getPatient().getReference());
-
-		// Send it again
-		Bundle outcome2 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
-		assertEquals("Patient/A/_history/1", outcome2.getEntry().get(0).getResponse().getLocation());
-		String eobId2 = outcome2.getEntry().get(1).getResponse().getLocation();
-		assertThat(eobId2, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
-
-		ExplanationOfBenefit eob2 = myExplanationOfBenefitDao.read(new IdType(eobId2), new SystemRequestDetails());
-		assertEquals("Patient/A/_history/1", eob2.getPatient().getReference());
+	@Nested
+	public class AutoVersionReferencesWithSettingAndExtension extends AutoVersionReferencesWithExtension {
+		@BeforeEach
+		public void before() {
+			beforeAutoVersionReferencesWithSetting();
+		}
 	}
 
-	@Test
-	public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToVersionedReferenceToUpsertWithNop() {
+	@Nested
+	public class AutoVersionReferencesWithSetting extends AutoVersionReferencesTestCases {
+		@BeforeEach
+		public void before() {
+			beforeAutoVersionReferencesWithSetting();
+		}
+	}
+
+	private void beforeAutoVersionReferencesWithSetting() {
 		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
 		myStorageSettings.setAutoVersionReferenceAtPaths(
 			"Patient.managingOrganization",
-			"ExplanationOfBenefit.patient"
+			"ExplanationOfBenefit.patient",
+			"Observation.subject",
+			"MessageHeader.focus"
 		);
-
-		// We'll submit the same bundle twice. It has an UPSERT (with no changes
-		// the second time) on a Patient, and a CREATE on an ExplanationOfBenefit
-		// referencing that Patient.
-		Supplier<Bundle> supplier = () -> {
-			BundleBuilder bb = new BundleBuilder(myFhirContext);
-
-			Organization organization = new Organization();
-			organization.setId("Organization/O");
-			organization.setActive(true);
-			bb.addTransactionUpdateEntry(organization);
-
-			Patient patient = new Patient();
-			patient.setId("Patient/A");
-			patient.setManagingOrganization(new Reference("Organization/O"));
-			patient.setActive(true);
-			bb.addTransactionUpdateEntry(patient);
-
-			ExplanationOfBenefit eob = new ExplanationOfBenefit();
-			eob.setId(IdType.newRandomUuid());
-			eob.setPatient(new Reference("Patient/A"));
-			bb.addTransactionCreateEntry(eob);
-
-			return (Bundle) bb.getBundle();
-		};
-
-		// Send it the first time
-		Bundle outcome1 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
-		assertEquals("Organization/O/_history/1", outcome1.getEntry().get(0).getResponse().getLocation());
-		assertEquals("Patient/A/_history/1", outcome1.getEntry().get(1).getResponse().getLocation());
-		String eobId1 = outcome1.getEntry().get(2).getResponse().getLocation();
-		assertThat(eobId1, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
-
-		ExplanationOfBenefit eob1 = myExplanationOfBenefitDao.read(new IdType(eobId1), new SystemRequestDetails());
-		assertEquals("Patient/A/_history/1", eob1.getPatient().getReference());
-
-		// Send it again
-		Bundle outcome2 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
-		assertEquals("Organization/O/_history/1", outcome2.getEntry().get(0).getResponse().getLocation());
-		// Technically the patient did not change - If this ever got optimized so that the version here
-		// was 1 that would be even better
-		String patientId = outcome2.getEntry().get(1).getResponse().getLocation();
-		assertEquals("Patient/A/_history/2", patientId);
-		String eobId2 = outcome2.getEntry().get(2).getResponse().getLocation();
-		assertThat(eobId2, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
-
-		Patient patient = myPatientDao.read(new IdType("Patient/A"), new SystemRequestDetails());
-		assertEquals(patientId, patient.getId());
-
-		ExplanationOfBenefit eob2 = myExplanationOfBenefitDao.read(new IdType(eobId2), new SystemRequestDetails());
-		assertEquals(patientId, eob2.getPatient().getReference());
 	}
 
-	@Test
-	public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToVersionedReferenceToUpsertWithChange() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths(
-			"Patient.managingOrganization",
-			"ExplanationOfBenefit.patient"
-		);
+	@Nested
+	public class AutoVersionReferencesWithExtension extends AutoVersionReferencesTestCases {
+		@BeforeEach
+		public void before() {
+			patientAutoVersionExtension = createAutoVersionReferencesExtensions("managingOrganization");
+			observationAutoVersionExtension = createAutoVersionReferencesExtensions("subject");
+			explanationOfBenefitAutoVersionExtension = createAutoVersionReferencesExtensions("patient");
+			messageHeaderAutoVersionExtension = createAutoVersionReferencesExtensions("focus");
+		}
 
-		AtomicInteger counter = new AtomicInteger();
-		Supplier<Bundle> supplier = () -> {
-			BundleBuilder bb = new BundleBuilder(myFhirContext);
+		@NotNull
+		private List<Extension> createAutoVersionReferencesExtensions(String... thePaths) {
+			return Arrays.stream(thePaths)
+				.map(path -> new Extension(EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH, new StringType(path)))
+				.collect(Collectors.toList());
+		}
+	}
 
-			Organization organization = new Organization();
-			organization.setId("Organization/O");
-			organization.setName("Org " + counter.incrementAndGet()); // change each time
-			organization.setActive(true);
-			bb.addTransactionUpdateEntry(organization);
+	@Testable
+	public abstract class AutoVersionReferencesTestCases {
+
+		protected List<Extension> patientAutoVersionExtension = Collections.emptyList();
+		protected List<Extension> observationAutoVersionExtension = Collections.emptyList();
+		protected List<Extension> explanationOfBenefitAutoVersionExtension = Collections.emptyList();
+		protected List<Extension> messageHeaderAutoVersionExtension = Collections.emptyList();
+
+		@Test
+		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToUpsertWithNop() {
+			// We'll submit the same bundle twice. It has an UPSERT (with no changes
+			// the second time) on a Patient, and a CREATE on an ExplanationOfBenefit
+			// referencing that Patient.
+			Supplier<Bundle> supplier = () -> {
+				BundleBuilder bb = new BundleBuilder(myFhirContext);
+
+				Patient patient = new Patient();
+				patient.setId("Patient/A");
+				patient.setActive(true);
+				bb.addTransactionUpdateEntry(patient);
+
+				ExplanationOfBenefit eob = new ExplanationOfBenefit();
+				eob.getMeta().setExtension(explanationOfBenefitAutoVersionExtension);
+				eob.setId(IdType.newRandomUuid());
+				eob.setPatient(new Reference("Patient/A"));
+				bb.addTransactionCreateEntry(eob);
+
+				return (Bundle) bb.getBundle();
+			};
+
+			// Send it the first time
+			Bundle outcome1 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
+			assertEquals("Patient/A/_history/1", outcome1.getEntry().get(0).getResponse().getLocation());
+			String eobId1 = outcome1.getEntry().get(1).getResponse().getLocation();
+			assertThat(eobId1, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+
+			ExplanationOfBenefit eob1 = myExplanationOfBenefitDao.read(new IdType(eobId1), new SystemRequestDetails());
+			assertEquals("Patient/A/_history/1", eob1.getPatient().getReference());
+
+			// Send it again
+			Bundle outcome2 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
+			assertEquals("Patient/A/_history/1", outcome2.getEntry().get(0).getResponse().getLocation());
+			String eobId2 = outcome2.getEntry().get(1).getResponse().getLocation();
+			assertThat(eobId2, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+
+			ExplanationOfBenefit eob2 = myExplanationOfBenefitDao.read(new IdType(eobId2), new SystemRequestDetails());
+			assertEquals("Patient/A/_history/1", eob2.getPatient().getReference());
+		}
+
+		@Test
+		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToVersionedReferenceToUpsertWithNop() {
+			// We'll submit the same bundle twice. It has an UPSERT (with no changes
+			// the second time) on a Patient, and a CREATE on an ExplanationOfBenefit
+			// referencing that Patient.
+			Supplier<Bundle> supplier = () -> {
+				BundleBuilder bb = new BundleBuilder(myFhirContext);
+
+				Organization organization = new Organization();
+				organization.setId("Organization/O");
+				organization.setActive(true);
+				bb.addTransactionUpdateEntry(organization);
+
+				Patient patient = new Patient();
+				patient.getMeta().setExtension(patientAutoVersionExtension);
+				patient.setId("Patient/A");
+				patient.setManagingOrganization(new Reference("Organization/O"));
+				patient.setActive(true);
+				bb.addTransactionUpdateEntry(patient);
+
+				ExplanationOfBenefit eob = new ExplanationOfBenefit();
+				eob.getMeta().setExtension(explanationOfBenefitAutoVersionExtension);
+				eob.setId(IdType.newRandomUuid());
+				eob.setPatient(new Reference("Patient/A"));
+				bb.addTransactionCreateEntry(eob);
+
+				return (Bundle) bb.getBundle();
+			};
+
+			// Send it the first time
+			Bundle outcome1 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
+			assertEquals("Organization/O/_history/1", outcome1.getEntry().get(0).getResponse().getLocation());
+			assertEquals("Patient/A/_history/1", outcome1.getEntry().get(1).getResponse().getLocation());
+			String eobId1 = outcome1.getEntry().get(2).getResponse().getLocation();
+			assertThat(eobId1, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+
+			ExplanationOfBenefit eob1 = myExplanationOfBenefitDao.read(new IdType(eobId1), new SystemRequestDetails());
+			assertEquals("Patient/A/_history/1", eob1.getPatient().getReference());
+
+			// Send it again
+			Bundle outcome2 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
+			assertEquals("Organization/O/_history/1", outcome2.getEntry().get(0).getResponse().getLocation());
+			// Technically the patient did not change - If this ever got optimized so that the version here
+			// was 1 that would be even better
+			String patientId = outcome2.getEntry().get(1).getResponse().getLocation();
+			assertEquals("Patient/A/_history/2", patientId);
+			String eobId2 = outcome2.getEntry().get(2).getResponse().getLocation();
+			assertThat(eobId2, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+
+			Patient patient = myPatientDao.read(new IdType("Patient/A"), new SystemRequestDetails());
+			assertEquals(patientId, patient.getId());
+
+			ExplanationOfBenefit eob2 = myExplanationOfBenefitDao.read(new IdType(eobId2), new SystemRequestDetails());
+			assertEquals(patientId, eob2.getPatient().getReference());
+		}
+
+		@Test
+		public void testCreateAndUpdateVersionedReferencesInTransaction_VersionedReferenceToVersionedReferenceToUpsertWithChange() {
+			AtomicInteger counter = new AtomicInteger();
+			Supplier<Bundle> supplier = () -> {
+				BundleBuilder bb = new BundleBuilder(myFhirContext);
+
+				Organization organization = new Organization();
+				organization.setId("Organization/O");
+				organization.setName("Org " + counter.incrementAndGet()); // change each time
+				organization.setActive(true);
+				bb.addTransactionUpdateEntry(organization);
+
+				Patient patient = new Patient();
+				patient.getMeta().setExtension(patientAutoVersionExtension);
+				patient.setId("Patient/A");
+				patient.setManagingOrganization(new Reference("Organization/O"));
+				patient.setActive(true);
+				bb.addTransactionUpdateEntry(patient);
+
+				ExplanationOfBenefit eob = new ExplanationOfBenefit();
+				eob.getMeta().setExtension(explanationOfBenefitAutoVersionExtension);
+				eob.setId(IdType.newRandomUuid());
+				eob.setPatient(new Reference("Patient/A"));
+				bb.addTransactionCreateEntry(eob);
+
+				return (Bundle) bb.getBundle();
+			};
+
+			// Send it the first time
+			Bundle outcome1 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
+			assertEquals("Organization/O/_history/1", outcome1.getEntry().get(0).getResponse().getLocation());
+			assertEquals("Patient/A/_history/1", outcome1.getEntry().get(1).getResponse().getLocation());
+			String eobId1 = outcome1.getEntry().get(2).getResponse().getLocation();
+			assertThat(eobId1, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+
+			ExplanationOfBenefit eob1 = myExplanationOfBenefitDao.read(new IdType(eobId1), new SystemRequestDetails());
+			assertEquals("Patient/A/_history/1", eob1.getPatient().getReference());
+
+			// Send it again
+			Bundle outcome2 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
+			assertEquals("Organization/O/_history/2", outcome2.getEntry().get(0).getResponse().getLocation());
+			String patientId = outcome2.getEntry().get(1).getResponse().getLocation();
+			assertEquals("Patient/A/_history/2", patientId);
+			String eobId2 = outcome2.getEntry().get(2).getResponse().getLocation();
+			assertThat(eobId2, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+
+			Patient patient = myPatientDao.read(new IdType("Patient/A"), new SystemRequestDetails());
+			assertEquals(patientId, patient.getId());
+
+			ExplanationOfBenefit eob2 = myExplanationOfBenefitDao.read(new IdType(eobId2), new SystemRequestDetails());
+			assertEquals(patientId, eob2.getPatient().getReference());
+		}
+
+		@Test
+		public void testInsertVersionedReferenceAtPath() {
+			Patient p = new Patient();
+			p.setActive(true);
+			IIdType patientId = myPatientDao.create(p).getId().toUnqualified();
+			assertEquals("1", patientId.getVersionIdPart());
+			assertEquals(null, patientId.getBaseUrl());
+			String patientIdString = patientId.getValue();
+
+			// Create - put an unversioned reference in the subject
+			Observation observation = new Observation();
+			observation.getMeta().setExtension(observationAutoVersionExtension);
+			observation.getSubject().setReference(patientId.toVersionless().getValue());
+			IIdType observationId = myObservationDao.create(observation).getId().toUnqualified();
+
+			// Read back and verify that reference is now versioned
+			observation = myObservationDao.read(observationId);
+			assertEquals(patientIdString, observation.getSubject().getReference());
+
+			myCaptureQueriesListener.clear();
+
+			// Update - put an unversioned reference in the subject
+			observation = new Observation();
+			observation.getMeta().setExtension(observationAutoVersionExtension);
+			observation.setId(observationId);
+			observation.addIdentifier().setSystem("http://foo").setValue("bar");
+			observation.getSubject().setReference(patientId.toVersionless().getValue());
+			myObservationDao.update(observation);
+
+			// Make sure we're not introducing any extra DB operations
+			assertEquals(5, myCaptureQueriesListener.logSelectQueries().size());
+
+			// Read back and verify that reference is now versioned
+			observation = myObservationDao.read(observationId);
+			assertEquals(patientIdString, observation.getSubject().getReference());
+		}
+
+
+		@Test
+		public void testInsertVersionedReferenceAtPath_InTransaction_SourceAndTargetBothCreated() {
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
 
 			Patient patient = new Patient();
-			patient.setId("Patient/A");
-			patient.setManagingOrganization(new Reference("Organization/O"));
+			patient.setId(IdType.newRandomUuid());
 			patient.setActive(true);
-			bb.addTransactionUpdateEntry(patient);
+			builder.addTransactionCreateEntry(patient);
 
-			ExplanationOfBenefit eob = new ExplanationOfBenefit();
-			eob.setId(IdType.newRandomUuid());
-			eob.setPatient(new Reference("Patient/A"));
-			bb.addTransactionCreateEntry(eob);
+			Encounter encounter = new Encounter();
+			encounter.setId(IdType.newRandomUuid());
+			encounter.addIdentifier().setSystem("http://baz").setValue("baz");
+			builder.addTransactionCreateEntry(encounter);
 
-			return (Bundle) bb.getBundle();
-		};
+			Observation observation = new Observation();
+			observation.getMeta().setExtension(observationAutoVersionExtension);
+			observation.getSubject().setReference(patient.getId()); // versioned
+			observation.getEncounter().setReference(encounter.getId()); // not versioned
+			builder.addTransactionCreateEntry(observation);
 
-		// Send it the first time
-		Bundle outcome1 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
-		assertEquals("Organization/O/_history/1", outcome1.getEntry().get(0).getResponse().getLocation());
-		assertEquals("Patient/A/_history/1", outcome1.getEntry().get(1).getResponse().getLocation());
-		String eobId1 = outcome1.getEntry().get(2).getResponse().getLocation();
-		assertThat(eobId1, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
+			Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
+			ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+			IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
+			IdType encounterId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
+			IdType observationId = new IdType(outcome.getEntry().get(2).getResponse().getLocation());
+			assertTrue(patientId.hasVersionIdPart());
+			assertTrue(encounterId.hasVersionIdPart());
+			assertTrue(observationId.hasVersionIdPart());
 
-		ExplanationOfBenefit eob1 = myExplanationOfBenefitDao.read(new IdType(eobId1), new SystemRequestDetails());
-		assertEquals("Patient/A/_history/1", eob1.getPatient().getReference());
+			// Read back and verify that reference is now versioned
+			observation = myObservationDao.read(observationId);
+			assertEquals(patientId.getValue(), observation.getSubject().getReference());
+			assertEquals(encounterId.toVersionless().getValue(), observation.getEncounter().getReference());
+		}
 
-		// Send it again
-		Bundle outcome2 = mySystemDao.transaction(new SystemRequestDetails(), supplier.get());
-		assertEquals("Organization/O/_history/2", outcome2.getEntry().get(0).getResponse().getLocation());
-		String patientId = outcome2.getEntry().get(1).getResponse().getLocation();
-		assertEquals("Patient/A/_history/2", patientId);
-		String eobId2 = outcome2.getEntry().get(2).getResponse().getLocation();
-		assertThat(eobId2, matchesPattern("ExplanationOfBenefit/[0-9]+/_history/1"));
 
-		Patient patient = myPatientDao.read(new IdType("Patient/A"), new SystemRequestDetails());
-		assertEquals(patientId, patient.getId());
+		@Test
+		public void testInsertVersionedReferenceAtPath_InTransaction_TargetConditionalCreatedNop() {
+			{
+				// Create patient
+				createAndUpdatePatient(IdType.newRandomUuid().getId());
 
-		ExplanationOfBenefit eob2 = myExplanationOfBenefitDao.read(new IdType(eobId2), new SystemRequestDetails());
-		assertEquals(patientId, eob2.getPatient().getReference());
+				// Create encounter
+				Encounter encounter = new Encounter();
+				encounter.setId(IdType.newRandomUuid());
+				encounter.addIdentifier().setSystem("http://baz").setValue("baz");
+				myEncounterDao.create(encounter);
+			}
+
+			// Verify Patient Version
+			assertEquals("2", myPatientDao.search(SearchParameterMap.newSynchronous("active", new TokenParam("false")))
+				.getResources(0, 1).get(0).getIdElement().getVersionIdPart());
+
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
+
+			Patient patient = new Patient();
+			patient.setId(IdType.newRandomUuid());
+			patient.setActive(true);
+			builder.addTransactionCreateEntry(patient).conditional("Patient?active=false");
+
+			Encounter encounter = new Encounter();
+			encounter.setId(IdType.newRandomUuid());
+			encounter.addIdentifier().setSystem("http://baz").setValue("baz");
+			builder.addTransactionCreateEntry(encounter).conditional("Encounter?identifier=http://baz|baz");
+
+			Observation observation = new Observation();
+			observation.getMeta().setExtension(observationAutoVersionExtension);
+			observation.getSubject().setReference(patient.getId()); // versioned
+			observation.getEncounter().setReference(encounter.getId()); // not versioned
+			builder.addTransactionCreateEntry(observation);
+
+			Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
+			ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+			assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
+			assertEquals("200 OK", outcome.getEntry().get(1).getResponse().getStatus());
+			assertEquals("201 Created", outcome.getEntry().get(2).getResponse().getStatus());
+			IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
+			IdType encounterId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
+			IdType observationId = new IdType(outcome.getEntry().get(2).getResponse().getLocation());
+			assertEquals("2", patientId.getVersionIdPart());
+			assertEquals("1", encounterId.getVersionIdPart());
+			assertEquals("1", observationId.getVersionIdPart());
+
+			// Read back and verify that reference is now versioned
+			observation = myObservationDao.read(observationId);
+			assertEquals(patientId.getValue(), observation.getSubject().getReference());
+			assertEquals("2", observation.getSubject().getReferenceElement().getVersionIdPart());
+			assertEquals(encounterId.toVersionless().getValue(), observation.getEncounter().getReference());
+		}
+
+
+		@Test
+		public void testInsertVersionedReferenceAtPath_InTransaction_TargetUpdate() {
+			myStorageSettings.setDeleteEnabled(false);
+
+			{
+				// Create patient
+				Patient patient = new Patient();
+				patient.setId("PATIENT");
+				patient.setActive(true);
+				myPatientDao.update(patient).getId();
+
+				// Update patient to make a second version
+				patient.setActive(false);
+				myPatientDao.update(patient);
+			}
+
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
+
+			Patient patient = new Patient();
+			patient.setId("Patient/PATIENT");
+			patient.setActive(true);
+			builder.addTransactionUpdateEntry(patient);
+
+			Observation observation = new Observation();
+			observation.getMeta().setExtension(observationAutoVersionExtension);
+			observation.getSubject().setReference(patient.getId()); // versioned
+			builder.addTransactionCreateEntry(observation);
+
+			myCaptureQueriesListener.clear();
+			Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
+			ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+			assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
+			assertEquals("201 Created", outcome.getEntry().get(1).getResponse().getStatus());
+			IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
+			IdType observationId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
+			assertEquals("3", patientId.getVersionIdPart());
+			assertEquals("1", observationId.getVersionIdPart());
+
+			// Make sure we're not introducing any extra DB operations
+			assertEquals(3, myCaptureQueriesListener.logSelectQueries().size());
+
+			// Read back and verify that reference is now versioned
+			observation = myObservationDao.read(observationId);
+			assertEquals(patientId.getValue(), observation.getSubject().getReference());
+
+		}
+
+		@Test
+		public void testInsertVersionedReferenceAtPath_InTransaction_TargetUpdateConditional() {
+			createAndUpdatePatient(IdType.newRandomUuid().getId());
+
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
+
+			Patient patient = new Patient();
+			patient.setId(IdType.newRandomUuid());
+			patient.setDeceased(new BooleanType(true));
+			patient.setActive(false);
+			builder
+				.addTransactionUpdateEntry(patient)
+				.conditional("Patient?active=false");
+
+			Observation observation = new Observation();
+			observation.getMeta().setExtension(observationAutoVersionExtension);
+			observation.getSubject().setReference(patient.getId()); // versioned
+			builder.addTransactionCreateEntry(observation);
+
+			myCaptureQueriesListener.clear();
+
+			Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
+			ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+			assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
+			assertEquals("201 Created", outcome.getEntry().get(1).getResponse().getStatus());
+			IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
+			IdType observationId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
+			assertEquals("3", patientId.getVersionIdPart());
+			assertEquals("1", observationId.getVersionIdPart());
+
+			// Make sure we're not introducing any extra DB operations
+			assertEquals(4, myCaptureQueriesListener.logSelectQueries().size());
+
+			// Read back and verify that reference is now versioned
+			observation = myObservationDao.read(observationId);
+			assertEquals(patientId.getValue(), observation.getSubject().getReference());
+		}
+
+		@Test
+		@DisplayName("Bundle transaction with AutoVersionReferenceAtPath on and with existing Patient resource should create")
+		public void bundleTransaction_autoreferenceAtPathWithPreexistingPatientReference_shouldCreate() {
+			String patientId = "Patient/RED";
+			IIdType idType = new IdDt(patientId);
+
+			// create patient ahead of time
+			Patient patient = new Patient();
+			patient.setId(patientId);
+			DaoMethodOutcome outcome = myPatientDao.update(patient);
+			assertThat(outcome.getResource().getIdElement().getValue(), is(equalTo(patientId + "/_history/1")));
+
+			Patient returned = myPatientDao.read(idType);
+			Assertions.assertNotNull(returned);
+			assertThat(returned.getId(), is(equalTo(patientId + "/_history/1")));
+
+			// update to change version
+			patient.setActive(true);
+			myPatientDao.update(patient);
+
+			Observation obs = new Observation();
+			obs.getMeta().setExtension(observationAutoVersionExtension);
+			obs.setId("Observation/DEF");
+			Reference patientRef = new Reference(patientId);
+			obs.setSubject(patientRef);
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
+			builder.addTransactionUpdateEntry(obs);
+
+			Bundle submitted = (Bundle) builder.getBundle();
+
+			Bundle returnedTr = mySystemDao.transaction(new SystemRequestDetails(), submitted);
+
+			Assertions.assertNotNull(returnedTr);
+
+			// some verification
+			Observation obRet = myObservationDao.read(obs.getIdElement());
+			Assertions.assertNotNull(obRet);
+		}
+
+		@Test
+		@DisplayName("GH-2901 Test no NPE is thrown on autoversioned references")
+		public void testNoNpeMinimal() {
+			myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+
+			Observation obs = new Observation();
+			obs.getMeta().setExtension(observationAutoVersionExtension);
+			obs.setId("Observation/DEF");
+			Reference patientRef = new Reference("Patient/RED");
+			obs.setSubject(patientRef);
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
+			builder.addTransactionUpdateEntry(obs);
+
+			Bundle submitted = (Bundle) builder.getBundle();
+
+			Bundle returnedTr = mySystemDao.transaction(new SystemRequestDetails(), submitted);
+
+			Assertions.assertNotNull(returnedTr);
+
+			// some verification
+			Observation obRet = myObservationDao.read(obs.getIdElement());
+			Assertions.assertNotNull(obRet);
+			Patient returned = myPatientDao.read(patientRef.getReferenceElement());
+			Assertions.assertNotNull(returned);
+		}
+
+		@Test
+		public void testInsertVersionedReferencesByPath_resourceReferenceNotInTransaction_addsVersionToTheReferences() {
+			Patient patient = createAndUpdatePatient(IdType.newRandomUuid().getId());
+
+			// create MessageHeader
+			MessageHeader messageHeader = new MessageHeader();
+			messageHeader.getMeta().setExtension(messageHeaderAutoVersionExtension);
+			// add reference
+			messageHeader.addFocus().setReference(patient.getIdElement().toVersionless().getValue());
+
+			BundleBuilder builder = new BundleBuilder(myFhirContext);
+			builder.addTransactionCreateEntry(messageHeader);
+
+			ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(builder.getBundle()));
+			Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
+			ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+			assertEquals("201 Created", outcome.getEntry().get(0).getResponse().getStatus());
+
+			IdType messageHeaderId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
+			assertEquals("2", patient.getIdElement().getVersionIdPart());
+			assertEquals("1", messageHeaderId.getVersionIdPart());
+
+			// read back and verify that reference is versioned
+			messageHeader = myMessageHeaderDao.read(messageHeaderId);
+			assertEquals(patient.getIdElement().getValue(), messageHeader.getFocus().get(0).getReference());
+		}
+
+		private Patient createAndUpdatePatient(String thePatientId) {
+			Patient patient = new Patient();
+			patient.setId(thePatientId);
+			patient.setActive(true);
+			myPatientDao.create(patient).getId();
+
+			// update patient to make a second version
+			patient.setActive(false);
+			myPatientDao.update(patient);
+			return patient;
+		}
 	}
 
 	@Test
@@ -268,297 +632,6 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		// Read back
 		observation = myObservationDao.read(observationId);
 		assertEquals(patientId.withVersion("1").getValue(), observation.getSubject().getReference());
-	}
-
-	@Test
-	public void testInsertVersionedReferenceAtPath() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		Patient p = new Patient();
-		p.setActive(true);
-		IIdType patientId = myPatientDao.create(p).getId().toUnqualified();
-		assertEquals("1", patientId.getVersionIdPart());
-		assertEquals(null, patientId.getBaseUrl());
-		String patientIdString = patientId.getValue();
-
-		// Create - put an unversioned reference in the subject
-		Observation observation = new Observation();
-		observation.getSubject().setReference(patientId.toVersionless().getValue());
-		IIdType observationId = myObservationDao.create(observation).getId().toUnqualified();
-
-		// Read back and verify that reference is now versioned
-		observation = myObservationDao.read(observationId);
-		assertEquals(patientIdString, observation.getSubject().getReference());
-
-		myCaptureQueriesListener.clear();
-
-		// Update - put an unversioned reference in the subject
-		observation = new Observation();
-		observation.setId(observationId);
-		observation.addIdentifier().setSystem("http://foo").setValue("bar");
-		observation.getSubject().setReference(patientId.toVersionless().getValue());
-		myObservationDao.update(observation);
-
-		// Make sure we're not introducing any extra DB operations
-		assertEquals(5, myCaptureQueriesListener.logSelectQueries().size());
-
-		// Read back and verify that reference is now versioned
-		observation = myObservationDao.read(observationId);
-		assertEquals(patientIdString, observation.getSubject().getReference());
-	}
-
-	@Test
-	public void testInsertVersionedReferenceAtPath_InTransaction_SourceAndTargetBothCreated() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-
-		Patient patient = new Patient();
-		patient.setId(IdType.newRandomUuid());
-		patient.setActive(true);
-		builder.addTransactionCreateEntry(patient);
-
-		Encounter encounter = new Encounter();
-		encounter.setId(IdType.newRandomUuid());
-		encounter.addIdentifier().setSystem("http://baz").setValue("baz");
-		builder.addTransactionCreateEntry(encounter);
-
-		Observation observation = new Observation();
-		observation.getSubject().setReference(patient.getId()); // versioned
-		observation.getEncounter().setReference(encounter.getId()); // not versioned
-		builder.addTransactionCreateEntry(observation);
-
-		Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
-		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
-		IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
-		IdType encounterId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
-		IdType observationId = new IdType(outcome.getEntry().get(2).getResponse().getLocation());
-		assertTrue(patientId.hasVersionIdPart());
-		assertTrue(encounterId.hasVersionIdPart());
-		assertTrue(observationId.hasVersionIdPart());
-
-		// Read back and verify that reference is now versioned
-		observation = myObservationDao.read(observationId);
-		assertEquals(patientId.getValue(), observation.getSubject().getReference());
-		assertEquals(encounterId.toVersionless().getValue(), observation.getEncounter().getReference());
-	}
-
-	@Test
-	public void testInsertVersionedReferenceAtPath_InTransaction_TargetConditionalCreatedNop() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		{
-			// Create patient
-			createAndUpdatePatient(IdType.newRandomUuid().getId());
-
-			// Create encounter
-			Encounter encounter = new Encounter();
-			encounter.setId(IdType.newRandomUuid());
-			encounter.addIdentifier().setSystem("http://baz").setValue("baz");
-			myEncounterDao.create(encounter);
-		}
-
-		// Verify Patient Version
-		assertEquals("2", myPatientDao.search(SearchParameterMap.newSynchronous("active", new TokenParam("false"))).getResources(0, 1).get(0).getIdElement().getVersionIdPart());
-
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-
-		Patient patient = new Patient();
-		patient.setId(IdType.newRandomUuid());
-		patient.setActive(true);
-		builder.addTransactionCreateEntry(patient).conditional("Patient?active=false");
-
-		Encounter encounter = new Encounter();
-		encounter.setId(IdType.newRandomUuid());
-		encounter.addIdentifier().setSystem("http://baz").setValue("baz");
-		builder.addTransactionCreateEntry(encounter).conditional("Encounter?identifier=http://baz|baz");
-
-		Observation observation = new Observation();
-		observation.getSubject().setReference(patient.getId()); // versioned
-		observation.getEncounter().setReference(encounter.getId()); // not versioned
-		builder.addTransactionCreateEntry(observation);
-
-		Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
-		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
-		assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
-		assertEquals("200 OK", outcome.getEntry().get(1).getResponse().getStatus());
-		assertEquals("201 Created", outcome.getEntry().get(2).getResponse().getStatus());
-		IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
-		IdType encounterId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
-		IdType observationId = new IdType(outcome.getEntry().get(2).getResponse().getLocation());
-		assertEquals("2", patientId.getVersionIdPart());
-		assertEquals("1", encounterId.getVersionIdPart());
-		assertEquals("1", observationId.getVersionIdPart());
-
-		// Read back and verify that reference is now versioned
-		observation = myObservationDao.read(observationId);
-		assertEquals(patientId.getValue(), observation.getSubject().getReference());
-		assertEquals("2", observation.getSubject().getReferenceElement().getVersionIdPart());
-		assertEquals(encounterId.toVersionless().getValue(), observation.getEncounter().getReference());
-	}
-
-
-	@Test
-	public void testInsertVersionedReferenceAtPath_InTransaction_TargetUpdate() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setDeleteEnabled(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		{
-			// Create patient
-			Patient patient = new Patient();
-			patient.setId("PATIENT");
-			patient.setActive(true);
-			myPatientDao.update(patient).getId();
-
-			// Update patient to make a second version
-			patient.setActive(false);
-			myPatientDao.update(patient);
-		}
-
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-
-		Patient patient = new Patient();
-		patient.setId("Patient/PATIENT");
-		patient.setActive(true);
-		builder.addTransactionUpdateEntry(patient);
-
-		Observation observation = new Observation();
-		observation.getSubject().setReference(patient.getId()); // versioned
-		builder.addTransactionCreateEntry(observation);
-
-		myCaptureQueriesListener.clear();
-		Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
-		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
-		assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
-		assertEquals("201 Created", outcome.getEntry().get(1).getResponse().getStatus());
-		IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
-		IdType observationId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
-		assertEquals("3", patientId.getVersionIdPart());
-		assertEquals("1", observationId.getVersionIdPart());
-
-		// Make sure we're not introducing any extra DB operations
-		assertEquals(3, myCaptureQueriesListener.logSelectQueries().size());
-
-		// Read back and verify that reference is now versioned
-		observation = myObservationDao.read(observationId);
-		assertEquals(patientId.getValue(), observation.getSubject().getReference());
-
-	}
-
-
-	@Test
-	public void testInsertVersionedReferenceAtPath_InTransaction_TargetUpdateConditional() {
-		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		createAndUpdatePatient(IdType.newRandomUuid().getId());
-
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-
-		Patient patient = new Patient();
-		patient.setId(IdType.newRandomUuid());
-		patient.setDeceased(new BooleanType(true));
-		patient.setActive(false);
-		builder
-			.addTransactionUpdateEntry(patient)
-			.conditional("Patient?active=false");
-
-		Observation observation = new Observation();
-		observation.getSubject().setReference(patient.getId()); // versioned
-		builder.addTransactionCreateEntry(observation);
-
-		myCaptureQueriesListener.clear();
-
-		Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
-		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
-		assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
-		assertEquals("201 Created", outcome.getEntry().get(1).getResponse().getStatus());
-		IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
-		IdType observationId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
-		assertEquals("3", patientId.getVersionIdPart());
-		assertEquals("1", observationId.getVersionIdPart());
-
-		// Make sure we're not introducing any extra DB operations
-		assertEquals(4, myCaptureQueriesListener.logSelectQueries().size());
-
-		// Read back and verify that reference is now versioned
-		observation = myObservationDao.read(observationId);
-		assertEquals(patientId.getValue(), observation.getSubject().getReference());
-	}
-
-	@Test
-	public void testInsertVersionedReferencesByPath_withExtensionInResourceMeta_addsVersionToTheReferences() {
-		Patient patient = createAndUpdatePatient(IdType.newRandomUuid().getId());
-
-		// create Location
-		Location location = new Location();
-		location.setId(IdType.newRandomUuid());
-		location.setStatus(Location.LocationStatus.ACTIVE);
-		myLocationDao.create(location);
-
-		// Update Location to make a second version
-		location.setStatus(Location.LocationStatus.INACTIVE);
-		IIdType locationId = myLocationDao.update(location).getId();
-
-		// update Patient
-		patient.setDeceased(new BooleanType(true));
-		patient.setActive(false);
-
-		// create Encounter
-		Encounter encounter = new Encounter();
-		encounter.setId(IdType.newRandomUuid());
-		encounter.setStatus(Encounter.EncounterStatus.PLANNED);
-
-		// create MessageHeader
-		MessageHeader messageHeader = new MessageHeader();
-		// add extension to MessageHeader.meta
-		messageHeader.getMeta().addExtension(EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH, new StringType("focus"));
-		// add references
-		messageHeader.addFocus().setReference(patient.getIdElement().toVersionless().getValue());
-		messageHeader.addFocus().setReference(encounter.getId());
-		messageHeader.addFocus().setReference(locationId.toVersionless().getValue());
-
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-		builder.addTransactionUpdateEntry(patient);
-		builder.addTransactionCreateEntry(encounter);
-		builder.addTransactionCreateEntry(messageHeader);
-
-		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(builder.getBundle()));
-		Bundle outcome = mySystemDao.transaction(mySrd, (Bundle) builder.getBundle());
-		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
-		assertEquals("200 OK", outcome.getEntry().get(0).getResponse().getStatus());
-		assertEquals("201 Created", outcome.getEntry().get(1).getResponse().getStatus());
-		assertEquals("201 Created", outcome.getEntry().get(2).getResponse().getStatus());
-
-		IdType patientId = new IdType(outcome.getEntry().get(0).getResponse().getLocation());
-		IdType encounterId = new IdType(outcome.getEntry().get(1).getResponse().getLocation());
-		IdType messageHeaderId = new IdType(outcome.getEntry().get(2).getResponse().getLocation());
-		assertEquals("3", patientId.getVersionIdPart());
-		assertEquals("1", encounterId.getVersionIdPart());
-		assertEquals("2", locationId.getVersionIdPart());
-		assertEquals("1", messageHeaderId.getVersionIdPart());
-
-		// read back and verify that references are versioned
-		messageHeader = myMessageHeaderDao.read(messageHeaderId);
-		assertEquals(patientId.getValue(), messageHeader.getFocus().get(0).getReference());
-		assertEquals(encounterId.getValue(), messageHeader.getFocus().get(1).getReference());
-		assertEquals(locationId.getValue(), messageHeader.getFocus().get(2).getReference());
-	}
-
-	private Patient createAndUpdatePatient(String thePatientId) {
-		Patient patient = new Patient();
-		patient.setId(thePatientId);
-		patient.setActive(true);
-		myPatientDao.create(patient).getId();
-
-		// update patient to make a second version
-		patient.setActive(false);
-        myPatientDao.update(patient);
-		return patient;
 	}
 
 	@Test
@@ -925,71 +998,5 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 		// the bundle above contains an observation, so we'll verify it was created here
 		Observation obs = myObservationDao.read(idType);
 		Assertions.assertNotNull(obs);
-	}
-
-	@Test
-	@DisplayName("Bundle transaction with AutoVersionReferenceAtPath on and with existing Patient resource should create")
-	public void bundleTransaction_autoreferenceAtPathWithPreexistingPatientReference_shouldCreate() {
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		String patientId = "Patient/RED";
-		IIdType idType = new IdDt(patientId);
-
-		// create patient ahead of time
-		Patient patient = new Patient();
-		patient.setId(patientId);
-		DaoMethodOutcome outcome = myPatientDao.update(patient);
-		assertThat(outcome.getResource().getIdElement().getValue(), is(equalTo(patientId + "/_history/1")));
-
-		Patient returned = myPatientDao.read(idType);
-		Assertions.assertNotNull(returned);
-		assertThat(returned.getId(), is(equalTo(patientId + "/_history/1")));
-
-		// update to change version
-		patient.setActive(true);
-		myPatientDao.update(patient);
-
-		Observation obs = new Observation();
-		obs.setId("Observation/DEF");
-		Reference patientRef = new Reference(patientId);
-		obs.setSubject(patientRef);
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-		builder.addTransactionUpdateEntry(obs);
-
-		Bundle submitted = (Bundle)builder.getBundle();
-
-		Bundle returnedTr = mySystemDao.transaction(new SystemRequestDetails(), submitted);
-
-		Assertions.assertNotNull(returnedTr);
-
-		// some verification
-		Observation obRet = myObservationDao.read(obs.getIdElement());
-		Assertions.assertNotNull(obRet);
-	}
-
-	@Test
-	@DisplayName("GH-2901 Test no NPE is thrown on autoversioned references")
-	public void testNoNpeMinimal() {
-		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
-		myStorageSettings.setAutoVersionReferenceAtPaths("Observation.subject");
-
-		Observation obs = new Observation();
-		obs.setId("Observation/DEF");
-		Reference patientRef = new Reference("Patient/RED");
-		obs.setSubject(patientRef);
-		BundleBuilder builder = new BundleBuilder(myFhirContext);
-		builder.addTransactionUpdateEntry(obs);
-
-		Bundle submitted = (Bundle)builder.getBundle();
-
-		Bundle returnedTr = mySystemDao.transaction(new SystemRequestDetails(), submitted);
-
-		Assertions.assertNotNull(returnedTr);
-
-		// some verification
-		Observation obRet = myObservationDao.read(obs.getIdElement());
-		Assertions.assertNotNull(obRet);
-		Patient returned = myPatientDao.read(patientRef.getReferenceElement());
-		Assertions.assertNotNull(returned);
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
@@ -157,6 +157,7 @@ import org.hl7.fhir.r4.model.Media;
 import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r4.model.MedicationAdministration;
 import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.MessageHeader;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.MolecularSequence;
 import org.hl7.fhir.r4.model.NamingSystem;
@@ -432,6 +433,9 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 	@Autowired
 	@Qualifier("myExplanationOfBenefitDaoR4")
 	protected IFhirResourceDao<ExplanationOfBenefit> myExplanationOfBenefitDao;
+	@Autowired
+	@Qualifier("myMessageHeaderDaoR4")
+	protected IFhirResourceDao<MessageHeader> myMessageHeaderDao;
 	@Autowired
 	protected IResourceTableDao myResourceTableDao;
 	@Autowired

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseStorageDao.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseStorageDao.java
@@ -59,6 +59,7 @@ import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.rest.server.util.ResourceSearchParams;
 import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.FhirTerser;
+import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.IMetaTagSorter;
 import ca.uhn.fhir.util.MetaUtil;
 import ca.uhn.fhir.util.OperationOutcomeUtil;
@@ -693,7 +694,10 @@ public abstract class BaseStorageDao {
 	}
 
 	/**
-	 * @see StorageSettings#getAutoVersionReferenceAtPaths()
+	 * Extracts a list of references that should be auto-versioned.
+	 *
+	 * @return A set of references that should be versioned according to both storage settings
+	 * 		   and auto-version reference extensions, or it may also be empty.
 	 */
 	@Nonnull
 	public static Set<IBaseReference> extractReferencesToAutoVersion(
@@ -709,6 +713,11 @@ public abstract class BaseStorageDao {
 				.keySet();
 	}
 
+	/**
+	 * Extracts a list of references that should be auto-versioned according to
+	 * <code>auto-version-references-at-path</code> extensions.
+	 * @see HapiExtensions#EXTENSION_AUTO_VERSION_REFERENCES_AT_PATH
+	 */
 	@Nonnull
 	private static Set<IBaseReference> getReferencesToAutoVersionFromExtension(
 			FhirContext theFhirContext, IBaseResource theResource) {
@@ -722,6 +731,10 @@ public abstract class BaseStorageDao {
 		return Collections.emptySet();
 	}
 
+	/**
+	 * Extracts a list of references that should be auto-versioned according to storage configuration.
+	 * @see StorageSettings#getAutoVersionReferenceAtPaths()
+	 */
 	@Nonnull
 	private static Set<IBaseReference> getReferencesToAutoVersionFromConfig(
 			FhirContext theFhirContext, StorageSettings theStorageSettings, IBaseResource theResource) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -58,6 +58,7 @@ import ca.uhn.fhir.rest.api.PreferReturnEnum;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.DeferredInterceptorBroadcasts;
+import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
 import ca.uhn.fhir.rest.param.ParameterUtil;
 import ca.uhn.fhir.rest.server.RestfulServerUtils;
@@ -1680,13 +1681,10 @@ public abstract class BaseTransactionProcessor {
 				if (newId != null) {
 					ourLog.debug(" * Replacing resource ref {} with {}", nextId, newId);
 
-					addRollbackReferenceRestore(theTransactionDetails, resourceReference);
 					if (theReferencesToAutoVersion.contains(resourceReference)) {
-						resourceReference.setReference(newId.getValue());
-						resourceReference.setResource(null);
+						replaceResourceReference(newId, resourceReference, theTransactionDetails);
 					} else {
-						resourceReference.setReference(newId.toVersionless().getValue());
-						resourceReference.setResource(null);
+						replaceResourceReference(newId.toVersionless(), resourceReference, theTransactionDetails);
 					}
 				}
 			} else if (nextId.getValue().startsWith("urn:")) {
@@ -1724,9 +1722,15 @@ public abstract class BaseTransactionProcessor {
 					DaoMethodOutcome outcome = theIdToPersistedOutcome.get(nextId);
 
 					if (outcome != null && !outcome.isNop() && !Boolean.TRUE.equals(outcome.getCreated())) {
-						addRollbackReferenceRestore(theTransactionDetails, resourceReference);
-						resourceReference.setReference(nextId.getValue());
-						resourceReference.setResource(null);
+						replaceResourceReference(nextId, resourceReference, theTransactionDetails);
+					}
+
+					// if resource reference is not in transaction but exists in the DB, resolving its version
+					IResourcePersistentId persistedReferenceId = resourceVersionMap.getResourcePersistentId(nextId);
+					if (outcome == null && persistedReferenceId != null && persistedReferenceId.getVersion() != null) {
+						IIdType newReferenceId = nextId.withVersion(
+								persistedReferenceId.getVersion().toString());
+						replaceResourceReference(newReferenceId, resourceReference, theTransactionDetails);
 					}
 				}
 			}
@@ -1812,6 +1816,13 @@ public abstract class BaseTransactionProcessor {
 				myVersionAdapter.setResponseOutcome(responseEntry, theDaoMethodOutcome.getOperationOutcome());
 			}
 		}
+	}
+
+	private void replaceResourceReference(
+			IIdType theReferenceId, IBaseReference theResourceReference, TransactionDetails theTransactionDetails) {
+		addRollbackReferenceRestore(theTransactionDetails, theResourceReference);
+		theResourceReference.setReference(theReferenceId.getValue());
+		theResourceReference.setResource(null);
 	}
 
 	private void addRollbackReferenceRestore(

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -1725,7 +1725,7 @@ public abstract class BaseTransactionProcessor {
 						replaceResourceReference(nextId, resourceReference, theTransactionDetails);
 					}
 
-					// if resource reference is not in transaction but exists in the DB, resolving its version
+					// if referenced resource is not in transaction but exists in the DB, resolving its version
 					IResourcePersistentId persistedReferenceId = resourceVersionMap.getResourcePersistentId(nextId);
 					if (outcome == null && persistedReferenceId != null && persistedReferenceId.getVersion() != null) {
 						IIdType newReferenceId = nextId.withVersion(


### PR DESCRIPTION
Added `auto-version-references-at-path` extension that allows to 
enable auto versioning references at specified paths of resource instances.