### PR TITLE
Resolve 5602 bulk export would fail if type parameter is not provided

### DIFF
--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.rest.server.tenant.UrlBaseTenantIdentificationStrategy;
 import ca.uhn.fhir.test.utilities.HttpClientExtension;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
 import ca.uhn.fhir.util.JsonUtil;
+import ca.uhn.fhir.util.SearchParameterUtil;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
@@ -60,13 +61,16 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -820,9 +824,12 @@ public class BulkDataExportProviderTest {
 			assertEquals(myServer.getBaseUrl() + "/$export-poll-status?_jobId=" + A_JOB_ID, response.getFirstHeader(Constants.HEADER_CONTENT_LOCATION).getValue());
 		}
 
+		// verify
+		Set<String> expectedResourceTypes = new HashSet<>(SearchParameterUtil.getAllResourceTypesThatAreInPatientCompartment(myCtx));
+		expectedResourceTypes.add("Device");
 		BulkExportJobParameters bp = verifyJobStartAndReturnParameters();
 		assertEquals(Constants.CT_FHIR_NDJSON, bp.getOutputFormat());
-		assertThat(bp.getResourceTypes(), containsInAnyOrder("Patient"));
+		assertThat(bp.getResourceTypes(), containsInAnyOrder(expectedResourceTypes.toArray()));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -803,8 +804,9 @@ public class BulkDataExportProviderTest {
 		assertThat(bp.getFilters(), containsInAnyOrder("Patient?gender=male", "Patient?gender=female"));
 	}
 
-	@Test
-	public void testInitiateBulkExportOnPatient_noTypeParam_addsTypeBeforeBulkExport() throws IOException {
+	@ParameterizedTest
+	@ValueSource(strings = {"onType", "onInstance"})
+	public void testInitiateBulkExportOnPatient_noTypeParam_addsTypeBeforeBulkExport(String mode) throws IOException {
 		// when
 		when(myJobCoordinator.startInstance(isNotNull(), any()))
 			.thenReturn(createJobStartResponse());
@@ -813,7 +815,13 @@ public class BulkDataExportProviderTest {
 		input.addParameter(JpaConstants.PARAM_EXPORT_OUTPUT_FORMAT, new StringType(Constants.CT_FHIR_NDJSON));
 
 		// call
-		HttpPost post = new HttpPost(myServer.getBaseUrl() + "/Patient/" + ProviderConstants.OPERATION_EXPORT);
+		HttpPost post;
+
+		if ("onType".equals(mode)) {
+			post = new HttpPost(myServer.getBaseUrl() + "/Patient/" + ProviderConstants.OPERATION_EXPORT);
+		} else {
+			post = new HttpPost(myServer.getBaseUrl() + "/Patient/p1/" + ProviderConstants.OPERATION_EXPORT);
+		}
 		post.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RESPOND_ASYNC);
 		post.setEntity(new ResourceEntity(myCtx, input));
 		ourLog.info("Request: {}", post);

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -647,8 +647,8 @@ public class BulkDataExportProvider {
 			List<IPrimitiveType<String>> theTypePostFetchFilterUrl) {
 		IPrimitiveType<String> type = theType;
 		if (type == null) {
-			// Type is optional, but the job requires it
-			type = new StringDt("Patient");
+			// set type to all patient compartment resources if it is null
+			type = new StringDt(String.join(",", getPatientCompartmentResources()));
 		}
 		BulkExportJobParameters BulkExportJobParameters = buildBulkExportJobParameters(
 				theOutputFormat,
@@ -673,9 +673,14 @@ public class BulkDataExportProvider {
 			IPrimitiveType<String> theExportIdentifier,
 			IIdType thePatientId,
 			List<IPrimitiveType<String>> theTypePostFetchFilterUrl) {
+		IPrimitiveType<String> type = theType;
+		if (type == null) {
+			// set type to all patient compartment resources if it is null
+			type = new StringDt(String.join(",", getPatientCompartmentResources()));
+		}
 		BulkExportJobParameters BulkExportJobParameters = buildBulkExportJobParameters(
 				theOutputFormat,
-				theType,
+				type,
 				theSince,
 				theTypeFilter,
 				theExportIdentifier,


### PR DESCRIPTION
What was done:
- default `_type` to all resource in the patient compartment (+ Device) if `_type` is empty.
- modified corresponding test 
- added changelog