### PR TITLE
5606 trigger subscription failure

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5606-partition-triggering.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5606-partition-triggering.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5606
+jira: SMILE-7678
+title: "Fixed an issue where executing $trigger-subscription with a search URL criteria on a partitioned Subscription resource would result in the failure to deliver the affected resources. This issue has now been resolved."

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -155,7 +155,6 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 		CanonicalSubscription subscription = theActiveSubscription.getSubscription();
 		if (subscription != null
 				&& theMsg.getPartitionId() != null
-
 				&& theMsg.getPartitionId().hasPartitionIds()
 				&& !subscription.getCrossPartitionEnabled()
 				&& !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -155,6 +155,7 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 		CanonicalSubscription subscription = theActiveSubscription.getSubscription();
 		if (subscription != null
 				&& theMsg.getPartitionId() != null
+
 				&& theMsg.getPartitionId().hasPartitionIds()
 				&& !subscription.getCrossPartitionEnabled()
 				&& !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
@@ -220,6 +220,12 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 	}
 
 	@Override
+	public IBaseParameters triggerSubscription(@Nullable List<IPrimitiveType<String>> theResourceIds, @Nullable List<IPrimitiveType<String>> theSearchUrls, @Nullable IIdType theSubscriptionId) {
+		return triggerSubscription(theResourceIds, theSearchUrls, theSubscriptionId, SystemRequestDetails.newSystemRequestAllPartitions());
+
+	}
+
+	@Override
 	public void runDeliveryPass() {
 
 		synchronized (myActiveJobs) {

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
@@ -190,7 +190,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 
 		SubscriptionTriggeringJobDetails jobDetails = new SubscriptionTriggeringJobDetails();
 		jobDetails.setJobId(UUID.randomUUID().toString());
-		jobDetails.setRequestPartitionId(requestPartitionId);
+		jobDetails.setRequestPartitionId(requestPartitionId == null ? RequestPartitionId.allPartitions() : requestPartitionId);
 		jobDetails.setRemainingResourceIds(
 				resourceIds.stream().map(IPrimitiveType::getValue).collect(Collectors.toList()));
 		jobDetails.setRemainingSearchUrls(

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
@@ -220,9 +220,12 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 	}
 
 	@Override
-	public IBaseParameters triggerSubscription(@Nullable List<IPrimitiveType<String>> theResourceIds, @Nullable List<IPrimitiveType<String>> theSearchUrls, @Nullable IIdType theSubscriptionId) {
-		return triggerSubscription(theResourceIds, theSearchUrls, theSubscriptionId, SystemRequestDetails.newSystemRequestAllPartitions());
-
+	public IBaseParameters triggerSubscription(
+			@Nullable List<IPrimitiveType<String>> theResourceIds,
+			@Nullable List<IPrimitiveType<String>> theSearchUrls,
+			@Nullable IIdType theSubscriptionId) {
+		return triggerSubscription(
+				theResourceIds, theSearchUrls, theSubscriptionId, SystemRequestDetails.newSystemRequestAllPartitions());
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
@@ -190,7 +190,8 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 
 		SubscriptionTriggeringJobDetails jobDetails = new SubscriptionTriggeringJobDetails();
 		jobDetails.setJobId(UUID.randomUUID().toString());
-		jobDetails.setRequestPartitionId(requestPartitionId == null ? RequestPartitionId.allPartitions() : requestPartitionId);
+		jobDetails.setRequestPartitionId(
+				requestPartitionId == null ? RequestPartitionId.allPartitions() : requestPartitionId);
 		jobDetails.setRemainingResourceIds(
 				resourceIds.stream().map(IPrimitiveType::getValue).collect(Collectors.toList()));
 		jobDetails.setRemainingSearchUrls(

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
@@ -26,15 +26,12 @@ import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.search.PersistedJpaSearchFirstPageBundleProvider;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
-import ca.uhn.fhir.jpa.searchparam.submit.interceptor.SearchParamValidatingInterceptor;
-import ca.uhn.fhir.jpa.subscription.submit.interceptor.SubscriptionValidatingInterceptor;
 import ca.uhn.fhir.jpa.subscription.submit.svc.ResourceModifiedSubmitterSvc;
 import ca.uhn.fhir.jpa.subscription.triggering.ISubscriptionTriggeringSvc;
 import ca.uhn.fhir.jpa.subscription.triggering.SubscriptionTriggeringSvcImpl;
 import ca.uhn.fhir.jpa.term.TermReadSvcImpl;
 import ca.uhn.fhir.jpa.test.util.SubscriptionTestUtil;
 import ca.uhn.fhir.jpa.util.SqlQuery;
-import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
@@ -119,7 +116,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -3103,7 +3099,7 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 
 			waitForActivatedSubscriptionCount(1);
 
-			mySubscriptionTriggeringSvc.triggerSubscription(null, List.of(new StringType("Patient?")), subscriptionId);
+			mySubscriptionTriggeringSvc.triggerSubscription(null, List.of(new StringType("Patient?")),  subscriptionId, mySrd);
 
 			// Test
 			myCaptureQueriesListener.clear();

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/provider/SubscriptionTriggeringProvider.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/provider/SubscriptionTriggeringProvider.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.model.dstu2.valueset.ResourceTypeEnum;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
@@ -45,6 +46,7 @@ public class SubscriptionTriggeringProvider implements IResourceProvider {
 
 	@Operation(name = JpaConstants.OPERATION_TRIGGER_SUBSCRIPTION)
 	public IBaseParameters triggerSubscription(
+			ca.uhn.fhir.rest.api.server.RequestDetails theRequestDetails,
 			@OperationParam(
 							name = ProviderConstants.SUBSCRIPTION_TRIGGERING_PARAM_RESOURCE_ID,
 							min = 0,
@@ -57,11 +59,12 @@ public class SubscriptionTriggeringProvider implements IResourceProvider {
 							max = OperationParam.MAX_UNLIMITED,
 							typeName = "string")
 					List<IPrimitiveType<String>> theSearchUrls) {
-		return mySubscriptionTriggeringSvc.triggerSubscription(theResourceIds, theSearchUrls, null);
+		return mySubscriptionTriggeringSvc.triggerSubscription(theResourceIds, theSearchUrls, null, theRequestDetails);
 	}
 
 	@Operation(name = JpaConstants.OPERATION_TRIGGER_SUBSCRIPTION)
 	public IBaseParameters triggerSubscription(
+			ca.uhn.fhir.rest.api.server.RequestDetails theRequestDetails,
 			@IdParam IIdType theSubscriptionId,
 			@OperationParam(
 							name = ProviderConstants.SUBSCRIPTION_TRIGGERING_PARAM_RESOURCE_ID,
@@ -75,7 +78,7 @@ public class SubscriptionTriggeringProvider implements IResourceProvider {
 							max = OperationParam.MAX_UNLIMITED,
 							typeName = "string")
 					List<IPrimitiveType<String>> theSearchUrls) {
-		return mySubscriptionTriggeringSvc.triggerSubscription(theResourceIds, theSearchUrls, theSubscriptionId);
+		return mySubscriptionTriggeringSvc.triggerSubscription(theResourceIds, theSearchUrls, theSubscriptionId, theRequestDetails);
 	}
 
 	@Override

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/provider/SubscriptionTriggeringProvider.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/provider/SubscriptionTriggeringProvider.java
@@ -26,7 +26,6 @@ import ca.uhn.fhir.model.dstu2.valueset.ResourceTypeEnum;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
-import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
@@ -78,7 +77,8 @@ public class SubscriptionTriggeringProvider implements IResourceProvider {
 							max = OperationParam.MAX_UNLIMITED,
 							typeName = "string")
 					List<IPrimitiveType<String>> theSearchUrls) {
-		return mySubscriptionTriggeringSvc.triggerSubscription(theResourceIds, theSearchUrls, theSubscriptionId, theRequestDetails);
+		return mySubscriptionTriggeringSvc.triggerSubscription(
+				theResourceIds, theSearchUrls, theSubscriptionId, theRequestDetails);
 	}
 
 	@Override

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceModifiedMessage.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceModifiedMessage.java
@@ -60,7 +60,10 @@ public class ResourceModifiedMessage extends BaseResourceModifiedMessage {
 	}
 
 	public ResourceModifiedMessage(
-		FhirContext theFhirContext, IBaseResource theResource, OperationTypeEnum theOperationType, RequestPartitionId theRequestPartitionId) {
+			FhirContext theFhirContext,
+			IBaseResource theResource,
+			OperationTypeEnum theOperationType,
+			RequestPartitionId theRequestPartitionId) {
 		super(theFhirContext, theResource, theOperationType);
 		setPartitionId(theRequestPartitionId);
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceModifiedMessage.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceModifiedMessage.java
@@ -60,6 +60,12 @@ public class ResourceModifiedMessage extends BaseResourceModifiedMessage {
 	}
 
 	public ResourceModifiedMessage(
+		FhirContext theFhirContext, IBaseResource theResource, OperationTypeEnum theOperationType, RequestPartitionId theRequestPartitionId) {
+		super(theFhirContext, theResource, theOperationType);
+		setPartitionId(theRequestPartitionId);
+	}
+
+	public ResourceModifiedMessage(
 			FhirContext theFhirContext,
 			IBaseResource theNewResource,
 			OperationTypeEnum theOperationType,

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
@@ -30,9 +30,10 @@ import java.util.List;
 public interface ISubscriptionTriggeringSvc {
 
 	IBaseParameters triggerSubscription(
-		@Nullable List<IPrimitiveType<String>> theResourceIds,
-		@Nullable List<IPrimitiveType<String>> theSearchUrls,
-		@Nullable IIdType theSubscriptionId, RequestDetails theRequestDetails);
+			@Nullable List<IPrimitiveType<String>> theResourceIds,
+			@Nullable List<IPrimitiveType<String>> theSearchUrls,
+			@Nullable IIdType theSubscriptionId,
+			RequestDetails theRequestDetails);
 
 	void runDeliveryPass();
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
@@ -41,10 +41,9 @@ public interface ISubscriptionTriggeringSvc {
 	 * This implementation uses a SystemRequestDetails for All Partitions, as the previous behaviour did.
 	 */
 	IBaseParameters triggerSubscription(
-		@Nullable List<IPrimitiveType<String>> theResourceIds,
-		@Nullable List<IPrimitiveType<String>> theSearchUrls,
-		@Nullable IIdType theSubscriptionId
-		);
+			@Nullable List<IPrimitiveType<String>> theResourceIds,
+			@Nullable List<IPrimitiveType<String>> theSearchUrls,
+			@Nullable IIdType theSubscriptionId);
 
 	void runDeliveryPass();
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
@@ -35,5 +35,16 @@ public interface ISubscriptionTriggeringSvc {
 			@Nullable IIdType theSubscriptionId,
 			RequestDetails theRequestDetails);
 
+	@Deprecated(forRemoval = true)
+	/**
+	 * Use {@link ISubscriptionTriggeringSvc#triggerSubscription(List, List, IIdType, RequestDetails)} instead.
+	 * This implementation uses a SystemRequestDetails for All Partitions, as the previous behaviour did.
+	 */
+	IBaseParameters triggerSubscription(
+		@Nullable List<IPrimitiveType<String>> theResourceIds,
+		@Nullable List<IPrimitiveType<String>> theSearchUrls,
+		@Nullable IIdType theSubscriptionId
+		);
+
 	void runDeliveryPass();
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/ISubscriptionTriggeringSvc.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.subscription.triggering;
 
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -29,9 +30,9 @@ import java.util.List;
 public interface ISubscriptionTriggeringSvc {
 
 	IBaseParameters triggerSubscription(
-			@Nullable List<IPrimitiveType<String>> theResourceIds,
-			@Nullable List<IPrimitiveType<String>> theSearchUrls,
-			@Nullable IIdType theSubscriptionId);
+		@Nullable List<IPrimitiveType<String>> theResourceIds,
+		@Nullable List<IPrimitiveType<String>> theSearchUrls,
+		@Nullable IIdType theSubscriptionId, RequestDetails theRequestDetails);
 
 	void runDeliveryPass();
 }


### PR DESCRIPTION
- $trigger-subscription now propagates partition ID in the ResourceModifiedMessage, permitting the matcher to succeed. Previously it was defaulting every message to DEFAULT partition. 
- Changelog 
- Test addition
- Fix an existing invalid test.
