### PR TITLE
Fix Measure group id null pointer exception

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5640-measurescore-popid-nullpointer-bug.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5640-measurescore-popid-nullpointer-bug.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5640
+jira: SMILE-7977
+title: "Clinical reasoning version bump to address reported 'null pointer' error that is encountered when running $evaluate-measure against a measure with an omitted measure.group.population.id"

--- a/pom.xml
+++ b/pom.xml
@@ -993,7 +993,7 @@
 		<ucum_version>1.0.8</ucum_version>
 
 		<!-- CQL Support -->
-		<clinical-reasoning.version>3.0.0-PRE14</clinical-reasoning.version>
+		<clinical-reasoning.version>3.0.0-PRE15</clinical-reasoning.version>
 
 		<!-- Site properties -->
 		<fontawesomeVersion>5.4.1</fontawesomeVersion>


### PR DESCRIPTION
* Update to Clinical Reasoning 3.0.0-PRE15
* Includes a fix for a null pointer exception of Measure group Ids

closes #5640 
closes https://simpaticois.atlassian.net/browse/SMILE-7977