### PR TITLE
5621 deadlock on caffeine cache when creating a resource with conditional create

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5621-fix-potential-deadlock-on-caffeine-cash-on-conditional-create.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5621-fix-potential-deadlock-on-caffeine-cash-on-conditional-create.yaml
@@ -1,5 +1,4 @@
 ---
 type: fix
 issue: 5621
-title: "Previously, a fhir endpoint could end up in a deadlock when creating a resource with conditional create. 
-The issue has been fixed."
+title: "Fixed a deadlock in resource conditional create."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5621-fix-potential-deadlock-on-caffeine-cash-on-conditional-create.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5621-fix-potential-deadlock-on-caffeine-cash-on-conditional-create.yaml
@@ -1,5 +1,5 @@
 ---
 type: fix
 issue: 5621
-title: "Previously, a fhir endpoint could end up in a deadlock when creating a resource with contitional create. 
+title: "Previously, a fhir endpoint could end up in a deadlock when creating a resource with conditional create. 
 The issue has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5621-fix-potential-deadlock-on-caffeine-cash-on-conditional-create.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5621-fix-potential-deadlock-on-caffeine-cash-on-conditional-create.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5621
+title: "Previously, a fhir endpoint could end up in a deadlock when creating a resource with contitional create. 
+The issue has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -478,19 +478,15 @@ public class IdHelperService implements IIdHelperService<JpaPid> {
 	@Override
 	public Optional<String> translatePidIdToForcedIdWithCache(JpaPid theId) {
 		// do getIfPresent and then put to avoid doing I/O inside the cache.
-		Optional<String> forcedId = myMemoryCacheService.getIfPresent(
-			MemoryCacheService.CacheEnum.PID_TO_FORCED_ID,
-			theId.getId());
+		Optional<String> forcedId =
+				myMemoryCacheService.getIfPresent(MemoryCacheService.CacheEnum.PID_TO_FORCED_ID, theId.getId());
 
 		if (forcedId == null) {
 			// This is only called when we know the resource exists.
 			// So this optional is only empty when there is no hfj_forced_id table
 			// note: this is obsolete with the new fhir_id column, and will go away.
 			forcedId = myResourceTableDao.findById(theId.getId()).map(ResourceTable::asTypedFhirResourceId);
-			myMemoryCacheService.put(
-				MemoryCacheService.CacheEnum.PID_TO_FORCED_ID,
-				theId.getId(),
-				forcedId);
+			myMemoryCacheService.put(MemoryCacheService.CacheEnum.PID_TO_FORCED_ID, theId.getId(), forcedId);
 		}
 
 		return forcedId;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -477,10 +477,23 @@ public class IdHelperService implements IIdHelperService<JpaPid> {
 
 	@Override
 	public Optional<String> translatePidIdToForcedIdWithCache(JpaPid theId) {
-		return myMemoryCacheService.get(
+		// do getIfPresent and then put to avoid doing I/O inside the cache.
+		Optional<String> forcedId = myMemoryCacheService.getIfPresent(
+			MemoryCacheService.CacheEnum.PID_TO_FORCED_ID,
+			theId.getId());
+
+		if (forcedId == null) {
+			// This is only called when we know the resource exists.
+			// So this optional is only empty when there is no hfj_forced_id table
+			// note: this is obsolete with the new fhir_id column, and will go away.
+			forcedId = myResourceTableDao.findById(theId.getId()).map(ResourceTable::asTypedFhirResourceId);
+			myMemoryCacheService.put(
 				MemoryCacheService.CacheEnum.PID_TO_FORCED_ID,
 				theId.getId(),
-				pid -> myResourceTableDao.findById(pid).map(ResourceTable::asTypedFhirResourceId));
+				forcedId);
+		}
+
+		return forcedId;
 	}
 
 	private ListMultimap<String, String> organizeIdsByResourceType(Collection<IIdType> theIds) {

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/src/main/java/ca/uhn/fhir/sl/cache/caffeine/CacheProvider.java
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/src/main/java/ca/uhn/fhir/sl/cache/caffeine/CacheProvider.java
@@ -44,6 +44,8 @@ public class CacheProvider<K, V> implements ca.uhn.fhir.sl.cache.CacheProvider<K
 	public Cache<K, V> create(long timeoutMillis, long maximumSize) {
 		return new CacheDelegator<K, V>(Caffeine.newBuilder()
 				.expireAfterWrite(timeoutMillis, TimeUnit.MILLISECONDS)
+				// Caffeine locks the whole array when growing the hash table.
+				// Set initial capacity to max to avoid this.  All our caches are <1M entries.
 				.initialCapacity((int) maximumSize)
 				.maximumSize(maximumSize)
 				.build());
@@ -52,6 +54,8 @@ public class CacheProvider<K, V> implements ca.uhn.fhir.sl.cache.CacheProvider<K
 	public LoadingCache<K, V> create(long timeoutMillis, long maximumSize, CacheLoader<K, V> loading) {
 		return new LoadingCacheDelegator<K, V>(Caffeine.newBuilder()
 				.expireAfterWrite(timeoutMillis, TimeUnit.MILLISECONDS)
+				// Caffeine locks the whole array when growing the hash table.
+				// Set initial capacity to max to avoid this.  All our caches are <1M entries.
 				.initialCapacity((int) maximumSize)
 				.maximumSize(maximumSize)
 				.build(loading::load));

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/src/main/java/ca/uhn/fhir/sl/cache/caffeine/CacheProvider.java
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/src/main/java/ca/uhn/fhir/sl/cache/caffeine/CacheProvider.java
@@ -44,6 +44,7 @@ public class CacheProvider<K, V> implements ca.uhn.fhir.sl.cache.CacheProvider<K
 	public Cache<K, V> create(long timeoutMillis, long maximumSize) {
 		return new CacheDelegator<K, V>(Caffeine.newBuilder()
 				.expireAfterWrite(timeoutMillis, TimeUnit.MILLISECONDS)
+				.initialCapacity((int) maximumSize)
 				.maximumSize(maximumSize)
 				.build());
 	}
@@ -51,6 +52,7 @@ public class CacheProvider<K, V> implements ca.uhn.fhir.sl.cache.CacheProvider<K
 	public LoadingCache<K, V> create(long timeoutMillis, long maximumSize, CacheLoader<K, V> loading) {
 		return new LoadingCacheDelegator<K, V>(Caffeine.newBuilder()
 				.expireAfterWrite(timeoutMillis, TimeUnit.MILLISECONDS)
+				.initialCapacity((int) maximumSize)
 				.maximumSize(maximumSize)
 				.build(loading::load));
 	}


### PR DESCRIPTION
**What was done:**
- replaced the atomic operation of cache access and cache miss value generation to a two stage process where we check if a value is present in the cache and if it is not, we invoke the supplier and add the result to the cache;
- Setting the initial capacity of instantiated caches to the cache max size to avoid a resizing during operations;
- added changelog.