### PR TITLE
Check index existence on raw SQL creation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5547-collation-index-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5547-collation-index-fix.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5547
+title: "The addition of the indexes `idx_sp_uri_hash_identity_pattern_ops` and `idx_sp_string_hash_nrm_pattern_ops` could occasionally timeout during migration in Postgresql on large databases, leaving the migration table in a failed state, and Smile CDR unable to boot. 
+Now existence of the index is checked before attempting to add it again."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -185,8 +185,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 									"HFJ_SPIDX_STRING".toLowerCase(),
 									"SP_VALUE_NORMALIZED".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing")
-
-					.onlyIf("SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_string_hash_nrm_pattern_ops')", "Index idx_sp_string_hash_nrm_pattern_ops already exists");
+					.onlyIf(
+							"SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_string_hash_nrm_pattern_ops')",
+							"Index idx_sp_string_hash_nrm_pattern_ops already exists");
 
 			version.executeRawSql(
 							"20231212.2",
@@ -198,8 +199,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 									"HFJ_SPIDX_URI".toLowerCase(),
 									"SP_URI".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing")
-				.onlyIf("SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_uri_hash_identity_pattern_ops')", "Index idx_sp_uri_hash_identity_pattern_ops already exists.");
-
+					.onlyIf(
+							"SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_uri_hash_identity_pattern_ops')",
+							"Index idx_sp_uri_hash_identity_pattern_ops already exists.");
 		}
 
 		// This fix was bad for MSSQL, it has been set to do nothing.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -184,7 +184,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 									QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
 									"HFJ_SPIDX_STRING".toLowerCase(),
 									"SP_VALUE_NORMALIZED".toLowerCase()),
-							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
+							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing")
+
+					.onlyIf("SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_string_hash_nrm_pattern_ops')", "Index idx_sp_string_hash_nrm_pattern_ops already exists");
 
 			version.executeRawSql(
 							"20231212.2",
@@ -195,7 +197,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 									QUERY_FOR_COLUMN_COLLATION_TEMPLATE,
 									"HFJ_SPIDX_URI".toLowerCase(),
 									"SP_URI".toLowerCase()),
-							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing");
+							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing")
+				.onlyIf("SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_uri_hash_identity_pattern_ops')", "Index idx_sp_uri_hash_identity_pattern_ops already exists.");
+
 		}
 
 		// This fix was bad for MSSQL, it has been set to do nothing.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.jpa.entity.BulkExportJobEntity;
 import ca.uhn.fhir.jpa.entity.BulkImportJobEntity;
 import ca.uhn.fhir.jpa.entity.Search;
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import ca.uhn.fhir.jpa.migrate.JdbcUtils;
 import ca.uhn.fhir.jpa.migrate.taskdef.ArbitrarySqlTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateHashesTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateOrdinalDatesTask;
@@ -186,9 +187,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 									"SP_VALUE_NORMALIZED".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing")
 					.onlyIf(
-							"SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_string_hash_nrm_pattern_ops')",
+							"SELECT NOT EXISTS(select 1 from pg_indexes where indexname='idx_sp_string_hash_nrm_pattern_ops')",
 							"Index idx_sp_string_hash_nrm_pattern_ops already exists");
-
 			version.executeRawSql(
 							"20231212.2",
 							"CREATE UNIQUE INDEX idx_sp_uri_hash_identity_pattern_ops ON public.hfj_spidx_uri USING btree (hash_identity, sp_uri varchar_pattern_ops, res_id, partition_id)")
@@ -200,7 +200,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 									"SP_URI".toLowerCase()),
 							"Column HFJ_SPIDX_STRING.SP_VALUE_NORMALIZED already has a collation of 'C' so doing nothing")
 					.onlyIf(
-							"SELECT EXISTS(select 1 from pg_indexes where indexname='idx_sp_uri_hash_identity_pattern_ops')",
+							"SELECT NOT EXISTS(select 1 from pg_indexes where indexname='idx_sp_uri_hash_identity_pattern_ops')",
 							"Index idx_sp_uri_hash_identity_pattern_ops already exists.");
 		}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -24,7 +24,6 @@ import ca.uhn.fhir.jpa.entity.BulkExportJobEntity;
 import ca.uhn.fhir.jpa.entity.BulkImportJobEntity;
 import ca.uhn.fhir.jpa.entity.Search;
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
-import ca.uhn.fhir.jpa.migrate.JdbcUtils;
 import ca.uhn.fhir.jpa.migrate.taskdef.ArbitrarySqlTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateHashesTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateOrdinalDatesTask;

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -601,7 +601,7 @@ public class Builder {
 
 			myTask.addPrecondition(new ExecuteTaskPrecondition(
 					() -> {
-						ourLog.info("Checking precondition for SQL: {}", theSql);
+						ourLog.debug("Checking precondition for SQL: {}", theSql);
 						return MigrationJdbcUtils.queryForSingleBooleanResultMultipleThrowsException(
 								theSql, myTask.newJdbcTemplate());
 					},

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -610,7 +610,6 @@ public class Builder {
 			return this;
 		}
 
-
 		public BuilderCompleteTask runEvenDuringSchemaInitialization() {
 			myTask.setRunDuringSchemaInitialization(true);
 			return this;

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -597,7 +597,7 @@ public class Builder {
 								"Only SELECT statements (including CTEs) are allowed here.  Please check your SQL: [%s]",
 								theSql));
 			}
-			ourLog.info("SQL to evaluate: {}", theSql);
+			ourLog.debug("SQL to evaluate: {}", theSql);
 
 			myTask.addPrecondition(new ExecuteTaskPrecondition(
 					() -> {

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -610,6 +610,7 @@ public class Builder {
 			return this;
 		}
 
+
 		public BuilderCompleteTask runEvenDuringSchemaInitialization() {
 			myTask.setRunDuringSchemaInitialization(true);
 			return this;


### PR DESCRIPTION
- Add a one-off check to check for existence of index before creating. More strategic fix to come in the future. 
- Changelog 

