### PR TITLE
Avoiding Exception being thrown on @EventListener invocation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5626-fix-potential-exception-thrown-on-eventlistener.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5626-fix-potential-exception-thrown-on-eventlistener.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5626
+title: "Previously, an exception could be thrown by the container when executing a contextClosedEvent on the
+ Scheduler Service.  This issue has been fixed."

--- a/hapi-fhir-jpa/src/main/java/ca/uhn/fhir/jpa/sched/BaseSchedulerServiceImpl.java
+++ b/hapi-fhir-jpa/src/main/java/ca/uhn/fhir/jpa/sched/BaseSchedulerServiceImpl.java
@@ -28,13 +28,13 @@ import ca.uhn.fhir.jpa.model.sched.ScheduledJobDefinition;
 import ca.uhn.fhir.util.StopWatch;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.quartz.JobKey;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
@@ -177,7 +177,7 @@ public abstract class BaseSchedulerServiceImpl implements ISchedulerService {
 		values.forEach(t -> t.scheduleJobs(this));
 	}
 
-	@EventListener(ContextClosedEvent.class)
+	@PreDestroy
 	public void stop() {
 		ourLog.info("Shutting down task scheduler...");
 


### PR DESCRIPTION
**Background:**
Base method stop() of class HapiSchedulerServiceImpl causes a BeanCreationNotAllowedException to be thrown in certain application context configuration due to being annotated with @eventlistener(ContextClosedEvent.class)

One such configuration is having class HapiSchedulerServiceImpl instantiated as a Bean in ParentContext. then a WebContext is created with ParentContext as parent. Upon doing a ParentContext.close(), a first ContextClosedEvent is published by the ParentContext to all Bean in the context AND a second ContextClosedEvent is published by WebContext to all Beans in the context and its parent context. As a result, method stop() of Bean HapiSchedulerServiceImpl is called twice with an exception thrown on the second invocation.

**What was done:**
- Replaced annotation @EventListener with @PreDestroy in class HapiSchedulerServiceImpl
- Added changelog