### PR TITLE
Refactor `CommonCodeSystemTerminologyService` method `validateCode`

### DIFF
--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -1,6 +1,10 @@
 
 org.hl7.fhir.common.hapi.validation.support.InMemoryTerminologyServerValidationSupport.displayMismatch=Concept Display "{0}" does not match expected "{1}"
 
+org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.unknownCodeInSystem=Unknown code "{0}#{1}"
+org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.invalidCodeInSystem=Code {0} is not valid for system: {1}
+org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.mismatchCodeSystem=Inappropriate CodeSystem URL "{0}" for ValueSet: {1}
+org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.codeNotFoundInValueSet=Code "{0}" is not in valueset: {1}
 
 ca.uhn.fhir.jpa.term.TermReadSvcImpl.expansionRefersToUnknownCs=Unknown CodeSystem URI "{0}" referenced from ValueSet
 ca.uhn.fhir.jpa.term.TermReadSvcImpl.valueSetNotYetExpanded=ValueSet "{0}" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: {1} | {2}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheSearchR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheSearchR4Test.java
@@ -20,9 +20,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class NpmSearchR4Test extends BaseJpaR4Test {
+public class JpaPackageCacheSearchR4Test extends BaseJpaR4Test {
 
-	private static final Logger ourLog = LoggerFactory.getLogger(NpmSearchR4Test.class);
+	private static final Logger ourLog = LoggerFactory.getLogger(JpaPackageCacheSearchR4Test.class);
 	@Autowired
 	public IPackageInstallerSvc igInstaller;
 	@Autowired

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -158,21 +158,6 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 		myPackageInstallerSvc.install(spec);
 	}
 
-	@Disabled("This test was added to validate IG installation scenario for OH")
-	@Test
-	public void testInstallOntarioHealthIG() {
-		JpaPackageCache jpaPackageCache = ProxyUtil.getSingletonTarget(myPackageCacheManager, JpaPackageCache.class);
-		jpaPackageCache.getPackageServers().clear();
-		jpaPackageCache.addPackageServer(new PackageServer("https://packages.fhir.org"));
-
-		PackageInstallationSpec spec = new PackageInstallationSpec()
-				.setName("accdr.fhir.ig.pkg")
-				.setVersion("0.9.0-alpha")
-				.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL)
-				.setFetchDependencies(true);
-		myPackageInstallerSvc.install(spec);
-	}
-
 	@Test
 	public void testValidationCache_whenInstallingIG_isRefreshed() {
 		Patient patient = new Patient();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -24,15 +24,11 @@ import ca.uhn.fhir.rest.param.UriParam;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
-import ca.uhn.fhir.test.utilities.JettyUtil;
 import ca.uhn.fhir.test.utilities.ProxyUtil;
 import ca.uhn.fhir.test.utilities.server.HttpServletExtension;
 import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.util.JsonUtil;
 import ca.uhn.fhir.validation.ValidationResult;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.ee10.servlet.ServletHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Enumerations;
@@ -82,9 +78,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
-public class NpmR4Test extends BaseJpaR4Test {
+public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 
-	private static final Logger ourLog = LoggerFactory.getLogger(NpmR4Test.class);
+	private static final Logger ourLog = LoggerFactory.getLogger(PackageInstallerSvcR4Test.class);
 	@Autowired
 	@Qualifier("myImplementationGuideDaoR4")
 	protected IFhirResourceDao<ImplementationGuide> myImplementationGuideDao;
@@ -159,6 +155,21 @@ public class NpmR4Test extends BaseJpaR4Test {
 			}
 		});
 
+		myPackageInstallerSvc.install(spec);
+	}
+
+	@Disabled("This test was added to validate IG installation scenario for OH")
+	@Test
+	public void testInstallOntarioHealthIG() {
+		JpaPackageCache jpaPackageCache = ProxyUtil.getSingletonTarget(myPackageCacheManager, JpaPackageCache.class);
+		jpaPackageCache.getPackageServers().clear();
+		jpaPackageCache.addPackageServer(new PackageServer("https://packages.fhir.org"));
+
+		PackageInstallationSpec spec = new PackageInstallationSpec()
+				.setName("accdr.fhir.ig.pkg")
+				.setVersion("0.9.0-alpha")
+				.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL)
+				.setFetchDependencies(true);
 		myPackageInstallerSvc.install(spec);
 	}
 

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
@@ -52,21 +52,16 @@ public class CommonCodeSystemsTerminologyServiceTest extends BaseValidationTestW
 	@ParameterizedTest
 	@CsvSource({"Cel, (degree Celsius)", "kg/m2, (kilogram) / (meter ^ 2)"})
 	public void testLookupCode_withUnitsOfMeasureWithKnownCode_returnsFound(final String theCode, final String theDisplay) {
-		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(UCUM_CODESYSTEM_URL, theCode));
-		assertNotNull(outcome);
-		assertTrue(outcome.isFound());
-		assertEquals(theCode, outcome.getSearchedForCode());
-		assertEquals(theDisplay, outcome.getCodeDisplay());
+		final String system = UCUM_CODESYSTEM_URL;
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, theCode));
+		lookupCodeResultOk(outcome, theCode, system, theDisplay);
 	}
 
 	@Test
 	public void testLookupCode_withUnitsOfMeasureWithUnknownCode_returnsNotFound() {
 		final String code = "someCode";
 		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(UCUM_CODESYSTEM_URL, code));
-		assertNotNull(outcome);
-		assertFalse(outcome.isFound());
-		assertEquals(code, outcome.getSearchedForCode());
-		assertEquals("Error processing unit '" + code +"': The unit '" + code + "' is unknown' at position 0", outcome.getErrorMessage());
+		lookupCodeResultError(outcome, code, "Error processing unit '" + code +"': The unit '" + code + "' is unknown' at position 0");
 	}
 
 	@Test
@@ -78,134 +73,99 @@ public class CommonCodeSystemsTerminologyServiceTest extends BaseValidationTestW
 	@ParameterizedTest
 	@CsvSource({"SGN, Sign languages", "sgn, Sign languages", "EN-US, English United States", "en-us, English United States"})
 	public void testLookupCode_withLanguageOnlyWithKnownCode_returnsFound(final String theCode, final String theDisplay) {
-		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(CommonCodeSystemsTerminologyService.LANGUAGES_CODESYSTEM_URL, theCode, null, null));
-		assertNotNull(outcome);
-		assertTrue(outcome.isFound());
-		assertEquals(theCode, outcome.getSearchedForCode());
-		assertEquals(theDisplay, outcome.getCodeDisplay());
+		final String system = LANGUAGES_CODESYSTEM_URL;
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, theCode, null, null));
+		lookupCodeResultOk(outcome, theCode, system, theDisplay);
 	}
 
 	@Test
 	public void testValidateCode_withUnitsOfMeasureWithKnownCode_returnsValid() {
 		final String code = "mg";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, UCUM_VALUESET_URL);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(code, outcome.getCode());
-		assertEquals("(milligram)", outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, UCUM_VALUESET_URL);
+		validateCodeResultOk(result, code, "(milligram)");
 	}
 
 	@Test
 	public void testValidateCodeInValueSet_withUnitsOfMeasureWithKnownCode_returnsValid() {
 		final ValueSet vs = new ValueSet().setUrl(UCUM_VALUESET_URL);
 		final String code = "mg";
-		CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, vs);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(code, outcome.getCode());
-		assertEquals("(milligram)", outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCodeInValueSet(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, vs);
+		validateCodeResultOk(result, code, "(milligram)");
 	}
 
 	@Test
 	public void testValidateCodeInValueSet_withUnitsOfMeasureWithInferSystem_returnsValid() {
 		final ValueSet vs = new ValueSet().setUrl(UCUM_VALUESET_URL);
 		final String code = "mg";
-		CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions().setInferSystem(true), null, code, null, vs);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(code, outcome.getCode());
-		assertEquals("(milligram)", outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCodeInValueSet(newSupport(), newOptions().setInferSystem(true), null, code, null, vs);
+		validateCodeResultOk(result, code, "(milligram)");
 	}
 
 	@Test
 	public void testValidateCodeInValueSet_withUnitsOfMeasureWithUnknownCode_returnsInvalid() {
 		final String code = "FOO";
 		final ValueSet vs = new ValueSet().setUrl(UCUM_VALUESET_URL);
-		CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, vs);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Error processing unit '" + code +"': The unit '" + code + "' is unknown' at position 0", outcome.getMessage());
+		CodeValidationResult result = mySvc.validateCodeInValueSet(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, vs);
+		validateCodeResultError(result, "Error processing unit '" + code +"': The unit '" + code + "' is unknown' at position 0");
 	}
 
 	@ParameterizedTest
 	@CsvSource({"en-CA, English Canada", "en-US, English United States"})
 	public void testValidateLookupCode_withLanguagesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateLookupCode(newSupport(), theCode, LANGUAGES_CODESYSTEM_URL);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCodeUsingSystemLookup(newSupport(), theCode, LANGUAGES_CODESYSTEM_URL);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 	@ParameterizedTest
 	@CsvSource({"en-CA, English (Canada)", "en-US, English (United States)"})
 	public void testValidateCode_withLanguagesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, theCode, null, LANGUAGES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, theCode, null, LANGUAGES_VALUESET_URL);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 	@Test
 	public void testValidateCode_withLanguagesWithUnknownCode_returnsInvalid() {
 		final String code = "FOO";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, code, null, LANGUAGES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Code \""+ code +"\" is not in valueset: " + LANGUAGES_VALUESET_URL, outcome.getMessage());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, code, null, LANGUAGES_VALUESET_URL);
+		validateCodeResultError(result, "Code \""+ code +"\" is not in valueset: " + LANGUAGES_VALUESET_URL);
 	}
 
 	@Test
 	public void testValidateCode_withLanguagesWithIncorrectSystem_returnsInvalid() {
 		final String system = "FOO";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, "en-US", null, LANGUAGES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + LANGUAGES_VALUESET_URL, outcome.getMessage());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), system, "en-US", null, LANGUAGES_VALUESET_URL);
+		validateCodeResultError(result, "Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + LANGUAGES_VALUESET_URL);
 	}
 
 	@ParameterizedTest
 	@CsvSource({"en-CA, English Canada", "en-US, English United States"})
 	public void testValidateCode_withAllLanguagesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, theCode, null, ALL_LANGUAGES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, theCode, null, ALL_LANGUAGES_VALUESET_URL);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 
 	@Test
 	public void testValidateCode_withAllLanguagesWithUnknownCode_returnsInvalid() {
 		final String code = "FOO";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, code, null, ALL_LANGUAGES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Code \"" + code + "\" is not in valueset: " + ALL_LANGUAGES_VALUESET_URL, outcome.getMessage());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, code, null, ALL_LANGUAGES_VALUESET_URL);
+		validateCodeResultError(result, "Code \"" + code + "\" is not in valueset: " + ALL_LANGUAGES_VALUESET_URL);
 	}
 
 	@Test
 	public void testValidateCode_withAllLanguagesWithIncorrectSystem_returnsInvalid() {
 		final String system = "FOO";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, "en-US", null, ALL_LANGUAGES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + ALL_LANGUAGES_VALUESET_URL, outcome.getMessage());
+		final String valueSet = ALL_LANGUAGES_VALUESET_URL;
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), system, "en-US", null, valueSet);
+		validateCodeResultError(result, "Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + valueSet);
 	}
 
 	@ParameterizedTest
 	@CsvSource({"nl, Dutch", "nl-NL, Dutch Netherlands"})
-	public void testLookupCode_withLanguagesWithKnownLanguageOnlyCode_returnsCode(final String theCode, final String theDisplay) {
-		LookupCodeResult nl = mySvc.lookupCode(newSupport(), new LookupCodeRequest(LANGUAGES_CODESYSTEM_URL, theCode));
-		assertTrue(nl != null && nl.isFound());
-		assertEquals(theCode, nl.getSearchedForCode());
-		assertEquals(theDisplay, nl.getCodeDisplay());
+	public void testLookupCode_withLanguagesWithKnownLanguageOnlyCode_returnsFound(final String theCode, final String theDisplay) {
+		final String system = LANGUAGES_CODESYSTEM_URL;
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, theCode));
+		lookupCodeResultOk(result, theCode, system, theDisplay);
 	}
 
 	@Test
@@ -241,105 +201,77 @@ public class CommonCodeSystemsTerminologyServiceTest extends BaseValidationTestW
 	@ParameterizedTest
 	@CsvSource({"WA, Washington", "PR, Puerto Rico"})
 	public void testValidateCode_withUSPostalWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), USPS_CODESYSTEM_URL, theCode, null, null);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), USPS_CODESYSTEM_URL, theCode, null, null);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 	@ParameterizedTest
 	@CsvSource({"WA, Washington", "PR, Puerto Rico"})
 	public void testValidateCode_withUSPostalValueSetWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), USPS_CODESYSTEM_URL, theCode, null, USPS_VALUESET_URL);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), USPS_CODESYSTEM_URL, theCode, null, USPS_VALUESET_URL);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 	@Test
 	public void testValidateCode_withUSPostalValueSetWithUnknownCode_returnsInvalid() {
 		final String system = USPS_CODESYSTEM_URL;
 		final String code = "FOO";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, code, null, USPS_VALUESET_URL);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Unknown code \"" + system + "#" + code + "\"", outcome.getMessage());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), system, code, null, USPS_VALUESET_URL);
+		validateCodeResultError(result, "Unknown code \"" + system + "#" + code + "\"");
 	}
 
 	@ParameterizedTest
 	@CsvSource({"WA, Washington", "PR, Puerto Rico"})
 	public void testLookupCode_withUSPostalWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(USPS_CODESYSTEM_URL, theCode));
-		assertNotNull(outcome);
-		assertTrue(outcome.isFound());
-		assertEquals(theCode, outcome.getSearchedForCode());
-		assertEquals(theDisplay, outcome.getCodeDisplay());
+		final String system = USPS_CODESYSTEM_URL;
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, theCode));
+		lookupCodeResultOk(result, theCode, system, theDisplay);
 	}
 
 	@Test
 	public void testLookupCode_withUSPostalWithUnknownCode_returnsNotFound() {
 		final String system = USPS_CODESYSTEM_URL;
-		final String code = "FOO";
-		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
-		assertNotNull(outcome);
-		assertFalse(outcome.isFound());
-		assertEquals(code, outcome.getSearchedForCode());
-		assertEquals("Code " + code + " is not valid for system: " + system, outcome.getErrorMessage());
+		final String code = "invalidUSPS";
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
+		lookupCodeResultError(result, code, "Code " + code + " is not valid for system: " + system);
 	}
 
 	@ParameterizedTest
 	@CsvSource({"USD, United States dollar", "CAD, Canadian dollar", "EUR, Euro"})
 	public void testValidateCode_withCurrenciesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), CURRENCIES_CODESYSTEM_URL, theCode, null, null);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), CURRENCIES_CODESYSTEM_URL, theCode, null, null);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 	@ParameterizedTest
 	@CsvSource({"USD, United States dollar", "CAD, Canadian dollar", "EUR, Euro"})
 	public void testValidateCode_withCurrenciesValueSetWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), CURRENCIES_CODESYSTEM_URL, theCode, null, CURRENCIES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals(theCode, outcome.getCode());
-		assertEquals(theDisplay, outcome.getDisplay());
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), CURRENCIES_CODESYSTEM_URL, theCode, null, CURRENCIES_VALUESET_URL);
+		validateCodeResultOk(result, theCode, theDisplay);
 	}
 
 	@Test
 	public void testValidateCode_withCurrenciesValueSetWithUnknownCode_returnsInvalid() {
 		final String system = CURRENCIES_CODESYSTEM_URL;
-		final String code = "FOO";
-		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, code, null, CURRENCIES_VALUESET_URL);
-		assertNotNull(outcome);
-		assertFalse(outcome.isOk());
-		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
-		assertEquals("Unknown code \"" + system + "#" + code + "\"", outcome.getMessage());
+		final String code = "invalidCurrency";
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), system, code, null, CURRENCIES_VALUESET_URL);
+		validateCodeResultError(result, "Unknown code \"" + system + "#" + code + "\"");
 	}
 
 	@ParameterizedTest
 	@CsvSource({"USD, United States dollar", "CAD, Canadian dollar", "EUR, Euro"})
 	public void testLookupCode_withCurrenciesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
-		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(CURRENCIES_CODESYSTEM_URL, theCode));
-		assertNotNull(outcome);
-		assertTrue(outcome.isFound());
-		assertEquals(theCode, outcome.getSearchedForCode());
-		assertEquals(theDisplay, outcome.getCodeDisplay());
+		final String system = CURRENCIES_CODESYSTEM_URL;
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, theCode));
+		lookupCodeResultOk(result, theCode, system, theDisplay);
 	}
 
 	@Test
 	public void testLookupCode_withCurrenciesWithUnknownCode_returnsNotFound() {
 		final String system = CURRENCIES_CODESYSTEM_URL;
 		final String code = "FOO";
-		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
-		assertNotNull(outcome);
-		assertFalse(outcome.isFound());
-		assertEquals(code, outcome.getSearchedForCode());
-		assertEquals("Code " + code + " is not valid for system: " + system, outcome.getErrorMessage());
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
+		lookupCodeResultError(result, code, "Code " + code + " is not valid for system: " + system);
 	}
 
 	@Test
@@ -373,123 +305,99 @@ public class CommonCodeSystemsTerminologyServiceTest extends BaseValidationTestW
 
 	@ParameterizedTest
 	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
-	public void testValidateCode_withMimetypesValueSetWithStandardCode_returnsValid(String code) {
-		// test
-		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, null, MIMETYPES_VALUESET_URL);
-
-		// verify
-		assertNotNull(result);
-		assertEquals(code, result.getCode());
-		assertTrue(result.isOk());
-		assertNull(result.getSeverity());
-		assertNull(result.getMessage());
+	public void testValidateCode_withMimetypesValueSetWithStandardCode_returnsValid(String theCode) {
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, theCode, null, MIMETYPES_VALUESET_URL);
+		validateCodeResultOk(result, theCode, null);
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
-	public void testValidateCode_withMimetypesValueSetWithInferSystemWithStandardCode_returnsValid(String code) {
-		// test
-		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions().setInferSystem(true), null, code, null, MIMETYPES_VALUESET_URL);
-
-		// verify
-		assertNotNull(result);
-		assertEquals(code, result.getCode());
-		assertTrue(result.isOk());
-		assertNull(result.getSeverity());
-		assertNull(result.getMessage());
+	public void testValidateCode_withMimetypesValueSetWithInferSystemWithStandardCode_returnsValid(String theCode) {
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions().setInferSystem(true), null, theCode, null, MIMETYPES_VALUESET_URL);
+		validateCodeResultOk(result, theCode, null);
 	}
 
 	@Test
 	public void testValidateCode_withMimetypesValueSetWithMismatchSystem_returnsInvalid() {
 		final String system = "someSystem";
 		final String valueSet = MIMETYPES_VALUESET_URL;
-		// test
 		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), system, system, null, valueSet);
-
-		// verify
-		assertNotNull(result);
-		assertFalse(result.isOk());
-		assertEquals(IssueSeverity.ERROR, result.getSeverity());
-		assertEquals("Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + valueSet, result.getMessage());
+		validateCodeResultError(result, "Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + valueSet);
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
-	public void testValidateCode_withMimetypesWithStandardCode_returnsValid(String code) {
-		// test
-		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, null, null);
-
-		// verify
-		assertNotNull(result);
-		assertEquals(code, result.getCode());
-		assertTrue(result.isOk());
-		assertNull(result.getSeverity());
-		assertNull(result.getMessage());
+	public void testValidateCode_withMimetypesWithStandardCode_returnsValid(String theCode) {
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, theCode, null, null);
+		validateCodeResultOk(result, theCode, null);
 	}
 
 	@Test
 	public void testValidateCode_withMimetypeValueSetWithArbitraryCode_returnsValid() {
-		// setup
 		final String code = "someCode";
 		final String display = "displayValue";
-
-		// test
 		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, display, MIMETYPES_VALUESET_URL);
-
-		// verify
-		assertNotNull(result);
-		assertEquals(code, result.getCode());
-		assertTrue(result.isOk());
-		assertEquals(display, result.getDisplay());
+		validateCodeResultOk(result, code, display);
 	}
 
 	@Test
 	public void testValidateCode_withMimetypesWithArbitraryCode_returnsValid() {
-		// setup
 		final String code = "someCode";
 		final String display = "displayValue";
-
-		// test
 		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, display, null);
+		validateCodeResultOk(result, code, null);
 
-		// verify
-		assertNotNull(result);
-		assertEquals(code, result.getCode());
-		assertTrue(result.isOk());
+		// the display null in result bug is reported here:  https://github.com/hapifhir/hapi-fhir/issues/5643
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.FORMAT_TURTLE, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
 	public void testLookupCode_withMimetypesWithStandardCode_returnFound(String code) {
-		// setup
 		final String system = MIMETYPES_CODESYSTEM_URL;
-
-		// test
 		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
-
-		// verify
-		assertNotNull(result);
-		assertEquals(system, result.getSearchedForSystem());
-		assertEquals(code, result.getSearchedForCode());
-		assertTrue(result.isFound());
+		lookupCodeResultOk(result, code, system, null);
 	}
 
 	@Test
 	public void testLookupCode_withMimetypesWithArbitraryCode_returnsFound() {
-		// setup
 		final String system = MIMETYPES_CODESYSTEM_URL;
 		final String code = "someCode";
-
-		// test
 		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
-
-		// verify
-		assertNotNull(result);
-		assertEquals(system, result.getSearchedForSystem());
-		assertEquals(code, result.getSearchedForCode());
-		assertTrue(result.isFound());
-		assertNull(result.getCodeDisplay());
+		lookupCodeResultOk(result, code, system, null);
 	}
+
+	private void validateCodeResultOk(final CodeValidationResult theResult, final String theCode, final String theDisplay) {
+		assertNotNull(theResult);
+		assertTrue(theResult.isOk());
+		assertEquals(theCode, theResult.getCode());
+		assertEquals(theDisplay, theResult.getDisplay());
+		assertNull(theResult.getSeverity());
+		assertNull(theResult.getMessage());
+	}
+
+	private void validateCodeResultError(final CodeValidationResult theResult, final String theError) {
+		assertNotNull(theResult);
+		assertFalse(theResult.isOk());
+		assertEquals(IssueSeverity.ERROR, theResult.getSeverity());
+		assertEquals(theError, theResult.getMessage());
+	}
+
+	private void lookupCodeResultOk(final LookupCodeResult theResult, final String theCode, final String theSystem, final String theDisplay) {
+		assertNotNull(theResult);
+		assertEquals(theSystem, theResult.getSearchedForSystem());
+		assertEquals(theCode, theResult.getSearchedForCode());
+		assertTrue(theResult.isFound());
+		assertEquals(theDisplay, theResult.getCodeDisplay());
+	}
+
+	private void lookupCodeResultError(final LookupCodeResult theResult, final String theCode, final String theMessage) {
+		assertNotNull(theResult);
+		assertEquals(theCode, theResult.getSearchedForCode());
+		assertFalse(theResult.isFound());
+		assertEquals(theMessage, theResult.getErrorMessage());
+		assertNull(theResult.getCodeDisplay());
+	}
+
 
 	private ValidationSupportContext newSupport() {
 		return new ValidationSupportContext(myCtx.getValidationSupport());

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyServiceTest.java
@@ -2,17 +2,35 @@ package org.hl7.fhir.common.hapi.validation.support;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.ConceptValidationOptions;
-import ca.uhn.fhir.context.support.IValidationSupport;
-import ca.uhn.fhir.context.support.ValidationSupportContext;
+import ca.uhn.fhir.context.support.IValidationSupport.CodeValidationResult;
+import ca.uhn.fhir.context.support.IValidationSupport.IssueSeverity;
+import ca.uhn.fhir.context.support.IValidationSupport.LookupCodeResult;
 import ca.uhn.fhir.context.support.LookupCodeRequest;
+import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.fhirpath.BaseValidationTestWithInlineMocks;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.EncodingEnum;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.ALL_LANGUAGES_VALUESET_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.CURRENCIES_CODESYSTEM_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.CURRENCIES_VALUESET_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.LANGUAGES_CODESYSTEM_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.LANGUAGES_VALUESET_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.MIMETYPES_CODESYSTEM_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.MIMETYPES_VALUESET_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.UCUM_CODESYSTEM_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.UCUM_VALUESET_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.USPS_CODESYSTEM_URL;
+import static org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService.USPS_VALUESET_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,212 +49,446 @@ public class CommonCodeSystemsTerminologyServiceTest extends BaseValidationTestW
 		mySvc = new CommonCodeSystemsTerminologyService(myCtx);
 	}
 
-	@Test
-	public void testUcum_LookupCode_Good() {
-		IValidationSupport.LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest("http://unitsofmeasure.org", "Cel"));
-		assert outcome != null;
+	@ParameterizedTest
+	@CsvSource({"Cel, (degree Celsius)", "kg/m2, (kilogram) / (meter ^ 2)"})
+	public void testLookupCode_withUnitsOfMeasureWithKnownCode_returnsFound(final String theCode, final String theDisplay) {
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(UCUM_CODESYSTEM_URL, theCode));
+		assertNotNull(outcome);
 		assertTrue(outcome.isFound());
+		assertEquals(theCode, outcome.getSearchedForCode());
+		assertEquals(theDisplay, outcome.getCodeDisplay());
 	}
 
 	@Test
-	public void testUcum_LookupCode_Good2() {
-		IValidationSupport.LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest("http://unitsofmeasure.org", "kg/m2"));
-		assert outcome != null;
-		assertTrue(outcome.isFound());
-	}
-
-	@Test
-	public void testUcum_LookupCode_Bad() {
-		IValidationSupport.LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest("http://unitsofmeasure.org", "AAAAA"));
-		assert outcome != null;
+	public void testLookupCode_withUnitsOfMeasureWithUnknownCode_returnsNotFound() {
+		final String code = "someCode";
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(UCUM_CODESYSTEM_URL, code));
+		assertNotNull(outcome);
 		assertFalse(outcome.isFound());
+		assertEquals(code, outcome.getSearchedForCode());
+		assertEquals("Error processing unit '" + code +"': The unit '" + code + "' is unknown' at position 0", outcome.getErrorMessage());
 	}
 
 	@Test
-	public void testUcum_LookupCode_UnknownSystem() {
-		IValidationSupport.LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest("http://foo", "AAAAA"));
+	public void testLookupCode_withUnknownSystem_returnsNull() {
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest("http://foo", "someCode"));
 		assertNull(outcome);
 	}
 
-	@Test
-	public void lookupCode_languageOnlyLookup_isCaseInsensitive() {
-		IValidationSupport.LookupCodeResult outcomeUpper = mySvc.lookupCode(newSupport(), new LookupCodeRequest("urn:ietf:bcp:47", "SGN", "Sign Languages", null));
-		IValidationSupport.LookupCodeResult outcomeLower = mySvc.lookupCode(newSupport(), new LookupCodeRequest("urn:ietf:bcp:47", "sgn", "Sign Languages", null));
-		assertNotNull(outcomeUpper);
-		assertNotNull(outcomeLower);
-		assertTrue(outcomeLower.isFound());
-		assertTrue(outcomeUpper.isFound());
+	@ParameterizedTest
+	@CsvSource({"SGN, Sign languages", "sgn, Sign languages", "EN-US, English United States", "en-us, English United States"})
+	public void testLookupCode_withLanguageOnlyWithKnownCode_returnsFound(final String theCode, final String theDisplay) {
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(CommonCodeSystemsTerminologyService.LANGUAGES_CODESYSTEM_URL, theCode, null, null));
+		assertNotNull(outcome);
+		assertTrue(outcome.isFound());
+		assertEquals(theCode, outcome.getSearchedForCode());
+		assertEquals(theDisplay, outcome.getCodeDisplay());
 	}
 
 	@Test
-	public void lookupCode_languageAndRegionLookup_isCaseInsensitive() {
-		IValidationSupport.LookupCodeResult outcomeUpper = mySvc.lookupCode(newSupport(), new LookupCodeRequest("urn:ietf:bcp:47", "EN-US", "English", null));
-		IValidationSupport.LookupCodeResult outcomeLower = mySvc.lookupCode(newSupport(), new LookupCodeRequest("urn:ietf:bcp:47", "en-us", "English", null));
-		assertNotNull(outcomeUpper);
-		assertNotNull(outcomeLower);
-		assertTrue(outcomeLower.isFound());
-		assertTrue(outcomeUpper.isFound());
-	}
-
-	@Test
-	public void testUcum_ValidateCode_Good() {
-		ValueSet vs = new ValueSet();
-		vs.setUrl("http://hl7.org/fhir/ValueSet/ucum-units");
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions(), "http://unitsofmeasure.org", "mg", null, vs);
-		assert outcome != null;
+	public void testValidateCode_withUnitsOfMeasureWithKnownCode_returnsValid() {
+		final String code = "mg";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, UCUM_VALUESET_URL);
+		assertNotNull(outcome);
 		assertTrue(outcome.isOk());
+		assertEquals(code, outcome.getCode());
 		assertEquals("(milligram)", outcome.getDisplay());
 	}
 
 	@Test
-	public void testUcum_ValidateCode_Good_SystemInferred() {
-		ValueSet vs = new ValueSet();
-		vs.setUrl("http://hl7.org/fhir/ValueSet/ucum-units");
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions().setInferSystem(true), null, "mg", null, vs);
-		assert outcome != null;
+	public void testValidateCodeInValueSet_withUnitsOfMeasureWithKnownCode_returnsValid() {
+		final ValueSet vs = new ValueSet().setUrl(UCUM_VALUESET_URL);
+		final String code = "mg";
+		CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, vs);
+		assertNotNull(outcome);
 		assertTrue(outcome.isOk());
+		assertEquals(code, outcome.getCode());
 		assertEquals("(milligram)", outcome.getDisplay());
 	}
 
 	@Test
-	public void testUcum_ValidateCode_Bad() {
-		ValueSet vs = new ValueSet();
-		vs.setUrl("http://hl7.org/fhir/ValueSet/ucum-units");
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions(), "http://unitsofmeasure.org", "aaaaa", null, vs);
+	public void testValidateCodeInValueSet_withUnitsOfMeasureWithInferSystem_returnsValid() {
+		final ValueSet vs = new ValueSet().setUrl(UCUM_VALUESET_URL);
+		final String code = "mg";
+		CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions().setInferSystem(true), null, code, null, vs);
+		assertNotNull(outcome);
+		assertTrue(outcome.isOk());
+		assertEquals(code, outcome.getCode());
+		assertEquals("(milligram)", outcome.getDisplay());
+	}
+
+	@Test
+	public void testValidateCodeInValueSet_withUnitsOfMeasureWithUnknownCode_returnsInvalid() {
+		final String code = "FOO";
+		final ValueSet vs = new ValueSet().setUrl(UCUM_VALUESET_URL);
+		CodeValidationResult outcome = mySvc.validateCodeInValueSet(newSupport(), newOptions(), UCUM_CODESYSTEM_URL, code, null, vs);
 		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertEquals("Error processing unit 'aaaaa': The unit 'aaaaa' is unknown' at position 0", outcome.getMessage());
-		assertEquals("error", outcome.getSeverityCode());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Error processing unit '" + code +"': The unit '" + code + "' is unknown' at position 0", outcome.getMessage());
 	}
 
-	@Test
-	public void testLanguagesLanguagesCs_GoodCode() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateLookupCode(newSupport(), "en-CA", "urn:ietf:bcp:47");
-		assert outcome != null;
+	@ParameterizedTest
+	@CsvSource({"en-CA, English Canada", "en-US, English United States"})
+	public void testValidateLookupCode_withLanguagesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateLookupCode(newSupport(), theCode, LANGUAGES_CODESYSTEM_URL);
+		assertNotNull(outcome);
 		assertTrue(outcome.isOk());
-		assertEquals("English Canada", outcome.getDisplay());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
 	}
 
-	@Test
-	public void testLanguagesLanguagesCs_BadCode() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateLookupCode(newSupport(), "en-FOO", "urn:ietf:bcp:47");
-		assertNull(outcome);
-	}
-
-	@Test
-	public void testLanguages_CommonLanguagesVs_GoodCode() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), "urn:ietf:bcp:47", "en-US", null, "http://hl7.org/fhir/ValueSet/languages");
-		assert outcome != null;
+	@ParameterizedTest
+	@CsvSource({"en-CA, English (Canada)", "en-US, English (United States)"})
+	public void testValidateCode_withLanguagesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, theCode, null, LANGUAGES_VALUESET_URL);
+		assertNotNull(outcome);
 		assertTrue(outcome.isOk());
-		assertEquals("English (United States)", outcome.getDisplay());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
 	}
 
 	@Test
-	public void testLanguages_CommonLanguagesVs_OnlyLanguage_NoRegion() {
-		IValidationSupport.LookupCodeResult nl = mySvc.lookupCode(newSupport(), new LookupCodeRequest("urn:ietf:bcp:47", "nl"));
-		assertTrue(nl.isFound());
-		assertEquals("Dutch", nl.getCodeDisplay());
-	}
-
-	@Test
-	public void testLanguages_CommonLanguagesVs_LanguageAndRegion() {
-		IValidationSupport.LookupCodeResult nl = mySvc.lookupCode(newSupport(), new LookupCodeRequest("urn:ietf:bcp:47", "nl-NL"));
-		assertTrue(nl.isFound());
-		assertEquals("Dutch Netherlands", nl.getCodeDisplay());
-	}
-
-	@Test
-	public void testLanguages_CommonLanguagesVs_BadCode() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), "urn:ietf:bcp:47", "FOO", null, "http://hl7.org/fhir/ValueSet/languages");
-		assert outcome != null;
+	public void testValidateCode_withLanguagesWithUnknownCode_returnsInvalid() {
+		final String code = "FOO";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, code, null, LANGUAGES_VALUESET_URL);
+		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertEquals("Code \"FOO\" is not in valueset: http://hl7.org/fhir/ValueSet/languages", outcome.getMessage());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Code \""+ code +"\" is not in valueset: " + LANGUAGES_VALUESET_URL, outcome.getMessage());
 	}
 
 	@Test
-	public void testLanguages_CommonLanguagesVs_BadSystem() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), "FOO", "en-US", null, "http://hl7.org/fhir/ValueSet/languages");
-		assert outcome != null;
+	public void testValidateCode_withLanguagesWithIncorrectSystem_returnsInvalid() {
+		final String system = "FOO";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, "en-US", null, LANGUAGES_VALUESET_URL);
+		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertEquals("Inappropriate CodeSystem URL \"FOO\" for ValueSet: http://hl7.org/fhir/ValueSet/languages", outcome.getMessage());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + LANGUAGES_VALUESET_URL, outcome.getMessage());
 	}
 
-	@Test
-	public void testLanguages_AllLanguagesVs_GoodCode() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), "urn:ietf:bcp:47", "en-US", null, "http://hl7.org/fhir/ValueSet/all-languages");
-		assert outcome != null;
+	@ParameterizedTest
+	@CsvSource({"en-CA, English Canada", "en-US, English United States"})
+	public void testValidateCode_withAllLanguagesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, theCode, null, ALL_LANGUAGES_VALUESET_URL);
+		assertNotNull(outcome);
 		assertTrue(outcome.isOk());
-		assertEquals("English United States", outcome.getDisplay());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
 	}
 
+
 	@Test
-	public void testLanguages_AllLanguagesVs_BadCode() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), "urn:ietf:bcp:47", "FOO", null, "http://hl7.org/fhir/ValueSet/all-languages");
-		assert outcome != null;
+	public void testValidateCode_withAllLanguagesWithUnknownCode_returnsInvalid() {
+		final String code = "FOO";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), LANGUAGES_CODESYSTEM_URL, code, null, ALL_LANGUAGES_VALUESET_URL);
+		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertEquals("Code \"FOO\" is not in valueset: http://hl7.org/fhir/ValueSet/all-languages", outcome.getMessage());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Code \"" + code + "\" is not in valueset: " + ALL_LANGUAGES_VALUESET_URL, outcome.getMessage());
 	}
 
 	@Test
-	public void testLanguages_AllLanguagesVs_BadSystem() {
-		IValidationSupport.CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), "FOO", "en-US", null, "http://hl7.org/fhir/ValueSet/all-languages");
-		assert outcome != null;
+	public void testValidateCode_withAllLanguagesWithIncorrectSystem_returnsInvalid() {
+		final String system = "FOO";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, "en-US", null, ALL_LANGUAGES_VALUESET_URL);
+		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertEquals("Inappropriate CodeSystem URL \"FOO\" for ValueSet: http://hl7.org/fhir/ValueSet/all-languages", outcome.getMessage());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + ALL_LANGUAGES_VALUESET_URL, outcome.getMessage());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"nl, Dutch", "nl-NL, Dutch Netherlands"})
+	public void testLookupCode_withLanguagesWithKnownLanguageOnlyCode_returnsCode(final String theCode, final String theDisplay) {
+		LookupCodeResult nl = mySvc.lookupCode(newSupport(), new LookupCodeRequest(LANGUAGES_CODESYSTEM_URL, theCode));
+		assertTrue(nl != null && nl.isFound());
+		assertEquals(theCode, nl.getSearchedForCode());
+		assertEquals(theDisplay, nl.getCodeDisplay());
 	}
 
 	@Test
-	public void testFetchCodeSystemBuiltIn_Iso3166_R4() {
-		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem(CommonCodeSystemsTerminologyService.COUNTRIES_CODESYSTEM_URL);
-		assert cs != null;
-		assertEquals(498, cs.getConcept().size());
-	}
-
-	@Test
-	public void testFetchCodeSystemBuiltIn_Iso3166_DSTU3() {
+	public void testFetchCodeSystem_withCountriesForDSTU3_returnsOk() {
 		CommonCodeSystemsTerminologyService svc = new CommonCodeSystemsTerminologyService(FhirContext.forDstu3Cached());
 		org.hl7.fhir.dstu3.model.CodeSystem cs = (org.hl7.fhir.dstu3.model.CodeSystem) svc.fetchCodeSystem(CommonCodeSystemsTerminologyService.COUNTRIES_CODESYSTEM_URL);
-		assert cs != null;
+		assertNotNull(cs);
 		assertEquals(498, cs.getConcept().size());
 	}
 
 	@Test
-	public void testFetchCodeSystemBuiltIn_Iso3166_R5() {
+	public void testFetchCodeSystem_withCountriesForR4_returnsOk() {
+		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem(CommonCodeSystemsTerminologyService.COUNTRIES_CODESYSTEM_URL);
+		assertNotNull(cs);
+		assertEquals(498, cs.getConcept().size());
+	}
+
+	@Test
+	public void testFetchCodeSystem_withCountriesForR5_returnsOk() {
 		CommonCodeSystemsTerminologyService svc = new CommonCodeSystemsTerminologyService(FhirContext.forR5Cached());
 		org.hl7.fhir.r5.model.CodeSystem cs = (org.hl7.fhir.r5.model.CodeSystem) svc.fetchCodeSystem(CommonCodeSystemsTerminologyService.COUNTRIES_CODESYSTEM_URL);
-		assert cs != null;
+		assertNotNull(cs);
 		assertEquals(498, cs.getConcept().size());
 	}
 
 	@Test
-	public void testFetchCodeSystemBuiltIn_Iso3166_DSTU2() {
+	public void testFetchCodeSystem_withCountriesForDSTU2_returnsOk() {
 		CommonCodeSystemsTerminologyService svc = new CommonCodeSystemsTerminologyService(FhirContext.forDstu2Cached());
 		IBaseResource cs = svc.fetchCodeSystem(CommonCodeSystemsTerminologyService.COUNTRIES_CODESYSTEM_URL);
 		assertNull(cs);
 	}
 
+	@ParameterizedTest
+	@CsvSource({"WA, Washington", "PR, Puerto Rico"})
+	public void testValidateCode_withUSPostalWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), USPS_CODESYSTEM_URL, theCode, null, null);
+		assertNotNull(outcome);
+		assertTrue(outcome.isOk());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"WA, Washington", "PR, Puerto Rico"})
+	public void testValidateCode_withUSPostalValueSetWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), USPS_CODESYSTEM_URL, theCode, null, USPS_VALUESET_URL);
+		assertNotNull(outcome);
+		assertTrue(outcome.isOk());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
+	}
+
 	@Test
-	public void testFetchCodeSystemBuiltIn_Iso_R4() {
-		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem(CommonCodeSystemsTerminologyService.CURRENCIES_CODESYSTEM_URL);
-		assert cs != null;
+	public void testValidateCode_withUSPostalValueSetWithUnknownCode_returnsInvalid() {
+		final String system = USPS_CODESYSTEM_URL;
+		final String code = "FOO";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, code, null, USPS_VALUESET_URL);
+		assertNotNull(outcome);
+		assertFalse(outcome.isOk());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Unknown code \"" + system + "#" + code + "\"", outcome.getMessage());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"WA, Washington", "PR, Puerto Rico"})
+	public void testLookupCode_withUSPostalWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(USPS_CODESYSTEM_URL, theCode));
+		assertNotNull(outcome);
+		assertTrue(outcome.isFound());
+		assertEquals(theCode, outcome.getSearchedForCode());
+		assertEquals(theDisplay, outcome.getCodeDisplay());
+	}
+
+	@Test
+	public void testLookupCode_withUSPostalWithUnknownCode_returnsNotFound() {
+		final String system = USPS_CODESYSTEM_URL;
+		final String code = "FOO";
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
+		assertNotNull(outcome);
+		assertFalse(outcome.isFound());
+		assertEquals(code, outcome.getSearchedForCode());
+		assertEquals("Code " + code + " is not valid for system: " + system, outcome.getErrorMessage());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"USD, United States dollar", "CAD, Canadian dollar", "EUR, Euro"})
+	public void testValidateCode_withCurrenciesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), CURRENCIES_CODESYSTEM_URL, theCode, null, null);
+		assertNotNull(outcome);
+		assertTrue(outcome.isOk());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"USD, United States dollar", "CAD, Canadian dollar", "EUR, Euro"})
+	public void testValidateCode_withCurrenciesValueSetWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), CURRENCIES_CODESYSTEM_URL, theCode, null, CURRENCIES_VALUESET_URL);
+		assertNotNull(outcome);
+		assertTrue(outcome.isOk());
+		assertEquals(theCode, outcome.getCode());
+		assertEquals(theDisplay, outcome.getDisplay());
+	}
+
+	@Test
+	public void testValidateCode_withCurrenciesValueSetWithUnknownCode_returnsInvalid() {
+		final String system = CURRENCIES_CODESYSTEM_URL;
+		final String code = "FOO";
+		CodeValidationResult outcome = mySvc.validateCode(newSupport(), newOptions(), system, code, null, CURRENCIES_VALUESET_URL);
+		assertNotNull(outcome);
+		assertFalse(outcome.isOk());
+		assertEquals(IssueSeverity.ERROR, outcome.getSeverity());
+		assertEquals("Unknown code \"" + system + "#" + code + "\"", outcome.getMessage());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"USD, United States dollar", "CAD, Canadian dollar", "EUR, Euro"})
+	public void testLookupCode_withCurrenciesWithKnownCode_returnsValid(final String theCode, final String theDisplay) {
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(CURRENCIES_CODESYSTEM_URL, theCode));
+		assertNotNull(outcome);
+		assertTrue(outcome.isFound());
+		assertEquals(theCode, outcome.getSearchedForCode());
+		assertEquals(theDisplay, outcome.getCodeDisplay());
+	}
+
+	@Test
+	public void testLookupCode_withCurrenciesWithUnknownCode_returnsNotFound() {
+		final String system = CURRENCIES_CODESYSTEM_URL;
+		final String code = "FOO";
+		LookupCodeResult outcome = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
+		assertNotNull(outcome);
+		assertFalse(outcome.isFound());
+		assertEquals(code, outcome.getSearchedForCode());
+		assertEquals("Code " + code + " is not valid for system: " + system, outcome.getErrorMessage());
+	}
+
+	@Test
+	public void testFetchCodeSystem_withCurrencies_returnsOk() {
+		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem(CURRENCIES_CODESYSTEM_URL);
+		assertNotNull(cs);
 		assertEquals(182, cs.getConcept().size());
 	}
 
 	@Test
-	public void testFetchCodeSystemBuiltIn_Unknown() {
+	public void testFetchCodeSystem_withUnknownSystem_returnsNull() {
 		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem("http://foo");
 		assertNull(cs);
 	}
 
 	@Test
-	public void testFetchCodeSystemUrlDstu3() {
+	public void testGetCodeSystemUrl_forDSTU3_throwsException() {
 		try {
 			CommonCodeSystemsTerminologyService.getCodeSystemUrl(myCtx, new org.hl7.fhir.dstu3.model.CodeSystem());
-
 			fail();
 		} catch (IllegalArgumentException e) {
 			assertEquals(Msg.code(696) + "Can not handle version: DSTU3", e.getMessage());
 		}
+	}
+
+	@Test
+	public void testFetchCodeSystem_withMimeType_returnsOk() {
+		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem(MIMETYPES_CODESYSTEM_URL);
+		assertNull(cs);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
+	public void testValidateCode_withMimetypesValueSetWithStandardCode_returnsValid(String code) {
+		// test
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, null, MIMETYPES_VALUESET_URL);
+
+		// verify
+		assertNotNull(result);
+		assertEquals(code, result.getCode());
+		assertTrue(result.isOk());
+		assertNull(result.getSeverity());
+		assertNull(result.getMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
+	public void testValidateCode_withMimetypesValueSetWithInferSystemWithStandardCode_returnsValid(String code) {
+		// test
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions().setInferSystem(true), null, code, null, MIMETYPES_VALUESET_URL);
+
+		// verify
+		assertNotNull(result);
+		assertEquals(code, result.getCode());
+		assertTrue(result.isOk());
+		assertNull(result.getSeverity());
+		assertNull(result.getMessage());
+	}
+
+	@Test
+	public void testValidateCode_withMimetypesValueSetWithMismatchSystem_returnsInvalid() {
+		final String system = "someSystem";
+		final String valueSet = MIMETYPES_VALUESET_URL;
+		// test
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), system, system, null, valueSet);
+
+		// verify
+		assertNotNull(result);
+		assertFalse(result.isOk());
+		assertEquals(IssueSeverity.ERROR, result.getSeverity());
+		assertEquals("Inappropriate CodeSystem URL \"" + system + "\" for ValueSet: " + valueSet, result.getMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
+	public void testValidateCode_withMimetypesWithStandardCode_returnsValid(String code) {
+		// test
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, null, null);
+
+		// verify
+		assertNotNull(result);
+		assertEquals(code, result.getCode());
+		assertTrue(result.isOk());
+		assertNull(result.getSeverity());
+		assertNull(result.getMessage());
+	}
+
+	@Test
+	public void testValidateCode_withMimetypeValueSetWithArbitraryCode_returnsValid() {
+		// setup
+		final String code = "someCode";
+		final String display = "displayValue";
+
+		// test
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, display, MIMETYPES_VALUESET_URL);
+
+		// verify
+		assertNotNull(result);
+		assertEquals(code, result.getCode());
+		assertTrue(result.isOk());
+		assertEquals(display, result.getDisplay());
+	}
+
+	@Test
+	public void testValidateCode_withMimetypesWithArbitraryCode_returnsValid() {
+		// setup
+		final String code = "someCode";
+		final String display = "displayValue";
+
+		// test
+		CodeValidationResult result = mySvc.validateCode(newSupport(), newOptions(), MIMETYPES_CODESYSTEM_URL, code, display, null);
+
+		// verify
+		assertNotNull(result);
+		assertEquals(code, result.getCode());
+		assertTrue(result.isOk());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { EncodingEnum.JSON_PLAIN_STRING, Constants.FORMAT_TURTLE, Constants.CT_FHIR_JSON_NEW, Constants.CT_FHIR_JSON })
+	public void testLookupCode_withMimetypesWithStandardCode_returnFound(String code) {
+		// setup
+		final String system = MIMETYPES_CODESYSTEM_URL;
+
+		// test
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
+
+		// verify
+		assertNotNull(result);
+		assertEquals(system, result.getSearchedForSystem());
+		assertEquals(code, result.getSearchedForCode());
+		assertTrue(result.isFound());
+	}
+
+	@Test
+	public void testLookupCode_withMimetypesWithArbitraryCode_returnsFound() {
+		// setup
+		final String system = MIMETYPES_CODESYSTEM_URL;
+		final String code = "someCode";
+
+		// test
+		LookupCodeResult result = mySvc.lookupCode(newSupport(), new LookupCodeRequest(system, code));
+
+		// verify
+		assertNotNull(result);
+		assertEquals(system, result.getSearchedForSystem());
+		assertEquals(code, result.getSearchedForCode());
+		assertTrue(result.isFound());
+		assertNull(result.getCodeDisplay());
 	}
 
 	private ValidationSupportContext newSupport() {


### PR DESCRIPTION
Found that `CommonCodeSystemTerminologyService` method `validateCode` was hard to follow and inconsistent across different types of supported `CodeSystem`. 

What was done:
- Create common methods for creating validation output object, for success and failure
- Create common method for retrieving localized error message
- Extract method for mapping `ValueSet` url to the corresponding `CodeSystem` url
- Check that `CodeSystem` matches uniformly across all types
- Use infer system option uniformly across all types
- Add a bunch of new test cases

Bonus:
- Renamed some test classes to reflect the tested service. Npm vs PackageInstallerSvc.