### PR TITLE
Fix contentType request parameter in UploadTerminologyCommand

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/UploadTerminologyCommand.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/UploadTerminologyCommand.java
@@ -36,6 +36,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.commons.lang3.StringUtils;
@@ -268,7 +269,7 @@ public class UploadTerminologyCommand extends BaseRequestGeneratingCommand {
 
 		byte[] bytes = theBytes;
 		String fileName = theFileName;
-		String suffix = fileName.substring(fileName.lastIndexOf("."));
+		String suffix = FilenameUtils.getExtension(fileName);
 
 		if (bytes.length > ourTransferSizeLimit) {
 			ourLog.info(

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/UploadTerminologyCommandTest.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/UploadTerminologyCommandTest.java
@@ -388,7 +388,6 @@ public class UploadTerminologyCommandTest {
 			},
 			"-t", theIncludeTls, myBaseRestServerHelper
 		));
-		UploadTerminologyCommand uploadTerminologyCommand = new UploadTerminologyCommand();
 
 		verify(myTermLoaderSvc, times(1)).loadCustom(any(), myDescriptorListCaptor.capture(), any());
 


### PR DESCRIPTION
What was done:
- correct the extension value to not include the dot character
- unfortunately this change is not testable the contentType is currently not used in the operation implementation.