### PR TITLE
Searching for Bundles with read all Bundles permission returns 403

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/valueset/BundleTypeEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/valueset/BundleTypeEnum.java
@@ -91,7 +91,7 @@ public enum BundleTypeEnum {
 	/**
 	 * Returns the enumerated value associated with this code
 	 */
-	public BundleTypeEnum forCode(String theCode) {
+	public static BundleTypeEnum forCode(String theCode) {
 		BundleTypeEnum retVal = CODE_TO_ENUM.get(theCode);
 		return retVal;
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleUtil.java
@@ -238,7 +238,7 @@ public class BundleUtil {
 
 	public static BundleTypeEnum getBundleTypeEnum(FhirContext theContext, IBaseBundle theBundle) {
 		String bundleTypeCode = BundleUtil.getBundleType(theContext, theBundle);
-		if (isBlank(bundleTypeCode)){
+		if (isBlank(bundleTypeCode)) {
 			return null;
 		}
 		return BundleTypeEnum.forCode(bundleTypeCode);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleUtil.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.api.PatchTypeEnum;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
@@ -233,6 +234,14 @@ public class BundleUtil {
 			return typeElement.getValueAsString();
 		}
 		return null;
+	}
+
+	public static BundleTypeEnum getBundleTypeEnum(FhirContext theContext, IBaseBundle theBundle) {
+		String bundleTypeCode = BundleUtil.getBundleType(theContext, theBundle);
+		if (isBlank(bundleTypeCode)){
+			return null;
+		}
+		return BundleTypeEnum.forCode(bundleTypeCode);
 	}
 
 	public static void setBundleType(FhirContext theContext, IBaseBundle theBundle, String theType) {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5644-searching-for-bundles-with-read-all-bundles-permissions-returns-403.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5644-searching-for-bundles-with-read-all-bundles-permissions-returns-403.yaml
@@ -4,5 +4,5 @@ issue: 5644
 title: "Previously, searching for `Bundle` resources with read all `Bundle` resources permissions, returned an 
 HTTP 403 Forbidden error. This was because the `AuthorizationInterceptor` applied permissions to the resources inside 
 the `Bundle`, instead of the `Bundle` itself. This has been fixed and permissions are no longer applied to the resources 
-inside a `Bundle` of type `document`, `message`, or `collection`."
+inside a `Bundle` of type `document`, `message`, or `collection` for `Bundle` requests."
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5644-searching-for-bundles-with-read-all-bundles-permissions-returns-403.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5644-searching-for-bundles-with-read-all-bundles-permissions-returns-403.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 5644
+title: "Previously, searching for `Bundle` resources with read all `Bundle` resources permissions, returned an 
+HTTP 403 Forbidden error. This was because the `AuthorizationInterceptor` applied permissions to the resources inside 
+the `Bundle`, instead of the `Bundle` itself. This has been fixed and permissions are no longer applied to the resources 
+inside a `Bundle` of type `document`, `message`, or `collection`."
+

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/AuthorizationInterceptorJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/AuthorizationInterceptorJpaR4Test.java
@@ -1693,7 +1693,7 @@ public class AuthorizationInterceptorJpaR4Test extends BaseResourceProviderR4Tes
 	}
 
 	private void assertSearchContainsResources(String theUrl, Resource... theExpectedResources){
-		List<String> expectedIds = Arrays.stream(theExpectedResources).toList().stream()
+		List<String> expectedIds = Arrays.stream(theExpectedResources)
 			.map(resource -> resource.getIdPart())
 			.toList();
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
@@ -619,13 +619,15 @@ public class AuthorizationInterceptor implements IRuleApplier {
 	 * this scenario we want to apply permissions to the Bundle itself and not the resources inside if
 	 * the Bundle is of type document, collection, or message.
 	 */
-	public static boolean shouldExamineBundleChildResources(RequestDetails theRequestDetails, FhirContext theFhirContext, IBaseBundle theBundle) {
+	public static boolean shouldExamineBundleChildResources(
+			RequestDetails theRequestDetails, FhirContext theFhirContext, IBaseBundle theBundle) {
 		boolean isBundleRequest = theRequestDetails != null && BUNDLE.equals(theRequestDetails.getResourceName());
 		if (!isBundleRequest) {
 			return true;
 		}
 		BundleTypeEnum bundleType = BundleUtil.getBundleTypeEnum(theFhirContext, theBundle);
-		boolean isStandaloneBundleResource = bundleType != null && STANDALONE_BUNDLE_RESOURCE_TYPES.contains(bundleType);
+		boolean isStandaloneBundleResource =
+				bundleType != null && STANDALONE_BUNDLE_RESOURCE_TYPES.contains(bundleType);
 		return !isStandaloneBundleResource;
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
@@ -83,7 +83,7 @@ public class AuthorizationInterceptor implements IRuleApplier {
 	private static final AtomicInteger ourInstanceCount = new AtomicInteger(0);
 	private static final Logger ourLog = LoggerFactory.getLogger(AuthorizationInterceptor.class);
 	private static final Set<BundleTypeEnum> STANDALONE_BUNDLE_RESOURCE_TYPES =
-		Set.of(BundleTypeEnum.DOCUMENT, BundleTypeEnum.COLLECTION, BundleTypeEnum.MESSAGE);
+			Set.of(BundleTypeEnum.DOCUMENT, BundleTypeEnum.COLLECTION, BundleTypeEnum.MESSAGE);
 
 	private final int myInstanceIndex = ourInstanceCount.incrementAndGet();
 	private final String myRequestSeenResourcesKey =
@@ -578,7 +578,7 @@ public class AuthorizationInterceptor implements IRuleApplier {
 	}
 
 	public static List<IBaseResource> toListOfResourcesAndExcludeContainer(
-		IBaseResource theResponseObject, FhirContext fhirContext) {
+			IBaseResource theResponseObject, FhirContext fhirContext) {
 		if (theResponseObject == null) {
 			return Collections.emptyList();
 		}
@@ -616,7 +616,8 @@ public class AuthorizationInterceptor implements IRuleApplier {
 
 		IBaseBundle bundle = (IBaseBundle) theResource;
 		BundleTypeEnum bundleType = BundleUtil.getBundleTypeEnum(theFhirContext, bundle);
-		boolean isStandaloneBundleResource = bundleType != null && STANDALONE_BUNDLE_RESOURCE_TYPES.contains(bundleType);
+		boolean isStandaloneBundleResource =
+				bundleType != null && STANDALONE_BUNDLE_RESOURCE_TYPES.contains(bundleType);
 		return !isStandaloneBundleResource;
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
@@ -817,7 +817,7 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 		} else if (theOutputResource != null) {
 
 			List<IBaseResource> outputResources = AuthorizationInterceptor.toListOfResourcesAndExcludeContainer(
-					theOutputResource, theRequestDetails.getFhirContext());
+					theRequestDetails, theOutputResource, theRequestDetails.getFhirContext());
 
 			Verdict verdict = null;
 			for (IBaseResource nextResource : outputResources) {

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/bundle/BundleUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/bundle/BundleUtilTest.java
@@ -3,10 +3,12 @@ package ca.uhn.fhir.util.bundle;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.BundleBuilder;
 import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.TestUtil;
+import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -25,8 +27,9 @@ import org.hl7.fhir.r4.model.UriType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import jakarta.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -553,6 +556,37 @@ public class BundleUtilTest {
 		final IBaseResource actual = BundleUtil.getResourceByReferenceAndResourceType(ourCtx, bundle, reference);
 		// validate
 		assertNull(actual);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+		 // Actual BundleType            Expected BundleTypeEnum
+		 "TRANSACTION,                   TRANSACTION",
+		 "DOCUMENT,                      DOCUMENT",
+		 "MESSAGE,                       MESSAGE",
+		 "BATCHRESPONSE,                 BATCH_RESPONSE",
+		 "TRANSACTIONRESPONSE,           TRANSACTION_RESPONSE",
+		 "HISTORY,                       HISTORY",
+		 "SEARCHSET,                     SEARCHSET",
+		 "COLLECTION,                    COLLECTION"
+	})
+	public void testGetBundleTypeEnum_withKnownBundleTypes_returnsCorrectBundleTypeEnum(Bundle.BundleType theBundleType, BundleTypeEnum theExpectedBundleTypeEnum){
+		Bundle bundle = new Bundle();
+		bundle.setType(theBundleType);
+		assertEquals(theExpectedBundleTypeEnum, BundleUtil.getBundleTypeEnum(ourCtx, bundle));
+	}
+
+	@Test
+	public void testGetBundleTypeEnum_withNullBundleType_returnsNull(){
+		Bundle bundle = new Bundle();
+		bundle.setType(Bundle.BundleType.NULL);
+		assertNull(BundleUtil.getBundleTypeEnum(ourCtx, bundle));
+	}
+
+	@Test
+	public void testGetBundleTypeEnum_withNoBundleType_returnsNull(){
+		Bundle bundle = new Bundle();
+		assertNull(BundleUtil.getBundleTypeEnum(ourCtx, bundle));
 	}
 
 	@Nonnull


### PR DESCRIPTION
Previously, searching for `Bundle` resources with read all `Bundle` resources permissions, returned an  HTTP 403 Forbidden error. This was because the `AuthorizationInterceptor` applied permissions to the resources inside the `Bundle`, instead of the `Bundle` itself. This has been fixed and permissions are no longer applied to the resources inside a `Bundle` of type `document`, `message`, or `collection`  for `Bundle` requests.