### PR TITLE
Fix NullPointerException when performing a system bulk export in the presence of PatientIdPartitionInterceptor

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5659-npe-system-bulk-export-patientid-interceptor.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5659-npe-system-bulk-export-patientid-interceptor.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5659
+title: "Previously, after registering built-in interceptor `PatientIdPartitionInterceptor`, the system bulk export 
+(with no filters) operation would fail with a NullPointerException. This has been fixed."

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/interceptor/model/ReadPartitionIdRequestDetails.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/interceptor/model/ReadPartitionIdRequestDetails.java
@@ -116,7 +116,7 @@ public class ReadPartitionIdRequestDetails extends PartitionIdRequestDetails {
 		} else if (theResourceType != null) {
 			op = RestOperationTypeEnum.EXTENDED_OPERATION_TYPE;
 		} else {
-			op = RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE;
+			op = RestOperationTypeEnum.EXTENDED_OPERATION_SERVER;
 		}
 
 		return new ReadPartitionIdRequestDetails(theResourceType, op, null, null, null, null, theExtendedOperationName);

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.model.ReadPartitionIdRequestDetails;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
@@ -185,9 +186,12 @@ public class BulkDataExportProvider {
 			theOptions.setResourceTypes(resourceTypes);
 		}
 
+		ReadPartitionIdRequestDetails theDetails =
+				ReadPartitionIdRequestDetails.forOperation(null, null, ProviderConstants.OPERATION_EXPORT);
+
 		// Determine and validate partition permissions (if needed).
 		RequestPartitionId partitionId =
-				myRequestPartitionHelperService.determineReadPartitionForRequest(theRequestDetails, null);
+				myRequestPartitionHelperService.determineReadPartitionForRequest(theRequestDetails, theDetails);
 		myRequestPartitionHelperService.validateHasPartitionPermissions(theRequestDetails, "Binary", partitionId);
 		theOptions.setPartitionId(partitionId);
 


### PR DESCRIPTION
#5659 

- populate the ReadPartitionIdRequestDetails which was null before causing the NPE
- fix forOperation method in ReadPartitionIdRequestDetails to return EXTENDED_OPERATION_SERVER when resource type and resource id are both null
- change logic in PatientIdPartitionInterceptor to return all partitions for EXTENDED_OPERATION_SERVER operations
- tests