### PR TITLE
Revert Remote Terminology lookup operation to support all types of CodeSystem property and convert to them to string type.

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5700-remote-terminology-service-throws-exception-unsupported-property-types.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_0_0/5700-remote-terminology-service-throws-exception-unsupported-property-types.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5700
+title: "Previously (this release cycle), when you call `RemoteTerminologyServiceValidationSupport` method `lookupCode` 
+with a `CodeSystem` that has properties that are not `string` or `Coding`, the method would throw an exception. 
+It should instead accept any type and convert any unsupported type to `string`. This has been fixed."

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -313,10 +313,10 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				conceptProperty = new CodingConceptProperty(
 						propertyName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
+				// TODO: add other property types as per FHIR spec https://github.com/hapifhir/hapi-fhir/issues/5699
 			default:
+				// other types will not fail for Remote Terminology
 				conceptProperty = new StringConceptProperty(propertyName, value.toString());
-				// throw new InternalErrorException(Msg.code(2450) + "Property type " + fhirType + " is not
-				// supported.");
 		}
 		return conceptProperty;
 	}
@@ -348,10 +348,10 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				conceptProperty =
 						new CodingConceptProperty(theName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
+				// TODO: add other property types as per FHIR spec https://github.com/hapifhir/hapi-fhir/issues/5699
 			default:
+				// other types will not fail for Remote Terminology
 				conceptProperty = new StringConceptProperty(theName, theValue.toString());
-				// throw new InternalErrorException(Msg.code(2451) + "Property type " + fhirType + " is not supportedis
-				// not supported.");
 		}
 		return conceptProperty;
 	}
@@ -450,10 +450,10 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				conceptProperty = new CodingConceptProperty(
 						propertyName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
+				// TODO: add other property types as per FHIR spec https://github.com/hapifhir/hapi-fhir/issues/5699
 			default:
+				// other types will not fail for Remote Terminology
 				conceptProperty = new StringConceptProperty(propertyName, value.toString());
-				// throw new InternalErrorException(Msg.code(2452) + "Property type " + fhirType + " is not
-				// supported.");
 		}
 		return conceptProperty;
 	}
@@ -472,10 +472,10 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				conceptProperty =
 						new CodingConceptProperty(theName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
+				// TODO: add other property types as per FHIR spec https://github.com/hapifhir/hapi-fhir/issues/5699
 			default:
+				// other types will not fail for Remote Terminology
 				conceptProperty = new StringConceptProperty(theName, theValue.toString());
-				// throw new InternalErrorException(Msg.code(2453) + "Property type " + fhirType + " is not
-				// supported.");
 		}
 		return conceptProperty;
 	}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -315,7 +315,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 						propertyName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
 			default:
-				throw new InternalErrorException(Msg.code(2450) + "Property type " + fhirType + " is not supported.");
+				conceptProperty = new StringConceptProperty(propertyName, value.toString());
+				// throw new InternalErrorException(Msg.code(2450) + "Property type " + fhirType + " is not supported.");
 		}
 		return conceptProperty;
 	}
@@ -348,7 +349,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 						new CodingConceptProperty(theName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
 			default:
-				throw new InternalErrorException(Msg.code(2451) + "Property type " + fhirType + " is not supported.");
+				conceptProperty = new StringConceptProperty(theName, theValue.toString());
+				// throw new InternalErrorException(Msg.code(2451) + "Property type " + fhirType + " is not supportedis not supported.");
 		}
 		return conceptProperty;
 	}
@@ -448,7 +450,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 						propertyName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
 			default:
-				throw new InternalErrorException(Msg.code(2452) + "Property type " + fhirType + " is not supported.");
+				conceptProperty = new StringConceptProperty(propertyName, value.toString());
+				// throw new InternalErrorException(Msg.code(2452) + "Property type " + fhirType + " is not supported.");
 		}
 		return conceptProperty;
 	}
@@ -468,7 +471,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 						new CodingConceptProperty(theName, coding.getSystem(), coding.getCode(), coding.getDisplay());
 				break;
 			default:
-				throw new InternalErrorException(Msg.code(2453) + "Property type " + fhirType + " is not supported.");
+				conceptProperty = new StringConceptProperty(theName, theValue.toString());
+				// throw new InternalErrorException(Msg.code(2453) + "Property type " + fhirType + " is not supported.");
 		}
 		return conceptProperty;
 	}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -12,7 +12,6 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IQuery;
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.ParametersUtil;
 import jakarta.annotation.Nonnull;
@@ -316,7 +315,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				break;
 			default:
 				conceptProperty = new StringConceptProperty(propertyName, value.toString());
-				// throw new InternalErrorException(Msg.code(2450) + "Property type " + fhirType + " is not supported.");
+				// throw new InternalErrorException(Msg.code(2450) + "Property type " + fhirType + " is not
+				// supported.");
 		}
 		return conceptProperty;
 	}
@@ -350,7 +350,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				break;
 			default:
 				conceptProperty = new StringConceptProperty(theName, theValue.toString());
-				// throw new InternalErrorException(Msg.code(2451) + "Property type " + fhirType + " is not supportedis not supported.");
+				// throw new InternalErrorException(Msg.code(2451) + "Property type " + fhirType + " is not supportedis
+				// not supported.");
 		}
 		return conceptProperty;
 	}
@@ -451,7 +452,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				break;
 			default:
 				conceptProperty = new StringConceptProperty(propertyName, value.toString());
-				// throw new InternalErrorException(Msg.code(2452) + "Property type " + fhirType + " is not supported.");
+				// throw new InternalErrorException(Msg.code(2452) + "Property type " + fhirType + " is not
+				// supported.");
 		}
 		return conceptProperty;
 	}
@@ -472,7 +474,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 				break;
 			default:
 				conceptProperty = new StringConceptProperty(theName, theValue.toString());
-				// throw new InternalErrorException(Msg.code(2453) + "Property type " + fhirType + " is not supported.");
+				// throw new InternalErrorException(Msg.code(2453) + "Property type " + fhirType + " is not
+				// supported.");
 		}
 		return conceptProperty;
 	}

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/ILookupCodeTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/ILookupCodeTest.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.common.hapi.validation.support.RemoteTerminologyServiceValidationSupport;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +50,8 @@ public interface ILookupCodeTest {
 		@Override
 		IMySimpleCodeSystemProvider getCodeSystemProvider();
 
+		//TODO: workaround for unsupported types, enable this test when rest of the types are supported
+		@Disabled
 		@Test
 		default void testLookupCode_forCodeSystemWithPropertyInvalidValue_throwsException() {
 			// test and verify
@@ -60,6 +63,8 @@ public interface ILookupCodeTest {
 			}
 		}
 
+		//TODO: workaround for unsupported types, enable this test when rest of the types are supported
+		@Disabled
 		@Test
 		default void testCreateConceptProperty_forCodeSystemWithPropertyInvalidValue_throwsException() {
 			// test and verify

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/ILookupCodeTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/ILookupCodeTest.java
@@ -7,7 +7,6 @@ import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.common.hapi.validation.support.RemoteTerminologyServiceValidationSupport;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,47 +40,10 @@ public interface ILookupCodeTest {
 	}
 
 	@Nested
-	interface ILookupCodeUnsupportedPropertyTypeTest extends IValidationTest {
-
-		String getInvalidValueErrorCode();
-
-		String getInvalidValueErrorCodeForConvert();
-
-		@Override
-		IMySimpleCodeSystemProvider getCodeSystemProvider();
-
-		//TODO: workaround for unsupported types, enable this test when rest of the types are supported
-		@Disabled
-		@Test
-		default void testLookupCode_forCodeSystemWithPropertyInvalidValue_throwsException() {
-			// test and verify
-			try {
-				getService().lookupCode(null, new LookupCodeRequest(CODE_SYSTEM, CODE, LANGUAGE, null));
-				fail();
-			} catch (InternalErrorException e) {
-				assertTrue(e.getMessage().contains(getInvalidValueErrorCode() + ": Property type " + getCodeSystemProvider().getPropertyValue().fhirType() + " is not supported"));
-			}
-		}
-
-		//TODO: workaround for unsupported types, enable this test when rest of the types are supported
-		@Disabled
-		@Test
-		default void testCreateConceptProperty_forCodeSystemWithPropertyInvalidValue_throwsException() {
-			// test and verify
-			try {
-				RemoteTerminologyServiceValidationSupport.createConceptProperty("property", getCodeSystemProvider().getPropertyValue());
-				fail();
-			} catch (InternalErrorException e) {
-				assertTrue(e.getMessage().contains(getInvalidValueErrorCodeForConvert() + ": Property type " + getCodeSystemProvider().getPropertyValue().fhirType() + " is not supported"));
-			}
-		}
-	}
-
-	@Nested
 	interface ILookupCodeSupportedPropertyTest extends IValidationTest {
 		IMyCodeSystemProvider getCodeSystemProvider();
 
-		 Stream<Arguments> getEmptyPropertyValues();
+		Stream<Arguments> getEmptyPropertyValues();
 
 		Stream<Arguments> getPropertyValues();
 

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/LookupCodeDstu3Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/LookupCodeDstu3Test.java
@@ -22,6 +22,7 @@ import org.hl7.fhir.dstu3.model.BooleanType;
 import org.hl7.fhir.dstu3.model.CodeSystem;
 import org.hl7.fhir.dstu3.model.CodeType;
 import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.dstu3.model.StringType;
@@ -29,12 +30,16 @@ import org.hl7.fhir.dstu3.model.Type;
 import org.hl7.fhir.dstu3.model.UriType;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DecimalType;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -84,9 +89,8 @@ public class LookupCodeDstu3Test {
 
 		@BeforeEach
 		public void before() {
-			// TODO: use another type when "code" is added to the supported types
 			myMySimplePropertyCodeSystemProvider.myPropertyName = "somePropertyName";
-			myMySimplePropertyCodeSystemProvider.myPropertyValue = new CodeType("someCode");
+			myMySimplePropertyCodeSystemProvider.myPropertyValue = new IdType(123);
 			ourRestfulServerExtension.getRestfulServer().registerProvider(myMySimplePropertyCodeSystemProvider);
 		}
 	}
@@ -116,8 +120,13 @@ public class LookupCodeDstu3Test {
 			String type = theConceptProperty.getType();
 			switch (type) {
 				case IValidationSupport.TYPE_STRING -> {
-					assertTrue(theExpectedValue instanceof StringType);
-					StringType stringValue = (StringType) theExpectedValue;
+					if (!(theExpectedValue instanceof StringType stringValue)) {
+						// TODO: workaround for unsupported types, remove this branch when rest of the types are supported
+						IValidationSupport.StringConceptProperty stringConceptProperty = (IValidationSupport.StringConceptProperty) theConceptProperty;
+						assertEquals(theExpectedValue.toString(), stringConceptProperty.getValue());
+						break;
+					}
+					// StringType stringValue = (StringType) theExpectedValue;
 					assertTrue(theConceptProperty instanceof StringConceptProperty);
 					StringConceptProperty stringConceptProperty = (StringConceptProperty) theConceptProperty;
 					assertEquals(stringValue.getValue(), stringConceptProperty.getValue());
@@ -150,7 +159,12 @@ public class LookupCodeDstu3Test {
 		public Stream<Arguments> getPropertyValues() {
 			return Stream.of(
 				Arguments.arguments(new StringType("value")),
-				Arguments.arguments(new Coding("code", "system", "display"))
+				Arguments.arguments(new Coding("code", "system", "display")),
+				Arguments.arguments(new CodeType("code")),
+				Arguments.arguments(new BooleanType(true)),
+				Arguments.arguments(new IntegerType(1)),
+				Arguments.arguments(new DecimalType(1.1)),
+				Arguments.arguments(new DateTimeType(Calendar.getInstance()))
 			);
 		}
 

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/LookupCodeR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/LookupCodeR4Test.java
@@ -23,6 +23,10 @@ import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DecimalType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Type;
@@ -33,6 +37,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -80,9 +85,8 @@ public class LookupCodeR4Test {
 
 		@BeforeEach
 		public void before() {
-			// TODO: use another type when "code" is added to the supported types
 			myMySimplePropertyCodeSystemProvider.myPropertyName = "somePropertyName";
-			myMySimplePropertyCodeSystemProvider.myPropertyValue = new CodeType("someCode");
+			myMySimplePropertyCodeSystemProvider.myPropertyValue = new IdType(123);
 			ourRestfulServerExtension.getRestfulServer().registerProvider(myMySimplePropertyCodeSystemProvider);
 		}
 	}
@@ -113,8 +117,13 @@ public class LookupCodeR4Test {
 			String type = theConceptProperty.getType();
 			switch (type) {
 				case IValidationSupport.TYPE_STRING -> {
-					assertTrue(theExpectedValue instanceof StringType);
-					StringType stringValue = (StringType) theExpectedValue;
+					if (!(theExpectedValue instanceof StringType stringValue)) {
+						// TODO: workaround for unsupported types, remove this when rest of the types are supported
+						IValidationSupport.StringConceptProperty stringConceptProperty = (IValidationSupport.StringConceptProperty) theConceptProperty;
+						assertEquals(theExpectedValue.toString(), stringConceptProperty.getValue());
+						break;
+					}
+					// StringType stringValue = (StringType) theExpectedValue;
 					assertTrue(theConceptProperty instanceof IValidationSupport.StringConceptProperty);
 					IValidationSupport.StringConceptProperty stringConceptProperty = (IValidationSupport.StringConceptProperty) theConceptProperty;
 					assertEquals(stringValue.getValue(), stringConceptProperty.getValue());
@@ -147,11 +156,14 @@ public class LookupCodeR4Test {
 		public Stream<Arguments> getPropertyValues() {
 			return Stream.of(
 				Arguments.arguments(new StringType("value")),
-				Arguments.arguments(new Coding("code", "system", "display"))
+				Arguments.arguments(new Coding("code", "system", "display")),
+				Arguments.arguments(new CodeType("code")),
+				Arguments.arguments(new BooleanType(true)),
+				Arguments.arguments(new IntegerType(1)),
+				Arguments.arguments(new DecimalType(1.1)),
+				Arguments.arguments(new DateTimeType(Calendar.getInstance()))
 			);
 		}
-
-
 
 		public Stream<Arguments> getDesignations() {
 			return Stream.of(


### PR DESCRIPTION
Closes #5700 
Related #5699 