### PR TITLE
Fix validation caching issue with initially unpopulated StructureDefinitions

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5707-structure-definition-cache-not-refreshed-with-new-entry.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5707-structure-definition-cache-not-refreshed-with-new-entry.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 5707
+jira: SMILE-7270
+title: "Previously, with validation active, when a user POSTed a resource with a meta profile with a non-existent 
+        StructureDefinition URL, then POSTed the StructureDefinition, POSTing the same or another patient with that same 
+        meta profile URL would still fail with a VALIDATION_VAL_PROFILE_UNKNOWN_NOT_POLICY validation error.
+        This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/9999-something.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/9999-something.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 9999
+title: "Something"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/9999-something.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/9999-something.yaml
@@ -1,4 +1,0 @@
----
-type: fix
-issue: 9999
-title: "Something"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
@@ -191,7 +191,8 @@ public class JpaPersistedResourceValidationSupport implements IValidationSupport
 		IBaseResource fetched = myLoadCache.get(key, t -> doFetchResource(theClass, theUri));
 
 		if (fetched == myNoMatch) {
-			ourLog.debug("Invalidating cache entry for URI: {} since the result of the underlying query is empty", theUri);
+			ourLog.debug(
+					"Invalidating cache entry for URI: {} since the result of the underlying query is empty", theUri);
 			myLoadCache.invalidate(key);
 			return null;
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
@@ -188,6 +188,7 @@ public class JpaPersistedResourceValidationSupport implements IValidationSupport
 		IBaseResource fetched = myLoadCache.get(key, t -> doFetchResource(theClass, theUri));
 
 		if (fetched == myNoMatch) {
+			myLoadCache.invalidate(key);
 			return null;
 		}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
@@ -91,6 +91,9 @@ public class JpaPersistedResourceValidationSupport implements IValidationSupport
 	// TermReadSvcImpl calls these methods as a part of its "isCodeSystemSupported" calls.
 	// We should modify CachingValidationSupport to cache the results of "isXXXSupported"
 	// at which point we could do away with this cache
+	// TODO:  LD: This cache seems to supersede the cache in CachingValidationSupport, as that cache is set to
+	// 10 minutes, but this 1 minute cache now determines the expiry.
+	// This new behaviour was introduced between the 7.0.0 release and the current master (7.2.0)
 	private Cache<String, IBaseResource> myLoadCache = CacheFactory.build(TimeUnit.MINUTES.toMillis(1), 1000);
 
 	/**
@@ -188,6 +191,7 @@ public class JpaPersistedResourceValidationSupport implements IValidationSupport
 		IBaseResource fetched = myLoadCache.get(key, t -> doFetchResource(theClass, theUri));
 
 		if (fetched == myNoMatch) {
+			ourLog.debug("Invalidating cache entry for URI: {} since the result of the underlying query is empty", theUri);
 			myLoadCache.invalidate(key);
 			return null;
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
@@ -600,7 +600,7 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 			fail(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(e.getOperationOutcome()));
 		}
 		myCaptureQueriesListener.logSelectQueriesForCurrentThread();
-		assertEquals(12, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+		assertEquals(14, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getDeleteQueriesForCurrentThread().size());
@@ -610,14 +610,14 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 		myCaptureQueriesListener.clear();
 		myObservationDao.validate(obs, null, null, null, null, null, null);
 		myCaptureQueriesListener.logSelectQueriesForCurrentThread();
-		assertEquals(0, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+		assertEquals(6, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		myCaptureQueriesListener.logUpdateQueriesForCurrentThread();
 		assertEquals(0, myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
 		myCaptureQueriesListener.logInsertQueriesForCurrentThread();
 		assertEquals(0, myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
 		myCaptureQueriesListener.logDeleteQueriesForCurrentThread();
 		assertEquals(0, myCaptureQueriesListener.getDeleteQueriesForCurrentThread().size());
-		assertEquals(0, myCaptureQueriesListener.getCommitCount());
+		assertEquals(6, myCaptureQueriesListener.getCommitCount());
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ValidateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ValidateTest.java
@@ -1991,7 +1991,7 @@ public class FhirResourceDaoR4ValidateTest extends BaseJpaR4Test {
 		private static final Patient PATIENT_WITH_FAKE_URL = createPatient("https://www.i.do.not.exist.com");
 
 		@Test
-		public void testValidateUsingDifferentialProfile_StructDefThenPatient() throws IOException {
+		public void createStructDefThenValidatePatientWithRealUrl() throws IOException {
 			// setup
 			createStructureDefinitionInDao();
 
@@ -2003,7 +2003,7 @@ public class FhirResourceDaoR4ValidateTest extends BaseJpaR4Test {
 		}
 
 		@Test
-		public void testValidateUsingDifferentialProfile_PatientWithFakeUrlStructDefThenPatientWithRealUrl() throws IOException {
+		public void validatePatientWithFakeUrlStructDefThenValidatePatientWithRealUrl() throws IOException {
 			// setup
 			final String outcomePatientValidateFakeUrl = validate(PATIENT_WITH_FAKE_URL);
 			assertTrue(outcomePatientValidateFakeUrl.contains(I18nConstants.VALIDATION_VAL_PROFILE_UNKNOWN_NOT_POLICY));
@@ -2017,7 +2017,7 @@ public class FhirResourceDaoR4ValidateTest extends BaseJpaR4Test {
 		}
 
 		@Test
-		public void testValidateUsingDifferentialProfile_PatientThenStructDef() throws IOException {
+		public void validatePatientRealUrlThenCreateStructDefThenValidatePatientWithRealUrl() throws IOException {
 			// setup
 			final String outcomePatientValidateInitial = validate(PATIENT_WITH_REAL_URL);
 			assertTrue(outcomePatientValidateInitial.contains(I18nConstants.VALIDATION_VAL_PROFILE_UNKNOWN_NOT_POLICY));

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
@@ -256,7 +256,8 @@ public class CachingValidationSupport extends BaseValidationSupportWrapper imple
 
 		// UGH!  Animal sniffer :(
 		if (!result.isPresent()) {
-			ourLog.debug("Invalidating cache entry for key: {} since the result of the underlying query is empty", theKey);
+			ourLog.debug(
+					"Invalidating cache entry for key: {} since the result of the underlying query is empty", theKey);
 			theCache.invalidate(theKey);
 		}
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
@@ -254,9 +254,9 @@ public class CachingValidationSupport extends BaseValidationSupportWrapper imple
 		Optional<T> result = (Optional<T>) theCache.get(theKey, loaderWrapper);
 		assert result != null;
 
-		// LUKETODO:  this is new code:
-		if (result.isEmpty()) {
-			ourLog.info("5167: INVALIDATED!");
+		// UGH!  Animal sniffer :(
+		if (!result.isPresent()) {
+			ourLog.debug("Invalidating cache entry for key: {} since the result of the underlying query is empty", theKey);
 			theCache.invalidate(theKey);
 		}
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
@@ -254,6 +254,12 @@ public class CachingValidationSupport extends BaseValidationSupportWrapper imple
 		Optional<T> result = (Optional<T>) theCache.get(theKey, loaderWrapper);
 		assert result != null;
 
+		// LUKETODO:  this is new code:
+		if (result.isEmpty()) {
+			ourLog.info("5167: INVALIDATED!");
+			theCache.invalidate(theKey);
+		}
+
 		return result.orElse(null);
 	}
 


### PR DESCRIPTION
- Invalidate 2 different caches if the underlying DAO query returns an empty result
- New tests
- A TODO indicating that a change happened in the validation caching behaviour

Closes https://github.com/hapifhir/hapi-fhir/issues/5707