### PR TITLE
Make seaech URL cleanup job clustered

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/ResourceSearchUrlSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/ResourceSearchUrlSvc.java
@@ -35,7 +35,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Date;
 
 /**
- * This service ensures uniqueness of resources during create or create-on-update by storing the resource searchUrl.
+ * This service ensures uniqueness of resources during create or create-on-update
+ * by storing the resource searchUrl.
+ *
+ * @see SearchUrlJobMaintenanceSvcImpl which deletes stale entities
  */
 @Transactional
 @Service

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchUrlJobMaintenanceSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchUrlJobMaintenanceSvcImpl.java
@@ -61,7 +61,7 @@ public class SearchUrlJobMaintenanceSvcImpl implements ISearchUrlJobMaintenanceS
 		ScheduledJobDefinition jobDetail = new ScheduledJobDefinition();
 		jobDetail.setId(SearchUrlMaintenanceJob.class.getName());
 		jobDetail.setJobClass(SearchUrlMaintenanceJob.class);
-		theSchedulerService.scheduleLocalJob(10 * DateUtils.MILLIS_PER_MINUTE, jobDetail);
+		theSchedulerService.scheduleClusteredJob(10 * DateUtils.MILLIS_PER_MINUTE, jobDetail);
 	}
 
 	private Date calculateCutoffDate() {

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceSearchUrlEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceSearchUrlEntity.java
@@ -29,6 +29,15 @@ import jakarta.persistence.TemporalType;
 
 import java.util.Date;
 
+/**
+ * This entity is used to enforce uniqueness on a given search URL being
+ * used as a conditional operation URL, e.g. a conditional create or a
+ * conditional update. When we perform a conditional operation that is
+ * creating a new resource, we store an entity with the conditional URL
+ * in this table. The URL is the PK of the table, so the database
+ * ensures that two concurrent threads don't accidentally create two
+ * resources with the same conditional URL.
+ */
 @Entity
 @Table(
 		name = "HFJ_RES_SEARCH_URL",


### PR DESCRIPTION
A scheduled job to clean up the Search URL table used to enforce uniqueness of conditional create/update jobs was created as a local job and not a clustered job. This has been fixed.