### PR TITLE
5771 patch operation failing for complex extension

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5711-fix-patch-operation-failing-for-complex-extension.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5711-fix-patch-operation-failing-for-complex-extension.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5771
+jira: SMILE-7837
+title: "Previously, a Patch operation would fail when adding a complex extension, i.e. an extension
+comprised of another extension.  This issue has been fixed."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/patch/FhirPatchApplyR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/patch/FhirPatchApplyR4Test.java
@@ -535,6 +535,10 @@ public class FhirPatchApplyR4Test {
 
 	@Test
 	public void testAddExtensionWithExtension() {
+		final String extensionUrl  = "http://foo/fhir/extension/foo";
+		final String innerExtensionUrl  = "http://foo/fhir/extension/innerExtension";
+		final String innerExtensionValue = "2021-07-24T13:23:30-04:00";
+
 		FhirPatch svc = new FhirPatch(ourCtx);
 		Patient patient = new Patient();
 
@@ -546,7 +550,7 @@ public class FhirPatchApplyR4Test {
 			.addPart(
 				new Parameters.ParametersParameterComponent()
 					.setName("url")
-					.setValue(new UriType("http://foo/fhir/extension/foo"))
+					.setValue(new UriType(extensionUrl))
 			)
 			.addPart(
 				new Parameters.ParametersParameterComponent()
@@ -554,18 +558,18 @@ public class FhirPatchApplyR4Test {
 					.addPart(
 						new Parameters.ParametersParameterComponent()
 							.setName("url")
-							.setValue(new UriType("http://foo/fhir/extension/innerExtension"))
+							.setValue(new UriType(innerExtensionUrl))
 					)
 					.addPart(
 						new Parameters.ParametersParameterComponent()
 							.setName("value")
-							.setValue(new DateTimeType("2021-07-24T13:23:30-04:00"))
+							.setValue(new DateTimeType(innerExtensionValue))
 					)
 			);
 
 		patch.addParameter(addOperation);
 
-		ourLog.debug("Patch:\n{}", ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(patch));
+		ourLog.info("Patch:\n{}", ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(patch));
 
 		svc.apply(patient, patch);
 		ourLog.debug("Outcome:\n{}", ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(patient));
@@ -573,11 +577,12 @@ public class FhirPatchApplyR4Test {
 		//Then: it adds the new extension correctly.
 		assertThat(patient.getExtension(), hasSize(1));
 		Extension extension = patient.getExtension().get(0);
-		assertThat(extension.getUrl(), is(equalTo("http://foo/fhir/extension/foo")));
+		assertThat(extension.getUrl(), is(equalTo(extensionUrl)));
 		Extension innerExtension = extension.getExtensionFirstRep();
 
 		assertThat(innerExtension, notNullValue());
-		assertThat(innerExtension.getUrl(), is(equalTo("http://foo/fhir/extension/innerExtension")));
+		assertThat(innerExtension.getUrl(), is(equalTo(innerExtensionUrl)));
+		assertThat(innerExtension.getValue().primitiveValue(), is(equalTo(innerExtensionValue)));
 
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/patch/FhirPatch.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/patch/FhirPatch.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseEnumeration;
-import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -315,12 +314,11 @@ public class FhirPatch {
 		Optional<IBase> valuePartValue =
 				ParametersUtil.getParameterPartValue(myContext, theParameters, PARAMETER_VALUE);
 
-		IBase newValue = null;
+		IBase newValue;
 		if (valuePartValue.isPresent()) {
 			newValue = valuePartValue.get();
 		} else {
-			List<IBase> partParts =
-					valuePart.isPresent() ? extractPartsFromPart(valuePart.get()) : Collections.emptyList();
+			List<IBase> partParts = valuePart.map(this::extractPartsFromPart).orElse(Collections.emptyList());
 
 			newValue = createAndPopulateNewElement(theChildDefinition, partParts);
 		}
@@ -420,17 +418,6 @@ public class FhirPatch {
 				if (theElement instanceof IPrimitiveType) {
 					((IPrimitiveType<?>) theElement).setValueAsString(null);
 				}
-				return true;
-			}
-
-			@Override
-			public boolean acceptUndeclaredExtension(
-					IBaseExtension<?, ?> theNextExt,
-					List<IBase> theContainingElementPath,
-					List<BaseRuntimeChildDefinition> theChildDefinitionPath,
-					List<BaseRuntimeElementDefinition<?>> theElementDefinitionPath) {
-				theNextExt.setUrl(null);
-				theNextExt.setValue(null);
 				return true;
 			}
 		});
@@ -597,7 +584,7 @@ public class FhirPatch {
 		 * If the value is a Resource or a datatype, we can put it into the part.value and that will cover
 		 * all of its children. If it's an infrastructure element though, such as Patient.contact we can't
 		 * just put it into part.value because it isn't an actual type. So we have to put all of its
-		 * childen in instead.
+		 * children in instead.
 		 */
 		if (valueDef.isStandardType()) {
 			ParametersUtil.addPart(myContext, operation, PARAMETER_VALUE, value);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/patch/FhirPatch.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/patch/FhirPatch.java
@@ -39,7 +39,6 @@ import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
 import java.util.ArrayList;
@@ -321,7 +320,8 @@ public class FhirPatch {
 			newValue = valuePartValue.get();
 		} else {
 			List<IBase> partParts =
-					extractPartsFromPart(valuePart.orElse(new Parameters.ParametersParameterComponent()));
+					valuePart.isPresent() ? extractPartsFromPart(valuePart.get()) : Collections.emptyList();
+
 			newValue = createAndPopulateNewElement(theChildDefinition, partParts);
 		}
 


### PR DESCRIPTION
**Supporting documents:**
- [Extension](https://hl7.org/fhir/extensibility.html#extension)
- [Fhirpatch](https://build.fhir.org/fhirpatch.html)

**What was done:**
- added a failing test;
- for a Patch.Add operation, added constructions to recursively process embedded composite types such as Extension that can be composed of an endless chain of Extensions.  for an example of a patch Parameter with multiple embedded Extensions, refer to the #5771 problem statement.
- added changelog.