### PR TITLE
Resolve 5790 Prefix a unit test log for hibernate exception in HapiFhirHibernateJpaDialect

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HapiFhirHibernateJpaDialect.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HapiFhirHibernateJpaDialect.java
@@ -74,7 +74,7 @@ public class HapiFhirHibernateJpaDialect extends HibernateJpaDialect {
 		}
 
 		if (HapiSystemProperties.isUnitTestModeEnabled()) {
-			ourLog.error("Hibernate exception", theException);
+			ourLog.error("Unit test: Hibernate exception", theException);
 		}
 
 		if (theException instanceof ConstraintViolationException) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HapiFhirHibernateJpaDialect.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HapiFhirHibernateJpaDialect.java
@@ -74,7 +74,7 @@ public class HapiFhirHibernateJpaDialect extends HibernateJpaDialect {
 		}
 
 		if (HapiSystemProperties.isUnitTestModeEnabled()) {
-			ourLog.error("Unit test: Hibernate exception", theException);
+			ourLog.error("Unit test mode: Hibernate exception", theException);
 		}
 
 		if (theException instanceof ConstraintViolationException) {


### PR DESCRIPTION
What was done:
- prefixed the log message with "Unit test: "  to avoid confusion in testing environments.