### PR TITLE
Add _language param to providers

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5XXX-add-_language-param.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5XXX-add-_language-param.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 5XXX
+title: "Support for the _language parameter was added and works for DSTU2/3, R4 and R5 but did not work
+because the _language parameter was not added to the resource providers. Additionally, no error message
+was returned when language support was disabled and a search with _language was performed. This has 
+been fixed."
+

--- a/hapi-fhir-jpaserver-test-dstu2/src/test/java/ca/uhn/fhir/jpa/provider/ResourceProviderLanguageParamDstu2Test.java
+++ b/hapi-fhir-jpaserver-test-dstu2/src/test/java/ca/uhn/fhir/jpa/provider/ResourceProviderLanguageParamDstu2Test.java
@@ -1,0 +1,78 @@
+package ca.uhn.fhir.jpa.provider;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.model.primitive.CodeDt;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.gclient.TokenClientParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.model.dstu2.resource.Patient;
+import ca.uhn.fhir.model.dstu2.resource.Bundle;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ResourceProviderLanguageParamDstu2Test extends BaseResourceProviderDstu2Test {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ResourceProviderLanguageParamDstu2Test.class);
+
+	@BeforeEach
+	@Override
+	public void before() throws Exception {
+		super.before();
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamEnabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(true);
+		mySearchParamRegistry.forceRefresh();
+
+		Patient pat = new Patient();
+		pat.setLanguage(new CodeDt("en"));
+		IIdType patId = myPatientDao.create(pat, mySrd).getId().toUnqualifiedVersionless();
+
+		Patient pat2 = new Patient();
+		pat.setLanguage(new CodeDt("fr"));
+		IIdType patId2 = myPatientDao.create(pat2, mySrd).getId().toUnqualifiedVersionless();
+
+		List<String> foundResources;
+		Bundle result;
+
+		result = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		foundResources = toUnqualifiedVersionlessIdValues(result);
+		assertThat(foundResources, contains(patId.getValue()));
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamDisabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myClient
+				.search()
+				.forResource(Patient.class)
+				.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+				.returnBundle(Bundle.class)
+				.execute();
+		});
+		assertThat(exception.getMessage(), containsString(Msg.code(1223)));
+	}
+}

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderLanguageParamDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderLanguageParamDstu3Test.java
@@ -1,0 +1,96 @@
+package ca.uhn.fhir.jpa.provider.dstu3;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.gclient.TokenClientParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ResourceProviderLanguageParamDstu3Test extends BaseResourceProviderDstu3Test {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ResourceProviderLanguageParamDstu3Test.class);
+
+	@BeforeEach
+	@Override
+	public void before() throws Exception {
+		super.before();
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamEnabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(true);
+		mySearchParamRegistry.forceRefresh();
+
+		Patient pat = new Patient();
+		pat.setLanguage("en");
+		IIdType patId = myPatientDao.create(pat, mySrd).getId().toUnqualifiedVersionless();
+
+		Patient pat2 = new Patient();
+		pat.setLanguage("fr");
+		IIdType patId2 = myPatientDao.create(pat2, mySrd).getId().toUnqualifiedVersionless();
+
+		SearchParameterMap map;
+		IBundleProvider results;
+		List<String> foundResources;
+		Bundle result;
+
+		result = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		foundResources = toUnqualifiedVersionlessIdValues(result);
+		assertThat(foundResources, contains(patId.getValue()));
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamDisabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+
+		Patient pat = new Patient();
+		pat.setLanguage("en");
+		IIdType patId = myPatientDao.create(pat, mySrd).getId().toUnqualifiedVersionless();
+
+		Patient pat2 = new Patient();
+		pat.setLanguage("fr");
+		IIdType patId2 = myPatientDao.create(pat2, mySrd).getId().toUnqualifiedVersionless();
+
+		SearchParameterMap map;
+		IBundleProvider results;
+		List<String> foundResources;
+		Bundle result;
+
+
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myClient
+				.search()
+				.forResource(Patient.class)
+				.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+				.returnBundle(Bundle.class)
+				.execute();
+		});
+		assertThat(exception.getMessage(), containsString(Msg.code(1223)));
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderLanguageParamR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderLanguageParamR4Test.java
@@ -1,0 +1,129 @@
+package ca.uhn.fhir.jpa.provider.r4;
+
+import ca.uhn.fhir.batch2.jobs.reindex.ReindexAppCtx;
+import ca.uhn.fhir.batch2.jobs.reindex.ReindexJobParameters;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
+import ca.uhn.fhir.jpa.entity.Search;
+import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamString;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.model.search.SearchStatusEnum;
+import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
+import ca.uhn.fhir.rest.gclient.StringClientParam;
+import ca.uhn.fhir.rest.gclient.TokenClientParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import ca.uhn.fhir.util.BundleUtil;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Appointment;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestComponent;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestResourceComponent;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestResourceSearchParamComponent;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Observation.ObservationStatus;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.SearchParameter;
+import org.hl7.fhir.r4.model.SearchParameter.XPathUsageType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ResourceProviderLanguageParamR4Test extends BaseResourceProviderR4Test {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ResourceProviderLanguageParamR4Test.class);
+
+	@BeforeEach
+	@Override
+	public void before() throws Exception {
+		super.before();
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamEnabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(true);
+		mySearchParamRegistry.forceRefresh();
+
+		Patient pat = new Patient();
+		pat.setLanguage("en");
+		IIdType patId = myPatientDao.create(pat, mySrd).getId().toUnqualifiedVersionless();
+
+		Patient pat2 = new Patient();
+		pat.setLanguage("fr");
+		IIdType patId2 = myPatientDao.create(pat2, mySrd).getId().toUnqualifiedVersionless();
+
+		List<String> foundResources;
+		Bundle result;
+
+		result = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		foundResources = toUnqualifiedVersionlessIdValues(result);
+		assertThat(foundResources, contains(patId.getValue()));
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamDisabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myClient
+				.search()
+				.forResource(Patient.class)
+				.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+				.returnBundle(Bundle.class)
+				.execute();
+		});
+		assertThat(exception.getMessage(), containsString(Msg.code(1223)));
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4b/src/test/java/ca/uhn/fhir/jpa/provider/r4b/ResourceProviderLanguageParamR4BTest.java
+++ b/hapi-fhir-jpaserver-test-r4b/src/test/java/ca/uhn/fhir/jpa/provider/r4b/ResourceProviderLanguageParamR4BTest.java
@@ -1,0 +1,77 @@
+package ca.uhn.fhir.jpa.provider.r4b;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.gclient.TokenClientParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4b.model.Bundle;
+import org.hl7.fhir.r4b.model.Patient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ResourceProviderLanguageParamR4BTest extends BaseResourceProviderR4BTest {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ResourceProviderLanguageParamR4BTest.class);
+
+	@BeforeEach
+	@Override
+	public void before() throws Exception {
+		super.before();
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamEnabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(true);
+		mySearchParamRegistry.forceRefresh();
+
+		Patient pat = new Patient();
+		pat.setLanguage("en");
+		IIdType patId = myPatientDao.create(pat, mySrd).getId().toUnqualifiedVersionless();
+
+		Patient pat2 = new Patient();
+		pat.setLanguage("fr");
+		IIdType patId2 = myPatientDao.create(pat2, mySrd).getId().toUnqualifiedVersionless();
+
+		List<String> foundResources;
+		Bundle result;
+
+		result = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		foundResources = toUnqualifiedVersionlessIdValues(result);
+		assertThat(foundResources, contains(patId.getValue()));
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamDisabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myClient
+				.search()
+				.forResource(Patient.class)
+				.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+				.returnBundle(Bundle.class)
+				.execute();
+		});
+		assertThat(exception.getMessage(), containsString(Msg.code(1223)));
+	}
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/provider/r5/ResourceProviderLanguageParamR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/provider/r5/ResourceProviderLanguageParamR5Test.java
@@ -1,0 +1,77 @@
+package ca.uhn.fhir.jpa.provider.r5;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.gclient.TokenClientParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.Patient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ResourceProviderLanguageParamR5Test extends BaseResourceProviderR5Test {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ResourceProviderLanguageParamR5Test.class);
+
+	@BeforeEach
+	@Override
+	public void before() throws Exception {
+		super.before();
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamEnabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(true);
+		mySearchParamRegistry.forceRefresh();
+
+		Patient pat = new Patient();
+		pat.setLanguage("en");
+		IIdType patId = myPatientDao.create(pat, mySrd).getId().toUnqualifiedVersionless();
+
+		Patient pat2 = new Patient();
+		pat.setLanguage("fr");
+		IIdType patId2 = myPatientDao.create(pat2, mySrd).getId().toUnqualifiedVersionless();
+
+		List<String> foundResources;
+		Bundle result;
+
+		result = myClient
+			.search()
+			.forResource(Patient.class)
+			.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		foundResources = toUnqualifiedVersionlessIdValues(result);
+		assertThat(foundResources, contains(patId.getValue()));
+	}
+
+	@SuppressWarnings("unused")
+	@Test
+	public void testSearchWithLanguageParamDisabled() {
+		myStorageSettings.setLanguageSearchParameterEnabled(new JpaStorageSettings().isLanguageSearchParameterEnabled());
+		mySearchParamRegistry.forceRefresh();
+
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myClient
+				.search()
+				.forResource(Patient.class)
+				.where(new TokenClientParam(Constants.PARAM_LANGUAGE).exactly().code("en"))
+				.returnBundle(Bundle.class)
+				.execute();
+		});
+		assertThat(exception.getMessage(), containsString(Msg.code(1223)));
+	}
+}

--- a/hapi-tinder-plugin/src/main/resources/vm/jpa_resource_provider.vm
+++ b/hapi-tinder-plugin/src/main/resources/vm/jpa_resource_provider.vm
@@ -73,11 +73,9 @@ public class ${className}ResourceProvider extends
 			@OptionalParam(name=ca.uhn.fhir.rest.api.Constants.PARAM_LIST)
 			StringAndListParam theList,
 
-#if ( $version == 'R5' )
 			@Description(shortDefinition="The language of the resource")
 			@OptionalParam(name=ca.uhn.fhir.rest.api.Constants.PARAM_LANGUAGE)
 			TokenAndListParam theResourceLanguage,
-#end
 
 			@Description(shortDefinition="Search for resources which have the given source value (Resource.meta.source)")
 			@OptionalParam(name=ca.uhn.fhir.rest.api.Constants.PARAM_SOURCE)
@@ -160,9 +158,8 @@ public class ${className}ResourceProvider extends
 			paramMap.add(ca.uhn.fhir.rest.api.Constants.PARAM_PROFILE, theSearchForProfile);
 			paramMap.add(ca.uhn.fhir.rest.api.Constants.PARAM_SOURCE, theSearchForSource);
 			paramMap.add(ca.uhn.fhir.rest.api.Constants.PARAM_LIST, theList);
-#if ( $version == 'R5' )
 			paramMap.add(ca.uhn.fhir.rest.api.Constants.PARAM_LANGUAGE, theResourceLanguage);
-#end
+
 			paramMap.add("_has", theHas);
 #foreach ( $param in $searchParams ) 
 			paramMap.add("${param.name}", the${param.nameCapitalized});


### PR DESCRIPTION
Support for the R5 `_language` parameter also exists for DSTU2/3, R4/4B by enabling `JpaStorageSettings.setLanguageSearchParameterEnabled`.

However, searches with `_language` would not work as expected (due to the parameter being filtered out and not passed to the Dao) and would also not return an error message that the parameter was not supported when `JpaStorageSettings.setLanguageSearchParameterEnabled` was set to `false`.

This PR fixes both of those.