### PR TITLE
MDM expansion doesn't work when using the :mdm qualifier in query string

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/TokenParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/TokenParam.java
@@ -151,7 +151,7 @@ public class TokenParam extends BaseParam /*implements IQueryParameterType*/ {
 		setSystem(null);
 
 		if (theQualifier != null) {
-			if(Constants.PARAMQUALIFIER_MDM.equals(theQualifier)){
+			if (Constants.PARAMQUALIFIER_MDM.equals(theQualifier)) {
 				setMdmExpand(true);
 			}
 
@@ -162,7 +162,6 @@ public class TokenParam extends BaseParam /*implements IQueryParameterType*/ {
 				setValue(ParameterUtil.unescape(theParameter));
 				return;
 			}
-
 		}
 
 		if (theParameter == null) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/TokenParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/TokenParam.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.model.base.composite.BaseCodingDt;
 import ca.uhn.fhir.model.base.composite.BaseIdentifierDt;
 import ca.uhn.fhir.model.primitive.UriDt;
+import ca.uhn.fhir.rest.api.Constants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -147,18 +148,23 @@ public class TokenParam extends BaseParam /*implements IQueryParameterType*/ {
 	@Override
 	void doSetValueAsQueryToken(FhirContext theContext, String theParamName, String theQualifier, String theParameter) {
 		setModifier(null);
+		setSystem(null);
+
 		if (theQualifier != null) {
+			if(Constants.PARAMQUALIFIER_MDM.equals(theQualifier)){
+				setMdmExpand(true);
+			}
+
 			TokenParamModifier modifier = TokenParamModifier.forValue(theQualifier);
 			setModifier(modifier);
 
 			if (modifier == TokenParamModifier.TEXT) {
-				setSystem(null);
 				setValue(ParameterUtil.unescape(theParameter));
 				return;
 			}
+
 		}
 
-		setSystem(null);
 		if (theParameter == null) {
 			setValue(null);
 		} else {

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/StringParamTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/StringParamTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.rest.param;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.api.Constants;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -132,6 +133,23 @@ public class StringParamTest {
 		assertNicknameWarningLogged(false);
 	}
 
+	@Test
+	public void testNameNickname() {
+		StringParam param = new StringParam();
+		assertFalse(param.isNicknameExpand());
+		param.setValueAsQueryToken(myContext, "name", Constants.PARAMQUALIFIER_NICKNAME, "kenny");
+		assertTrue(param.isNicknameExpand());
+	}
+
+	@Test
+	public void testGivenNickname() {
+		StringParam param = new StringParam();
+		assertFalse(param.isNicknameExpand());
+		param.setValueAsQueryToken(myContext, "given", Constants.PARAMQUALIFIER_NICKNAME, "kenny");
+		assertTrue(param.isNicknameExpand());
+	}
+
+
 	private void assertNicknameQualifierSearchParameterIsValid(StringParam theStringParam, String theExpectedValue){
 		assertTrue(theStringParam.isNicknameExpand());
 		assertFalse(theStringParam.isExact());
@@ -164,5 +182,5 @@ public class StringParamTest {
 			assertTrue(warningLogs.isEmpty());
 		}
 	}
-	
+
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5802-fix-mdm-expansion-not-returning-expected-resources.yml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5802-fix-mdm-expansion-not-returning-expected-resources.yml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5802
+title: "Previously, using the ':mdm' qualifier with the '_id' search parameter would not included expanded resources in 
+search result.  This issue has been fixed."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/param/TokenParamTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/param/TokenParamTest.java
@@ -51,12 +51,14 @@ public class TokenParamTest {
 
 	@Test
 	public void testMdmQualifier() {
+		final String value = "Patient/PJANE1";
+
 		TokenParam param = new TokenParam();
-		param.setValueAsQueryToken(ourCtx, "_id", Constants.PARAMQUALIFIER_MDM, "Patient/PJANE1");
+		param.setValueAsQueryToken(ourCtx, "_id", Constants.PARAMQUALIFIER_MDM, value);
 		assertNull(param.getModifier());
 		assertNull(param.getSystem());
 		assertTrue(param.isMdmExpand());
-		assertEquals("Patient/PJANE1", param.getValue());
+		assertEquals(value, param.getValue());
 	}
 
 

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/param/TokenParamTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/param/TokenParamTest.java
@@ -2,14 +2,13 @@ package ca.uhn.fhir.rest.param;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.Constants;
-import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class TokenParamTest {
 	private static final FhirContext ourCtx = FhirContext.forR4Cached();
@@ -51,19 +50,14 @@ public class TokenParamTest {
 	}
 
 	@Test
-	public void testNameNickname() {
-		StringParam param = new StringParam();
-		assertFalse(param.isNicknameExpand());
-		param.setValueAsQueryToken(ourCtx, "name", Constants.PARAMQUALIFIER_NICKNAME, "kenny");
-		assertTrue(param.isNicknameExpand());
+	public void testMdmQualifier() {
+		TokenParam param = new TokenParam();
+		param.setValueAsQueryToken(ourCtx, "_id", Constants.PARAMQUALIFIER_MDM, "Patient/PJANE1");
+		assertNull(param.getModifier());
+		assertNull(param.getSystem());
+		assertTrue(param.isMdmExpand());
+		assertEquals("Patient/PJANE1", param.getValue());
 	}
 
-	@Test
-	public void testGivenNickname() {
-		StringParam param = new StringParam();
-		assertFalse(param.isNicknameExpand());
-		param.setValueAsQueryToken(ourCtx, "given", Constants.PARAMQUALIFIER_NICKNAME, "kenny");
-		assertTrue(param.isNicknameExpand());
-	}
 
 }


### PR DESCRIPTION
When using the :mdm parameter qualifier with the _id search parameter, the fhir endpoint only returns the Resource with the id matching the value provided with _id SP.

**what was done:**

- added failing test;
- setting the mdmExpand flag on the TokenParam when qualifier ':mdm' is present
- added changelog.

closes #5802
