### PR TITLE
Change to new jetty maven plugin

### DIFF
--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -147,8 +147,8 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-maven-plugin</artifactId>
+					<groupId>org.eclipse.jetty.ee10</groupId>
+					<artifactId>jetty-ee10-maven-plugin</artifactId>
 					<configuration>
 						<webApp>
 							<contextPath>/</contextPath>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -106,8 +106,8 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-maven-plugin</artifactId>
+					<groupId>org.eclipse.jetty.ee10</groupId>
+					<artifactId>jetty-ee10-maven-plugin</artifactId>
 					<configuration>
 						<webApp>
 							<contextPath>/hapi-fhir-jpaserver-example</contextPath>

--- a/pom.xml
+++ b/pom.xml
@@ -2522,8 +2522,8 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-maven-plugin</artifactId>
+					<groupId>org.eclipse.jetty.ee10</groupId>
+					<artifactId>jetty-ee10-maven-plugin</artifactId>
 					<version>${jetty_version}</version>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
`jetty-maven-plugin` is not available for Jetty beyond version 11.x, which can result in errors in downstream projects due to an inability to resolve the 12+ version we're currently using.

It has been changed to the following:
```
<groupId>org.eclipse.jetty.ee10</groupId>
<artifactId>jetty-ee10-maven-plugin</artifactId>
```

See here for details: https://github.com/jetty/jetty.project/pull/10939/files#diff-a4f36866106c36c5a5f6342ad8343f2f04c930d48171f484deead1e2444ebcc7
