### PR TITLE
added otel span for interceptors

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -138,6 +138,11 @@
 			<artifactId>system-stubs-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- OpenTelemetry -->
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5855-opentelemetry-spans-for-interceptors.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5855-opentelemetry-spans-for-interceptors.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 5855
+title: "If using an OpenTelemetry agent, a span is now generated for each interceptor method call. The span is named 
+as 'hapifhir.interceptor' and it has the following attributes about the interceptor:
+'hapifhir.interceptor.pointcut_name','hapifhir.interceptor.class_name', 'hapifhir.interceptor.method_name'"

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
 			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- OpenTelemetry Annotations-->
+		<dependency>
+			<groupId>io.opentelemetry.instrumentation</groupId>
+			<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+		</dependency>
 	</dependencies>
 
 	<developers>
@@ -977,6 +982,7 @@
 		<maven_assembly_plugin_version>3.3.0</maven_assembly_plugin_version>
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
 		<okhttp_version>4.10.0</okhttp_version>
+		<otel.version>1.32.0</otel.version> <!-- BOM Version -->
 		<poi_version>4.1.2</poi_version>
 		<poi_ooxml_schemas_version>1.4</poi_ooxml_schemas_version>
 		<resteasy_version>6.2.5.Final</resteasy_version>
@@ -2263,6 +2269,19 @@
 				<version>2.12.2</version>
 				<scope>provided</scope>
 				<optional>true</optional>
+			</dependency>
+			<!-- OpenTelemetry -->
+			<dependency>
+				<groupId>io.opentelemetry</groupId>
+				<artifactId>opentelemetry-bom</artifactId>
+				<version>${otel.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.opentelemetry.instrumentation</groupId>
+				<artifactId>opentelemetry-instrumentation-annotations</artifactId>
+				<version>${otel.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Added OpenTelemetry spans for the interceptor calls, with pointcut name, interceptor class name, and interceptor method names captured as span attribute
The span is name as "hapifhir.interceptor", and the attributes are 
"hapifhir.interceptor.pointcut_name", "hapifhir.interceptor.class_name", "hapifhir.interceptor.method_name".

Added opentelemetry-instrumentation-annotations package as a global dependency so any package can use otel annotations like "WithSpan".

closes #5855 