### PR TITLE
Fixed bug with Golden resource tags being overwritten

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/5867-golden-resource-tags-being-overwritten.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/5867-golden-resource-tags-being-overwritten.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 5867
+title: "Previously, when adding multiple resources and defining a golden resource using MDM, the golden resource's tags were removed. This has been fixed"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
@@ -58,6 +58,7 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.util.IMetaTagSorter;
 import ca.uhn.fhir.util.MetaUtil;
 import jakarta.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -470,7 +471,7 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 		res.getMeta().setLastUpdated(theEntity.getUpdatedDate());
 		IDao.RESOURCE_PID.put(res, theEntity.getResourceId());
 
-		if (theTagList != null) {
+		if (CollectionUtils.isNotEmpty(theTagList)) {
 			res.getMeta().getTag().clear();
 			res.getMeta().getProfile().clear();
 			res.getMeta().getSecurity().clear();

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParserTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParserTest.java
@@ -1,0 +1,56 @@
+package ca.uhn.fhir.jpa.dao;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.jpa.entity.ResourceSearchView;
+import ca.uhn.fhir.jpa.model.entity.BaseTag;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.api.Constants;
+import org.hl7.fhir.r4.hapi.ctx.FhirR4;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class JpaStorageResourceParserTest {
+
+    @Mock
+    private FhirContext myFhirContext;
+
+    @Mock
+    private ResourceSearchView patientSearchView;
+    @InjectMocks
+    private final JpaStorageResourceParser jpaStorageResourceParser = new JpaStorageResourceParser();
+
+   @Test
+    public void testPopulateResourceMeta_doesNotRemoveTags_whenTagListIsEmpty() {
+       Mockito.when(myFhirContext.getVersion()).thenReturn(new FhirR4());
+       Mockito.when(patientSearchView.getIdDt()).thenReturn(new IdDt("Patient/test-patient/_history/1"));
+
+       Coding coding = new Coding("system", "code", "display");
+       List<BaseTag> tagList = Collections.emptyList();
+       boolean forHistoryOperation = false;
+       long version = 1L;
+       Patient resourceTarget = new Patient();
+       resourceTarget.getMeta().addTag(coding);
+
+       Patient actualResult = jpaStorageResourceParser
+               .populateResourceMetadata(patientSearchView, forHistoryOperation, tagList, version, resourceTarget);
+
+       List<Coding> actualTagList = actualResult.getMeta().getTag();
+       assertFalse(actualTagList.isEmpty());
+       assertEquals(actualTagList.size(), 1);
+       assertTrue(actualTagList.get(0).equals(coding));
+    }
+}


### PR DESCRIPTION
Previously, when adding multiple resources and defining a golden resource using MDM, the golden resource's tags were removed. This has been fixed.

Closes #5867 