### PR TITLE
5877 attempting to update a tokenparam with a value greater than 200 characters raises a sqlexception

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/5877-exception-when-updating-token-param-with-large-value.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/5877-exception-when-updating-token-param-with-large-value.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 5877
+title: "Previously, updating a tokenParam with a value greater than 200 characters would raise a SQLException.  
+This issue has been fixed."

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamToken.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamToken.java
@@ -36,6 +36,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
@@ -429,6 +430,7 @@ public class ResourceIndexedSearchParamToken extends BaseResourceIndexedSearchPa
 	 * We don't truncate earlier in the flow because the index hashes MUST be calculated on the full string.
 	 */
 	@PrePersist
+	@PreUpdate
 	public void truncateFieldsForDB() {
 		mySystem = StringUtils.truncate(mySystem, MAX_LENGTH);
 		myValue = StringUtils.truncate(myValue, MAX_LENGTH);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4Test.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
-import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
 import ca.uhn.fhir.jpa.api.model.HistoryCountModeEnum;
 import ca.uhn.fhir.jpa.api.pid.StreamTemplate;
 import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
@@ -55,7 +54,6 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.util.ClasspathUtil;
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -255,7 +253,7 @@ public class FhirResourceDaoR4Test extends BaseJpaR4Test {
 	public void testUpdateResource_whenTokenPropertyAssignedTooLargeValue_willTruncateLargeValueOnUpdate(){
 		// given
 		final String modifiedEmailPrefix = "modified";
-		final String originalEmail = "test200andmoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusancoresusssancoresusancoresusancoresusancorew@abcdusancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresususancoresusancoresuselasticsearchisworking.com";
+		final String originalEmail = RandomStringUtils.randomAlphanumeric(ResourceIndexedSearchParamToken.MAX_LENGTH) + "@acme.corp";
 		final String modifiedEmail = modifiedEmailPrefix + originalEmail;
 
 		// when


### PR DESCRIPTION
**Background:**
This PR follows in the footsteps of [4998](https://github.com/hapifhir/hapi-fhir/pull/4998) which captured changes that where tokenParam system / value are getting trimmed before persistence (insertion).  

**What was done:**
- added failing test;
- added annotation (@PreUpdate) to instructing Hibernate to perform trimming on update as well as create operations;
- added changelog.
