### PR TITLE
Fix query chained on sort bug where we over-filter results

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5904-query-chained-sort-returns-less-results.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5904-query-chained-sort-returns-less-results.yaml
@@ -4,4 +4,3 @@ issue: 5904
 title: "Under certain conditions, when running a GET query with a chained sort and linked resources will return less 
         resources than expected, including a smaller total.
         This has been fixed."
-u

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5904-query-chained-sort-returns-less-results.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5904-query-chained-sort-returns-less-results.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 5904
+title: "Under certain conditions, when running a GET query with a chained sort and linked resources will return less 
+        resources than expected, including a smaller total.
+        This has been fixed."
+u

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5904-query-chained-sort-returns-less-results.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_2_0/5904-query-chained-sort-returns-less-results.yaml
@@ -1,6 +1,4 @@
 ---
 type: fix
 issue: 5904
-title: "Under certain conditions, when running a GET query with a chained sort and linked resources will return less 
-        resources than expected, including a smaller total.
-        This has been fixed."
+title: "Chained sort would exclude results that did not have resources matching the sort chain.  These are now included, and sorted at the end."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -419,8 +419,9 @@ public class QueryStack {
 		}
 
 		addSortCustomJoin(resourceLinkPredicateBuilder.getColumnTargetResourceId(), chainedPredicateBuilder, null);
-// Support chained sort - when there is no data to sort, the outer join will produce null columns.  We need to include those too.
-				Condition predicate = chainedPredicateBuilder.createHashIdentityOrNullPredicate(targetType, theChain);
+		// Support chained sort - when there is no data to sort, the outer join will produce null columns.  We need to
+		// include those too.
+		Condition predicate = chainedPredicateBuilder.createHashIdentityOrNullPredicate(targetType, theChain);
 		mySqlBuilder.addPredicate(predicate);
 
 		for (DbColumn next : sortColumn) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -419,7 +419,7 @@ public class QueryStack {
 		}
 
 		addSortCustomJoin(resourceLinkPredicateBuilder.getColumnTargetResourceId(), chainedPredicateBuilder, null);
-		Condition predicate = chainedPredicateBuilder.createHashIdentityPredicate(targetType, theChain);
+		Condition predicate = chainedPredicateBuilder.createHashIdentityOrNullPredicate(targetType, theChain);
 		mySqlBuilder.addPredicate(predicate);
 
 		for (DbColumn next : sortColumn) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -419,7 +419,8 @@ public class QueryStack {
 		}
 
 		addSortCustomJoin(resourceLinkPredicateBuilder.getColumnTargetResourceId(), chainedPredicateBuilder, null);
-		Condition predicate = chainedPredicateBuilder.createHashIdentityOrNullPredicate(targetType, theChain);
+// Support chained sort - when there is no data to sort, the outer join will produce null columns.  We need to include those too.
+				Condition predicate = chainedPredicateBuilder.createHashIdentityOrNullPredicate(targetType, theChain);
 		mySqlBuilder.addPredicate(predicate);
 
 		for (DbColumn next : sortColumn) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/BaseSearchParamPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/BaseSearchParamPredicateBuilder.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.jpa.util.QueryParameterUtils;
 import com.healthmarketscience.sqlbuilder.BinaryCondition;
 import com.healthmarketscience.sqlbuilder.ComboCondition;
 import com.healthmarketscience.sqlbuilder.Condition;
+import com.healthmarketscience.sqlbuilder.Conditions;
 import com.healthmarketscience.sqlbuilder.NotCondition;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
 import com.healthmarketscience.sqlbuilder.UnaryCondition;
@@ -94,6 +95,15 @@ public abstract class BaseSearchParamPredicateBuilder extends BaseJoiningPredica
 				getPartitionSettings(), getRequestPartitionId(), theResourceType, theParamName);
 		String hashIdentityVal = generatePlaceholder(hashIdentity);
 		return BinaryCondition.equalTo(myColumnHashIdentity, hashIdentityVal);
+	}
+
+	@Nonnull
+	public Condition createHashIdentityOrNullPredicate(String theResourceType, String theParamName) {
+		final long hashIdentity = BaseResourceIndexedSearchParam.calculateHashIdentity(
+			getPartitionSettings(), getRequestPartitionId(), theResourceType, theParamName);
+		final String hashIdentityVal = generatePlaceholder(hashIdentity);
+		return Conditions.or(BinaryCondition.equalTo(myColumnHashIdentity, hashIdentityVal),
+							 Conditions.isNull(myColumnHashIdentity));
 	}
 
 	public Condition createPredicateParamMissingForNonReference(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/BaseSearchParamPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/BaseSearchParamPredicateBuilder.java
@@ -100,10 +100,11 @@ public abstract class BaseSearchParamPredicateBuilder extends BaseJoiningPredica
 	@Nonnull
 	public Condition createHashIdentityOrNullPredicate(String theResourceType, String theParamName) {
 		final long hashIdentity = BaseResourceIndexedSearchParam.calculateHashIdentity(
-			getPartitionSettings(), getRequestPartitionId(), theResourceType, theParamName);
+				getPartitionSettings(), getRequestPartitionId(), theResourceType, theParamName);
 		final String hashIdentityVal = generatePlaceholder(hashIdentity);
-		return Conditions.or(BinaryCondition.equalTo(myColumnHashIdentity, hashIdentityVal),
-							 Conditions.isNull(myColumnHashIdentity));
+		return Conditions.or(
+				BinaryCondition.equalTo(myColumnHashIdentity, hashIdentityVal),
+				Conditions.isNull(myColumnHashIdentity));
 	}
 
 	public Condition createPredicateParamMissingForNonReference(

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QuerySandboxTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QuerySandboxTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Sandbox for implementing queries.
@@ -143,21 +144,24 @@ public class FhirResourceDaoR4QuerySandboxTest extends BaseJpaTest {
 
 	@Test
 	void testChainedSort() {
+		final IIdType practitionerId = myDataBuilder.createPractitioner(myDataBuilder.withFamily("Jones"));
 
-		IIdType practitionerId = myDataBuilder.createPractitioner(myDataBuilder.withFamily("Jones"));
-
-		String id1 = myDataBuilder.createPatient(myDataBuilder.withFamily("Smithy")).getIdPart();
-		String id2 = myDataBuilder.createPatient(myDataBuilder.withFamily("Smithwick")).getIdPart();
-		String id3 = myDataBuilder.createPatient(
+		final String id1 = myDataBuilder.createPatient(myDataBuilder.withFamily("Smithy")).getIdPart();
+		final String id2 = myDataBuilder.createPatient(myDataBuilder.withFamily("Smithwick")).getIdPart();
+		final String id3 = myDataBuilder.createPatient(
 			myDataBuilder.withFamily("Smith"),
 			myDataBuilder.withReference("generalPractitioner", practitionerId)).getIdPart();
 
 
-		IBundleProvider iBundleProvider = myTestDaoSearch.searchForBundleProvider("Patient?_total=ACCURATE&_sort=Practitioner:general-practitioner.family");
+		final IBundleProvider iBundleProvider = myTestDaoSearch.searchForBundleProvider("Patient?_total=ACCURATE&_sort=Practitioner:general-practitioner.family");
 		assertEquals(3, iBundleProvider.size());
-		List<IBaseResource> allResources = iBundleProvider.getAllResources();
+
+		final List<IBaseResource> allResources = iBundleProvider.getAllResources();
 		assertEquals(3, iBundleProvider.size());
 		assertEquals(3, allResources.size());
+
+		final List<String> actualIds = allResources.stream().map(IBaseResource::getIdElement).map(IIdType::getIdPart).toList();
+		assertTrue(actualIds.containsAll(List.of(id1, id2, id3)));
 	}
 
 	public static final class TestDirtiesContextTestExecutionListener extends DirtiesContextTestExecutionListener {

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/UpliftedRefchainsAndChainedSortingR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/UpliftedRefchainsAndChainedSortingR5Test.java
@@ -724,7 +724,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		String querySql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
 		assertEquals(1, countMatches(querySql, "HFJ_SPIDX_STRING"), querySql);
 		assertEquals(0, countMatches(querySql, "HASH_NORM_PREFIX"), querySql);
-		assertEquals(1, countMatches(querySql, "HASH_IDENTITY"), querySql);
+		assertEquals(2, countMatches(querySql, "HASH_IDENTITY"), querySql);
 		assertEquals(1, countMatches(querySql, "HFJ_RES_LINK"), querySql);
 	}
 
@@ -760,7 +760,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		String querySql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
 		assertEquals(2, countMatches(querySql, "HFJ_SPIDX_STRING"), querySql);
 		assertEquals(1, countMatches(querySql, "HASH_NORM_PREFIX"), querySql);
-		assertEquals(1, countMatches(querySql, "HASH_IDENTITY"), querySql);
+		assertEquals(2, countMatches(querySql, "HASH_IDENTITY"), querySql);
 		assertEquals(2, countMatches(querySql, "HFJ_RES_LINK"), querySql);
 	}
 
@@ -794,7 +794,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		String querySql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
 		assertEquals(1, countMatches(querySql, "HFJ_SPIDX_TOKEN"), querySql);
-		assertEquals(1, countMatches(querySql, "HASH_IDENTITY"), querySql);
+		assertEquals(2, countMatches(querySql, "HASH_IDENTITY"), querySql);
 		assertEquals(1, countMatches(querySql, "HFJ_RES_LINK"), querySql);
 	}
 
@@ -828,7 +828,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		String querySql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
 		assertEquals(1, countMatches(querySql, "HFJ_SPIDX_DATE"), querySql);
-		assertEquals(1, countMatches(querySql, "HASH_IDENTITY"), querySql);
+		assertEquals(2, countMatches(querySql, "HASH_IDENTITY"), querySql);
 		assertEquals(1, countMatches(querySql, "HFJ_RES_LINK"), querySql);
 	}
 
@@ -863,7 +863,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		String querySql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
 		assertEquals(1, countMatches(querySql, "HFJ_SPIDX_STRING"), querySql);
 		assertEquals(0, countMatches(querySql, "HASH_NORM_PREFIX"), querySql);
-		assertEquals(1, countMatches(querySql, "HASH_IDENTITY"), querySql);
+		assertEquals(2, countMatches(querySql, "HASH_IDENTITY"), querySql);
 		assertEquals(1, countMatches(querySql, "HFJ_RES_LINK"), querySql);
 	}
 

--- a/hapi-fhir-storage-test-utilities/src/main/java/ca/uhn/fhir/storage/test/DaoTestDataBuilder.java
+++ b/hapi-fhir-storage-test-utilities/src/main/java/ca/uhn/fhir/storage/test/DaoTestDataBuilder.java
@@ -102,7 +102,9 @@ public class DaoTestDataBuilder implements ITestDataBuilder.WithSupport, ITestDa
 	public void cleanup() {
 		ourLog.info("cleanup {}", myIds);
 
-		myIds.keySet().forEach(nextType->{
+		myIds.keySet().stream()
+			.sorted() // Hack to ensure Patients are deleted before Practitioners.  This may need to be refined.
+			.forEach(nextType->{
 			// todo do this in a bundle for perf.
 			IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(nextType);
 			myIds.get(nextType).forEach(dao::delete);


### PR DESCRIPTION
- Ensure we don't over-filter result by adding an OR IS NULL clause on HASH_IDENTITY

Closes https://github.com/hapifhir/hapi-fhir/issues/5904