### PR TITLE
Resource Reference Include Match Fix

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * HAPI FHIR - Core Library
  * %%
- * Copyright (C) 2014 - 2023 Smile CDR, Inc.
+ * Copyright (C) 2014 - 2024 Smile CDR, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * HAPI FHIR - Core Library
  * %%
- * Copyright (C) 2014 - 2024 Smile CDR, Inc.
+ * Copyright (C) 2014 - 2023 Smile CDR, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,10 +93,17 @@ public class ResourceReferenceInfo {
 		int colonIndex = theInclude.getValue().indexOf(':');
 		if (colonIndex != -1) {
 			// DSTU2+ style
-			String resourceName = theInclude.getValue().substring(0, colonIndex);
-			String paramName = theInclude.getValue().substring(colonIndex + 1);
+			String targetResourceName = theInclude.getParamTargetType();
+			if (targetResourceName != null
+					&& !targetResourceName.equals(
+							myResource.getReferenceElement().getResourceType())) {
+				return false;
+			}
+
+			String resourceName = theInclude.getParamType();
 			RuntimeResourceDefinition resourceDef = myContext.getResourceDefinition(resourceName);
 			if (resourceDef != null) {
+				String paramName = theInclude.getParamName();
 				RuntimeSearchParam searchParamDef = resourceDef.getSearchParam(paramName);
 				if (searchParamDef != null) {
 					final String completeName = myOwningResource + "." + myName;

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/util/ResourceReferenceInfoTest.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/util/ResourceReferenceInfoTest.java
@@ -1,0 +1,48 @@
+package ca.uhn.fhir.util;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.Include;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResourceReferenceInfoTest {
+
+	private ResourceReferenceInfo resourceReferenceInfo;
+
+	private final FhirContext fhirContext = FhirContext.forDstu3();
+
+	@BeforeEach
+	public void setUp() {
+        Reference theElement = new Reference()
+                .setReference("Practitioner/123")
+                .setDisplay("Test Practitioner");
+
+        Patient theOwningResource = new Patient()
+                .addGeneralPractitioner(theElement);
+
+		  resourceReferenceInfo =
+			  new ResourceReferenceInfo(fhirContext, theOwningResource, List.of("generalPractitioner"), theElement);
+	}
+
+	@Test
+	public void matchesInclude_hasTargetResourceType_matched() {
+		assertTrue(resourceReferenceInfo.matchesInclude(new Include("Patient:general-practitioner:Practitioner")));
+	}
+
+	@Test
+	public void matchesInclude_hasNotTargetResourceType_matched() {
+		assertTrue(resourceReferenceInfo.matchesInclude(new Include("Patient:general-practitioner")));
+	}
+
+	@Test
+	public void matchesInclude_hasDifferentTargetResourceType_notMatched() {
+		assertFalse(resourceReferenceInfo.matchesInclude(new Include("Patient:general-practitioner:Organization")));
+	}
+}

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/util/ResourceReferenceInfoTest.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/util/ResourceReferenceInfoTest.java
@@ -20,15 +20,15 @@ public class ResourceReferenceInfoTest {
 
 	@BeforeEach
 	public void setUp() {
-        Reference theElement = new Reference()
-                .setReference("Practitioner/123")
-                .setDisplay("Test Practitioner");
+		Reference theElement = new Reference()
+			 .setReference("Practitioner/123")
+			 .setDisplay("Test Practitioner");
 
-        Patient theOwningResource = new Patient()
-                .addGeneralPractitioner(theElement);
+		Patient theOwningResource = new Patient()
+			 .addGeneralPractitioner(theElement);
 
-		  resourceReferenceInfo =
-			  new ResourceReferenceInfo(fhirContext, theOwningResource, List.of("generalPractitioner"), theElement);
+		resourceReferenceInfo =
+			 new ResourceReferenceInfo(fhirContext, theOwningResource, List.of("generalPractitioner"), theElement);
 	}
 
 	@Test


### PR DESCRIPTION
In the previous implementation, the `matchesInclude_hasTargetResourceType_matched` would fail. This PR fixes the issue in the `match` function by making it possible to take the target type into account. We are making use of this implementation to find the included resources to create a `Bundle` response.