### PR TITLE
Update dependencies / solving CVEs

### DIFF
--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/JsonParserDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/JsonParserDstu3Test.java
@@ -158,7 +158,7 @@ public class JsonParserDstu3Test {
 			fail();
 		} catch (DataFormatException e) {
 			assertEquals(Msg.code(1861) + "Failed to parse JSON encoded FHIR content: Unexpected character ('=' (code 61)): was expecting a colon to separate field name and value\n" +
-				" at [line: 4, column: 18]", e.getMessage());
+				" at [line: 4, column: 17]", e.getMessage());
 		}
 	}
 
@@ -2328,7 +2328,7 @@ public class JsonParserDstu3Test {
 			// I'm hoping at some point we can get rid of the REDACTED message entirely.
 			// Request filed with Jackson: https://github.com/FasterXML/jackson-core/issues/1158
 			assertEquals(Msg.code(1861) + "Failed to parse JSON encoded FHIR content: Unexpected close marker '}': expected ']' (for root starting at [line: 1])\n" +
-				" at [line: 4, column: 3]", e.getMessage());
+				" at [line: 4, column: 2]", e.getMessage());
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -989,29 +989,29 @@
 		<hibernate_validator_version>8.0.0.Final</hibernate_validator_version>
 		<httpcore_version>4.4.13</httpcore_version>
 		<httpclient_version>4.5.13</httpclient_version>
-		<jackson_version>2.16.1</jackson_version>
-		<jackson_databind_version>2.16.0</jackson_databind_version>
+		<jackson_version>2.17.1</jackson_version>
+		<jackson_databind_version>2.17.1</jackson_databind_version>
 		<maven_assembly_plugin_version>3.3.0</maven_assembly_plugin_version>
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
-		<okhttp_version>4.10.0</okhttp_version>
-		<otel.version>1.32.0</otel.version> <!-- BOM Version -->
+		<okhttp_version>4.12.0</okhttp_version>
+		<otel.version>1.38.0</otel.version> <!-- BOM Version -->
 		<poi_version>4.1.2</poi_version>
 		<poi_ooxml_schemas_version>1.4</poi_ooxml_schemas_version>
-		<resteasy_version>6.2.5.Final</resteasy_version>
+		<resteasy_version>6.2.9.Final</resteasy_version>
 		<ph_schematron_version>7.1.2</ph_schematron_version>
 		<ph_commons_version>9.5.4</ph_commons_version>
 		<plexus_compiler_api_version>2.13.0</plexus_compiler_api_version>
 		<reflections_version>0.9.11</reflections_version>
 		<servicemix_saxon_version>9.8.0-15</servicemix_saxon_version>
 		<servicemix_xmlresolver_version>1.2_5</servicemix_xmlresolver_version>
-		<swagger_version>2.2.19</swagger_version>
-		<slf4j_version>2.0.9</slf4j_version>
+		<swagger_version>2.2.22</swagger_version>
+		<slf4j_version>2.0.13</slf4j_version>
 		<log4j_to_slf4j_version>2.19.0</log4j_to_slf4j_version>
-		<spring_version>6.1.5</spring_version>
-		<spring_data_bom_version>2023.1.0</spring_data_bom_version>
-		<spring_batch_version>4.3.3</spring_batch_version>
-		<spring_boot_version>3.2.0</spring_boot_version>
-		<spring_retry_version>2.0.4</spring_retry_version>
+		<spring_version>6.1.8</spring_version>
+		<spring_data_bom_version>2023.1.6</spring_data_bom_version>
+		<spring_batch_version>4.3.10</spring_batch_version>
+		<spring_boot_version>3.2.6</spring_boot_version>
+		<spring_retry_version>2.0.6</spring_retry_version>
 
 		<stax2_api_version>3.1.4</stax2_api_version>
 		<testcontainers_version>1.19.3</testcontainers_version>

--- a/pom.xml
+++ b/pom.xml
@@ -995,6 +995,7 @@
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
 		<okhttp_version>4.12.0</okhttp_version>
 		<otel.version>1.38.0</otel.version> <!-- BOM Version -->
+		<otel_instrumentation.version>2.4.0</otel_instrumentation.version>
 		<poi_version>4.1.2</poi_version>
 		<poi_ooxml_schemas_version>1.4</poi_ooxml_schemas_version>
 		<resteasy_version>6.2.9.Final</resteasy_version>
@@ -2293,7 +2294,7 @@
 			<dependency>
 				<groupId>io.opentelemetry.instrumentation</groupId>
 				<artifactId>opentelemetry-instrumentation-annotations</artifactId>
-				<version>${otel.version}</version>
+				<version>${otel_instrumentation.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -3276,4 +3277,3 @@
 		</profile>
 	</profiles>
 </project>
-


### PR DESCRIPTION
Hello

with this PR i try to address some CVEs that involve especially the `jpaserver-starter`, which in turn depends on the `hapi-fhir` bom as parent. 

I've mostly updated to the very latest patch version available (e.g. SpringBoot), in some cases i've bumped the minor version (e.g. Jackson, OTel). 

OpenTelemetry comes with a small breaking change, the `opentelemetry-instrumentation-annotations` dependency has a different version number, documentation here: https://opentelemetry.io/docs/zero-code/java/agent/annotations/