### PR TITLE
5738: Skip alternate handling if already handled by previous step

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -1359,9 +1359,17 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 				String alternateName = keyIter.next();
 				if (alternateName.startsWith("_") && alternateName.length() > 1) {
 					BaseJsonLikeValue nextValue = theObject.get(alternateName);
+					String nextName = alternateName.substring(1);
+
 					if (nextValue != null) {
+						BaseJsonLikeValue nonAlternativeValue = theObject.get(nextName);
+
+						// Only alternate values with no corresponding "normal" value is unhandled from previous step.
+						if (nonAlternativeValue != null) {
+							continue;
+						}
+
 						if (nextValue.isObject()) {
-							String nextName = alternateName.substring(1);
 							if (theObject.get(nextName) == null) {
 								theState.enteringNewElement(null, nextName);
 								parseAlternates(nextValue, theState, alternateName, alternateName);

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/5971-fix-json-parsing-alternate-names.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/5971-fix-json-parsing-alternate-names.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 5971
+title: "The JSON Parser failed to parse alternate names (e.g. `_family`) containing extensions if the
+  corresponding regular named element (e.g. `family`) was not present. Thanks to Stefan Lindström for
+  the pull request!"

--- a/pom.xml
+++ b/pom.xml
@@ -917,6 +917,11 @@
 			<id>subigre</id>
 			<name>Renaud Subiger</name>
 		</developer>
+		<developer>
+			<id>stefan-lindstrom</id>
+			<name>Stefan Lindström</name>
+			<organization>Softhouse AB</organization>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Hi, 

first time through the code trying to fix an issue, so I hope I haven't violated too many architectural rules. :) 

We saw this problem when using extensions on datatypes (using data-absent-reason, with code masked and we had an object with both a primitive and an array-property with masked values. We got this output (example from practitioner):

```
{
    "resourceType": "Practitioner",
    "id": "1",
    "name": [{
           "_family": {
                    "extension": [{
                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
                            "valueString": "masked"
                        }
                    ]
                }
           } ,
            "given": [null],
            "_given": [{
                    "extension": [{
                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
                            "valueString": "masked"
                        }
                    ]
                }
            ],
	    }
	]
}
```

My understanding is that when the object is normally handled, the parser counts alternateNamesSeen, and alternateNames Handled, and when seen > handled, a second pass is done. But instead of only doing un-handled, the second pass will go over all alternates including non-primitive ones where the  alternate json.-type need not be an object but could be an array for (any non-primitive property). 

Som y idea is to check, and only do the secondary handling if the alternate property in an object does not have a corresponding "real" property. 