### PR TITLE
Search Param Matcher Performance Improvement

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/SearchParamMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/SearchParamMatcher.java
@@ -51,7 +51,8 @@ public class SearchParamMatcher {
 			return InMemoryMatchResult.successfulMatch();
 		}
 		ResourceIndexedSearchParams resourceIndexedSearchParams =
-				myIndexedSearchParamExtractor.extractIndexedSearchParams(theResource, null, getFilter(theSearchParameterMap));
+				myIndexedSearchParamExtractor.extractIndexedSearchParams(
+						theResource, null, getFilter(theSearchParameterMap));
 		RuntimeResourceDefinition resourceDefinition = myFhirContext.getResourceDefinition(theResource);
 		return myInMemoryResourceMatcher.match(
 				theSearchParameterMap, theResource, resourceDefinition, resourceIndexedSearchParams);
@@ -59,8 +60,7 @@ public class SearchParamMatcher {
 
 	private ISearchParamExtractor.ISearchParamFilter getFilter(SearchParameterMap searchParameterMap) {
 		return theSearchParams -> theSearchParams.stream()
-			.filter(runtimeSearchParam -> searchParameterMap.keySet().stream()
-				.anyMatch(parameter -> parameter.equals(runtimeSearchParam.getName())))
-			.collect(Collectors.toList());
+				.filter(runtimeSearchParam -> searchParameterMap.keySet().contains(runtimeSearchParam.getName()))
+				.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
`extractIndexedSearchParams` function uses `ISearchParamExtractor.ALL_PARAMS` by default. This tries to extract all possible values from a resource then tries to match the resource. By adding the `getFilter` function, we can extract only the values that is in search parameter map. I saw that this had a good impact on the performance of search param matcher.