### PR TITLE
Chained Parameter Matching Support Added

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
@@ -629,26 +629,29 @@ public class InMemoryResourceMatcher {
 
 	private boolean matchChainedReferenceParam(
 			String theParamName, String theResourceName, IBaseResource theResource, ReferenceParam referenceParam) {
+		// Obtain the next parameter and chain
+		String[] chains = referenceParam.getChain().split("\\.");
+		String parameterNameWithModifier = chains[0];
+		String chain = chains.length > 1 ? StringUtils.join(chains, ".", 1, chains.length) : null;
+
+		// Obtain the next parameter name and modifier
+		String[] parameterNameAndModifier = parameterNameWithModifier.split(":");
+		String parameterName = parameterNameAndModifier[0];
+		String modifier = parameterNameAndModifier.length > 1 ? parameterNameAndModifier[1] : null;
+
 		RuntimeSearchParam activeSearchParam =
 				mySearchParamRegistry.getActiveSearchParam(theResourceName, theParamName);
+
 		List<? extends IBase> bases = searchParamExtractor
 				.getPathValueExtractor(theResource, activeSearchParam.getPath())
 				.get();
+
 		return bases.stream()
 				.filter(IBaseReference.class::isInstance)
 				.map(IBaseReference.class::cast)
 				.map(IBaseReference::getResource)
 				.filter(Objects::nonNull)
 				.anyMatch(resource -> {
-					// Obtain the next parameter name, modifier and chain
-					String[] chains = referenceParam.getChain().split("\\.");
-					String parameterNameWithModifier = chains[0];
-					String chain = chains.length > 1 ? StringUtils.join(chains, ".", 1, chains.length) : null;
-
-					String[] parameterNameAndModifier = parameterNameWithModifier.split(":");
-					String parameterName = parameterNameAndModifier[0];
-					String modifier = parameterNameAndModifier.length > 1 ? parameterNameAndModifier[1] : null;
-
 					// Find the path of next search parameter in the next resource
 					RuntimeSearchParam resourceSearchParam = mySearchParamRegistry.getActiveSearchParam(
 							resource.getIdElement().getResourceType(), parameterName);

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
@@ -70,6 +70,7 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -637,6 +638,7 @@ public class InMemoryResourceMatcher {
 				.filter(IBaseReference.class::isInstance)
 				.map(IBaseReference.class::cast)
 				.map(IBaseReference::getResource)
+				.filter(Objects::nonNull)
 				.anyMatch(resource -> {
 					// Obtain the next parameter name, modifier and chain
 					String[] chains = referenceParam.getChain().split("\\.");

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherConfigurationR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherConfigurationR5Test.java
@@ -9,6 +9,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
+import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorR5;
 import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorService;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 import ca.uhn.fhir.rest.param.TokenParamModifier;
@@ -115,6 +116,22 @@ public class InMemoryResourceMatcherConfigurationR5Test {
 
 	@Configuration
 	public static class SpringConfig {
+
+		@Bean
+		PartitionSettings partitionSettings() {
+			return new PartitionSettings();
+		}
+
+		@Bean
+		SearchParamExtractorR5 searchParamExtractorR5() {
+			return new SearchParamExtractorR5();
+		}
+
+		@Bean
+		SearchParamMatcher searchParamMatcher() {
+			return new SearchParamMatcher();
+		}
+
 		@Bean
 		InMemoryResourceMatcher inMemoryResourceMatcher() {
 			return new InMemoryResourceMatcher();

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherConfigurationR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherConfigurationR5Test.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
+import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
 import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
 import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorR5;
 import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorService;
@@ -123,7 +124,7 @@ public class InMemoryResourceMatcherConfigurationR5Test {
 		}
 
 		@Bean
-		SearchParamExtractorR5 searchParamExtractorR5() {
+		ISearchParamExtractor searchParamExtractorR5() {
 			return new SearchParamExtractorR5();
 		}
 

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
@@ -1,13 +1,11 @@
 package ca.uhn.fhir.jpa.searchparam.matcher;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamDate;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamUri;
-import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams;
@@ -29,7 +27,6 @@ import org.hl7.fhir.r5.model.DateTimeType;
 import org.hl7.fhir.r5.model.Encounter;
 import org.hl7.fhir.r5.model.Observation;
 import org.hl7.fhir.r5.model.Reference;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,15 +34,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImplTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImplTest.java
@@ -12,9 +12,12 @@ import ca.uhn.fhir.jpa.cache.ResourceChangeListenerRegistryImpl;
 import ca.uhn.fhir.jpa.cache.ResourceChangeResult;
 import ca.uhn.fhir.jpa.cache.ResourceVersionMap;
 import ca.uhn.fhir.jpa.cache.config.RegisteredResourceListenerFactoryConfig;
+import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
+import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
+import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorR4;
 import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorService;
 import ca.uhn.fhir.jpa.searchparam.matcher.InMemoryMatchResult;
 import ca.uhn.fhir.jpa.searchparam.matcher.InMemoryResourceMatcher;
@@ -375,6 +378,17 @@ public class SearchParamRegistryImplTest {
 	@Configuration
 	@Import(RegisteredResourceListenerFactoryConfig.class)
 	static class SpringConfig {
+
+		@Bean
+		PartitionSettings partitionSettings() {
+			return new PartitionSettings();
+		}
+
+		@Bean
+		ISearchParamExtractor searchParamExtractorR5() {
+			return new SearchParamExtractorR4();
+		}
+
 		@Bean
 		FhirContext fhirContext() {
 			return ourFhirContext;

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/matcher/InMemorySubscriptionMatcherR3Test.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/matcher/InMemorySubscriptionMatcherR3Test.java
@@ -49,6 +49,11 @@ public class InMemorySubscriptionMatcherR3Test extends BaseSubscriptionDstu3Test
 	@Autowired
     StorageSettings myStorageSettings;
 
+	private void assertSupported(IBaseResource resource, String criteria) {
+		assertTrue(mySearchParamMatcher.match(criteria, resource, null).supported());
+		assertEquals(SubscriptionMatchingStrategy.IN_MEMORY, mySubscriptionStrategyEvaluator.determineStrategy(criteria));
+	}
+
 	private void assertUnsupported(IBaseResource resource, String criteria) {
 		assertFalse(mySearchParamMatcher.match(criteria, resource, null).supported());
 		assertEquals(SubscriptionMatchingStrategy.DATABASE, mySubscriptionStrategyEvaluator.determineStrategy(criteria));
@@ -185,17 +190,17 @@ public class InMemorySubscriptionMatcherR3Test extends BaseSubscriptionDstu3Test
 	}
 
 	@Test
-	public void testObservationContextTypeUnsupported() {
+	public void testObservationContextTypeSupported() {
 		String criteria = "Observation?code=17861-6&context.type=IHD";
 		{
 			Observation obs = new Observation();
 			obs.getCode().addCoding().setCode("XXX");
-			assertNotMatched(obs, criteria, SubscriptionMatchingStrategy.DATABASE);
+			assertNotMatched(obs, criteria, SubscriptionMatchingStrategy.IN_MEMORY);
 		}
 		{
 			Observation obs = new Observation();
 			obs.getCode().addCoding().setCode("17861-6");
-			assertUnsupported(obs, criteria);
+			assertSupported(obs, criteria);
 		}
 	}
 
@@ -206,12 +211,12 @@ public class InMemorySubscriptionMatcherR3Test extends BaseSubscriptionDstu3Test
 		{
 			Observation obs = new Observation();
 			obs.getCode().addCoding().setCode("XXX");
-			assertNotMatched(obs, criteria, SubscriptionMatchingStrategy.DATABASE);
+			assertNotMatched(obs, criteria, SubscriptionMatchingStrategy.IN_MEMORY);
 		}
 		{
 			Observation obs = new Observation();
 			obs.getCode().addCoding().setCode("17861-6");
-			assertUnsupported(obs, criteria);
+			assertSupported(obs, criteria);
 		}
 	}
 
@@ -299,12 +304,12 @@ public class InMemorySubscriptionMatcherR3Test extends BaseSubscriptionDstu3Test
 		{
 			Observation obs = new Observation();
 			obs.getCode().addCoding().setCode("FR_Org1Blood2nd");
-			assertUnsupported(obs, criteria);
+			assertSupported(obs, criteria);
 		}
 		{
 			Observation obs = new Observation();
 			obs.getCode().addCoding().setCode("XXX");
-			assertNotMatched(obs, criteria, SubscriptionMatchingStrategy.DATABASE);
+			assertNotMatched(obs, criteria, SubscriptionMatchingStrategy.IN_MEMORY);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/matcher/SubscriptionStrategyEvaluatorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/matcher/SubscriptionStrategyEvaluatorTest.java
@@ -24,7 +24,7 @@ public class SubscriptionStrategyEvaluatorTest extends BaseSubscriptionDstu3Test
 		assertInMemory("ProcedureRequest?intent=original-order");
 		assertInMemory("MedicationRequest?intent=instance-order&category=outpatient&date==2018-10-19");
 		assertInMemory("MedicationRequest?intent=plan&category=outpatient&status=suspended,entered-in-error,cancelled,stopped");
-		assertDatabase("Observation?code=FR_Org1Blood2nd,FR_Org1Blood3rd,FR_Org%201BldCult,FR_Org2Blood2nd,FR_Org2Blood3rd,FR_Org%202BldCult,FR_Org3Blood2nd,FR_Org3Blood3rd,FR_Org3BldCult,FR_Org4Blood2nd,FR_Org4Blood3rd,FR_Org4BldCult,FR_Org5Blood2nd,FR_Org5Blood3rd,FR_Org%205BldCult,FR_Org6Blood2nd,FR_Org6Blood3rd,FR_Org6BldCult,FR_Org7Blood2nd,FR_Org7Blood3rd,FR_Org7BldCult,FR_Org8Blood2nd,FR_Org8Blood3rd,FR_Org8BldCult,FR_Org9Blood2nd,FR_Org9Blood3rd,FR_Org9BldCult,FR_Bld2ndCulture,FR_Bld3rdCulture,FR_Blood%20Culture,FR_Com1Bld3rd,FR_Com1BldCult,FR_Com2Bld2nd,FR_Com2Bld3rd,FR_Com2BldCult,FR_CultureBld2nd,FR_CultureBld3rd,FR_CultureBldCul,FR_GmStainBldCul,FR_GramStain2Bld,FR_GramStain3Bld,FR_GramStNegBac&context.type=IHD");
+		assertInMemory("Observation?code=FR_Org1Blood2nd,FR_Org1Blood3rd,FR_Org%201BldCult,FR_Org2Blood2nd,FR_Org2Blood3rd,FR_Org%202BldCult,FR_Org3Blood2nd,FR_Org3Blood3rd,FR_Org3BldCult,FR_Org4Blood2nd,FR_Org4Blood3rd,FR_Org4BldCult,FR_Org5Blood2nd,FR_Org5Blood3rd,FR_Org%205BldCult,FR_Org6Blood2nd,FR_Org6Blood3rd,FR_Org6BldCult,FR_Org7Blood2nd,FR_Org7Blood3rd,FR_Org7BldCult,FR_Org8Blood2nd,FR_Org8Blood3rd,FR_Org8BldCult,FR_Org9Blood2nd,FR_Org9Blood3rd,FR_Org9BldCult,FR_Bld2ndCulture,FR_Bld3rdCulture,FR_Blood%20Culture,FR_Com1Bld3rd,FR_Com1BldCult,FR_Com2Bld2nd,FR_Com2Bld3rd,FR_Com2BldCult,FR_CultureBld2nd,FR_CultureBld3rd,FR_CultureBldCul,FR_GmStainBldCul,FR_GramStain2Bld,FR_GramStain3Bld,FR_GramStNegBac&context.type=IHD");
 		assertInMemory("Procedure?category=Hemodialysis");
 		assertInMemory("Procedure?code=HD_Standard&status=completed&location=Lab123");
 		assertInMemory("Procedure?code=HD_Standard&status=completed");
@@ -33,8 +33,8 @@ public class SubscriptionStrategyEvaluatorTest extends BaseSubscriptionDstu3Test
 		assertInMemory("Observation?code=111111111&_format=xml");
 		assertInMemory("Observation?code=SNOMED-CT|123&_format=xml");
 
-		assertDatabase("Observation?code=17861-6&context.type=IHD");
-		assertDatabase("Observation?context.type=IHD&code=17861-6");
+		assertInMemory("Observation?code=17861-6&context.type=IHD");
+		assertInMemory("Observation?context.type=IHD&code=17861-6");
 
 		try {
 			mySubscriptionStrategyEvaluator.determineStrategy("Observation?codeee=SNOMED-CT|123&_format=xml");

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestDstu3Test.java
@@ -201,7 +201,7 @@ public class RestHookTestDstu3Test extends BaseResourceProviderDstu3Test {
 		Subscription subscription = createSubscription(databaseCriteria, null, ourNotificationListenerServer);
 		List<Coding> tag = subscription.getMeta().getTag();
 		assertEquals(HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY, tag.get(0).getSystem());
-		assertEquals(SubscriptionMatchingStrategy.DATABASE.toString(), tag.get(0).getCode());
+		assertEquals(SubscriptionMatchingStrategy.IN_MEMORY.toString(), tag.get(0).getCode());
 	}
 
 	@Test
@@ -607,8 +607,8 @@ public class RestHookTestDstu3Test extends BaseResourceProviderDstu3Test {
 		assertThat(tags).hasSize(1);
 		Coding tag = tags.get(0);
 		assertEquals(HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY, tag.getSystem());
-		assertEquals(SubscriptionMatchingStrategy.DATABASE.toString(), tag.getCode());
-		assertEquals("Database", tag.getDisplay());
+		assertEquals(SubscriptionMatchingStrategy.IN_MEMORY.toString(), tag.getCode());
+		assertEquals("In-memory", tag.getDisplay());
 
 		// Wait for subscription to be moved to active
 		await().until(() -> Subscription.SubscriptionStatus.ACTIVE.equals(myClient.read().resource(Subscription.class).withId(subscriptionId.toUnqualifiedVersionless()).execute().getStatus()));

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestDstu3Test.java
@@ -619,8 +619,8 @@ public class RestHookTestDstu3Test extends BaseResourceProviderDstu3Test {
 		assertThat(tags).hasSize(1);
 		tag = tags.get(0);
 		assertEquals(HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY, tag.getSystem());
-		assertEquals(SubscriptionMatchingStrategy.DATABASE.toString(), tag.getCode());
-		assertEquals("Database", tag.getDisplay());
+		assertEquals(SubscriptionMatchingStrategy.IN_MEMORY.toString(), tag.getCode());
+		assertEquals("In-memory", tag.getDisplay());
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/BulkDataErrorAbuseTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/BulkDataErrorAbuseTest.java
@@ -24,6 +24,7 @@ import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -98,29 +99,33 @@ public class BulkDataErrorAbuseTest extends BaseResourceProviderR4Test {
 
 	private void duAbuseTest(int taskExecutions) {
 		// Create some resources
-		Patient patient = new Patient();
-		patient.setId("PING1");
-		patient.setGender(Enumerations.AdministrativeGender.FEMALE);
-		patient.setActive(true);
-		myClient.update().resource(patient).execute();
+		Patient patient1 = new Patient();
+		patient1.setId("PING1");
+		patient1.setGender(Enumerations.AdministrativeGender.FEMALE);
+		patient1.setActive(true);
+		myClient.update().resource(patient1).execute();
 
-		patient = new Patient();
-		patient.setId("PING2");
-		patient.setGender(Enumerations.AdministrativeGender.MALE);
-		patient.setActive(true);
-		myClient.update().resource(patient).execute();
+		Patient patient2 = new Patient();
+		patient2.setId("PING2");
+		patient2.setGender(Enumerations.AdministrativeGender.MALE);
+		patient2.setActive(true);
+		myClient.update().resource(patient2).execute();
 
-		patient = new Patient();
-		patient.setId("PNING3");
-		patient.setGender(Enumerations.AdministrativeGender.MALE);
-		patient.setActive(true);
-		myClient.update().resource(patient).execute();
+		Patient patient3 = new Patient();
+		patient3.setId("PNING3");
+		patient3.setGender(Enumerations.AdministrativeGender.MALE);
+		patient3.setActive(true);
+		myClient.update().resource(patient3).execute();
 
 		Group group = new Group();
 		group.setId("Group/G2");
 		group.setActive(true);
-		group.addMember().getEntity().setReference("Patient/PING1");
-		group.addMember().getEntity().setReference("Patient/PING2");
+		Reference entity = group.addMember().getEntity();
+		entity.setReference("Patient/PING1");
+		entity.setResource(patient1);
+		Reference entity1 = group.addMember().getEntity();
+		entity1.setReference("Patient/PING2");
+		entity1.setResource(patient2);
 		myClient.update().resource(group).execute();
 
 		// set the export options

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
@@ -1183,19 +1183,16 @@ public class BulkDataExportTest extends BaseResourceProviderR4Test {
 	}
 
 	@Test
-	public void testValidateParameters_InvalidPostFetch_UnsupportedParam() {
+	public void testValidateParameters_ValidPostFetch_SupportedParam() {
 		// Setup
 		final BulkExportJobParameters options = createOptionsWithPostFetchFilterUrl("Observation?subject.identifier=blah");
 
 		// Test
 		try {
 			startNewJob(options);
-			fail();
 		} catch (InvalidRequestException e) {
-
-			// Verify
-			assertThat(e.getMessage()).contains("Chained parameters are not supported");
-
+			// Fail
+			fail();
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ComboUniqueParamIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ComboUniqueParamIT.java
@@ -1295,7 +1295,9 @@ public class FhirResourceDaoR4ComboUniqueParamIT extends BaseComboParamsR4Test {
 
 		Patient pt1 = new Patient();
 		pt1.addName().setFamily("FAMILY1");
-		pt1.setManagingOrganization(new Reference("Organization/ORG"));
+		Reference r1 = new Reference("Organization/ORG");
+		r1.setResource(org);
+		pt1.setManagingOrganization(r1);
 		IIdType id1 = myPatientDao.update(pt1, "Patient?name=FAMILY1&organization.name=ORG").getId().toUnqualifiedVersionless();
 
 		runInTransaction(() -> {
@@ -1309,7 +1311,9 @@ public class FhirResourceDaoR4ComboUniqueParamIT extends BaseComboParamsR4Test {
 
 		pt1 = new Patient();
 		pt1.addName().setFamily("FAMILY1");
-		pt1.setManagingOrganization(new Reference("Organization/ORG"));
+		Reference r2 = new Reference("Organization/ORG");
+		r2.setResource(org);
+		pt1.setManagingOrganization(r2);
 		myPatientDao.update(pt1, "Patient?name=FAMILY1&organization.name=ORG").getId().toUnqualifiedVersionless();
 
 		runInTransaction(() -> {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/module/matcher/InMemorySubscriptionMatcherR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/module/matcher/InMemorySubscriptionMatcherR4Test.java
@@ -144,6 +144,12 @@ public class InMemorySubscriptionMatcherR4Test {
 		return mySearchParamMatcher.match(criteria, theResource, null);
 	}
 
+	private void assertSupported(Resource resource, SearchParameterMap theParams) {
+		InMemoryMatchResult result = match(resource, theParams);
+		assertTrue(result.supported());
+		assertEquals(SubscriptionMatchingStrategy.IN_MEMORY, mySubscriptionStrategyEvaluator.determineStrategy(getCriteria(resource, theParams)));
+	}
+
 	private void assertUnsupported(Resource resource, SearchParameterMap theParams) {
 		InMemoryMatchResult result = match(resource, theParams);
 		assertFalse(result.supported());
@@ -155,7 +161,7 @@ public class InMemorySubscriptionMatcherR4Test {
 	  */
 
 	@Test
-	public void testChainReferenceUnsupported() {
+	public void testChainReferenceSupported() {
 		Encounter enc1 = new Encounter();
 		IIdType pid1 = new IdType("Patient", 1L);
 		enc1.getSubject().setReference(pid1.getValue());
@@ -164,7 +170,7 @@ public class InMemorySubscriptionMatcherR4Test {
 
 		map = new SearchParameterMap();
 		map.add(Encounter.SP_SUBJECT, new ReferenceParam("subject", "foo|bar").setChain("identifier"));
-		assertUnsupported(enc1, map);
+		assertSupported(enc1, map);
 
 		MedicationAdministration ma = new MedicationAdministration();
 		IIdType mid1 = new IdType("Medication", 1L);
@@ -172,7 +178,7 @@ public class InMemorySubscriptionMatcherR4Test {
 
 		map = new SearchParameterMap();
 		map.add(MedicationAdministration.SP_MEDICATION, new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(new ReferenceParam("code", "04823543"))));
-		assertUnsupported(ma, map);
+		assertSupported(ma, map);
 	}
 
 	@Test
@@ -597,7 +603,7 @@ public class InMemorySubscriptionMatcherR4Test {
 		obs02.setSubject(new Reference(patientId02));
 
 		SearchParameterMap params = new SearchParameterMap().add(Observation.SP_SUBJECT, new ReferenceParam(Patient.SP_IDENTIFIER, "urn:system|testSearchResourceLinkWithChain01"));
-		assertUnsupported(obs01, params);
+		assertSupported(obs01, params);
 	}
 
 	@Test


### PR DESCRIPTION
Adds support for chained search parameters in `SearchParamMatcher`. The following type of parameters will be supported with this PR:
* `Observation?context.episodeofcare.condition.code=http://snomed.info/sct|77386006`
* `Observation?context:Encounter.episodeofcare:EpisodeOfCare.condition:Condition.code=http://snomed.info/sct|77386006`

Tests updated.