### PR TITLE
Use server name as narrative text in CapabilityStatement

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6060-use-server-name-in-cs-narrative.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6060-use-server-name-in-cs-narrative.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 6060
+title: "The server-generated CapabilityStatement will now use the server
+  name defined by `RestfulServer#setServerName(..)` instead of the hardcoded
+  string `HAPI FHIR`. Thanks to Renaud Subiger for the pull request!"

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
@@ -209,7 +209,7 @@ public class ServerCapabilityStatementProvider implements IServerConformanceProv
 		IBase text = terser.addElement(retVal, "text");
 		terser.addElement(text, "status", "generated");
 		terser.addElement(
-			text, "div", "<div xmlns=\"http://www.w3.org/1999/xhtml\">" + configuration.getServerName() + "</div>");
+				text, "div", "<div xmlns=\"http://www.w3.org/1999/xhtml\">" + configuration.getServerName() + "</div>");
 		terser.addElement(retVal, "publisher", myPublisher);
 		terser.addElement(retVal, "date", conformanceDate(configuration));
 		terser.addElement(

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
@@ -208,7 +208,8 @@ public class ServerCapabilityStatementProvider implements IServerConformanceProv
 		terser.addElement(retVal, "name", "RestServer");
 		IBase text = terser.addElement(retVal, "text");
 		terser.addElement(text, "status", "generated");
-		terser.addElement(text, "div", "<div xmlns=\"http://www.w3.org/1999/xhtml\">HAPI-FHIR Server</div>");
+		terser.addElement(
+			text, "div", "<div xmlns=\"http://www.w3.org/1999/xhtml\">" + configuration.getServerName() + "</div>");
 		terser.addElement(retVal, "publisher", myPublisher);
 		terser.addElement(retVal, "date", conformanceDate(configuration));
 		terser.addElement(

--- a/hapi-fhir-validation/src/test/java/ca/uhn/fhir/rest/server/ServerCapabilityStatementProviderR4Test.java
+++ b/hapi-fhir-validation/src/test/java/ca/uhn/fhir/rest/server/ServerCapabilityStatementProviderR4Test.java
@@ -161,6 +161,29 @@ public class ServerCapabilityStatementProviderR4Test extends BaseValidationTestW
 	}
 
 	@Test
+	public void testNarrativeText() throws ServletException {
+		RestfulServer rs = new RestfulServer(myCtx);
+
+		ServerCapabilityStatementProvider sc = new ServerCapabilityStatementProvider(rs);
+		rs.setServerConformanceProvider(sc);
+
+		rs.init(createServletConfig());
+
+		CapabilityStatement cs;
+		String narrativeText;
+
+		cs = (CapabilityStatement) sc.getServerConformance(createHttpServletRequest(), createRequestDetails(rs));
+		narrativeText = cs.getText().getDivAsString();
+		assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">HAPI FHIR Server</div>", narrativeText);
+
+		rs.setServerName("My Server Name");
+
+		cs = (CapabilityStatement) sc.getServerConformance(createHttpServletRequest(), createRequestDetails(rs));
+		narrativeText = cs.getText().getDivAsString();
+		assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">My Server Name</div>", narrativeText);
+	}
+
+	@Test
 	public void testFormats() throws ServletException {
 		RestfulServer rs = new RestfulServer(myCtx);
 		rs.setProviders(new ConditionalProvider());


### PR DESCRIPTION
It may be the expected behavior as name, version, copyright, etc. are all customizable but in my case, I would like to have my server name as narrative text of the CapabilityStatement.

Changelog:
- Use `configuration.getServerName()` as value for the narrative text generated by ServerCapabilityStatementProvider class
- Unit test

If this is the expected behavior, discard the PR