### PR TITLE
Fix issue 6097 duplicate bean names

### DIFF
--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/expunge/DeleteExpungeAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/expunge/DeleteExpungeAppCtx.java
@@ -65,7 +65,7 @@ public class DeleteExpungeAppCtx {
 						"load-ids",
 						"Load IDs of resources to expunge",
 						ResourceIdListWorkChunkJson.class,
-						loadIdsStep(theBatch2DaoSvc))
+						expungeLoadIdsStep(theBatch2DaoSvc))
 				.addLastStep(
 						"expunge",
 						"Perform the resource expunge",
@@ -85,7 +85,7 @@ public class DeleteExpungeAppCtx {
 	}
 
 	@Bean
-	public LoadIdsStep<DeleteExpungeJobParameters> loadIdsStep(IBatch2DaoSvc theBatch2DaoSvc) {
+	public LoadIdsStep<DeleteExpungeJobParameters> expungeLoadIdsStep(IBatch2DaoSvc theBatch2DaoSvc) {
 		return new LoadIdsStep<>(theBatch2DaoSvc);
 	}
 

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/reindex/ReindexAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/reindex/ReindexAppCtx.java
@@ -59,7 +59,7 @@ public class ReindexAppCtx {
 						"load-ids",
 						"Load IDs of resources to reindex",
 						ResourceIdListWorkChunkJson.class,
-						loadIdsStep(theBatch2DaoSvc))
+						reindexLoadIdsStep(theBatch2DaoSvc))
 				.addLastStep("reindex", "Perform the resource reindex", reindexStep())
 				.build();
 	}
@@ -70,7 +70,7 @@ public class ReindexAppCtx {
 	}
 
 	@Bean
-	public IJobStepWorker<ReindexJobParameters, ChunkRangeJson, ResourceIdListWorkChunkJson> loadIdsStep(
+	public IJobStepWorker<ReindexJobParameters, ChunkRangeJson, ResourceIdListWorkChunkJson> reindexLoadIdsStep(
 			IBatch2DaoSvc theBatch2DaoSvc) {
 		return new LoadIdsStep<>(theBatch2DaoSvc);
 	}

--- a/hapi-fhir-storage-mdm/src/main/java/ca/uhn/fhir/mdm/batch2/submit/MdmSubmitAppCtx.java
+++ b/hapi-fhir-storage-mdm/src/main/java/ca/uhn/fhir/mdm/batch2/submit/MdmSubmitAppCtx.java
@@ -58,7 +58,10 @@ public class MdmSubmitAppCtx {
 						ChunkRangeJson.class,
 						submitGenerateRangeChunksStep())
 				.addIntermediateStep(
-						"load-ids", "Load the IDs", ResourceIdListWorkChunkJson.class, loadIdsStep(theBatch2DaoSvc))
+						"load-ids",
+						"Load the IDs",
+						ResourceIdListWorkChunkJson.class,
+						mdmSubmitLoadIdsStep(theBatch2DaoSvc))
 				.addLastStep(
 						"inflate-and-submit-resources",
 						"Inflate and Submit resources",
@@ -78,7 +81,7 @@ public class MdmSubmitAppCtx {
 	}
 
 	@Bean
-	public LoadIdsStep<MdmSubmitJobParameters> loadIdsStep(IBatch2DaoSvc theBatch2DaoSvc) {
+	public LoadIdsStep<MdmSubmitJobParameters> mdmSubmitLoadIdsStep(IBatch2DaoSvc theBatch2DaoSvc) {
 		return new LoadIdsStep<>(theBatch2DaoSvc);
 	}
 


### PR DESCRIPTION
Closes #6097 

#### Changelog:
- Rename methods to prevent duplicate bean names

NB: I have renamed the methods to keep usage of Spring beans introduced in #6009 and to keep the consistency with the rest of the class. An alternative might use `@Bean(name = "mdmSubmitLoadIdsStep")`



