### PR TITLE
use SearchParamater validator in package installer

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6111-fix-package-install-composite-search-param-with-no-expression.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6111-fix-package-install-composite-search-param-with-no-expression.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 6111
+title: "Previously, the package installer wouldn't create a composite SearchParameter resource if the SearchParameter 
+resource didn't have an expression element at the root level. This has now been fixed by making
+SearchParameter validation in package installer consistent with the DAO level validations."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
@@ -360,7 +360,22 @@ public class FhirResourceDaoR4SearchCustomSearchParamTest extends BaseJpaR4Test 
 	}
 
 	@Test
-	public void testCreateInvalidParamNoPath() {
+	public void testCreateCompositeParamNoExpressionAtRootLevel() {
+		// allow composite search parameter to have no expression element at root level on the resource
+		SearchParameter fooSp = new SearchParameter();
+		fooSp.addBase("Patient");
+		fooSp.setCode("foo");
+		fooSp.setType(Enumerations.SearchParamType.COMPOSITE);
+		fooSp.setTitle("FOO SP");
+		fooSp.setStatus(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
+
+		// Ensure that no exceptions are thrown
+		mySearchParameterDao.create(fooSp, mySrd);
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	@Test
+	public void testCreateInvalidParamNoExpression() {
 		SearchParameter fooSp = new SearchParameter();
 		fooSp.addBase("Patient");
 		fooSp.setCode("foo");

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
@@ -9,10 +9,16 @@ import ca.uhn.fhir.jpa.entity.TermValueSet;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.param.TokenParam;
+import com.github.dnault.xmlpatch.repackaged.org.jaxen.util.SingletonList;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.NamingSystem;
+import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.npm.PackageGenerator;
@@ -147,6 +153,24 @@ public class PackageInstallerSvcImplCreateTest extends BaseJpaR4Test {
 		assertEquals(SECOND_IG_URL_SECOND_OID, actualValueSet2.getUrl());
 		assertEquals(version2, actualValueSet2.getVersion());
 		assertEquals(copyright2, actualValueSet2.getCopyright());
+	}
+
+	@Test
+	void installCompositeSearchParameterWithNoExpressionAtRoot() throws IOException {
+		final String spCode = "my-test-composite-sp-with-no-expression";
+		SearchParameter spR4 = new SearchParameter();
+		spR4.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		spR4.setType(Enumerations.SearchParamType.COMPOSITE);
+		spR4.setBase(List.of(new CodeType("Patient")));
+		spR4.setCode(spCode);
+
+		install(spR4);
+
+		// verify the SP is created
+		SearchParameterMap map = SearchParameterMap.newSynchronous()
+			.add(SearchParameter.SP_CODE, new TokenParam(spCode));
+		IBundleProvider outcome = mySearchParameterDao.search(map);
+		assertEquals(1, outcome.size());
 	}
 
 	@Nonnull


### PR DESCRIPTION
The PR fixes the issue that Package installer doesn't allow creating a composite SearchParameter (SP) resource if there is no `expression` element at the root level of the SearchParameter resource, whereas creating such a SP by other means (such as through FHIR endpoint) is allowed according to the spec. 

The cause was that there were some extra validation logic in the Package Installer that Dao level SearchParameter validation didn't have. This validation for SearchParameters in Package installer has now been refactored to use the same code as the SearchParameter validation used by the DAO layer, so that there is no difference between what can be created via PackageInstaller and other means. 


closes #6111 