### PR TITLE
make consent service dont call willSeeResource on children if parent resource is AUTHORIZED or REJECT

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6125-consentinterceptor-dont-call-children-if-parent-authorized-or-rejected.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6125-consentinterceptor-dont-call-children-if-parent-authorized-or-rejected.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 6124
+title: "Previously, when retrieving a resource which may contain other resources, such as a document Bundle, 
+if a ConsentService's willSeeResource returned AUTHORIZED or REJECT on this parent resource, the willSeeResource was 
+still being called for the child resources. This has now been fixed so that if a consent service 
+returns AUTHORIZED or REJECT for a parent resource, willSeeResource is not called for the child resources."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
@@ -31,7 +31,6 @@ import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters;
 import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
-import ca.uhn.fhir.rest.server.interceptor.consent.ConsentInterceptor;
 import ca.uhn.fhir.util.BundleUtil;
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nonnull;
@@ -508,8 +507,7 @@ public class AuthorizationInterceptor implements IRuleApplier {
 		}
 
 		// Don't check the value twice
-		IdentityHashMap<IBaseResource, Boolean> alreadySeenMap =
-				ConsentInterceptor.getAlreadySeenResourcesMap(theRequestDetails, myRequestSeenResourcesKey);
+		IdentityHashMap<IBaseResource, Boolean> alreadySeenMap = getAlreadySeenResourcesMap(theRequestDetails);
 		if (alreadySeenMap.putIfAbsent(theResponseObject, Boolean.TRUE) != null) {
 			return;
 		}
@@ -677,5 +675,16 @@ public class AuthorizationInterceptor implements IRuleApplier {
 		}
 
 		return theResource.getIdElement().getResourceType();
+	}
+
+	@SuppressWarnings("unchecked")
+	private IdentityHashMap<IBaseResource, Boolean> getAlreadySeenResourcesMap(RequestDetails theRequestDetails) {
+		IdentityHashMap<IBaseResource, Boolean> alreadySeenResources = (IdentityHashMap<IBaseResource, Boolean>)
+				theRequestDetails.getUserData().get(myRequestSeenResourcesKey);
+		if (alreadySeenResources == null) {
+			alreadySeenResources = new IdentityHashMap<>();
+			theRequestDetails.getUserData().put(myRequestSeenResourcesKey, alreadySeenResources);
+		}
+		return alreadySeenResources;
 	}
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/HashMapResourceProvider.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/HashMapResourceProvider.java
@@ -580,7 +580,10 @@ public class HashMapResourceProvider<T extends IBaseResource> implements IResour
 		List<IBaseResource> output =
 				fireInterceptorsAndFilterAsNeeded(Lists.newArrayList(theResource), theRequestDetails);
 		if (output.size() == 1) {
-			return theResource;
+			// do not return theResource here but return whatever the interceptor returned in the list because
+			// the interceptor might have set the resource in the list to null (if it didn't want it to be returned).
+			// ConsentInterceptor might do this for example.
+			return (T) output.get(0);
 		} else {
 			return null;
 		}


### PR DESCRIPTION
This PR makes sure that when retrieving a resource that may contain other resources (a bundle for example), if a ConsentService returns AUTHORIZED or REJECT for that parent resource on willSeeResource call, the willSeeResource is not called for the child resources contained in the parent resource. 


The ConsentInterceptor class (which calls the ConsentServices) had already in place this logic of not calling willSeeResource on the child Resources upon getting AUTHORIZED or REJECT from the parent, but it was working for the bundles returned for the Search results. It wasn't working when parent resource is retrieved directly by its id, for example a Bundle of type document that is persisted in the DB, not a search result bundle that is generated by the server. 

The main reason is why this wasn't working for persisted Bundles is as follows. ConsentInterceptor calls willSeeResource on two pointcuts in this flow: 
- first in STORAGE_PRESHOW_RESOURCES hook
- second in SERVER_OUTGOING_RESPONSE hook 

When retrieving a persisted bundle, the bundle is processed by the STORAGE_PRESHOW_RESOURCES hook, which sends the bundle to ConsentServices by calling willSeeResource. Then SERVER_OUTGOING_RESPONSE is invoked, which in the existing code was checking that the bundle resource was already processed and it was directly starting calling willSeeResource on the child resources. 

It seems that the reason for this existing logic is that on server generated bundles returned in the response ( for example for a bundle returning the search results) STORAGE_PRESHOW_RESOURCES is not called for the bundle,  but called for the child resources that is being returned in the bundle. This makes sense because the bundle is server generated when returning response (not an actual resource in the db). So the bundle is not available on STORAGE_PRESHOW_RESOURCES yet. The search result bundle itself is processed in 
SERVER_OUTGOING_RESPONSE for the first time, and the existing code detects this and does not call willSeeResource on the child resources. 

In summary, the existing code assumed that if we are returning a bundle, it will be processed for the first time in SERVER_OUTGOING_RESPONSE but not in STORAGE_PRESHOW_RESOURCES, and this assumption is wrong for persisted bundles. For a persisted bundle, STORAGE_PRESHOW_RESOURCES processes the bundle the first.
 
My change is  when STORAGE_PRESHOW_RESOURCES processes a resource, I store the ConsentService decision for the resource. When SERVER_OUTGOING_RESPONSE is called, I check if the resource was processed already and if it was and the decision was AUTHORIZED or REJECT, I make the function return immediately without calling willSeeResource on the children. (Otherwise if the decision was PROCEED or the resource wasn't processed before, I let the function run as before). 
