### PR TITLE
SearchParameterMap deep cloning via serialization/deserialization (#6104)

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/SearchParameterMap.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/SearchParameterMap.java
@@ -38,6 +38,7 @@ import ca.uhn.fhir.rest.param.TokenParamModifier;
 import ca.uhn.fhir.util.UrlUtil;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.annotation.Nonnull;
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.CompareToBuilder;
@@ -101,40 +102,12 @@ public class SearchParameterMap implements Serializable {
 	}
 
 	/**
-	 * Creates and returns a copy of this map
+	 * Creates and returns a deep clone of this map
 	 */
 	@JsonIgnore
 	@Override
 	public SearchParameterMap clone() {
-		SearchParameterMap map = new SearchParameterMap();
-		map.setSummaryMode(getSummaryMode());
-		map.setSort(getSort());
-		map.setSearchTotalMode(getSearchTotalMode());
-		map.setRevIncludes(getRevIncludes());
-		map.setIncludes(getIncludes());
-		map.setEverythingMode(getEverythingMode());
-		map.setCount(getCount());
-		map.setDeleteExpunge(isDeleteExpunge());
-		map.setLastN(isLastN());
-		map.setLastNMax(getLastNMax());
-		map.setLastUpdated(getLastUpdated());
-		map.setLoadSynchronous(isLoadSynchronous());
-		map.setNearDistanceParam(getNearDistanceParam());
-		map.setLoadSynchronousUpTo(getLoadSynchronousUpTo());
-		map.setOffset(getOffset());
-		map.setSearchContainedMode(getSearchContainedMode());
-
-		for (Map.Entry<String, List<List<IQueryParameterType>>> entry : mySearchParameterMap.entrySet()) {
-			List<List<IQueryParameterType>> andParams = entry.getValue();
-			List<List<IQueryParameterType>> newAndParams = new ArrayList<>();
-			for (List<IQueryParameterType> orParams : andParams) {
-				List<IQueryParameterType> newOrParams = new ArrayList<>(orParams);
-				newAndParams.add(newOrParams);
-			}
-			map.put(entry.getKey(), newAndParams);
-		}
-
-		return map;
+		return SerializationUtils.clone(this);
 	}
 
 	public SummaryEnum getSummaryMode() {


### PR DESCRIPTION
SearchParameterMap deep cloning via serialization/deserialization (#6104)

After careful research, I concluded that deep cloning through the implementation of Cloneable will not be the best solution. There are many classes in the hierarchy where it will not be possible to call the clone() method on the parent for some fields, and then we will have to assign a reference, which negates the whole purpose of deep cloning.

Cloning through serialization should help, and in the project I did not find any transient fields that could interfere with this method.