### PR TITLE
SearchParamMatcher `_id` Matching Fix

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
@@ -452,8 +452,8 @@ public class InMemoryResourceMatcher {
 
 	private boolean matchIdsOr(List<IQueryParameterType> theOrParams, IBaseResource theResource) {
 		return theOrParams.stream()
-				.anyMatch(param -> param instanceof StringParam
-						&& matchId(((StringParam) param).getValue(), theResource.getIdElement()));
+				.anyMatch(param -> param instanceof TokenParam
+						&& matchId(((TokenParam) param).getValue(), theResource.getIdElement()));
 	}
 
 	private boolean matchId(String theValue, IIdType theId) {


### PR DESCRIPTION
The issue is described in #6137.