### PR TITLE
fix hfj search migration task

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6142-fix-hfj-search-migration-task.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6142-fix-hfj-search-migration-task.yaml
@@ -2,5 +2,5 @@
 type: fix
 issue: 6142
 jira: SMILE-8701
-title: "Previously, if you upgraded from a HAPI version before 6.6.0, the `SEARCH_UUID` column length still showed as 36 
-despite it being updated to length 48. This has now been fixed."
+title: "Previously, if you upgraded from any older HAPI version to 6.6.0 or later, the `SEARCH_UUID` column length still 
+showed as 36 despite it being updated to have a length of 48. This has now been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6142-fix-hfj-search-migration-task.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6142-fix-hfj-search-migration-task.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 6142
+jira: SMILE-8701
+title: "Previously, if you upgraded from a HAPI version before 6.6.0, the `SEARCH_UUID` column length still showed as 36 
+despite it being updated to length 48. This has now been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -468,6 +468,11 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 						.failureAllowed();
 			}
 		}
+
+		version.onTable(Search.HFJ_SEARCH)
+			.modifyColumn("20240722.1", Search.SEARCH_UUID)
+			.nullable()
+			.withType(ColumnTypeEnum.STRING, Search.SEARCH_UUID_COLUMN_LENGTH);
 	}
 
 	protected void init720() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -472,7 +472,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable(Search.HFJ_SEARCH)
 			.modifyColumn("20240722.1", Search.SEARCH_UUID)
 			.nullable()
-			.withType(ColumnTypeEnum.STRING, Search.SEARCH_UUID_COLUMN_LENGTH);
+			.withType(ColumnTypeEnum.STRING, 48);
 	}
 
 	protected void init720() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -470,9 +470,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		}
 
 		version.onTable(Search.HFJ_SEARCH)
-			.modifyColumn("20240722.1", Search.SEARCH_UUID)
-			.nullable()
-			.withType(ColumnTypeEnum.STRING, 48);
+				.modifyColumn("20240722.1", Search.SEARCH_UUID)
+				.nullable()
+				.withType(ColumnTypeEnum.STRING, 48);
 	}
 
 	protected void init720() {


### PR DESCRIPTION
- Add a new migration for `HFJ_SEARCH` table to modify the `SEARCH_UUID` column length. Previously, we accidentally used `addColumn()` when modifying the length, which did nothing since the column already existed. 

Closes #6142 