### PR TITLE
Make transactions partition aware

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
@@ -96,6 +97,28 @@ public class RequestPartitionId implements IModelJson {
 		myPartitionNames = null;
 		myPartitionIds = null;
 		myAllPartitions = true;
+	}
+
+	/**
+	 * Creates a new RequestPartitionId which includes all partition IDs from
+	 * this {@link RequestPartitionId} but also includes all IDs from the given
+	 * {@link RequestPartitionId}. Any duplicates are only included once, and
+	 * partition dates are ignored and not returned. This {@link RequestPartitionId}
+	 * and {@literal theOther} are not modified.
+	 *
+	 * @since 7.4.0
+	 */
+	public RequestPartitionId mergeIds(RequestPartitionId theOther) {
+		if (isAllPartitions() || theOther.isAllPartitions()) {
+			return RequestPartitionId.allPartitions();
+		}
+
+		List<Integer> thisPartitionIds = getPartitionIds();
+		List<Integer> otherPartitionIds = theOther.getPartitionIds();
+		List<Integer> newPartitionIds = Stream.concat(thisPartitionIds.stream(), otherPartitionIds.stream())
+			.distinct()
+			.collect(Collectors.toList());
+		return RequestPartitionId.fromPartitionIds(newPartitionIds);
 	}
 
 	public static RequestPartitionId fromJson(String theJson) throws JsonProcessingException {

--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -91,6 +91,7 @@ ca.uhn.fhir.jpa.dao.BaseStorageDao.inlineMatchNotSupported=Inline match URLs are
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithMultipleMatchFailure=Failed to {0} resource with match URL "{1}" because this search matched {2} resources
 ca.uhn.fhir.jpa.dao.BaseStorageDao.deleteByUrlThresholdExceeded=Failed to DELETE resources with match URL "{0}" because the resolved number of resources: {1} exceeds the threshold of {2}
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithIdNotMatchFailure=Failed to {0} resource with match URL "{1}" because the matching resource does not match the provided ID
+ca.uhn.fhir.jpa.dao.BaseTransactionProcessor.multiplePartitionAccesses=Can not process transaction with {0} entries: Entries require access to multiple/conflicting partitions
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.transactionOperationFailedNoId=Failed to {0} resource in transaction because no ID was provided
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.transactionOperationFailedUnknownId=Failed to {0} resource in transaction because no resource could be found with ID {1}
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.uniqueIndexConflictFailure=Can not create resource of type {0} as it would create a duplicate unique index matching query: {1} (existing index belongs to {2}, new unique index created by {3})

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/model/RequestPartitionIdTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/model/RequestPartitionIdTest.java
@@ -42,6 +42,50 @@ public class RequestPartitionIdTest {
 	}
 
 	@Test
+	public void testMergeIds() {
+		RequestPartitionId input0 = RequestPartitionId.fromPartitionIds(1, 2, 3);
+		RequestPartitionId input1 = RequestPartitionId.fromPartitionIds(1, 2, 4);
+
+		RequestPartitionId actual = input0.mergeIds(input1);
+		RequestPartitionId expected = RequestPartitionId.fromPartitionIds(1, 2, 3, 4);
+		assertEquals(expected, actual);
+
+	}
+
+	@Test
+	public void testMergeIds_ThisAllPartitions() {
+		RequestPartitionId input0 = RequestPartitionId.allPartitions();
+		RequestPartitionId input1 = RequestPartitionId.fromPartitionIds(1, 2, 4);
+
+		RequestPartitionId actual = input0.mergeIds(input1);
+		RequestPartitionId expected = RequestPartitionId.allPartitions();
+		assertEquals(expected, actual);
+
+	}
+
+	@Test
+	public void testMergeIds_OtherAllPartitions() {
+		RequestPartitionId input0 = RequestPartitionId.fromPartitionIds(1, 2, 3);
+		RequestPartitionId input1 = RequestPartitionId.allPartitions();
+
+		RequestPartitionId actual = input0.mergeIds(input1);
+		RequestPartitionId expected = RequestPartitionId.allPartitions();
+		assertEquals(expected, actual);
+
+	}
+
+	@Test
+	public void testMergeIds_IncludesDefault() {
+		RequestPartitionId input0 = RequestPartitionId.fromPartitionIds(1, 2, 3);
+		RequestPartitionId input1 = RequestPartitionId.defaultPartition();
+
+		RequestPartitionId actual = input0.mergeIds(input1);
+		RequestPartitionId expected = RequestPartitionId.fromPartitionIds(1, 2, 3, null);
+		assertEquals(expected, actual);
+
+	}
+
+	@Test
 	public void testSerDeserSer() throws JsonProcessingException {
 		{
 			RequestPartitionId start = RequestPartitionId.fromPartitionId(123, LocalDate.of(2020, 1, 1));

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6163-make-transactions-better-partition-aware.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6163-make-transactions-better-partition-aware.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+jira: SMILE-8652
+title: "When JPA servers are configured to always require a new database
+  transaction when switching partitions, the server will now correctly
+  identify the correct partition for FHIR transaction operations, and
+  fail the operation if multiple partitions would be required."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -150,14 +150,8 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 			List<IBase> theEntries,
 			StopWatch theTransactionStopWatch) {
 
-		ITransactionProcessorVersionAdapter versionAdapter = getVersionAdapter();
-		RequestPartitionId requestPartitionId = null;
-		if (!myPartitionSettings.isPartitioningEnabled()) {
-			requestPartitionId = RequestPartitionId.allPartitions();
-		} else {
-			// If all entries in the transaction point to the exact same partition, we'll try and do a pre-fetch
-			requestPartitionId = super.determineRequestPartitionIdForWriteEntries(theRequest, theEntries);
-		}
+		ITransactionProcessorVersionAdapter<?, ?> versionAdapter = getVersionAdapter();
+		RequestPartitionId requestPartitionId = super.determineRequestPartitionIdForWriteEntries(theRequest, theEntries);
 
 		if (requestPartitionId != null) {
 			preFetch(theTransactionDetails, theEntries, versionAdapter, requestPartitionId);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -156,7 +156,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 			requestPartitionId = RequestPartitionId.allPartitions();
 		} else {
 			// If all entries in the transaction point to the exact same partition, we'll try and do a pre-fetch
-			requestPartitionId = getSinglePartitionForAllEntriesOrNull(theRequest, theEntries, versionAdapter);
+			requestPartitionId = super.determineRequestPartitionIdForWriteEntries(theRequest, theEntries);
 		}
 
 		if (requestPartitionId != null) {
@@ -470,24 +470,6 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 			theOutputSearchParameterMapsToResolve.add(new MatchUrlToResolve(
 					theRequestUrl, matchUrlSearchMap, resourceDefinition, theShouldPreFetchResourceBody));
 		}
-	}
-
-	private RequestPartitionId getSinglePartitionForAllEntriesOrNull(
-			RequestDetails theRequest, List<IBase> theEntries, ITransactionProcessorVersionAdapter versionAdapter) {
-		RequestPartitionId retVal = null;
-		Set<RequestPartitionId> requestPartitionIdsForAllEntries = new HashSet<>();
-		for (IBase nextEntry : theEntries) {
-			IBaseResource resource = versionAdapter.getResource(nextEntry);
-			if (resource != null) {
-				RequestPartitionId requestPartition = myRequestPartitionSvc.determineCreatePartitionForRequest(
-						theRequest, resource, myFhirContext.getResourceType(resource));
-				requestPartitionIdsForAllEntries.add(requestPartition);
-			}
-		}
-		if (requestPartitionIdsForAllEntries.size() == 1) {
-			retVal = requestPartitionIdsForAllEntries.iterator().next();
-		}
-		return retVal;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/interceptor/model/ReadPartitionIdRequestDetails.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/interceptor/model/ReadPartitionIdRequestDetails.java
@@ -114,7 +114,7 @@ public class ReadPartitionIdRequestDetails extends PartitionIdRequestDetails {
 	}
 
 	/**
-	 * @since 7.6.0
+	 * @since 7.4.0
 	 */
 	public static ReadPartitionIdRequestDetails forDelete(@Nonnull String theResourceType, @Nonnull IIdType theId) {
 		RestOperationTypeEnum op = RestOperationTypeEnum.DELETE;
@@ -123,7 +123,7 @@ public class ReadPartitionIdRequestDetails extends PartitionIdRequestDetails {
 	}
 
 	/**
-	 * @since 7.6.0
+	 * @since 7.4.0
 	 */
 	public static ReadPartitionIdRequestDetails forPatch(String theResourceType, IIdType theId) {
 		RestOperationTypeEnum op = RestOperationTypeEnum.PATCH;

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/interceptor/model/ReadPartitionIdRequestDetails.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/interceptor/model/ReadPartitionIdRequestDetails.java
@@ -113,6 +113,24 @@ public class ReadPartitionIdRequestDetails extends PartitionIdRequestDetails {
 				null, RestOperationTypeEnum.EXTENDED_OPERATION_SERVER, null, null, null, null, theOperationName);
 	}
 
+	/**
+	 * @since 7.6.0
+	 */
+	public static ReadPartitionIdRequestDetails forDelete(@Nonnull String theResourceType, @Nonnull IIdType theId) {
+		RestOperationTypeEnum op = RestOperationTypeEnum.DELETE;
+		return new ReadPartitionIdRequestDetails(
+				theResourceType, op, theId.withResourceType(theResourceType), null, null, null, null);
+	}
+
+	/**
+	 * @since 7.6.0
+	 */
+	public static ReadPartitionIdRequestDetails forPatch(String theResourceType, IIdType theId) {
+		RestOperationTypeEnum op = RestOperationTypeEnum.PATCH;
+		return new ReadPartitionIdRequestDetails(
+				theResourceType, op, theId.withResourceType(theResourceType), null, null, null, null);
+	}
+
 	public static ReadPartitionIdRequestDetails forRead(
 			String theResourceType, @Nonnull IIdType theId, boolean theIsVread) {
 		RestOperationTypeEnum op = theIsVread ? RestOperationTypeEnum.VREAD : RestOperationTypeEnum.READ;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/BasePartitioningR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/BasePartitioningR4Test.java
@@ -55,7 +55,7 @@ public abstract class BasePartitioningR4Test extends BaseJpaR4SystemTest {
 
 	@AfterEach
 	public void after() {
-		myPartitionInterceptor.assertNoRemainingIds();
+		assertNoRemainingPartitionIds();
 
 		myPartitionSettings.setIncludePartitionInSearchHashes(new PartitionSettings().isIncludePartitionInSearchHashes());
 		myPartitionSettings.setPartitioningEnabled(new PartitionSettings().isPartitioningEnabled());
@@ -68,6 +68,10 @@ public abstract class BasePartitioningR4Test extends BaseJpaR4SystemTest {
 		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(new JpaStorageSettings().isAutoCreatePlaceholderReferenceTargets());
 		myStorageSettings.setMassIngestionMode(new JpaStorageSettings().isMassIngestionMode());
 		myStorageSettings.setMatchUrlCacheEnabled(new JpaStorageSettings().getMatchUrlCache());
+	}
+
+	protected void assertNoRemainingPartitionIds() {
+		myPartitionInterceptor.assertNoRemainingIds();
 	}
 
 	@Override
@@ -89,7 +93,8 @@ public abstract class BasePartitioningR4Test extends BaseJpaR4SystemTest {
 		myPartitionId4 = 4;
 
 		myPartitionInterceptor = new MyReadWriteInterceptor();
-		mySrdInterceptorService.registerInterceptor(myPartitionInterceptor);
+
+		registerPartitionInterceptor();
 
 		myPartitionConfigSvc.createPartition(new PartitionEntity().setId(myPartitionId).setName(PARTITION_1), null);
 		myPartitionConfigSvc.createPartition(new PartitionEntity().setId(myPartitionId2).setName(PARTITION_2), null);
@@ -106,6 +111,11 @@ public abstract class BasePartitioningR4Test extends BaseJpaR4SystemTest {
 		for (int i = 1; i <= 4; i++) {
 			myPartitionConfigSvc.getPartitionById(i);
 		}
+
+	}
+
+	protected void registerPartitionInterceptor() {
+		mySrdInterceptorService.registerInterceptor(myPartitionInterceptor);
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitionedStrictTransactionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitionedStrictTransactionR4Test.java
@@ -1,0 +1,166 @@
+package ca.uhn.fhir.jpa.dao.r4;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.model.ReadPartitionIdRequestDetails;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
+import ca.uhn.fhir.util.BundleBuilder;
+import jakarta.annotation.Nonnull;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PartitionedStrictTransactionR4Test extends BasePartitioningR4Test {
+
+	@Autowired
+	private HapiTransactionService myTransactionService;
+
+	@Override
+	public void before() throws Exception {
+		super.before();
+		myTransactionService.setTransactionPropagationWhenChangingPartitions(Propagation.REQUIRES_NEW);
+	}
+
+	@Override
+	public void after() {
+		super.after();
+		myTransactionService.setTransactionPropagationWhenChangingPartitions(HapiTransactionService.DEFAULT_TRANSACTION_PROPAGATION_WHEN_CHANGING_PARTITIONS);
+		myInterceptorRegistry.unregisterInterceptorsIf(t->t instanceof MyPartitionSelectorInterceptor);
+	}
+
+	/**
+	 * We manually register {@link MyPartitionSelectorInterceptor} for this test class
+	 * as the partition interceptor
+	 */
+	@Override
+	protected void registerPartitionInterceptor() {
+		myInterceptorRegistry.registerInterceptor(new MyPartitionSelectorInterceptor());
+	}
+
+	@Override
+	protected void assertNoRemainingPartitionIds() {
+		// We don't use the superclass to manage partition IDs
+	}
+
+
+	@ParameterizedTest
+	@CsvSource({
+		"batch       , 2",
+		"transaction , 1",
+	})
+	public void testSinglePartitionCreate(String theBundleType, int theExpectedCommitCount) {
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionCreateEntry(newPatient());
+		bb.addTransactionCreateEntry(newPatient());
+		bb.setType(theBundleType);
+		Bundle input = bb.getBundleTyped();
+
+		// Test
+		myCaptureQueriesListener.clear();
+		Bundle output = mySystemDao.transaction(mySrd, input);
+
+		// Verify
+		assertEquals(theExpectedCommitCount, myCaptureQueriesListener.countCommits());
+		assertEquals(0, myCaptureQueriesListener.countRollbacks());
+		IdType id = new IdType(output.getEntry().get(0).getResponse().getLocation());
+		Patient actualPatient = myPatientDao.read(id, mySrd);
+		RequestPartitionId actualPartitionId = (RequestPartitionId) actualPatient.getUserData(Constants.RESOURCE_PARTITION_ID);
+		assertThat(actualPartitionId.getPartitionIds()).containsExactly(myPartitionId);
+	}
+
+
+	@Test
+	public void testSinglePartitionDelete() {
+		createPatient(withId("A"), withActiveTrue());
+
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionDeleteEntry(new IdType("Patient/A"));
+		Bundle input = bb.getBundleTyped();
+
+		// Test
+		myCaptureQueriesListener.clear();
+		Bundle output = mySystemDao.transaction(mySrd, input);
+
+		// Verify
+		assertEquals(1, myCaptureQueriesListener.countCommits());
+		assertEquals(0, myCaptureQueriesListener.countRollbacks());
+		IdType id = new IdType(output.getEntry().get(0).getResponse().getLocation());
+		assertEquals("2", id.getVersionIdPart());
+
+		assertThrows(ResourceGoneException.class, ()->myPatientDao.read(id.toUnqualifiedVersionless(), mySrd));
+	}
+
+	@Test
+	public void testMultipleNonMatchingPartitions() {
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionCreateEntry(newPatient());
+		bb.addTransactionCreateEntry(newObservation());
+		Bundle input = bb.getBundleTyped();
+
+		// Test
+		var e = assertThrows(InvalidRequestException.class, () -> mySystemDao.transaction(mySrd, input));
+		assertThat(e.getMessage()).contains("HAPI-2541: Can not process transaction with 2 entries: Entries require access to multiple/conflicting partitions");
+
+	}
+
+	private static @Nonnull Patient newPatient() {
+		Patient patient = new Patient();
+		patient.setActive(true);
+		return patient;
+	}
+
+	private static @Nonnull Observation newObservation() {
+		Observation observation = new Observation();
+		observation.setStatus(Observation.ObservationStatus.FINAL);
+		return observation;
+	}
+
+
+	public class MyPartitionSelectorInterceptor {
+
+		@Hook(Pointcut.STORAGE_PARTITION_IDENTIFY_CREATE)
+		public RequestPartitionId selectPartitionCreate(IBaseResource theResource) {
+			String resourceType = myFhirContext.getResourceType(theResource);
+			return selectPartition(resourceType);
+		}
+
+		@Hook(Pointcut.STORAGE_PARTITION_IDENTIFY_READ)
+		public RequestPartitionId selectPartitionRead(ReadPartitionIdRequestDetails theDetails) {
+			return selectPartition(theDetails.getResourceType());
+		}
+
+		@Nonnull
+		private RequestPartitionId selectPartition(String resourceType) {
+			switch (resourceType) {
+				case "Patient":
+					return RequestPartitionId.fromPartitionId(myPartitionId);
+				case "Observation":
+					return RequestPartitionId.fromPartitionId(myPartitionId2);
+				case "SearchParameter":
+				case "Organization":
+					return RequestPartitionId.defaultPartition();
+				default:
+					throw new InternalErrorException("Don't know how to handle resource type");
+			}
+		}
+
+	}
+
+
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/OracleCondition.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/OracleCondition.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2024 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.embedded;
 
 import org.apache.commons.lang3.StringUtils;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/annotation/OracleTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/annotation/OracleTest.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2024 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.embedded.annotation;
 
 import ca.uhn.fhir.jpa.embedded.OracleCondition;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -740,7 +740,7 @@ public abstract class BaseTransactionProcessor {
 	}
 
 	@Nullable
-	private RequestPartitionId determineRequestPartitionIdForWriteEntries(
+	protected RequestPartitionId determineRequestPartitionIdForWriteEntries(
 			RequestDetails theRequestDetails, List<IBase> theEntries) {
 		if (!myPartitionSettings.isPartitioningEnabled()
 				|| !myHapiTransactionService.isRequiresNewTransactionWhenChangingPartitions()) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/tx/IHapiTransactionService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/tx/IHapiTransactionService.java
@@ -90,6 +90,15 @@ public interface IHapiTransactionService {
 			@Nonnull Isolation theIsolation,
 			@Nonnull ICallable<T> theCallback);
 
+	/**
+	 * Returns {@literal true} if this transaction service will open a new
+	 * transaction when the request partition is for a different partition than
+	 * the currently executing partition.
+	 *
+	 * @since 7.6.0
+	 */
+	boolean isRequiresNewTransactionWhenChangingPartitions();
+
 	interface IExecutionBuilder extends TransactionOperations {
 
 		IExecutionBuilder withIsolation(Isolation theIsolation);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/tx/IHapiTransactionService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/tx/IHapiTransactionService.java
@@ -95,7 +95,7 @@ public interface IHapiTransactionService {
 	 * transaction when the request partition is for a different partition than
 	 * the currently executing partition.
 	 *
-	 * @since 7.6.0
+	 * @since 7.4.0
 	 */
 	boolean isRequiresNewTransactionWhenChangingPartitions();
 


### PR DESCRIPTION
Transactions on systems configured to require a new transaction when changing partitions will now be able to correctly execute  FHIR transactions