### PR TITLE
fix concepts with no display element for $apply-codesystem-delta-add …

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6159-code-system-delta-add-or-remove-fail-without-concept-display.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6159-code-system-delta-add-or-remove-fail-without-concept-display.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 6159
+jira: SMILE-8604
+title: "Previously, `$apply-codesystem-delta-add` and `$apply-codesystem-delta-remove` operations were failing 
+with a 500 Server Error when invoked with a CodeSystem Resource payload that had a concept without a  
+`display` element. This has now been fixed so that concepts without display field is accepted, as `display` 
+element is not required."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/TerminologyUploaderProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/TerminologyUploaderProvider.java
@@ -475,6 +475,9 @@ public class TerminologyUploaderProvider extends BaseJpaProvider {
 	}
 
 	private static String csvEscape(String theValue) {
+		if (theValue == null) {
+			return "";
+		}
 		return '"' + theValue.replace("\"", "\"\"").replace("\n", "\\n").replace("\r", "") + '"';
 	}
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
@@ -61,7 +61,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		delta.addRootConcept("RootA", "Root A");
 		delta.addRootConcept("RootB", "Root B");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			"RootB seq=0"
 		);
@@ -70,7 +70,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		delta.addRootConcept("RootC", "Root C");
 		delta.addRootConcept("RootD", "Root D");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			"RootB seq=0",
 			"RootC seq=0",
@@ -104,7 +104,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		ourLog.info("Starting testAddHierarchyConcepts");
 
 		createNotPresentCodeSystem();
-		assertHierarchyContains();
+		assertHierarchyContainsExactly();
 
 		ourLog.info("Have created code system");
 		runInTransaction(() -> {
@@ -117,7 +117,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		delta.addRootConcept("RootA", "Root A");
 		delta.addRootConcept("RootB", "Root B");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			"RootB seq=0"
 		);
@@ -139,7 +139,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 
 		myCaptureQueriesListener.logAllQueriesForCurrentThread();
 
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			" ChildAA seq=0",
 			" ChildAB seq=1",
@@ -151,7 +151,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 	@Test
 	public void testAddMoveConceptFromOneParentToAnother() {
 		createNotPresentCodeSystem();
-		assertHierarchyContains();
+		assertHierarchyContainsExactly();
 
 		UploadStatistics outcome;
 		CustomTerminologySet delta;
@@ -162,7 +162,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAAA").setDisplay("Child AAA");
 		delta.addRootConcept("RootB", "Root B");
 		outcome = myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			" ChildAA seq=0",
 			"  ChildAAA seq=0",
@@ -174,7 +174,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		delta.addRootConcept("RootB", "Root B")
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAA").setDisplay("Child AA");
 		outcome = myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			" ChildAA seq=0",
 			"  ChildAAA seq=0",
@@ -195,7 +195,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 	@Test
 	public void testReAddingConceptsDoesntRecreateExistingLinks() {
 		createNotPresentCodeSystem();
-		assertHierarchyContains();
+		assertHierarchyContainsExactly();
 
 		UploadStatistics outcome;
 		CustomTerminologySet delta;
@@ -206,7 +206,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		delta.addRootConcept("RootA", "Root A")
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAA").setDisplay("Child AA");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			" ChildAA seq=0"
 		);
@@ -223,7 +223,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAA").setDisplay("Child AA")
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAAA").setDisplay("Child AAA");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			" ChildAA seq=0",
 			"  ChildAAA seq=0"
@@ -242,7 +242,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAAA").setDisplay("Child AAA")
 			.addChild(TermConceptParentChildLink.RelationshipTypeEnum.ISA).setCode("ChildAAAA").setDisplay("Child AAAA");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"RootA seq=0",
 			" ChildAA seq=0",
 			"  ChildAAA seq=0",
@@ -293,7 +293,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo", set);
 
 		// Check so far
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"ParentA seq=0",
 			" ChildA seq=0"
 		);
@@ -306,7 +306,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo", set);
 
 		// Check so far
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"ParentA seq=0",
 			" ChildA seq=0",
 			"  ChildAA seq=0"
@@ -331,7 +331,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo", set);
 
 		// Check so far
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"ParentA seq=0",
 			" ChildA seq=0"
 		);
@@ -344,7 +344,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo", set);
 
 		// Check so far
-		assertHierarchyContains(
+		assertHierarchyContainsExactly(
 			"ParentA seq=0",
 			" ChildA seq=0",
 			"  ChildAA seq=0"
@@ -416,7 +416,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 			expectedHierarchy.add(expected);
 		}
 
-		assertHierarchyContains(expectedHierarchy.toArray(new String[0]));
+		assertHierarchyContainsExactly(expectedHierarchy.toArray(new String[0]));
 
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
@@ -740,7 +740,7 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 		dao.update(resourceParsed);
 	}
 
-	protected void assertHierarchyContains(String... theStrings) {
+	protected void assertHierarchyContainsExactly(String... theStrings) {
 		List<String> hierarchy = runInTransaction(() -> {
 			List<String> hierarchyHolder = new ArrayList<>();
 			TermCodeSystem codeSystem = myTermCodeSystemDao.findAll().iterator().next();


### PR DESCRIPTION
Make `$apply-codesystem-delta-add` and `$apply-codesystem-delta-remove` operations work when invoked with a CodeSystem Resource payload with concepts that doesn't have `display` elements.

close #6159 