### PR TITLE
SEARCH_UUID should be non-null

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -472,7 +472,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 		version.onTable(Search.HFJ_SEARCH)
 				.modifyColumn("20240722.1", Search.SEARCH_UUID)
-				.nullable()
+				.nonNullable()
 				.withType(ColumnTypeEnum.STRING, 48);
 
 		{
@@ -1025,7 +1025,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable(Search.HFJ_SEARCH)
 				.addColumn("20230215.1", Search.SEARCH_UUID)
 				.nullable()
-				.type(ColumnTypeEnum.STRING, Search.SEARCH_UUID_COLUMN_LENGTH);
+				.type(ColumnTypeEnum.STRING, 48);
 		version.onTable(BulkImportJobEntity.HFJ_BLK_IMPORT_JOB)
 				.addColumn("20230215.2", BulkImportJobEntity.JOB_ID)
 				.nullable()
@@ -3145,7 +3145,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable("HFJ_SEARCH")
 				.modifyColumn("20190814.7", "SEARCH_UUID")
 				.nonNullable()
-				.withType(ColumnTypeEnum.STRING, Search.SEARCH_UUID_COLUMN_LENGTH);
+				.withType(ColumnTypeEnum.STRING, 36);
 
 		version.onTable("HFJ_SEARCH_PARM").dropThisTable("20190814.8");
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -1025,7 +1025,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable(Search.HFJ_SEARCH)
 				.addColumn("20230215.1", Search.SEARCH_UUID)
 				.nullable()
-				.type(ColumnTypeEnum.STRING, 48);
+				.type(ColumnTypeEnum.STRING, 48)
+				.doNothing(); // This migration used add instead of modify, so was skipped.  See 20240722 for modify.
 		version.onTable(BulkImportJobEntity.HFJ_BLK_IMPORT_JOB)
 				.addColumn("20230215.2", BulkImportJobEntity.JOB_ID)
 				.nullable()


### PR DESCRIPTION
Avoid using constants in migrations because it creates false history.