### PR TITLE
6188 subscription not marked as a cross partition subscription matches operation on resources in other partitions

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,3 +10,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
@@ -332,6 +332,14 @@ public class RequestPartitionId implements IModelJson {
 		return new RequestPartitionId(thePartitionNames, thePartitionIds, thePartitionDate);
 	}
 
+	public static boolean isDefaultPartition(@Nullable RequestPartitionId thePartitionId) {
+		if (thePartitionId == null) {
+			return false;
+		}
+
+		return thePartitionId.isDefaultPartition();
+	}
+
 	/**
 	 * Create a string representation suitable for use as a cache key. Null aware.
 	 * <p>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SubscriptionUtil.java
@@ -65,7 +65,7 @@ public class SubscriptionUtil {
 		populatePrimitiveValue(theContext, theSubscription, "status", theStatus);
 	}
 
-	public static boolean isCrossPartition(IBaseResource theSubscription) {
+	public static boolean isDefinedAsCrossPartitionSubcription(IBaseResource theSubscription) {
 		if (theSubscription instanceof IBaseHasExtensions) {
 			IBaseExtension extension = ExtensionUtil.getExtensionByUrl(
 					theSubscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION);

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6188-non-cross-partition-subs-match-all-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6188-non-cross-partition-subs-match-all-resources.yaml
@@ -2,5 +2,5 @@
 type: fix
 issue: 6188
 jira: SMILE-8759
-title: "Previously, a Subscription not marked as a cross-partition subscription matched operation on resources in other
-partitions.  This issue is fixed."
+title: "Previously, a Subscription not marked as a cross-partition subscription could listen to incoming resources from
+other partitions.  This issue is fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6188-non-cross-partition-subs-match-all-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6188-non-cross-partition-subs-match-all-resources.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 6188
+jira: SMILE-8759
+title: "Previously, a Subscription not marked as a cross-partition subscription matched operation on resources in other
+partitions.  This issue is fixed."

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -32,7 +32,6 @@ import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
 import jakarta.annotation.Nonnull;
-import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.slf4j.Logger;

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/match/matcher/subscriber/SubscriptionMatchingSubscriber.java
@@ -151,13 +151,11 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 	 */
 	private boolean processSubscription(
 			ResourceModifiedMessage theMsg, IIdType theResourceId, ActiveSubscription theActiveSubscription) {
-		// skip if the partitions don't match
+
 		CanonicalSubscription subscription = theActiveSubscription.getSubscription();
-		if (subscription != null
-				&& theMsg.getPartitionId() != null
-				&& theMsg.getPartitionId().hasPartitionIds()
-				&& !subscription.getCrossPartitionEnabled()
-				&& !theMsg.getPartitionId().hasPartitionId(subscription.getRequestPartitionId())) {
+		boolean isMsgPartitionMatchingSubscriptionPartition = isMsgPartitionMatchingSubscriptionPartition(theMsg, subscription);
+
+		if (!isMsgPartitionMatchingSubscriptionPartition && !subscription.isCrossPartitionEnabled()) {
 			return false;
 		}
 		String nextSubscriptionId = theActiveSubscription.getId();
@@ -211,6 +209,14 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 
 		IBaseResource payload = theMsg.getNewPayload(myFhirContext);
 		return mySubscriptionMatchDeliverer.deliverPayload(payload, theMsg, theActiveSubscription, matchResult);
+	}
+
+	private boolean isMsgPartitionMatchingSubscriptionPartition(ResourceModifiedMessage theMsg, CanonicalSubscription theSubscription) {
+		return (theSubscription != null
+			&& theMsg.getPartitionId() != null
+			&& theMsg.getPartitionId().hasPartitionIds()
+			&& theMsg.getPartitionId().hasPartitionId(theSubscription.getRequestPartitionId()));
+
 	}
 
 	private boolean resourceTypeIsAppropriateForSubscription(

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -241,7 +241,7 @@ public class SubscriptionValidatingInterceptor {
 			RequestPartitionId theRequestPartitionId,
 			Pointcut thePointcut) {
 		// If the subscription has the cross partition tag
-		if (SubscriptionUtil.isCrossPartition(theSubscription)
+		if (SubscriptionUtil.isDefinedAsCrossPartitionSubcription(theSubscription)
 				&& !(theRequestDetails instanceof SystemRequestDetails)) {
 			if (!mySubscriptionSettings.isCrossPartitionSubscriptionEnabled()) {
 				throw new UnprocessableEntityException(

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/triggering/SubscriptionTriggeringSvcImpl.java
@@ -151,7 +151,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 		if (theSubscriptionId != null) {
 			IFhirResourceDao<?> subscriptionDao = myDaoRegistry.getSubscriptionDao();
 			IBaseResource subscription = subscriptionDao.read(theSubscriptionId, theRequestDetails);
-			if (mySubscriptionCanonicalizer.canonicalize(subscription).getCrossPartitionEnabled()) {
+			if (mySubscriptionCanonicalizer.canonicalize(subscription).isCrossPartitionEnabled()) {
 				requestPartitionId = RequestPartitionId.allPartitions();
 			} else {
 				// Otherwise, trust the partition passed in via tenant/interceptor.

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/util/SubscriptionUtil.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/util/SubscriptionUtil.java
@@ -34,7 +34,7 @@ public class SubscriptionUtil {
 		RequestPartitionId requestPartitionId =
 				new PartitionablePartitionId(theSubscription.getRequestPartitionId(), null).toPartitionId();
 
-		if (theSubscription.getCrossPartitionEnabled()) {
+		if (theSubscription.isCrossPartitionEnabled()) {
 			requestPartitionId = RequestPartitionId.allPartitions();
 		}
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizerTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizerTest.java
@@ -172,7 +172,7 @@ class SubscriptionCanonicalizerTest {
 
 	@ParameterizedTest
 	@MethodSource("crossPartitionParams")
-	void testCrossPartitionDstu2BWithExtension(RequestPartitionId theRequestPartitionId) {
+	void testSubscriptionCrossPartitionEnableProperty_forDstu2WithExtensionAndPartitions(RequestPartitionId theRequestPartitionId) {
 		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
 		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
 		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forDstu2(), subscriptionSettings);
@@ -187,7 +187,7 @@ class SubscriptionCanonicalizerTest {
 
 	@ParameterizedTest
 	@MethodSource("crossPartitionParams")
-	void testCrossPartitionDstu3BWithExtension(RequestPartitionId theRequestPartitionId) {
+	void testSubscriptionCrossPartitionEnableProperty_forDstu3WithExtensionAndPartitions(RequestPartitionId theRequestPartitionId) {
 		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
 		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
 		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forDstu3(), subscriptionSettings);
@@ -220,7 +220,7 @@ class SubscriptionCanonicalizerTest {
 
 	@ParameterizedTest
 	@MethodSource("crossPartitionParams")
-	void testCrossPartitionR4WithExtension(RequestPartitionId theRequestPartitionId) {
+	void testSubscriptionCrossPartitionEnableProperty_forR4WithExtensionAndPartitions(RequestPartitionId theRequestPartitionId) {
 		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
 		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
 
@@ -256,7 +256,7 @@ class SubscriptionCanonicalizerTest {
 
 	@ParameterizedTest
 	@MethodSource("crossPartitionParams")
-	void testCrossPartitionR4BWithExtension(RequestPartitionId theRequestPartitionId) {
+	void testSubscriptionCrossPartitionEnableProperty_forR4BWithExtensionAndPartitions(RequestPartitionId theRequestPartitionId) {
 		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
 		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
 		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4BCached(), subscriptionSettings);
@@ -289,7 +289,7 @@ class SubscriptionCanonicalizerTest {
 
 	@ParameterizedTest
 	@MethodSource("crossPartitionParams")
-	void testCrossPartitionR5BWithExtension(RequestPartitionId theRequestPartitionId) {
+	void testSubscriptionCrossPartitionEnableProperty_forR5WithExtensionAndPartitions(RequestPartitionId theRequestPartitionId) {
 		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
 		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
 		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forR5Cached(), subscriptionSettings);

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizerTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizerTest.java
@@ -1,43 +1,37 @@
 package ca.uhn.fhir.jpa.subscription.match.registry;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscriptionChannelType;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalTopicSubscriptionFilter;
-import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.model.api.ExtensionDt;
-import ca.uhn.fhir.model.api.IFhirVersion;
-import ca.uhn.fhir.model.dstu2.FhirDstu2;
 import ca.uhn.fhir.model.primitive.BooleanDt;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
 import ca.uhn.fhir.subscription.SubscriptionTestDataHelper;
+import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nonnull;
-import org.hl7.fhir.dstu3.hapi.ctx.FhirDstu3;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.hapi.ctx.FhirR4;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Subscription;
-import org.hl7.fhir.r4b.hapi.ctx.FhirR4B;
-import org.hl7.fhir.r5.hapi.ctx.FhirR5;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.Enumerations;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.stream.Stream;
 
 import static ca.uhn.fhir.rest.api.Constants.CT_FHIR_JSON_NEW;
+import static ca.uhn.fhir.rest.api.Constants.RESOURCE_PARTITION_ID;
 import static ca.uhn.fhir.util.HapiExtensions.EX_SEND_DELETE_MESSAGES;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class SubscriptionCanonicalizerTest {
 
@@ -172,44 +166,158 @@ class SubscriptionCanonicalizerTest {
 		verifyChannelParameters(canonical, thePayloadContent);
 	}
 
-
-	private static Stream<Arguments> crossPartitionParams() {
-		return Stream.of(
-			arguments(true, FhirContext.forDstu2Cached()),
-			arguments(false, FhirContext.forDstu2Cached()),
-			arguments(true, FhirContext.forDstu3Cached()),
-			arguments(false, FhirContext.forDstu3Cached()),
-			arguments(true, FhirContext.forR4Cached()),
-			arguments(false, FhirContext.forR4Cached()),
-			arguments(true, FhirContext.forR4BCached()),
-			arguments(false, FhirContext.forR4BCached()),
-			arguments(true, FhirContext.forR5Cached()),
-			arguments(false, FhirContext.forR5Cached())
-		);
+	private static Stream<RequestPartitionId> crossPartitionParams() {
+		return Stream.of(null, RequestPartitionId.fromPartitionId(1), RequestPartitionId.defaultPartition()) ;
 	}
+
 	@ParameterizedTest
 	@MethodSource("crossPartitionParams")
-	void testCrossPartition(boolean theCrossPartitionSubscriptionEnabled, FhirContext theFhirContext) {
-		final IFhirVersion version = theFhirContext.getVersion();
-		IBaseResource subscription = null;
-		if (version instanceof FhirDstu2){
-			subscription = new ca.uhn.fhir.model.dstu2.resource.Subscription();
-		} else if (version instanceof FhirDstu3){
-			subscription = new org.hl7.fhir.dstu3.model.Subscription();
-		} else if (version instanceof FhirR4){
-			subscription = new Subscription();
-		} else if (version instanceof FhirR4B){
-			subscription = new org.hl7.fhir.r4b.model.Subscription();
-		} else if (version instanceof FhirR5){
-			subscription = new org.hl7.fhir.r5.model.Subscription();
+	void testCrossPartitionDstu2BWithExtension(RequestPartitionId theRequestPartitionId) {
+		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
+		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
+		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forDstu2(), subscriptionSettings);
+
+		ca.uhn.fhir.model.dstu2.resource.Subscription subscriptionWithoutExtension = new ca.uhn.fhir.model.dstu2.resource.Subscription();
+		subscriptionWithoutExtension.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+
+		final CanonicalSubscription canonicalSubscriptionWithoutExtension = subscriptionCanonicalizer.canonicalize(subscriptionWithoutExtension);
+
+		assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+	}
+
+	@ParameterizedTest
+	@MethodSource("crossPartitionParams")
+	void testCrossPartitionDstu3BWithExtension(RequestPartitionId theRequestPartitionId) {
+		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
+		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
+		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forDstu3(), subscriptionSettings);
+
+		org.hl7.fhir.dstu3.model.Subscription subscriptionWithoutExtension = new org.hl7.fhir.dstu3.model.Subscription();
+		subscriptionWithoutExtension.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+
+		org.hl7.fhir.dstu3.model.Subscription subscriptionWithExtensionCrossPartitionTrue = new org.hl7.fhir.dstu3.model.Subscription();
+		subscriptionWithExtensionCrossPartitionTrue.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionTrue.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.dstu3.model.BooleanType().setValue(true));
+
+		org.hl7.fhir.dstu3.model.Subscription subscriptionWithExtensionCrossPartitionFalse = new org.hl7.fhir.dstu3.model.Subscription();
+		subscriptionWithExtensionCrossPartitionFalse.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.dstu3.model.BooleanType().setValue(false));
+
+		final CanonicalSubscription canonicalSubscriptionWithoutExtension = subscriptionCanonicalizer.canonicalize(subscriptionWithoutExtension);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
+
+		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		} else {
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("crossPartitionParams")
+	void testCrossPartitionR4WithExtension(RequestPartitionId theRequestPartitionId) {
+		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
+		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
+
+		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4Cached(), subscriptionSettings);
+
+		Subscription subscriptionWithoutExtension = new Subscription();
+		subscriptionWithoutExtension.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+
+		Subscription subscriptionWithExtensionCrossPartitionTrue = new Subscription();
+		subscriptionWithExtensionCrossPartitionTrue.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionTrue.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.r4.model.BooleanType().setValue(true));
+
+		Subscription subscriptionWithExtensionCrossPartitionFalse = new Subscription();
+		subscriptionWithExtensionCrossPartitionFalse.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.r4.model.BooleanType().setValue(false));
+
+
+		final CanonicalSubscription canonicalSubscriptionWithoutExtension = subscriptionCanonicalizer.canonicalize(subscriptionWithoutExtension);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
+
+		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		} else {
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
 		}
 
-		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
-		subscriptionSettings.setCrossPartitionSubscriptionEnabled(theCrossPartitionSubscriptionEnabled);
-		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(theFhirContext, subscriptionSettings);
-		final CanonicalSubscription canonicalSubscription = subscriptionCanonicalizer.canonicalize(subscription);
+	}
 
-		assertEquals(theCrossPartitionSubscriptionEnabled, canonicalSubscription.getCrossPartitionEnabled());
+	@ParameterizedTest
+	@MethodSource("crossPartitionParams")
+	void testCrossPartitionR4BWithExtension(RequestPartitionId theRequestPartitionId) {
+		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
+		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
+		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4BCached(), subscriptionSettings);
+
+		org.hl7.fhir.r4b.model.Subscription subscriptionWithoutExtension = new org.hl7.fhir.r4b.model.Subscription();
+		subscriptionWithoutExtension.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+
+		org.hl7.fhir.r4b.model.Subscription subscriptionWithExtensionCrossPartitionTrue = new org.hl7.fhir.r4b.model.Subscription();
+		subscriptionWithExtensionCrossPartitionTrue.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionTrue.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.r4b.model.BooleanType().setValue(true));
+
+		org.hl7.fhir.r4b.model.Subscription subscriptionWithExtensionCrossPartitionFalse = new org.hl7.fhir.r4b.model.Subscription();
+		subscriptionWithExtensionCrossPartitionFalse.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.r4b.model.BooleanType().setValue(false));
+
+		final CanonicalSubscription canonicalSubscriptionWithoutExtension = subscriptionCanonicalizer.canonicalize(subscriptionWithoutExtension);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
+
+		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		} else {
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("crossPartitionParams")
+	void testCrossPartitionR5BWithExtension(RequestPartitionId theRequestPartitionId) {
+		final SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
+		subscriptionSettings.setCrossPartitionSubscriptionEnabled(true);
+		final SubscriptionCanonicalizer subscriptionCanonicalizer = new SubscriptionCanonicalizer(FhirContext.forR5Cached(), subscriptionSettings);
+
+		org.hl7.fhir.r5.model.Subscription subscriptionWithoutExtension = new org.hl7.fhir.r5.model.Subscription();
+		subscriptionWithoutExtension.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+
+		org.hl7.fhir.r5.model.Subscription subscriptionWithExtensionCrossPartitionTrue = new org.hl7.fhir.r5.model.Subscription();
+		subscriptionWithExtensionCrossPartitionTrue.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionTrue.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.r5.model.BooleanType().setValue(true));
+
+		org.hl7.fhir.r5.model.Subscription subscriptionWithExtensionCrossPartitionFalse = new org.hl7.fhir.r5.model.Subscription();
+		subscriptionWithExtensionCrossPartitionFalse.setUserData(RESOURCE_PARTITION_ID, theRequestPartitionId);
+		subscriptionWithExtensionCrossPartitionFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new org.hl7.fhir.r5.model.BooleanType().setValue(false));
+
+		final CanonicalSubscription canonicalSubscriptionWithoutExtension = subscriptionCanonicalizer.canonicalize(subscriptionWithoutExtension);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
+		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
+
+		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		} else {
+			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
+			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+		}
 	}
 
 	private org.hl7.fhir.r4b.model.Subscription buildR4BSubscription(String thePayloadContent) {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -126,7 +126,7 @@ public class CanonicalSubscriptionTest {
 
 		System.out.print(canonicalSubscription);
 
-		// for s Subscription to be a cross-partition subscription, u need 3 things:
+		// for a Subscription to be a cross-partition subscription, 3 things are required:
 		// - The Subs need to be created on the default partition
 		// - The Subs need to have extension EXTENSION_SUBSCRIPTION_CROSS_PARTITION set to true
 		// - Global flag CrossPartitionSubscriptionEnabled needs to be true

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -2,19 +2,17 @@ package ca.uhn.fhir.jpa.subscription.module;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionCanonicalizer;
 import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryJsonMessage;
 import ca.uhn.fhir.jpa.subscription.model.ResourceDeliveryMessage;
-import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
-import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nonnull;
 import org.assertj.core.util.Lists;
 import org.hl7.fhir.r4.model.BooleanType;
-import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,11 +27,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static ca.uhn.fhir.rest.api.Constants.*;
+import static ca.uhn.fhir.rest.api.Constants.RESOURCE_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CanonicalSubscriptionTest {
@@ -76,7 +74,7 @@ public class CanonicalSubscriptionTest {
 	}
 
 	@Test
-	public void testCanonicalSubscriptionRetainsMetaTags() throws IOException {
+	public void testCanonicalSubscriptionRetainsMetaTags() {
 		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4(), new SubscriptionSettings());
 		CanonicalSubscription sub1 = canonicalizer.canonicalize(makeMdmSubscription());
 		assertThat(sub1.getTags()).containsKey(TAG_SYSTEM);
@@ -97,16 +95,11 @@ public class CanonicalSubscriptionTest {
 		final SubscriptionSettings subscriptionSettings = buildSubscriptionSettings(theIsCrossPartitionEnabled);
 		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4(), subscriptionSettings);
 
-		Subscription subscriptionWithExtensionSetToStringFalse = makeEmailSubscription();
-		subscriptionWithExtensionSetToStringFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new StringType().setValue("false"));
-
 		Subscription subscriptionWithExtensionSetToBooleanFalse = makeEmailSubscription();
 		subscriptionWithExtensionSetToBooleanFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new BooleanType().setValue(false));
 
-		CanonicalSubscription canonicalSubscriptionExtensionSetToStringFalse = canonicalizer.canonicalize(subscriptionWithExtensionSetToStringFalse);
 		CanonicalSubscription canonicalSubscriptionExtensionSetToBooleanFalse = canonicalizer.canonicalize(subscriptionWithExtensionSetToBooleanFalse);
 
-		assertEquals(canonicalSubscriptionExtensionSetToStringFalse.isCrossPartitionEnabled(), false);
 		assertEquals(canonicalSubscriptionExtensionSetToBooleanFalse.isCrossPartitionEnabled(), false);
 	}
 
@@ -139,7 +132,6 @@ public class CanonicalSubscriptionTest {
 		// - Global flag CrossPartitionSubscriptionEnabled needs to be true
 		assertThat(canonicalSubscription.isCrossPartitionEnabled()).isEqualTo(theExpectedIsCrossPartitionEnabled);
 	}
-
 
 	@Test
 	public void testLegacyCanonicalSubscription() throws JsonProcessingException {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/CanonicalSubscriptionTest.java
@@ -91,40 +91,23 @@ public class CanonicalSubscriptionTest {
 		assertTrue(sub1.equals(sub2));
 	}
 
-	@Test
-	public void testSerializeMultiPartitionSubscription(){
-		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4(), new SubscriptionSettings());
-		Subscription subscription = makeEmailSubscription();
-		subscription.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new BooleanType().setValue(true));
-		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
-
-		assertEquals(canonicalSubscription.isCrossPartitionEnabled(), true);
-	}
-
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	public void testSerializeIncorrectMultiPartitionSubscription(boolean theIsCrossPartitionEnabled){
+	public void testSubscriptionCrossPartitionEnabled_basedOnGlobalFlagAndExtensionFalse(boolean theIsCrossPartitionEnabled){
 		final SubscriptionSettings subscriptionSettings = buildSubscriptionSettings(theIsCrossPartitionEnabled);
 		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4(), subscriptionSettings);
-		Subscription subscription = makeEmailSubscription();
-		subscription.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new StringType().setValue("false"));
-		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
 
-		assertEquals(canonicalSubscription.isCrossPartitionEnabled(), false);
-	}
+		Subscription subscriptionWithExtensionSetToStringFalse = makeEmailSubscription();
+		subscriptionWithExtensionSetToStringFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new StringType().setValue("false"));
 
-	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
-	public void testSerializeNonMultiPartitionSubscription(boolean theIsCrossPartitionEnabled){
-		final SubscriptionSettings subscriptionSettings = buildSubscriptionSettings(theIsCrossPartitionEnabled);
-		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4(), subscriptionSettings);
-		Subscription subscription = makeEmailSubscription();
-		subscription.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new BooleanType().setValue(false));
-		CanonicalSubscription canonicalSubscription = canonicalizer.canonicalize(subscription);
+		Subscription subscriptionWithExtensionSetToBooleanFalse = makeEmailSubscription();
+		subscriptionWithExtensionSetToBooleanFalse.addExtension(HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, new BooleanType().setValue(false));
 
-		System.out.print(canonicalSubscription);
+		CanonicalSubscription canonicalSubscriptionExtensionSetToStringFalse = canonicalizer.canonicalize(subscriptionWithExtensionSetToStringFalse);
+		CanonicalSubscription canonicalSubscriptionExtensionSetToBooleanFalse = canonicalizer.canonicalize(subscriptionWithExtensionSetToBooleanFalse);
 
-		assertEquals(canonicalSubscription.isCrossPartitionEnabled(), false);
+		assertEquals(canonicalSubscriptionExtensionSetToStringFalse.isCrossPartitionEnabled(), false);
+		assertEquals(canonicalSubscriptionExtensionSetToBooleanFalse.isCrossPartitionEnabled(), false);
 	}
 
 	static Stream<Arguments> requestPartitionIds() {
@@ -139,7 +122,7 @@ public class CanonicalSubscriptionTest {
 	@ParameterizedTest
 	@MethodSource("requestPartitionIds")
 	public void testSubscriptionCrossPartitionEnabled_basedOnGlobalFlagAndExtensionAndPartitionId(RequestPartitionId theRequestPartitionId, boolean theExpectedIsCrossPartitionEnabled){
-		final boolean globalIsCrossPartitionEnabled = true;
+		final boolean globalIsCrossPartitionEnabled = true;   // not required but to help understand what the test is doing.
 		SubscriptionCanonicalizer canonicalizer = new SubscriptionCanonicalizer(FhirContext.forR4(), buildSubscriptionSettings(globalIsCrossPartitionEnabled));
 
 		Subscription subscription = makeEmailSubscription();

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriberTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriberTest.java
@@ -191,35 +191,16 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 		assertEquals(Constants.CT_FHIR_XML_NEW, ourContentTypes.get(0));
 	}
 
-	@Test
-	public void testSubscriptionAndResourceOnTheSamePartitionMatch() throws InterruptedException {
+	@ParameterizedTest
+	@ValueSource(ints = {0,1})
+	public void testSubscriptionAndResourceOnTheSamePartitionMatch(int thePartitionId) throws InterruptedException {
 		myPartitionSettings.setPartitioningEnabled(true);
 		String payload = "application/fhir+json";
 
 		String code = "1000000050";
 		String criteria = "Observation?code=SNOMED-CT|" + code + "&_format=xml";
 
-		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
-		Subscription subscription = makeActiveSubscription(criteria, payload, ourListenerServerBase);
-		mockSubscriptionRead(requestPartitionId, subscription);
-		sendSubscription(subscription, requestPartitionId, true);
-
-		ourObservationListener.setExpectedCount(1);
-		mySubscriptionResourceMatched.setExpectedCount(1);
-		sendObservation(code, "SNOMED-CT", requestPartitionId);
-		mySubscriptionResourceMatched.awaitExpected();
-		ourObservationListener.awaitExpected();
-	}
-
-	@Test
-	public void testSubscriptionAndResourceOnTheSamePartitionMatchPart2() throws InterruptedException {
-		myPartitionSettings.setPartitioningEnabled(true);
-		String payload = "application/fhir+json";
-
-		String code = "1000000050";
-		String criteria = "Observation?code=SNOMED-CT|" + code + "&_format=xml";
-
-		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(1);
+		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(thePartitionId);
 		Subscription subscription = makeActiveSubscription(criteria, payload, ourListenerServerBase);
 		mockSubscriptionRead(requestPartitionId, subscription);
 		sendSubscription(subscription, requestPartitionId, true);
@@ -233,7 +214,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	public void testSubscriptionMatching_whenSubcriptionAndResourceOnDiffPartition_matchesWhenIsCrossPartitionSubscription(boolean theIsCrossPartitionEnabled) throws InterruptedException {
+	public void testSubscriptionCrossPartitionMatching_whenSubscriptionAndResourceOnDiffPartition_withGlobalFlagCrossPartitionSubscriptionEnable(boolean theIsCrossPartitionEnabled) throws InterruptedException {
 		mySubscriptionSettings.setCrossPartitionSubscriptionEnabled(theIsCrossPartitionEnabled);
 		myPartitionSettings.setPartitioningEnabled(true);
 		String payload = "application/fhir+json";
@@ -256,7 +237,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 	}
 
 	@Test
-	public void testSubscriptionOnOnePartitionMatchResourceOnMultiplePartitions() throws InterruptedException {
+	public void testSubscriptionOnOnePartition_whenResourceCreatedOnMultiplePartitions_matchesOnlyResourceCreatedOnSamePartition() throws InterruptedException {
 		myPartitionSettings.setPartitioningEnabled(true);
 		String payload = "application/fhir+json";
 
@@ -278,7 +259,7 @@ public class SubscriptionMatchingSubscriberTest extends BaseBlockingQueueSubscri
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	public void testSubscriptionOnOnePartitionDoNotMatchResourceOnMultiplePartitions(boolean theIsCrossPartitionEnabled) throws InterruptedException {
+	public void testSubscriptionCrossPartitionMatching_whenSubscriptionAndResourceOnDiffPartition_withGlobalFlagCrossPartitionSubscriptionEnable2(boolean theIsCrossPartitionEnabled) throws InterruptedException {
 		mySubscriptionSettings.setCrossPartitionSubscriptionEnabled(theIsCrossPartitionEnabled);
 		myPartitionSettings.setPartitioningEnabled(true);
 		String payload = "application/fhir+json";

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
@@ -134,7 +134,7 @@ public class SubscriptionCanonicalizer {
 	private boolean extractDeleteExtensionDstu2(ca.uhn.fhir.model.dstu2.resource.Subscription theSubscription) {
 		return theSubscription.getChannel().getUndeclaredExtensionsByUrl(EX_SEND_DELETE_MESSAGES).stream()
 				.map(ExtensionDt::getValue)
-				.map(value -> (BooleanDt) value)
+				.map(BooleanDt.class::cast)
 				.map(BasePrimitive::getValue)
 				.findFirst()
 				.orElse(false);
@@ -401,7 +401,7 @@ public class SubscriptionCanonicalizer {
 		}
 
 		List<Extension> topicExts = subscription.getExtensionsByUrl("http://hl7.org/fhir/subscription/topics");
-		if (topicExts.size() > 0) {
+		if (!topicExts.isEmpty()) {
 			IBaseReference ref = (IBaseReference) topicExts.get(0).getValueAsPrimitive();
 			if (!"EventDefinition".equals(ref.getReferenceElement().getResourceType())) {
 				throw new PreconditionFailedException(Msg.code(563) + "Topic reference must be an EventDefinition");
@@ -499,7 +499,7 @@ public class SubscriptionCanonicalizer {
 
 		List<org.hl7.fhir.r4b.model.Extension> topicExts =
 				subscription.getExtensionsByUrl("http://hl7.org/fhir/subscription/topics");
-		if (topicExts.size() > 0) {
+		if (!topicExts.isEmpty()) {
 			IBaseReference ref = (IBaseReference) topicExts.get(0).getValueAsPrimitive();
 			if (!"EventDefinition".equals(ref.getReferenceElement().getResourceType())) {
 				throw new PreconditionFailedException(Msg.code(566) + "Topic reference must be an EventDefinition");
@@ -531,7 +531,7 @@ public class SubscriptionCanonicalizer {
 
 		List<org.hl7.fhir.r5.model.Extension> topicExts =
 				subscription.getExtensionsByUrl("http://hl7.org/fhir/subscription/topics");
-		if (topicExts.size() > 0) {
+		if (!topicExts.isEmpty()) {
 			IBaseReference ref = (IBaseReference) topicExts.get(0).getValueAsPrimitive();
 			if (!"EventDefinition".equals(ref.getReferenceElement().getResourceType())) {
 				throw new PreconditionFailedException(Msg.code(2325) + "Topic reference must be an EventDefinition");
@@ -568,9 +568,7 @@ public class SubscriptionCanonicalizer {
 		retVal.getTopicSubscription().setTopic(subscription.getTopic());
 		retVal.setChannelType(getChannelType(subscription));
 
-		subscription.getFilterBy().forEach(filter -> {
-			retVal.getTopicSubscription().addFilter(convertFilter(filter));
-		});
+		subscription.getFilterBy().forEach(filter -> retVal.getTopicSubscription().addFilter(convertFilter(filter)));
 
 		retVal.getTopicSubscription().setHeartbeatPeriod(subscription.getHeartbeatPeriod());
 		retVal.getTopicSubscription().setMaxCount(subscription.getMaxCount());
@@ -783,17 +781,21 @@ public class SubscriptionCanonicalizer {
 
 	private boolean handleCrossPartition(IBaseResource theSubscription) {
 		RequestPartitionId requestPartitionId =
-			(RequestPartitionId) theSubscription.getUserData(Constants.RESOURCE_PARTITION_ID);
+				(RequestPartitionId) theSubscription.getUserData(Constants.RESOURCE_PARTITION_ID);
 
 		boolean isSubscriptionCreatedOnDefaultPartition = false;
 
-		if(nonNull(requestPartitionId)){
-			isSubscriptionCreatedOnDefaultPartition =  requestPartitionId.isDefaultPartition();
+		if (nonNull(requestPartitionId)) {
+			isSubscriptionCreatedOnDefaultPartition = requestPartitionId.isDefaultPartition();
 		}
 
-		boolean isSubscriptionDefinededAsCrossPartitionSubscription = SubscriptionUtil.isDefinedAsCrossPartitionSubcription(theSubscription);
-		boolean isGlobalSettingCrossPartitionSubscriptionEnabled = mySubscriptionSettings.isCrossPartitionSubscriptionEnabled();
+		boolean isSubscriptionDefinededAsCrossPartitionSubscription =
+				SubscriptionUtil.isDefinedAsCrossPartitionSubcription(theSubscription);
+		boolean isGlobalSettingCrossPartitionSubscriptionEnabled =
+				mySubscriptionSettings.isCrossPartitionSubscriptionEnabled();
 
-		return isSubscriptionCreatedOnDefaultPartition && isSubscriptionDefinededAsCrossPartitionSubscription && isGlobalSettingCrossPartitionSubscriptionEnabled;
+		return isSubscriptionCreatedOnDefaultPartition
+				&& isSubscriptionDefinededAsCrossPartitionSubscription
+				&& isGlobalSettingCrossPartitionSubscriptionEnabled;
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
@@ -568,7 +568,8 @@ public class SubscriptionCanonicalizer {
 		retVal.getTopicSubscription().setTopic(subscription.getTopic());
 		retVal.setChannelType(getChannelType(subscription));
 
-		subscription.getFilterBy().forEach(filter -> retVal.getTopicSubscription().addFilter(convertFilter(filter)));
+		subscription.getFilterBy().forEach(filter -> retVal.getTopicSubscription()
+				.addFilter(convertFilter(filter)));
 
 		retVal.getTopicSubscription().setHeartbeatPeriod(subscription.getHeartbeatPeriod());
 		retVal.getTopicSubscription().setMaxCount(subscription.getMaxCount());

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizer.java
@@ -123,7 +123,7 @@ public class SubscriptionCanonicalizer {
 			retVal.setIdElement(subscription.getIdElement());
 			retVal.setPayloadString(channel.getPayload());
 			retVal.setTags(extractTags(subscription));
-			handleCrossPartition(theSubscription, retVal);
+			retVal.setCrossPartitionEnabled(handleCrossPartition(theSubscription));
 			retVal.setSendDeleteMessages(extractDeleteExtensionDstu2(subscription));
 		} catch (FHIRException theE) {
 			throw new InternalErrorException(Msg.code(557) + theE);
@@ -175,7 +175,7 @@ public class SubscriptionCanonicalizer {
 			retVal.setPayloadSearchCriteria(
 					getExtensionString(subscription, HapiExtensions.EXT_SUBSCRIPTION_PAYLOAD_SEARCH_CRITERIA));
 			retVal.setTags(extractTags(subscription));
-			handleCrossPartition(theSubscription, retVal);
+			retVal.setCrossPartitionEnabled(handleCrossPartition(theSubscription));
 
 			if (retVal.getChannelType() == CanonicalSubscriptionChannelType.EMAIL) {
 				String from;
@@ -306,7 +306,7 @@ public class SubscriptionCanonicalizer {
 				getExtensionString(subscription, HapiExtensions.EXT_SUBSCRIPTION_PAYLOAD_SEARCH_CRITERIA));
 		retVal.setTags(extractTags(subscription));
 		setPartitionIdOnReturnValue(theSubscription, retVal);
-		handleCrossPartition(theSubscription, retVal);
+		retVal.setCrossPartitionEnabled(handleCrossPartition(theSubscription));
 
 		List<org.hl7.fhir.r4.model.CanonicalType> profiles =
 				subscription.getMeta().getProfile();
@@ -511,7 +511,7 @@ public class SubscriptionCanonicalizer {
 			retVal.setSendDeleteMessages(extension.getValueBooleanType().booleanValue());
 		}
 
-		handleCrossPartition(theSubscription, retVal);
+		retVal.setCrossPartitionEnabled(handleCrossPartition(theSubscription));
 
 		return retVal;
 	}
@@ -577,7 +577,7 @@ public class SubscriptionCanonicalizer {
 
 		setR5FlagsBasedOnChannelType(subscription, retVal);
 
-		handleCrossPartition(theSubscription, retVal);
+		retVal.setCrossPartitionEnabled(handleCrossPartition(theSubscription));
 
 		return retVal;
 	}
@@ -781,11 +781,19 @@ public class SubscriptionCanonicalizer {
 		return status.getValueAsString();
 	}
 
-	private void handleCrossPartition(IBaseResource theSubscription, CanonicalSubscription retVal) {
-		if (mySubscriptionSettings.isCrossPartitionSubscriptionEnabled()) {
-			retVal.setCrossPartitionEnabled(true);
-		} else {
-			retVal.setCrossPartitionEnabled(SubscriptionUtil.isCrossPartition(theSubscription));
+	private boolean handleCrossPartition(IBaseResource theSubscription) {
+		RequestPartitionId requestPartitionId =
+			(RequestPartitionId) theSubscription.getUserData(Constants.RESOURCE_PARTITION_ID);
+
+		boolean isSubscriptionCreatedOnDefaultPartition = false;
+
+		if(nonNull(requestPartitionId)){
+			isSubscriptionCreatedOnDefaultPartition =  requestPartitionId.isDefaultPartition();
 		}
+
+		boolean isSubscriptionDefinededAsCrossPartitionSubscription = SubscriptionUtil.isDefinedAsCrossPartitionSubcription(theSubscription);
+		boolean isGlobalSettingCrossPartitionSubscriptionEnabled = mySubscriptionSettings.isCrossPartitionSubscriptionEnabled();
+
+		return isSubscriptionCreatedOnDefaultPartition && isSubscriptionDefinededAsCrossPartitionSubscription && isGlobalSettingCrossPartitionSubscriptionEnabled;
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/CanonicalSubscription.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/CanonicalSubscription.java
@@ -261,7 +261,7 @@ public class CanonicalSubscription implements Serializable, Cloneable, IModelJso
 		myPartitionId = thePartitionId;
 	}
 
-	public boolean getCrossPartitionEnabled() {
+	public boolean isCrossPartitionEnabled() {
 		return myCrossPartitionEnabled;
 	}
 


### PR DESCRIPTION
What was done:
- provided a failing test;
- modified the criterias to consider a subscription to be a cross-partition subscription.  A Subscription will considered a cross-partition subscription if:

  * global flag subscription.cross_partition.enable = TRUE;
       AND
  * the Subscription is created on the DEFAULT partition;
       AND
  * the Subscription has extension `https://smilecdr.com/fhir/ns/StructureDefinition/subscription-cross-partition ` = TRUE;
- renamed/removed tests;
- added changelog