### PR TITLE
Reverting package version dependency to core fhir-test-cases 1.1.14 and re-enabling test case

### DIFF
--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/patch/FhirPatchCoreTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/patch/FhirPatchCoreTest.java
@@ -6,7 +6,6 @@ import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.util.XmlUtil;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -25,7 +24,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@Disabled
 public class FhirPatchCoreTest extends BaseTest {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(FhirPatchCoreTest.class);
@@ -52,12 +50,9 @@ public class FhirPatchCoreTest extends BaseTest {
 
 	public static List<Object[]> parameters() throws TransformerException, SAXException, IOException {
 		String testSpecR4 = "/org/hl7/fhir/testcases/r4/patch/fhir-path-tests.xml";
-		// the above file is missing an <output></output> section on line 1413 due to a processing error during file generation
-		// as per the error statement found in the file.
 		Collection<Object[]> retValR4 = loadTestSpec(FhirContext.forR4Cached(), testSpecR4);
 
 		String testSpecR5 = "/org/hl7/fhir/testcases/r5/patch/fhir-path-tests.xml";
-		// The above file his missing xml closing tag '/>' on line 241 and 245
 		Collection<Object[]> retValR5 = loadTestSpec(FhirContext.forR5Cached(), testSpecR5);
 
 		ArrayList<Object[]> retVal = new ArrayList<>();

--- a/pom.xml
+++ b/pom.xml
@@ -1306,7 +1306,7 @@
 			<dependency>
 				<groupId>org.hl7.fhir.testcases</groupId>
 				<artifactId>fhir-test-cases</artifactId>
-				<version>1.5.15</version>
+				<version>1.1.14</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jdom</groupId>


### PR DESCRIPTION
**Background:**

PR [6190](https://github.com/hapifhir/hapi-fhir/pull/6190) bumped the version of package fhir-test-cases (org.hl7) to 1.5.15 because version 1.1.14 was no longer available;

**What was done:**
- Reverting dependency to version 1.1.14;
- Re-enabling test that was failing with version 1.5.15

[Issue 6200](https://github.com/hapifhir/hapi-fhir/issues/6200) was opened to address the bump and failing test in the next release.
