### PR TITLE
Bump dependencies

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/changes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/changes.yaml
@@ -1,0 +1,10 @@
+---
+- item:
+      type: "add"
+      title: "The version of a few dependencies have been bumped to more recent versions
+      (dependent HAPI modules listed in brackets):
+      <ul>
+      <li>Bower/Moment.js (hapi-fhir-testpage-overlay): 2.27.0 -&gt; 2.29.4</li>
+      <li>htmlunit (Base): 3.9.0 -&gt; 3.11.0</li>
+      <li>Elasticsearch (Base): 8.11.1 -&gt; 8.14.3</li>
+      </ul>"

--- a/hapi-fhir-jpaserver-elastic-test-utilities/src/test/java/ca/uhn/fhir/jpa/config/ElasticsearchWithPrefixConfig.java
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/src/test/java/ca/uhn/fhir/jpa/config/ElasticsearchWithPrefixConfig.java
@@ -13,6 +13,7 @@ import ca.uhn.fhir.jpa.test.config.BlockLargeNumbersOfParamsListener;
 import ca.uhn.fhir.jpa.test.config.TestHSearchAddInConfig;
 import ca.uhn.fhir.jpa.util.CurrentThreadCaptureQueriesListener;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.elasticsearch.indices.PutTemplateResponse;
 import co.elastic.clients.json.JsonData;
 import net.ttddyy.dsproxy.listener.logging.SLF4JLogLevel;
@@ -129,7 +130,7 @@ public class ElasticsearchWithPrefixConfig {
 				.putTemplate(b -> b
 					.name("ngram-template")
 					.indexPatterns("*resourcetable-*", "*termconcept-*")
-					.settings(Map.of("index.max_ngram_diff", JsonData.of(50))));
+					.settings(new IndexSettings.Builder().maxNgramDiff(50).build()));
 			assert acknowledgedResponse.acknowledged();
 		} catch (IOException theE) {
 			theE.printStackTrace();

--- a/pom.xml
+++ b/pom.xml
@@ -2180,7 +2180,7 @@
 			<dependency>
 				<groupId>org.webjars.bower</groupId>
 				<artifactId>moment</artifactId>
-				<version>2.27.0</version>
+				<version>2.29.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars.npm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1833,7 +1833,7 @@
 			<dependency>
 				<groupId>org.htmlunit</groupId>
 				<artifactId>htmlunit</artifactId>
-				<version>3.9.0</version>
+				<version>3.11.0</version>
 				<exclusions>
 					<exclusion>
 						<!-- Don't let HTMLUnit bring in Jetty 9 -->

--- a/pom.xml
+++ b/pom.xml
@@ -1031,7 +1031,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<ebay_cors_filter_version>1.0.1</ebay_cors_filter_version>
 		<elastic_apm_version>1.44.0</elastic_apm_version>
-		<elasticsearch_version>8.11.1</elasticsearch_version>
+		<elasticsearch_version>8.14.3</elasticsearch_version>
 		<ucum_version>1.0.8</ucum_version>
 
 		<!-- Clinical Reasoning & CQL Support -->


### PR DESCRIPTION
Bumps:

elasticsearch 8.11.1 -> 8.14.3
org.htmlunit:htmlunit:3.9.0 -> 3.11.0
maven:org.webjars.bower:moment:2.27.0 -> 2.29.4
