### PR TITLE
Improving performance, using caching when testing for primitives (#6252)

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6252-improve-validator-performance.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6252-improve-validator-performance.yaml
@@ -1,0 +1,6 @@
+---
+type: perf
+issue: 6253
+title: "A cache has been added to the validation services layer which results
+  in improved validation performance. Thanks to Max Bureck for the
+  contribution!"

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapperTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapperTest.java
@@ -7,7 +7,10 @@ import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.fhirpath.BaseValidationTestWithInlineMocks;
 import ca.uhn.fhir.i18n.HapiLocalizer;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
+
 import org.hl7.fhir.r5.model.Resource;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionKind;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
+
+import java.util.List;
 
 public class VersionSpecificWorkerContextWrapperTest extends BaseValidationTestWithInlineMocks {
 
@@ -94,6 +99,66 @@ public class VersionSpecificWorkerContextWrapperTest extends BaseValidationTestW
 		// verify
 		verify(validationSupport, times(1)).validateCodeInValueSet(any(), any(), eq("http://codesystems.com/system"), eq("code0"), any(), any());
 		verify(validationSupport, times(1)).validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code0"), any(), any());
+	}
+
+	@Test
+	public void isPrimitive_primitive() {
+		// setup
+		IValidationSupport validationSupport = mockValidationSupport();
+		ValidationSupportContext mockContext = mockValidationSupportContext(validationSupport);
+		VersionCanonicalizer versionCanonicalizer = new VersionCanonicalizer(FhirContext.forR5Cached());
+		VersionSpecificWorkerContextWrapper wrapper = new VersionSpecificWorkerContextWrapper(mockContext, versionCanonicalizer);
+
+		List<StructureDefinition> structDefs = createStructureDefinitions();
+
+		when(mockContext.getRootValidationSupport().<StructureDefinition>fetchAllStructureDefinitions()).thenReturn(structDefs);
+		assertThat(wrapper.isPrimitiveType("boolean")).isTrue();
+
+		// try again to check if lookup after cache is built is working
+		assertThat(wrapper.isPrimitiveType("string")).isTrue();
+	}
+
+	@Test
+	public void isPrimitive_not_primitive() {
+		// setup
+		IValidationSupport validationSupport = mockValidationSupport();
+		ValidationSupportContext mockContext = mockValidationSupportContext(validationSupport);
+		VersionCanonicalizer versionCanonicalizer = new VersionCanonicalizer(FhirContext.forR5Cached());
+		VersionSpecificWorkerContextWrapper wrapper = new VersionSpecificWorkerContextWrapper(mockContext, versionCanonicalizer);
+
+		List<StructureDefinition> structDefs = createStructureDefinitions();
+
+		when(mockContext.getRootValidationSupport().<StructureDefinition>fetchAllStructureDefinitions()).thenReturn(structDefs);
+		assertThat(wrapper.isPrimitiveType("Person")).isFalse();
+
+		// try again to check if lookup after cache is built is working
+		assertThat(wrapper.isPrimitiveType("Organization")).isFalse();
+
+		// Assert that unknown types are not regarded as primitive
+		assertThat(wrapper.isPrimitiveType("Unknown")).isFalse();
+	}
+
+	private List<StructureDefinition> createStructureDefinitions() {
+		StructureDefinition stringType = createPrimitive("string");
+		StructureDefinition boolType = createPrimitive("boolean");
+		StructureDefinition personType = createComplex("Person");
+		StructureDefinition orgType = createComplex("Organization");
+
+		return List.of(personType, boolType, orgType, stringType);
+	}
+
+	private StructureDefinition createComplex(String name){
+		return createStructureDefinition(name).setKind(StructureDefinitionKind.COMPLEXTYPE);
+	}
+
+	private StructureDefinition createPrimitive(String name){
+		return createStructureDefinition(name).setKind(StructureDefinitionKind.PRIMITIVETYPE);
+	}
+
+	private StructureDefinition createStructureDefinition(String name) {
+		StructureDefinition sd = new StructureDefinition();
+		sd.setUrl("http://hl7.org/fhir/StructureDefinition/"+name).setName(name);
+		return sd;
 	}
 
 	private IValidationSupport mockValidationSupportWithTwoBinaries() {

--- a/pom.xml
+++ b/pom.xml
@@ -944,6 +944,10 @@
 			<id>plchldr</id>
 			<name>Jonas Beyer</name>
 		</developer>
+		<developer>
+			<id>Boereck</id>
+			<name>Max Bureck</name>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Caching primitive type names for faster lookup if a type is primitive.
Fixes #6252