### PR TITLE
#5768 Upgrade to latest simple-java-mail and switch to jakarta.mail

### DIFF
--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -70,6 +70,11 @@
 			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.mail</groupId>
+			<artifactId>jakarta.mail-api</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/hapi-fhir-jpaserver-test-dstu2/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSubscriptionDstu2Test.java
+++ b/hapi-fhir-jpaserver-test-dstu2/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSubscriptionDstu2Test.java
@@ -28,8 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSenderImplTest.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSenderImplTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSubscriptionDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSubscriptionDstu3Test.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -79,25 +79,11 @@
 		<dependency>
 			<groupId>org.simplejavamail</groupId>
 			<artifactId>simple-java-mail</artifactId>
-			<!-- Excluded in favor of jakarta.activation:jakarta.activation-api -->
-			<exclusions>
-				<exclusion>
-					<groupId>com.sun.activation</groupId>
-					<artifactId>jakarta.activation</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.icegreen</groupId>
 			<artifactId>greenmail</artifactId>
 			<scope>compile</scope>
-			<!-- Excluded in favor of jakarta.activation:jakarta.activation-api -->
-			<exclusions>
-				<exclusion>
-					<groupId>com.sun.activation</groupId>
-					<artifactId>jakarta.activation</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/mail/IMailSvc.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/mail/IMailSvc.java
@@ -21,9 +21,9 @@ package ca.uhn.fhir.rest.server.mail;
 
 import jakarta.annotation.Nonnull;
 import org.simplejavamail.api.email.Email;
-import org.simplejavamail.api.mailer.AsyncResponse;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public interface IMailSvc {
 	void sendMail(@Nonnull List<Email> theEmails);
@@ -31,7 +31,5 @@ public interface IMailSvc {
 	void sendMail(@Nonnull Email theEmail);
 
 	void sendMail(
-			@Nonnull Email theEmail,
-			@Nonnull Runnable theOnSuccess,
-			@Nonnull AsyncResponse.ExceptionConsumer theErrorHandler);
+			@Nonnull Email theEmail, @Nonnull Runnable theOnSuccess, @Nonnull Consumer<Throwable> theErrorHandler);
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/mail/MailSvc.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/mail/MailSvc.java
@@ -20,12 +20,9 @@
 package ca.uhn.fhir.rest.server.mail;
 
 import jakarta.annotation.Nonnull;
-import org.apache.commons.lang3.Validate;
 import org.simplejavamail.MailException;
 import org.simplejavamail.api.email.Email;
 import org.simplejavamail.api.email.Recipient;
-import org.simplejavamail.api.mailer.AsyncResponse;
-import org.simplejavamail.api.mailer.AsyncResponse.ExceptionConsumer;
 import org.simplejavamail.api.mailer.Mailer;
 import org.simplejavamail.api.mailer.config.TransportStrategy;
 import org.simplejavamail.mailer.MailerBuilder;
@@ -33,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class MailSvc implements IMailSvc {
@@ -42,14 +41,14 @@ public class MailSvc implements IMailSvc {
 	private final Mailer myMailer;
 
 	public MailSvc(@Nonnull MailConfig theMailConfig) {
-		Validate.notNull(theMailConfig);
+		Objects.requireNonNull(theMailConfig);
 		myMailConfig = theMailConfig;
 		myMailer = makeMailer(myMailConfig);
 	}
 
 	@Override
 	public void sendMail(@Nonnull List<Email> theEmails) {
-		Validate.notNull(theEmails);
+		Objects.requireNonNull(theEmails);
 		theEmails.forEach(theEmail -> send(theEmail, new OnSuccess(theEmail), new ErrorHandler(theEmail)));
 	}
 
@@ -60,21 +59,23 @@ public class MailSvc implements IMailSvc {
 
 	@Override
 	public void sendMail(
-			@Nonnull Email theEmail, @Nonnull Runnable theOnSuccess, @Nonnull ExceptionConsumer theErrorHandler) {
+			@Nonnull Email theEmail, @Nonnull Runnable theOnSuccess, @Nonnull Consumer<Throwable> theErrorHandler) {
 		send(theEmail, theOnSuccess, theErrorHandler);
 	}
 
 	private void send(
-			@Nonnull Email theEmail, @Nonnull Runnable theOnSuccess, @Nonnull ExceptionConsumer theErrorHandler) {
-		Validate.notNull(theEmail);
-		Validate.notNull(theOnSuccess);
-		Validate.notNull(theErrorHandler);
+			@Nonnull Email theEmail, @Nonnull Runnable theOnSuccess, @Nonnull Consumer<Throwable> theErrorHandler) {
+		Objects.requireNonNull(theEmail);
+		Objects.requireNonNull(theOnSuccess);
+		Objects.requireNonNull(theErrorHandler);
 		try {
-			final AsyncResponse asyncResponse = myMailer.sendMail(theEmail, true);
-			if (asyncResponse != null) {
-				asyncResponse.onSuccess(theOnSuccess);
-				asyncResponse.onException(theErrorHandler);
-			}
+			myMailer.sendMail(theEmail, true).whenComplete((result, ex) -> {
+				if (ex != null) {
+					theErrorHandler.accept(ex);
+				} else {
+					theOnSuccess.run();
+				}
+			});
 		} catch (MailException e) {
 			theErrorHandler.accept(e);
 		}
@@ -117,7 +118,7 @@ public class MailSvc implements IMailSvc {
 		}
 	}
 
-	private class ErrorHandler implements ExceptionConsumer {
+	private class ErrorHandler implements Consumer<Throwable> {
 		private final Email myEmail;
 
 		private ErrorHandler(@Nonnull Email theEmail) {
@@ -125,7 +126,7 @@ public class MailSvc implements IMailSvc {
 		}
 
 		@Override
-		public void accept(Exception t) {
+		public void accept(Throwable t) {
 			ourLog.error("Email not sent" + makeMessage(myEmail), t);
 		}
 	}

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/mail/MailSvcIT.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/mail/MailSvcIT.java
@@ -4,6 +4,7 @@ import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.annotation.Nonnull;
+import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -11,7 +12,6 @@ import org.simplejavamail.MailException;
 import org.simplejavamail.api.email.Email;
 import org.simplejavamail.email.EmailBuilder;
 
-import javax.mail.internet.MimeMessage;
 import java.util.Arrays;
 import java.util.List;
 
@@ -86,13 +86,14 @@ public class MailSvcIT {
 	@Test
 	public void testSendMailWithInvalidToAddressExpectErrorHandler() {
 		// setup
-		final Email email = withEmail("xyz");
+		String invalidEmailAdress = "xyz";
+		final Email email = withEmail(invalidEmailAdress);
 		// execute
 		fixture.sendMail(email,
 			() -> fail("Should not execute on Success"),
 			(e) -> {
 				assertTrue(e instanceof MailException);
-				assertEquals("Invalid TO address: " + email, e.getMessage());
+				assertEquals("Invalid TO address: " + invalidEmailAdress, e.getMessage());
 			});
 		// validate
 		assertTrue(ourGreenMail.waitForIncomingEmail(1000, 0));

--- a/pom.xml
+++ b/pom.xml
@@ -1150,27 +1150,38 @@
 			<dependency>
 				<groupId>org.simplejavamail</groupId>
 				<artifactId>simple-java-mail</artifactId>
-				<version>6.6.1</version>
+				<version>8.11.2</version>
 				<exclusions>
 					<exclusion>
-						<groupId>com.sun.activation</groupId>
-						<artifactId>jakarta.activation-api</artifactId>
+						<groupId>com.github.bbottema</groupId>
+						<artifactId>jetbrains-runtime-annotations</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId>com.sun.activation</groupId>
-						<artifactId>jakarta.activation</artifactId>
+						<groupId>jakarta.mail</groupId>
+						<artifactId>jakarta.mail-api</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>jakarta.mail</groupId>
+				<artifactId>jakarta.mail-api</artifactId>
+				<version>2.1.3</version>
+			</dependency>
+			<dependency>
+				<groupId>com.icegreen</groupId>
+				<artifactId>greenmail</artifactId>
+				<version>2.1.0-rc-1</version>
+				<exclusions>
+					<exclusion>
+						<groupId>jakarta.mail</groupId>
+						<artifactId>jakarta.mail-api</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.icegreen</groupId>
-				<artifactId>greenmail</artifactId>
-				<version>1.6.4</version>
-			</dependency>
-			<dependency>
-				<groupId>com.icegreen</groupId>
 				<artifactId>greenmail-junit5</artifactId>
-				<version>1.6.4</version>
+				<version>2.1.0-rc-1</version>
 				<scope>compile</scope>
 			</dependency>
 			<!-- mail end -->


### PR DESCRIPTION
Upgrading javasimplemail to most recent version which use jakarta.mail api's.
Greenmail was updated as well to provide compatiblity during testing.

Because jakarta.mail api's are also packaged within java simplemail, it need to be excluded by default to avoid duplicated classes on the classpath.