### PR TITLE
[Bugfix] mdm pointcut missing link update

### DIFF
--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImpl.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImpl.java
@@ -188,6 +188,12 @@ public class MdmLinkUpdaterSvcImpl implements IMdmLinkUpdaterSvc {
 			// pointcut for MDM_POST_UPDATE_LINK
 			MdmLinkEvent event = new MdmLinkEvent();
 			event.addMdmLink(myModelConverter.toJson(mdmLink));
+
+			// add any link updates from side effects
+			mdmContext.getMdmLinks().stream().forEach(link -> {
+				event.addMdmLink(myModelConverter.toJson(link));
+			});
+
 			HookParams hookParams = new HookParams();
 			hookParams.add(RequestDetails.class, theParams.getRequestDetails()).add(MdmLinkEvent.class, event);
 			myInterceptorBroadcaster.callHooks(Pointcut.MDM_POST_UPDATE_LINK, hookParams);

--- a/pom.xml
+++ b/pom.xml
@@ -922,6 +922,11 @@
 			<organization>Galileo, Inc.</organization>
 		</developer>
 		<developer>
+			<id>Jake-Gillberg</id>
+			<name>Jake Gillberg</name>
+			<organization>Galileo, Inc.</organization>
+		</developer>
+		<developer>
 			<id>melihaydogd</id>
 			<name>Ahmet Melih Aydoğdu</name>
 		</developer>


### PR DESCRIPTION
When an MDM link is updated to be `NO_MATCH`, it is possible that [other links will be updated as well](https://github.com/hapifhir/hapi-fhir/blob/02d38bce1467aefad359385d2052221808a376db/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/svc/MdmLinkUpdaterSvcImpl.java#L176-L177).

All updated links should be reflected in the link event available to the `MDM_POST_UPDATE_LINK` pointcut.

Resolves #6297