### PR TITLE
Composite unique search parameter with dateTime component does not reject resource duplication

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6317-fix-resource-duplication-for-composite-unique-sp-with-date-time-component.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6317-fix-resource-duplication-for-composite-unique-sp-with-date-time-component.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 6317
+title: "Previously, defining a unique combo Search Parameter with the DateTime component and submitting multiple 
+resources with the same dateTime element (e.g. Observation.effectiveDateTime) resulted in duplicate resource creation. 
+This has been fixed."
+

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -1972,7 +1972,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 			 * The loop allows us to create multiple combo index joins if there
 			 * are multiple AND expressions for the related parameters.
 			 */
-			while (validateParamValuesAreValidForComboParam(theRequest, theParams, comboParamNames)) {
+			while (validateParamValuesAreValidForComboParam(theRequest, theParams, comboParamNames, comboParam)) {
 				applyComboSearchParam(theQueryStack, theParams, theRequest, comboParamNames, comboParam);
 			}
 		}
@@ -2068,7 +2068,10 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 	 * (e.g. <code>?date=gt2024-02-01</code>), etc.
 	 */
 	private boolean validateParamValuesAreValidForComboParam(
-			RequestDetails theRequest, @Nonnull SearchParameterMap theParams, List<String> theComboParamNames) {
+			RequestDetails theRequest,
+			@Nonnull SearchParameterMap theParams,
+			List<String> theComboParamNames,
+			RuntimeSearchParam theComboParam) {
 		boolean paramValuesAreValidForCombo = true;
 		List<List<IQueryParameterType>> paramOrValues = new ArrayList<>(theComboParamNames.size());
 
@@ -2128,6 +2131,19 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 					paramValuesAreValidForCombo = false;
 					break;
 				}
+			}
+
+			// Date params are not eligible for using composite unique index
+			// as index could contain date with different precision (e.g. DAY, SECOND)
+			if (nextParamDef.getParamType() == RestSearchParameterTypeEnum.DATE
+					&& theComboParam.getComboSearchParamType() == ComboSearchParamType.UNIQUE) {
+				ourLog.debug(
+						"Search with params {} is not a candidate for combo searching - "
+								+ "Unique combo search parameter '{}' has DATE type",
+						theComboParamNames,
+						nextParamName);
+				paramValuesAreValidForCombo = false;
+				break;
 			}
 		}
 

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -566,7 +566,8 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 				for (BaseResourceIndexedSearchParam nextParam : paramsListForCompositePart) {
 					IQueryParameterType nextParamAsClientParam = nextParam.toQueryParameterType();
 
-					if (nextParamAsClientParam instanceof DateParam) {
+					if (theParam.getComboSearchParamType() == ComboSearchParamType.NON_UNIQUE
+							&& nextParamAsClientParam instanceof DateParam) {
 						DateParam date = (DateParam) nextParamAsClientParam;
 						if (date.getPrecision() != TemporalPrecisionEnum.DAY) {
 							continue;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/BasePartitioningR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/BasePartitioningR4Test.java
@@ -135,10 +135,10 @@ public abstract class BasePartitioningR4Test extends BaseJpaR4SystemTest {
 		addCreateDefaultPartition();
 		addReadDefaultPartition(); // one for search param validation
 		SearchParameter sp = new SearchParameter();
-		sp.setId("SearchParameter/patient-birthdate");
-		sp.setType(Enumerations.SearchParamType.DATE);
-		sp.setCode("birthdate");
-		sp.setExpression("Patient.birthDate");
+		sp.setId("SearchParameter/patient-gender");
+		sp.setType(Enumerations.SearchParamType.TOKEN);
+		sp.setCode("gender");
+		sp.setExpression("Patient.gender");
 		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		sp.addBase("Patient");
 		mySearchParameterDao.update(sp, mySrd);
@@ -156,13 +156,13 @@ public abstract class BasePartitioningR4Test extends BaseJpaR4SystemTest {
 
 		addCreateDefaultPartition();
 		sp = new SearchParameter();
-		sp.setId("SearchParameter/patient-birthdate-unique");
+		sp.setId("SearchParameter/patient-gender-family-unique");
 		sp.setType(Enumerations.SearchParamType.COMPOSITE);
 		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		sp.addBase("Patient");
 		sp.addComponent()
 			.setExpression("Patient")
-			.setDefinition("SearchParameter/patient-birthdate");
+			.setDefinition("SearchParameter/patient-gender");
 		sp.addComponent()
 			.setExpression("Patient")
 			.setDefinition("SearchParameter/patient-family");

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ComboUniqueParamTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ComboUniqueParamTest.java
@@ -1805,7 +1805,7 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 			fail();
 		} catch (ResourceVersionConflictException e) {
 			assertThat(e.getMessage())
-				.contains("new unique index created by SearchParameter/observation-subject-date-code");
+				.contains("new unique index created by SearchParameter/observation-date-code");
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ComboUniqueParamTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ComboUniqueParamTest.java
@@ -13,10 +13,10 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.util.JpaParamUtil;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
-import ca.uhn.fhir.rest.param.DateAndListParam;
-import ca.uhn.fhir.rest.param.DateOrListParam;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.StringOrListParam;
+import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
@@ -33,6 +33,7 @@ import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Organization;
@@ -105,6 +106,46 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		sp.addComponent()
 			.setExpression("Patient")
 			.setDefinition("SearchParameter/patient-birthdate");
+		sp.addExtension()
+			.setUrl(HapiExtensions.EXT_SP_UNIQUE)
+			.setValue(new BooleanType(true));
+		mySearchParameterDao.update(sp, mySrd);
+
+		mySearchParamRegistry.forceRefresh();
+
+		myMessages.clear();
+	}
+
+	private void createUniqueGenderFamilyComboSp() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-gender");
+		sp.setType(Enumerations.SearchParamType.TOKEN);
+		sp.setCode("gender");
+		sp.setExpression("Patient.gender");
+		sp.setStatus(PublicationStatus.ACTIVE);
+		sp.addBase("Patient");
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-family");
+		sp.setType(Enumerations.SearchParamType.STRING);
+		sp.setCode("family");
+		sp.setExpression("Patient.name.family");
+		sp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		sp.addBase("Patient");
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/patient-gender-family");
+		sp.setType(Enumerations.SearchParamType.COMPOSITE);
+		sp.setStatus(PublicationStatus.ACTIVE);
+		sp.addBase("Patient");
+		sp.addComponent()
+			.setExpression("Patient")
+			.setDefinition("SearchParameter/patient-gender");
+		sp.addComponent()
+			.setExpression("Patient")
+			.setDefinition("SearchParameter/patient-family");
 		sp.addExtension()
 			.setUrl(HapiExtensions.EXT_SP_UNIQUE)
 			.setValue(new BooleanType(true));
@@ -268,6 +309,45 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		sp.addComponent()
 			.setExpression("Patient")
 			.setDefinition("SearchParameter/patient-organization");
+		sp.addExtension()
+			.setUrl(HapiExtensions.EXT_SP_UNIQUE)
+			.setValue(new BooleanType(true));
+		mySearchParameterDao.update(sp, mySrd);
+
+		mySearchParamRegistry.forceRefresh();
+	}
+
+	private void createUniqueObservationDateCode() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/obs-effective");
+		sp.setType(Enumerations.SearchParamType.DATE);
+		sp.setCode("date");
+		sp.setExpression("Observation.effective");
+		sp.setStatus(PublicationStatus.ACTIVE);
+		sp.addBase("Observation");
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/obs-code");
+		sp.setType(Enumerations.SearchParamType.TOKEN);
+		sp.setCode("code");
+		sp.setExpression("Observation.code");
+		sp.setStatus(PublicationStatus.ACTIVE);
+		sp.addBase("Observation");
+		mySearchParameterDao.update(sp, mySrd);
+
+		sp = new SearchParameter();
+		sp.setId("SearchParameter/observation-date-code");
+		sp.setType(Enumerations.SearchParamType.COMPOSITE);
+		sp.setStatus(PublicationStatus.ACTIVE);
+		sp.addBase("Observation");
+		sp.setExpression("Observation.code");
+		sp.addComponent()
+			.setExpression("Observation")
+			.setDefinition("SearchParameter/obs-effective");
+		sp.addComponent()
+			.setExpression("Observation")
+			.setDefinition("SearchParameter/obs-code");
 		sp.addExtension()
 			.setUrl(HapiExtensions.EXT_SP_UNIQUE)
 			.setValue(new BooleanType(true));
@@ -471,11 +551,11 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 	public void testDoubleMatchingOnAnd_Search_TwoAndOrValues() {
 		myStorageSettings.setUniqueIndexesCheckedBeforeSave(false);
 
-		createUniqueBirthdateAndGenderSps();
+		createUniqueGenderFamilyComboSp();
 
 		Patient pt1 = new Patient();
 		pt1.setGender(Enumerations.AdministrativeGender.MALE);
-		pt1.setBirthDateElement(new DateType("2011-01-01"));
+		pt1.getName().add(new HumanName().setFamily("Family1"));
 		String id1 = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless().getValue();
 
 		// Two OR values on the same resource - Currently composite SPs don't work for this
@@ -484,17 +564,22 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		sp.setLoadSynchronous(true);
 		sp.add(Patient.SP_GENDER,
 			new TokenAndListParam()
-				.addAnd(new TokenParam("http://hl7.org/fhir/administrative-gender","male"), new TokenParam( "http://hl7.org/fhir/administrative-gender","female"))
+				.addAnd(new TokenParam("http://hl7.org/fhir/administrative-gender","male"),
+					new TokenParam( "http://hl7.org/fhir/administrative-gender","female"))
 		);
-		sp.add(Patient.SP_BIRTHDATE,
-			new DateAndListParam()
-				.addAnd(new DateParam("2011-01-01"), new DateParam( "2011-02-02"))
+		sp.add(Patient.SP_FAMILY,
+			new StringOrListParam()
+				.addOr(new StringParam("Family1")).addOr(new StringParam("Family2"))
 		);
 		IBundleProvider outcome = myPatientDao.search(sp, mySrd);
 		myCaptureQueriesListener.logFirstSelectQueryForCurrentThread();
 		assertThat(toUnqualifiedVersionlessIdValues(outcome)).containsExactlyInAnyOrder(id1);
 		String unformattedSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
-		assertEquals("SELECT t0.RES_ID FROM HFJ_IDX_CMP_STRING_UNIQ t0 WHERE (t0.IDX_STRING IN ('Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cfemale','Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale','Patient?birthdate=2011-02-02&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cfemale','Patient?birthdate=2011-02-02&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale') )", unformattedSql);
+		assertEquals("SELECT t0.RES_ID FROM HFJ_IDX_CMP_STRING_UNIQ t0 WHERE (t0.IDX_STRING IN (" +
+			"'Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cfemale'," +
+			"'Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale'," +
+			"'Patient?family=Family2&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cfemale'," +
+			"'Patient?family=Family2&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale') )", unformattedSql);
 	}
 
 
@@ -1167,16 +1252,16 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 	@Test
 	public void testOrQuery() {
 		myStorageSettings.setAdvancedHSearchIndexing(false);
-		createUniqueBirthdateAndGenderSps();
+		createUniqueGenderFamilyComboSp();
 
 		Patient pt1 = new Patient();
 		pt1.setGender(Enumerations.AdministrativeGender.MALE);
-		pt1.setBirthDateElement(new DateType("2011-01-01"));
+		pt1.getName().add(new HumanName().setFamily("Family1"));
 		IIdType id1 = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless();
 
 		Patient pt2 = new Patient();
 		pt2.setGender(Enumerations.AdministrativeGender.MALE);
-		pt2.setBirthDateElement(new DateType("2011-01-02"));
+		pt2.getName().add(new HumanName().setFamily("Family2"));
 		IIdType id2 = myPatientDao.create(pt2, mySrd).getId().toUnqualifiedVersionless();
 
 		myCaptureQueriesListener.clear();
@@ -1184,16 +1269,21 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		SearchParameterMap params = new SearchParameterMap();
 		params.setLoadSynchronousUpTo(100);
 		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
-		params.add("birthdate", new DateOrListParam().addOr(new DateParam("2011-01-01")).addOr(new DateParam("2011-01-02")));
+		params.add("family", new StringOrListParam()
+			.addOr(new StringParam("Family1")).addOr(new StringParam("Family2")));
 		myCaptureQueriesListener.clear();
 		IBundleProvider results = myPatientDao.search(params, mySrd);
 		myCaptureQueriesListener.logFirstSelectQueryForCurrentThread();
 		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactlyInAnyOrder(id1.getValue(), id2.getValue());
 
 		assertThat(myCaptureQueriesListener.getSelectQueries().get(0).getSql(true, false))
-			.contains("SELECT t0.RES_ID FROM HFJ_IDX_CMP_STRING_UNIQ t0 WHERE (t0.IDX_STRING IN ('Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale','Patient?birthdate=2011-01-02&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale') )");
+			.contains("SELECT t0.RES_ID FROM HFJ_IDX_CMP_STRING_UNIQ t0 WHERE (t0.IDX_STRING IN " +
+				"('Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale'," +
+				"'Patient?family=Family2&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale') )");
 		logCapturedMessages();
-		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: [Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale, Patient?birthdate=2011-01-02&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale]");
+		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: " +
+			"[Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale, " +
+			"Patient?family=Family2&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale]");
 		myMessages.clear();
 
 	}
@@ -1201,16 +1291,16 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 	@Test
 	public void testSearchSynchronousUsingUniqueComposite() {
 		myStorageSettings.setAdvancedHSearchIndexing(false);
-		createUniqueBirthdateAndGenderSps();
+		createUniqueGenderFamilyComboSp();
 
 		Patient pt1 = new Patient();
 		pt1.setGender(Enumerations.AdministrativeGender.MALE);
-		pt1.setBirthDateElement(new DateType("2011-01-01"));
+		pt1.getName().add(new HumanName().setFamily("Family1"));
 		IIdType id1 = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless();
 
 		Patient pt2 = new Patient();
 		pt2.setGender(Enumerations.AdministrativeGender.MALE);
-		pt2.setBirthDateElement(new DateType("2011-01-02"));
+		pt2.getName().add(new HumanName().setFamily("Family2"));
 		myPatientDao.create(pt2, mySrd).getId().toUnqualifiedVersionless();
 
 		myCaptureQueriesListener.clear();
@@ -1218,13 +1308,14 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		SearchParameterMap params = new SearchParameterMap();
 		params.setLoadSynchronousUpTo(100);
 		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
-		params.add("birthdate", new DateParam("2011-01-01"));
+		params.add("family", new StringParam("Family1"));
 		IBundleProvider results = myPatientDao.search(params, mySrd);
 		myCaptureQueriesListener.logFirstSelectQueryForCurrentThread();
 		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactlyInAnyOrder(id1.getValue());
 
 		logCapturedMessages();
-		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
+		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: " +
+			"Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
 		myMessages.clear();
 
 	}
@@ -1232,33 +1323,34 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 
 	@Test
 	public void testSearchUsingUniqueComposite() {
-		createUniqueBirthdateAndGenderSps();
+		createUniqueGenderFamilyComboSp();
 
 		Patient pt1 = new Patient();
 		pt1.setGender(Enumerations.AdministrativeGender.MALE);
-		pt1.setBirthDateElement(new DateType("2011-01-01"));
+		pt1.getName().add(new HumanName().setFamily("Family1"));
 		String id1 = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless().getValue();
 
 		Patient pt2 = new Patient();
 		pt2.setGender(Enumerations.AdministrativeGender.MALE);
-		pt2.setBirthDateElement(new DateType("2011-01-02"));
+		pt2.getName().add(new HumanName().setFamily("Family2"));
 		myPatientDao.create(pt2, mySrd).getId().toUnqualifiedVersionless();
 
 		myMessages.clear();
 		SearchParameterMap params = new SearchParameterMap();
 		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
-		params.add("birthdate", new DateParam("2011-01-01"));
+		params.add("family", new StringParam("Family1"));
 		IBundleProvider results = myPatientDao.search(params, mySrd);
 		String searchId = results.getUuid();
 		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactlyInAnyOrder(id1);
 		logCapturedMessages();
-		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
+		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: " +
+			"Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
 		myMessages.clear();
 
 		// Other order
 		myMessages.clear();
 		params = new SearchParameterMap();
-		params.add("birthdate", new DateParam("2011-01-01"));
+		params.add("family", new StringParam("Family1"));
 		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
 		results = myPatientDao.search(params, mySrd);
 		assertEquals(searchId, results.getUuid());
@@ -1272,16 +1364,17 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		myMessages.clear();
 		params = new SearchParameterMap();
 		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
-		params.add("birthdate", new DateParam("2011-01-03"));
+		params.add("family", new StringParam("Family3"));
 		results = myPatientDao.search(params, mySrd);
 		assertThat(toUnqualifiedVersionlessIdValues(results)).isEmpty();
 		logCapturedMessages();
-		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: Patient?birthdate=2011-01-03&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
+		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: " +
+			"Patient?family=Family3&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
 		myMessages.clear();
 
 		myMessages.clear();
 		params = new SearchParameterMap();
-		params.add("birthdate", new DateParam("2011-01-03"));
+		params.add("family", new StringParam("Family3"));
 		results = myPatientDao.search(params, mySrd);
 		assertThat(toUnqualifiedVersionlessIdValues(results)).isEmpty();
 		// STANDARD QUERY
@@ -1666,7 +1759,7 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 	}
 
 	@Test
-	public void testDuplicateUniqueValuesAreRejected() {
+	public void testDuplicateUniqueValuesWithDateAreRejected() {
 		createUniqueBirthdateAndGenderSps();
 
 		Patient pt1 = new Patient();
@@ -1699,13 +1792,75 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 	}
 
 	@Test
-	public void testReplaceOneWithAnother() {
-		myStorageSettings.setAdvancedHSearchIndexing(false);
+	public void testDuplicateUniqueValuesWithDateTimeAreRejected() {
+		createUniqueObservationDateCode();
+
+		Observation obs = new Observation();
+		obs.getCode().addCoding().setSystem("foo").setCode("bar");
+		obs.setEffective(new DateTimeType("2017-10-10T00:00:00"));
+		myObservationDao.create(obs, mySrd).getId().toUnqualifiedVersionless();
+
+		try {
+			myObservationDao.create(obs, mySrd).getId().toUnqualifiedVersionless();
+			fail();
+		} catch (ResourceVersionConflictException e) {
+			assertThat(e.getMessage())
+				.contains("new unique index created by SearchParameter/observation-subject-date-code");
+		}
+	}
+
+	@Test
+	public void testUniqueComboSearchWithDateNotUsingUniqueIndex() {
 		createUniqueBirthdateAndGenderSps();
 
 		Patient pt1 = new Patient();
 		pt1.setGender(Enumerations.AdministrativeGender.MALE);
 		pt1.setBirthDateElement(new DateType("2011-01-01"));
+		String pId = myPatientDao.create(pt1, mySrd).getId().toUnqualifiedVersionless().getValue();
+
+		myCaptureQueriesListener.clear();
+		SearchParameterMap params = new SearchParameterMap();
+		params.setLoadSynchronousUpTo(100);
+		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
+		params.add("birthdate", new DateParam("2011-01-01"));
+
+		IBundleProvider results = myPatientDao.search(params, mySrd);
+		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactlyInAnyOrder(pId);
+		myCaptureQueriesListener.logFirstSelectQueryForCurrentThread();
+		String unformattedSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
+		assertThat(unformattedSql).doesNotContain("HFJ_IDX_CMP_STRING_UNIQ");
+	}
+
+	@Test
+	public void testUniqueComboSearchWithDateTimeNotUsingUniqueIndex() {
+		createUniqueObservationDateCode();
+
+		Observation obs = new Observation();
+		obs.getCode().addCoding().setSystem("foo").setCode("bar");
+		obs.setEffective(new DateTimeType("2017-10-10T00:00:00"));
+		String obsId = myObservationDao.create(obs, mySrd).getId().toUnqualifiedVersionless().getValue();
+
+		myCaptureQueriesListener.clear();
+		SearchParameterMap params = new SearchParameterMap();
+		params.setLoadSynchronousUpTo(100);
+		params.add("code", new TokenParam("foo", "bar"));
+		params.add("date", new DateParam("2017-10-10T00:00:00"));
+
+		IBundleProvider results = myObservationDao.search(params, mySrd);
+		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactlyInAnyOrder(obsId);
+		myCaptureQueriesListener.logFirstSelectQueryForCurrentThread();
+		String unformattedSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, false);
+		assertThat(unformattedSql).doesNotContain("HFJ_IDX_CMP_STRING_UNIQ");
+	}
+
+	@Test
+	public void testReplaceOneWithAnother() {
+		myStorageSettings.setAdvancedHSearchIndexing(false);
+		createUniqueGenderFamilyComboSp();
+
+		Patient pt1 = new Patient();
+		pt1.setGender(Enumerations.AdministrativeGender.MALE);
+		pt1.getName().add(new HumanName().setFamily("Family1"));
 		IIdType id1 = myPatientDao.create(pt1, mySrd).getId().toUnqualified();
 		assertNotNull(id1);
 
@@ -1714,27 +1869,28 @@ public class FhirResourceDaoR4ComboUniqueParamTest extends BaseComboParamsR4Test
 		pt1 = new Patient();
 		pt1.setId(id1);
 		pt1.setGender(Enumerations.AdministrativeGender.FEMALE);
-		pt1.setBirthDateElement(new DateType("2011-01-01"));
+		pt1.getName().add(new HumanName().setFamily("Family1"));
 		id1 = myPatientDao.update(pt1, mySrd).getId().toUnqualified();
 		assertNotNull(id1);
 		assertEquals("2", id1.getVersionIdPart());
 
 		Patient pt2 = new Patient();
 		pt2.setGender(Enumerations.AdministrativeGender.MALE);
-		pt2.setBirthDateElement(new DateType("2011-01-01"));
+		pt2.getName().add(new HumanName().setFamily("Family1"));
 		IIdType id2 = myPatientDao.create(pt2, mySrd).getId().toUnqualifiedVersionless();
 
 		myMessages.clear();
 		SearchParameterMap params = new SearchParameterMap();
 		params.add("gender", new TokenParam("http://hl7.org/fhir/administrative-gender", "male"));
-		params.add("birthdate", new DateParam("2011-01-01"));
+		params.add("family", new StringParam("Family1"));
 		IBundleProvider results = myPatientDao.search(params, mySrd);
 		String searchId = results.getUuid();
 		assertThat(searchId).isNotBlank();
 		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactlyInAnyOrder(id2.getValue());
 
 		logCapturedMessages();
-		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: Patient?birthdate=2011-01-01&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
+		assertThat(myMessages.toString()).contains("Using UNIQUE index(es) for query for search: " +
+			"Patient?family=Family1&gender=http%3A%2F%2Fhl7.org%2Ffhir%2Fadministrative-gender%7Cmale");
 		myMessages.clear();
 
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitioningSqlR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitioningSqlR4Test.java
@@ -413,7 +413,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 		p.getMeta().addTag("http://system", "code", "diisplay");
 		p.addName().setFamily("FAM");
 		p.addIdentifier().setSystem("system").setValue("value");
-		p.setBirthDateElement(new DateType("2020-01-01"));
+		p.setGender(Enumerations.AdministrativeGender.MALE);
 		p.getManagingOrganization().setReferenceElement(orgId);
 		Long patientId = myPatientDao.create(p, mySrd).getId().getIdPartAsLong();
 
@@ -502,7 +502,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 		p.getMeta().addTag("http://system", "code", "diisplay");
 		p.addName().setFamily("FAM");
 		p.addIdentifier().setSystem("system").setValue("value");
-		p.setBirthDate(new Date());
+		p.setGender(Enumerations.AdministrativeGender.MALE);
 		p.getManagingOrganization().setReferenceElement(orgId);
 		Long patientId = myPatientDao.create(p, mySrd).getId().getIdPartAsLong();
 
@@ -679,7 +679,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 		p.getMeta().addTag("http://system", "code", "display");
 		p.addName().setFamily("FAM");
 		p.addIdentifier().setSystem("system").setValue("value");
-		p.setBirthDate(new Date());
+		p.setGender(Enumerations.AdministrativeGender.MALE);
 		p.getManagingOrganization().setReference(org.getId());
 		input.addEntry()
 			.setFullUrl(p.getId())
@@ -2541,14 +2541,14 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 	public void testSearch_UniqueParam_SearchAllPartitions() {
 		createUniqueComboSp();
 
-		IIdType id = createPatient(withPartition(1), withBirthdate("2020-01-01"), withFamily("FAM"));
+		IIdType id = createPatient(withPartition(1), withGender("male"), withFamily("FAM"));
 
 		addReadAllPartitions();
 
 		myCaptureQueriesListener.clear();
 		SearchParameterMap map = new SearchParameterMap();
 		map.add(Patient.SP_FAMILY, new StringParam("FAM"));
-		map.add(Patient.SP_BIRTHDATE, new DateParam("2020-01-01"));
+		map.add(Patient.SP_GENDER, new TokenParam(null, "male"));
 		map.setLoadSynchronous(true);
 		IBundleProvider results = myPatientDao.search(map, mySrd);
 		List<IIdType> ids = toUnqualifiedVersionlessIds(results);
@@ -2558,7 +2558,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 		String searchSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, true);
 		ourLog.info("Search SQL:\n{}", searchSql);
 		assertThat(searchSql).doesNotContain("PARTITION_ID");
-		assertThat(searchSql).containsOnlyOnce("IDX_STRING = 'Patient?birthdate=2020-01-01&family=FAM'");
+		assertThat(searchSql).containsOnlyOnce("IDX_STRING = 'Patient?family=FAM&gender=male'");
 	}
 
 
@@ -2566,13 +2566,13 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 	public void testSearch_UniqueParam_SearchOnePartition() {
 		createUniqueComboSp();
 
-		IIdType id = createPatient(withPartition(1), withBirthdate("2020-01-01"), withFamily("FAM"));
+		IIdType id = createPatient(withPartition(1), withGender("male"), withFamily("FAM"));
 
 		addReadPartition(1);
 		myCaptureQueriesListener.clear();
 		SearchParameterMap map = new SearchParameterMap();
 		map.add(Patient.SP_FAMILY, new StringParam("FAM"));
-		map.add(Patient.SP_BIRTHDATE, new DateParam("2020-01-01"));
+		map.add(Patient.SP_GENDER, new TokenParam(null, "male"));
 		map.setLoadSynchronous(true);
 		IBundleProvider results = myPatientDao.search(map, mySrd);
 		List<IIdType> ids = toUnqualifiedVersionlessIds(results);
@@ -2582,13 +2582,13 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 		String searchSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(0).getSql(true, true);
 		ourLog.info("Search SQL:\n{}", searchSql);
 		assertThat(searchSql).containsOnlyOnce( "PARTITION_ID = '1'");
-		assertThat(searchSql).containsOnlyOnce("IDX_STRING = 'Patient?birthdate=2020-01-01&family=FAM'");
+		assertThat(searchSql).containsOnlyOnce("IDX_STRING = 'Patient?family=FAM&gender=male'");
 
 		// Same query, different partition
 		addReadPartition(2);
 		myCaptureQueriesListener.clear();
 		map = new SearchParameterMap();
-		map.add(Patient.SP_BIRTHDATE, new DateParam("2020-01-01"));
+		map.add(Patient.SP_GENDER, new TokenParam(null, "male"));
 		map.setLoadSynchronous(true);
 		results = myPatientDao.search(map, mySrd);
 		ids = toUnqualifiedVersionlessIds(results);
@@ -2661,7 +2661,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 	public void testSearch_RefParam_TargetPid_SearchOnePartition() {
 		createUniqueComboSp();
 
-		IIdType patientId = createPatient(withPartition(myPartitionId), withBirthdate("2020-01-01"));
+		IIdType patientId = createPatient(withPartition(myPartitionId), withGender("male"));
 		IIdType observationId = createObservation(withPartition(myPartitionId), withSubject(patientId));
 
 		addReadPartition(myPartitionId);
@@ -2698,7 +2698,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 	public void testSearch_RefParam_TargetPid_SearchDefaultPartition() {
 		createUniqueComboSp();
 
-		IIdType patientId = createPatient(withPartition(null), withBirthdate("2020-01-01"));
+		IIdType patientId = createPatient(withPartition(null), withGender("male"));
 		IIdType observationId = createObservation(withPartition(null), withSubject(patientId));
 
 		addReadDefaultPartition();
@@ -2735,7 +2735,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 	public void testSearch_RefParam_TargetForcedId_SearchOnePartition() {
 		createUniqueComboSp();
 
-		IIdType patientId = createPatient(withPartition(myPartitionId), withId("ONE"), withBirthdate("2020-01-01"));
+		IIdType patientId = createPatient(withPartition(myPartitionId), withId("ONE"), withGender("male"));
 		IIdType observationId = createObservation(withPartition(myPartitionId), withSubject(patientId));
 
 		addReadPartition(myPartitionId);
@@ -2805,7 +2805,7 @@ public class PartitioningSqlR4Test extends BasePartitioningR4Test {
 	public void testSearch_RefParam_TargetForcedId_SearchDefaultPartition() {
 		createUniqueComboSp();
 
-		IIdType patientId = createPatient(withPartition(null), withId("ONE"), withBirthdate("2020-01-01"));
+		IIdType patientId = createPatient(withPartition(null), withId("ONE"), withGender("male"));
 		IIdType observationId = createObservation(withPartition(null), withSubject(patientId));
 
 		addReadDefaultPartition();


### PR DESCRIPTION
- changed usage of Combo Unique search index if one of the component search parameters has a Date or DateTime type;  in this case, index will be only used to enforce uniqueness, and will not be used during search.
- for Combo Non-Unique search parameters, Date and DateTime types will only be indexed if the date has DAY precision (i.e. yyyy-MM-dd) (as it was before)
- unit tests updated
- added changelog
