### PR TITLE
6323 resource creation deadlock

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6323-concurrent-constructor-access.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6323-concurrent-constructor-access.yaml
@@ -1,0 +1,5 @@
+---
+type: perf
+issue: 6323
+title: "A synchronization choke point was removed from the model object initialization code, reducing the risk of
+multi-thread contention."


### PR DESCRIPTION
The use of a synchronized map was causing threads to suspend in a client production system. The code has been rewritten so that reads from the map are concurrent, and we only synchronize if an update to the contents of the map is required.