### PR TITLE
HapiSchemaMigrationTest intermittent failure fix

### DIFF
--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/HapiEmbeddedDatabasesExtension.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/HapiEmbeddedDatabasesExtension.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.jpa.embedded;
 
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import ca.uhn.fhir.jpa.util.DatabaseSupportUtil;
 import ca.uhn.fhir.test.utilities.docker.DockerRequiredCondition;
 import ca.uhn.fhir.util.VersionEnum;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -54,7 +55,7 @@ public class HapiEmbeddedDatabasesExtension implements AfterAllCallback {
 			myEmbeddedDatabases.add(new H2EmbeddedDatabase());
 			myEmbeddedDatabases.add(new PostgresEmbeddedDatabase());
 			myEmbeddedDatabases.add(new MsSqlEmbeddedDatabase());
-			if (OracleCondition.canUseOracle()) {
+			if (DatabaseSupportUtil.canUseOracle()) {
 				myEmbeddedDatabases.add(new OracleEmbeddedDatabase());
 			} else {
 				String message =
@@ -136,7 +137,7 @@ public class HapiEmbeddedDatabasesExtension implements AfterAllCallback {
 			arguments.add(Arguments.of(DriverTypeEnum.POSTGRES_9_4));
 			arguments.add(Arguments.of(DriverTypeEnum.MSSQL_2012));
 
-			if (OracleCondition.canUseOracle()) {
+			if (DatabaseSupportUtil.canUseOracle()) {
 				arguments.add(Arguments.of(DriverTypeEnum.ORACLE_12C));
 			}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/MsSqlEmbeddedDatabase.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/MsSqlEmbeddedDatabase.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.jpa.embedded;
 
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import ca.uhn.fhir.jpa.util.DatabaseSupportUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MSSQLServerContainer;
@@ -43,9 +44,19 @@ public class MsSqlEmbeddedDatabase extends JpaEmbeddedDatabase {
 	private final MSSQLServerContainer myContainer;
 
 	public MsSqlEmbeddedDatabase() {
-		DockerImageName msSqlImage = DockerImageName.parse("mcr.microsoft.com/azure-sql-edge:latest")
-				.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server");
-		myContainer = new MSSQLServerContainer(msSqlImage).acceptLicense();
+
+		// azure-sql-edge docker image does not support kernel 6.7+
+		// as a result, mssql container fails to start most of the time
+		// mssql/server:2019 image support kernel 6.7+, so use it for amd64 architecture
+		// See: https://github.com/microsoft/mssql-docker/issues/868
+		if (DatabaseSupportUtil.canUseMsSql2019()) {
+			myContainer = new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-latest").acceptLicense();
+		} else {
+			DockerImageName msSqlImage = DockerImageName.parse("mcr.microsoft.com/azure-sql-edge:latest")
+					.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server");
+			myContainer = new MSSQLServerContainer(msSqlImage).acceptLicense();
+		}
+
 		myContainer.start();
 		super.initialize(
 				DriverTypeEnum.MSSQL_2012,

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/OracleCondition.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/OracleCondition.java
@@ -19,8 +19,7 @@
  */
 package ca.uhn.fhir.jpa.embedded;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
+import ca.uhn.fhir.jpa.util.DatabaseSupportUtil;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -33,25 +32,8 @@ public class OracleCondition implements ExecutionCondition {
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext theExtensionContext) {
-		return canUseOracle()
+		return DatabaseSupportUtil.canUseOracle()
 				? ConditionEvaluationResult.enabled(ENABLED_MSG)
 				: ConditionEvaluationResult.disabled(DISABLED_MSG);
-	}
-
-	public static boolean canUseOracle() {
-		if (!isMac()) {
-			return true;
-		}
-		return isColimaConfigured();
-	}
-
-	private static boolean isMac() {
-		return SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX;
-	}
-
-	private static boolean isColimaConfigured() {
-		return StringUtils.isNotBlank(System.getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"))
-				&& StringUtils.isNotBlank(System.getenv("DOCKER_HOST"))
-				&& System.getenv("DOCKER_HOST").contains("colima");
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/util/DatabaseSupportUtil.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/util/DatabaseSupportUtil.java
@@ -1,0 +1,34 @@
+package ca.uhn.fhir.jpa.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+
+public final class DatabaseSupportUtil {
+
+	private DatabaseSupportUtil() {}
+
+	public static boolean canUseMsSql2019() {
+		return isSupportAmd64Architecture();
+	}
+
+	public static boolean canUseOracle() {
+		return isSupportAmd64Architecture();
+	}
+
+	private static boolean isSupportAmd64Architecture() {
+		if (!isMac()) {
+			return true;
+		}
+		return isColimaConfigured();
+	}
+
+	private static boolean isMac() {
+		return SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX;
+	}
+
+	private static boolean isColimaConfigured() {
+		return StringUtils.isNotBlank(System.getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"))
+				&& StringUtils.isNotBlank(System.getenv("DOCKER_HOST"))
+				&& System.getenv("DOCKER_HOST").contains("colima");
+	}
+}


### PR DESCRIPTION
Changed MsSqlEmbeddedDatabase - MSSQL image used for test now depends on the platform it is running:
- if test is started on amd64 environment - mcr.microsoft.com/mssql/server:2019-latest image is used
- if test is started on arm64 environment - mcr.microsoft.com/azure-sql-edge:latest is used