### PR TITLE
replaced otel bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1015,8 +1015,7 @@
 		<maven_assembly_plugin_version>3.3.0</maven_assembly_plugin_version>
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
 		<okhttp_version>4.12.0</okhttp_version>
-		<otel.version>1.38.0</otel.version> <!-- BOM Version -->
-		<otel_instrumentation.version>2.4.0</otel_instrumentation.version>
+		<otel_instrumentation.version>2.8.0</otel_instrumentation.version>
 		<poi_version>4.1.2</poi_version>
 		<poi_ooxml_schemas_version>1.4</poi_ooxml_schemas_version>
 		<resteasy_version>6.2.9.Final</resteasy_version>
@@ -2280,19 +2279,16 @@
 				<scope>provided</scope>
 				<optional>true</optional>
 			</dependency>
+
 			<!-- OpenTelemetry -->
 			<dependency>
-				<groupId>io.opentelemetry</groupId>
-				<artifactId>opentelemetry-bom</artifactId>
-				<version>${otel.version}</version>
+				<groupId>io.opentelemetry.instrumentation</groupId>
+				<artifactId>opentelemetry-instrumentation-bom</artifactId>
+				<version>${otel_instrumentation.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-			<dependency>
-				<groupId>io.opentelemetry.instrumentation</groupId>
-				<artifactId>opentelemetry-instrumentation-annotations</artifactId>
-				<version>${otel_instrumentation.version}</version>
-			</dependency>
+
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>


### PR DESCRIPTION
Removed the unused import for the `opentelemetry-bom` and instead imported `opentelemetry-instrumentation-bom` which contains the `opentelemetry-instrumentation-annotations` that hapifhir uses.

Also updated the instrumentation version from 2.4.0 to 2.8.0