### PR TITLE
Fix Postgres migration when schema is not public.

### DIFF
--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropPrimaryKeyTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropPrimaryKeyTask.java
@@ -115,7 +115,7 @@ public class DropPrimaryKeyTask extends BaseTableTask {
 				return null; // Irrelevant:  We don't need to run the SQL for these databases.
 			case POSTGRES_9_4:
 				return "SELECT constraint_name " + "FROM information_schema.table_constraints "
-						+ "WHERE table_schema = 'public' "
+						+ "WHERE table_schema = coalesce(current_schema(), 'public') "
 						+ "AND constraint_type = 'PRIMARY KEY' "
 						+ "AND table_name = ?";
 			case ORACLE_12C:


### PR DESCRIPTION
https://github.com/hapifhir/hapi-fhir/issues/6339

If the schema being used for HAPI in Postgres is not the `public` schema, the 7.4.0 migrations fails because the new `DeletePrimaryKeyTask` assumes the active schema is `public` when it looks up the primary key name.

This changes it to use `current_schema()` if available (i.e. the HAPI user has a search_path set) and `'public'` otherwise.

Tested by running the 7.4.2 migrations with this change incorporated against a database where the old migrations were failing.
