### PR TITLE
Expand translation cache

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6341-expand-translation-cache.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6341-expand-translation-cache.yaml
@@ -1,0 +1,6 @@
+---
+type: change
+issue: 6341
+title: "The CachingValidationSupport cache for concept translations will 
+   now keep up to 500000 translations instead of the previous 5000. 
+   This will be made configurable in a future release."

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java
@@ -79,7 +79,7 @@ public class CachingValidationSupport extends BaseValidationSupportWrapper imple
 		myExpandValueSetCache = CacheFactory.build(theCacheTimeouts.getExpandValueSetMillis(), 100);
 		myValidateCodeCache = CacheFactory.build(theCacheTimeouts.getValidateCodeMillis(), 5000);
 		myLookupCodeCache = CacheFactory.build(theCacheTimeouts.getLookupCodeMillis(), 5000);
-		myTranslateCodeCache = CacheFactory.build(theCacheTimeouts.getTranslateCodeMillis(), 5000);
+		myTranslateCodeCache = CacheFactory.build(theCacheTimeouts.getTranslateCodeMillis(), 500000);
 		myCache = CacheFactory.build(theCacheTimeouts.getMiscMillis(), 5000);
 		myNonExpiringCache = Collections.synchronizedMap(new HashMap<>());
 


### PR DESCRIPTION
The CachingValidationSupport cache for concept translations will now keep up to 500000 translations instead of the previous 5000. This will be made configurable in a future release.