### PR TITLE
Add missing search using POST HTTP method to OpenAPI specification

### DIFF
--- a/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.html
+++ b/hapi-fhir-server-openapi/src/main/resources/ca/uhn/fhir/rest/openapi/index.html
@@ -43,6 +43,22 @@
 <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
 <script>
     window.onload = function() {
+		 //Uncheck send empty value by default
+		 const UncheckSendEmptyValuePlugin = function() {
+			 return {
+				 wrapComponents: {
+					 ParameterIncludeEmpty: (Original, { React }) => (props) => {
+						 props.isIncludedOptions.defaultValue = false;
+						 return React.createElement(Original, props)
+					 },
+					 TryItOutButton: (Original, { React }) => (props) => {
+						 if (props.isOAS3 && props.hasUserEditedBody) { props.hasUserEditedBody = false; }
+						 return React.createElement(Original, props)
+					 }
+				 }
+			 }
+		 };
+
         // Begin Swagger UI call region
         const ui = SwaggerUIBundle({
             url: "[[${OPENAPI_DOCS} + '?page=' + ${PAGE}]]",
@@ -53,6 +69,7 @@
                 SwaggerUIStandalonePreset
             ],
             plugins: [
+					UncheckSendEmptyValuePlugin
                 // SwaggerUIBundle.plugins.DownloadUrl
             ],
             // layout: "StandaloneLayout",


### PR DESCRIPTION
In OpenAPI specification searching using the POST HTTP method is missing.