### PR TITLE
Jr 20241008 merge data absent reason

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -26,10 +26,12 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeChildChoiceDefinition;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.slf4j.Logger;
@@ -93,6 +95,7 @@ public final class TerserUtil {
 
 	private static final Logger ourLog = getLogger(TerserUtil.class);
 	private static final String EQUALS_DEEP = "equalsDeep";
+	public static final String DATA_ABSENT_REASON_EXTENSION_URI = "http://hl7.org/fhir/StructureDefinition/data-absent-reason";
 
 	private TerserUtil() {}
 
@@ -264,6 +267,15 @@ public final class TerserUtil {
 	private static boolean contains(IBase theItem, List<IBase> theItems) {
 		final Method method = getMethod(theItem, EQUALS_DEEP);
 		return theItems.stream().anyMatch(i -> equals(i, theItem, method));
+	}
+
+	private static boolean hasDataAbsentReason(IBase theItem) {
+		if (theItem instanceof IBaseHasExtensions) {
+			IBaseHasExtensions hasExtensions = (IBaseHasExtensions) theItem;
+			return hasExtensions.getExtension().stream()
+				.anyMatch(t -> StringUtils.equals(t.getUrl(), DATA_ABSENT_REASON_EXTENSION_URI));
+		}
+		return false;
 	}
 
 	/**
@@ -700,6 +712,12 @@ public final class TerserUtil {
 				continue;
 			}
 
+			if (hasDataAbsentReason(theFromFieldValue) && !theToFieldValues.isEmpty()) {
+				// if the from field value asserts a reason the field isn't populated, but the to field is populated,
+				// we don't want to overwrite real data with the extension
+				continue;
+			}
+
 			IBase newFieldValue = newElement(theTerser, childDefinition, theFromFieldValue, null);
 			if (theFromFieldValue instanceof IPrimitiveType) {
 				try {
@@ -708,8 +726,8 @@ public final class TerserUtil {
 						newFieldValue = (IBase) copyMethod.invoke(theFromFieldValue, new Object[] {});
 					}
 				} catch (Throwable t) {
-					((IPrimitiveType) newFieldValue)
-							.setValueAsString(((IPrimitiveType) theFromFieldValue).getValueAsString());
+					((IPrimitiveType<?>) newFieldValue)
+							.setValueAsString(((IPrimitiveType<?>) theFromFieldValue).getValueAsString());
 				}
 			} else {
 				theTerser.cloneInto(theFromFieldValue, newFieldValue, true);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TerserUtil.java
@@ -95,7 +95,8 @@ public final class TerserUtil {
 
 	private static final Logger ourLog = getLogger(TerserUtil.class);
 	private static final String EQUALS_DEEP = "equalsDeep";
-	public static final String DATA_ABSENT_REASON_EXTENSION_URI = "http://hl7.org/fhir/StructureDefinition/data-absent-reason";
+	public static final String DATA_ABSENT_REASON_EXTENSION_URI =
+			"http://hl7.org/fhir/StructureDefinition/data-absent-reason";
 
 	private TerserUtil() {}
 
@@ -273,7 +274,7 @@ public final class TerserUtil {
 		if (theItem instanceof IBaseHasExtensions) {
 			IBaseHasExtensions hasExtensions = (IBaseHasExtensions) theItem;
 			return hasExtensions.getExtension().stream()
-				.anyMatch(t -> StringUtils.equals(t.getUrl(), DATA_ABSENT_REASON_EXTENSION_URI));
+					.anyMatch(t -> StringUtils.equals(t.getUrl(), DATA_ABSENT_REASON_EXTENSION_URI));
 		}
 		return false;
 	}
@@ -707,30 +708,36 @@ public final class TerserUtil {
 			BaseRuntimeChildDefinition childDefinition,
 			List<IBase> theFromFieldValues,
 			List<IBase> theToFieldValues) {
-		for (IBase theFromFieldValue : theFromFieldValues) {
-			if (contains(theFromFieldValue, theToFieldValues)) {
+		if (!theFromFieldValues.isEmpty() && theToFieldValues.stream().anyMatch(TerserUtil::hasDataAbsentReason)) {
+			// If the to resource has a data absent reason, and there is potentially real data incoming
+			// in the from resource, we should clear the data absent reason because it won't be absent anymore.
+			theToFieldValues = removeDataAbsentReason(theTo, childDefinition, theToFieldValues);
+		}
+
+		for (IBase fromFieldValue : theFromFieldValues) {
+			if (contains(fromFieldValue, theToFieldValues)) {
 				continue;
 			}
 
-			if (hasDataAbsentReason(theFromFieldValue) && !theToFieldValues.isEmpty()) {
+			if (hasDataAbsentReason(fromFieldValue) && !theToFieldValues.isEmpty()) {
 				// if the from field value asserts a reason the field isn't populated, but the to field is populated,
 				// we don't want to overwrite real data with the extension
 				continue;
 			}
 
-			IBase newFieldValue = newElement(theTerser, childDefinition, theFromFieldValue, null);
-			if (theFromFieldValue instanceof IPrimitiveType) {
+			IBase newFieldValue = newElement(theTerser, childDefinition, fromFieldValue, null);
+			if (fromFieldValue instanceof IPrimitiveType) {
 				try {
-					Method copyMethod = getMethod(theFromFieldValue, "copy");
+					Method copyMethod = getMethod(fromFieldValue, "copy");
 					if (copyMethod != null) {
-						newFieldValue = (IBase) copyMethod.invoke(theFromFieldValue, new Object[] {});
+						newFieldValue = (IBase) copyMethod.invoke(fromFieldValue, new Object[] {});
 					}
 				} catch (Throwable t) {
 					((IPrimitiveType<?>) newFieldValue)
-							.setValueAsString(((IPrimitiveType<?>) theFromFieldValue).getValueAsString());
+							.setValueAsString(((IPrimitiveType<?>) fromFieldValue).getValueAsString());
 				}
 			} else {
-				theTerser.cloneInto(theFromFieldValue, newFieldValue, true);
+				theTerser.cloneInto(fromFieldValue, newFieldValue, true);
 			}
 
 			try {
@@ -740,6 +747,21 @@ public final class TerserUtil {
 				theToFieldValues = childDefinition.getAccessor().getValues(theTo);
 			}
 		}
+	}
+
+	private static List<IBase> removeDataAbsentReason(
+			IBaseResource theResource, BaseRuntimeChildDefinition theFieldDefinition, List<IBase> theFieldValues) {
+		for (int i = 0; i < theFieldValues.size(); i++) {
+			if (hasDataAbsentReason(theFieldValues.get(i))) {
+				try {
+					theFieldDefinition.getMutator().remove(theResource, i);
+				} catch (UnsupportedOperationException e) {
+					// the field must be single-valued, just clear it
+					theFieldDefinition.getMutator().setValue(theResource, null);
+				}
+			}
+		}
+		return theFieldDefinition.getAccessor().getValues(theResource);
 	}
 
 	/**

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6370-data-absent-merge.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6370-data-absent-merge.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 6370
+title: "When using the FHIR `TerserUtil` to merge two resource, if one resource has real data in a particular field,
+and the other resource has a `data-absent-reason` extension in the same field, the real data will be given
+precedence in the merged resource, and the extension will be ignored."


### PR DESCRIPTION
During a FHIRTerser merge operation, if one resource provides real data, and the other resource provides a `data-absent-reason` extension, the real data will be given precedence over the extension.