### PR TITLE
Add hash identity token mode

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6375-add-hash-identity-token-mode.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6375-add-hash-identity-token-mode.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 6375
+title: "A new experimental JPA setting has been added to JpaStorageSettings which
+  causes searches for token SearchParameters to include a predicate on the
+  HASH_IDENTITY column even if it is not needed because other hashes are in use."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/TokenPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/TokenPredicateBuilder.java
@@ -79,12 +79,16 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 	private final DbColumn myColumnSystem;
 	private final DbColumn myColumnValue;
 	private final DbColumn myColumnHashIdentity;
+
 	@Autowired
 	private IValidationSupport myValidationSupport;
+
 	@Autowired
 	private ITermReadSvc myTerminologySvc;
+
 	@Autowired
 	private FhirContext myContext;
+
 	@Autowired
 	private JpaStorageSettings myStorageSettings;
 
@@ -113,22 +117,22 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 	}
 
 	public Condition createPredicateToken(
-		Collection<IQueryParameterType> theParameters,
-		String theResourceName,
-		String theSpnamePrefix,
-		RuntimeSearchParam theSearchParam,
-		RequestPartitionId theRequestPartitionId) {
+			Collection<IQueryParameterType> theParameters,
+			String theResourceName,
+			String theSpnamePrefix,
+			RuntimeSearchParam theSearchParam,
+			RequestPartitionId theRequestPartitionId) {
 		return createPredicateToken(
-			theParameters, theResourceName, theSpnamePrefix, theSearchParam, null, theRequestPartitionId);
+				theParameters, theResourceName, theSpnamePrefix, theSearchParam, null, theRequestPartitionId);
 	}
 
 	public Condition createPredicateToken(
-		Collection<IQueryParameterType> theParameters,
-		String theResourceName,
-		String theSpnamePrefix,
-		RuntimeSearchParam theSearchParam,
-		SearchFilterParser.CompareOperation theOperation,
-		RequestPartitionId theRequestPartitionId) {
+			Collection<IQueryParameterType> theParameters,
+			String theResourceName,
+			String theSpnamePrefix,
+			RuntimeSearchParam theSearchParam,
+			SearchFilterParser.CompareOperation theOperation,
+			RequestPartitionId theRequestPartitionId) {
 
 		final List<FhirVersionIndependentConcept> codes = new ArrayList<>();
 
@@ -164,20 +168,20 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 
 			if (system != null && system.length() > ResourceIndexedSearchParamToken.MAX_LENGTH) {
 				ourLog.info(
-					"Parameter[{}] has system ({}) that is longer than maximum ({}) so will truncate: {} ",
-					paramName,
-					system.length(),
-					ResourceIndexedSearchParamToken.MAX_LENGTH,
-					system);
+						"Parameter[{}] has system ({}) that is longer than maximum ({}) so will truncate: {} ",
+						paramName,
+						system.length(),
+						ResourceIndexedSearchParamToken.MAX_LENGTH,
+						system);
 			}
 
 			if (code != null && code.length() > ResourceIndexedSearchParamToken.MAX_LENGTH) {
 				ourLog.info(
-					"Parameter[{}] has code ({}) that is longer than maximum ({}) so will truncate: {} ",
-					paramName,
-					code.length(),
-					ResourceIndexedSearchParamToken.MAX_LENGTH,
-					code);
+						"Parameter[{}] has code ({}) that is longer than maximum ({}) so will truncate: {} ",
+						paramName,
+						code.length(),
+						ResourceIndexedSearchParamToken.MAX_LENGTH,
+						code);
 			}
 
 			/*
@@ -189,7 +193,7 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 					ValueSetExpansionOptions valueSetExpansionOptions = new ValueSetExpansionOptions();
 					valueSetExpansionOptions.setCount(myStorageSettings.getMaximumExpansionSize());
 					IValidationSupport.ValueSetExpansionOutcome expanded = myValidationSupport.expandValueSet(
-						new ValidationSupportContext(myValidationSupport), valueSetExpansionOptions, code);
+							new ValidationSupportContext(myValidationSupport), valueSetExpansionOptions, code);
 
 					codes.addAll(extractValueSetCodes(expanded.getValueSet()));
 				} else {
@@ -209,7 +213,7 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 			} else if (modifier == TokenParamModifier.OF_TYPE) {
 				if (!myStorageSettings.isIndexIdentifierOfType()) {
 					throw new MethodNotAllowedException(
-						Msg.code(2012) + "The :of-type modifier is not enabled on this server");
+							Msg.code(2012) + "The :of-type modifier is not enabled on this server");
 				}
 				if (isBlank(system) || isBlank(code)) {
 					throw new InvalidRequestException(Msg.code(2013) + "Invalid parameter value for :of-type query");
@@ -230,10 +234,10 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 		}
 
 		List<FhirVersionIndependentConcept> sortedCodesList = codes.stream()
-			.filter(t -> t.getCode() != null || t.getSystem() != null)
-			.sorted()
-			.distinct()
-			.collect(Collectors.toList());
+				.filter(t -> t.getCode() != null || t.getSystem() != null)
+				.sorted()
+				.distinct()
+				.collect(Collectors.toList());
 
 		if (codes.isEmpty()) {
 			// This will never match anything
@@ -250,9 +254,9 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 			 */
 
 			long hashIdentity = BaseResourceIndexedSearchParam.calculateHashIdentity(
-				getPartitionSettings(), theRequestPartitionId, theResourceName, paramName);
+					getPartitionSettings(), theRequestPartitionId, theResourceName, paramName);
 			Condition hashIdentityPredicate =
-				BinaryCondition.equalTo(getColumnHashIdentity(), generatePlaceholder(hashIdentity));
+					BinaryCondition.equalTo(getColumnHashIdentity(), generatePlaceholder(hashIdentity));
 
 			Condition hashValuePredicate = createPredicateOrList(theResourceName, paramName, sortedCodesList, false);
 			predicate = QueryParameterUtils.toAndPredicate(hashIdentityPredicate, hashValuePredicate);
@@ -263,9 +267,9 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 
 			if (myStorageSettings.isIncludeHashIdentityForTokenSearches()) {
 				long hashIdentity = BaseResourceIndexedSearchParam.calculateHashIdentity(
-					getPartitionSettings(), theRequestPartitionId, theResourceName, paramName);
+						getPartitionSettings(), theRequestPartitionId, theResourceName, paramName);
 				Condition hashIdentityPredicate =
-					BinaryCondition.equalTo(getColumnHashIdentity(), generatePlaceholder(hashIdentity));
+						BinaryCondition.equalTo(getColumnHashIdentity(), generatePlaceholder(hashIdentity));
 				predicate = QueryParameterUtils.toAndPredicate(hashIdentityPredicate, predicate);
 			}
 		}
@@ -282,7 +286,7 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 		if (expansionOpt.isPresent()) {
 			IBase expansion = expansionOpt.get();
 			BaseRuntimeElementCompositeDefinition<?> expansionDef =
-				(BaseRuntimeElementCompositeDefinition<?>) myContext.getElementDefinition(expansion.getClass());
+					(BaseRuntimeElementCompositeDefinition<?>) myContext.getElementDefinition(expansion.getClass());
 			BaseRuntimeChildDefinition containsChild = expansionDef.getChildByName("contains");
 			List<IBase> contains = containsChild.getAccessor().getValues(expansion);
 
@@ -291,26 +295,26 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 			for (IBase nextContains : contains) {
 				if (systemAccessor == null) {
 					systemAccessor = myContext
-						.getElementDefinition(nextContains.getClass())
-						.getChildByName("system")
-						.getAccessor();
+							.getElementDefinition(nextContains.getClass())
+							.getChildByName("system")
+							.getAccessor();
 				}
 				if (codeAccessor == null) {
 					codeAccessor = myContext
-						.getElementDefinition(nextContains.getClass())
-						.getChildByName("code")
-						.getAccessor();
+							.getElementDefinition(nextContains.getClass())
+							.getChildByName("code")
+							.getAccessor();
 				}
 				String system = systemAccessor
-					.getFirstValueOrNull(nextContains)
-					.map(t -> (IPrimitiveType<?>) t)
-					.map(t -> t.getValueAsString())
-					.orElse(null);
+						.getFirstValueOrNull(nextContains)
+						.map(t -> (IPrimitiveType<?>) t)
+						.map(t -> t.getValueAsString())
+						.orElse(null);
 				String code = codeAccessor
-					.getFirstValueOrNull(nextContains)
-					.map(t -> (IPrimitiveType<?>) t)
-					.map(t -> t.getValueAsString())
-					.orElse(null);
+						.getFirstValueOrNull(nextContains)
+						.map(t -> (IPrimitiveType<?>) t)
+						.map(t -> t.getValueAsString())
+						.orElse(null);
 				if (isNotBlank(system) && isNotBlank(code)) {
 					retVal.add(new FhirVersionIndependentConcept(system, code));
 				}
@@ -327,10 +331,10 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 				Set<String> valueSetUris = Sets.newHashSet();
 				for (String nextPath : theSearchParam.getPathsSplitForResourceType(getResourceType())) {
 					Class<? extends IBaseResource> type = getFhirContext()
-						.getResourceDefinition(getResourceType())
-						.getImplementingClass();
+							.getResourceDefinition(getResourceType())
+							.getImplementingClass();
 					BaseRuntimeChildDefinition def =
-						getFhirContext().newTerser().getDefinition(type, nextPath);
+							getFhirContext().newTerser().getDefinition(type, nextPath);
 					if (def instanceof BaseRuntimeDeclaredChildDefinition) {
 						String valueSet = ((BaseRuntimeDeclaredChildDefinition) def).getBindingValueSet();
 						if (isNotBlank(valueSet)) {
@@ -342,7 +346,7 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 					String valueSet = valueSetUris.iterator().next();
 					ValueSetExpansionOptions options = new ValueSetExpansionOptions().setFailOnMissingCodeSystem(false);
 					List<FhirVersionIndependentConcept> candidateCodes =
-						myTerminologySvc.expandValueSetIntoConceptList(options, valueSet);
+							myTerminologySvc.expandValueSetIntoConceptList(options, valueSet);
 					for (FhirVersionIndependentConcept nextCandidate : candidateCodes) {
 						if (nextCandidate.getCode().equals(code)) {
 							retVal = nextCandidate.getSystem();
@@ -368,29 +372,29 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 		String codeDesc = defaultIfBlank(theCode, "(missing)");
 		if (isBlank(theCode)) {
 			String msg = getFhirContext()
-				.getLocalizer()
-				.getMessage(
-					TokenPredicateBuilder.class,
-					"invalidCodeMissingSystem",
-					theParamName,
-					systemDesc,
-					codeDesc);
+					.getLocalizer()
+					.getMessage(
+							TokenPredicateBuilder.class,
+							"invalidCodeMissingSystem",
+							theParamName,
+							systemDesc,
+							codeDesc);
 			throw new InvalidRequestException(Msg.code(1239) + msg);
 		}
 		if (isBlank(theSystem)) {
 			String msg = getFhirContext()
-				.getLocalizer()
-				.getMessage(
-					TokenPredicateBuilder.class, "invalidCodeMissingCode", theParamName, systemDesc, codeDesc);
+					.getLocalizer()
+					.getMessage(
+							TokenPredicateBuilder.class, "invalidCodeMissingCode", theParamName, systemDesc, codeDesc);
 			throw new InvalidRequestException(Msg.code(1240) + msg);
 		}
 	}
 
 	private Condition createPredicateOrList(
-		String theResourceType,
-		String theSearchParamName,
-		List<FhirVersionIndependentConcept> theCodes,
-		boolean theWantEquals) {
+			String theResourceType,
+			String theSearchParamName,
+			List<FhirVersionIndependentConcept> theCodes,
+			boolean theWantEquals) {
 		Condition[] conditions = new Condition[theCodes.size()];
 
 		Long[] hashes = new Long[theCodes.size()];
@@ -403,28 +407,28 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 			DbColumn column;
 			if (nextToken.getSystem() == null) {
 				hash = ResourceIndexedSearchParamToken.calculateHashValue(
-					getPartitionSettings(),
-					getRequestPartitionId(),
-					theResourceType,
-					theSearchParamName,
-					nextToken.getCode());
+						getPartitionSettings(),
+						getRequestPartitionId(),
+						theResourceType,
+						theSearchParamName,
+						nextToken.getCode());
 				column = myColumnHashValue;
 			} else if (isBlank(nextToken.getCode())) {
 				hash = ResourceIndexedSearchParamToken.calculateHashSystem(
-					getPartitionSettings(),
-					getRequestPartitionId(),
-					theResourceType,
-					theSearchParamName,
-					nextToken.getSystem());
+						getPartitionSettings(),
+						getRequestPartitionId(),
+						theResourceType,
+						theSearchParamName,
+						nextToken.getSystem());
 				column = myColumnHashSystem;
 			} else {
 				hash = ResourceIndexedSearchParamToken.calculateHashSystemAndValue(
-					getPartitionSettings(),
-					getRequestPartitionId(),
-					theResourceType,
-					theSearchParamName,
-					nextToken.getSystem(),
-					nextToken.getCode());
+						getPartitionSettings(),
+						getRequestPartitionId(),
+						theResourceType,
+						theSearchParamName,
+						nextToken.getSystem(),
+						nextToken.getCode());
 				column = myColumnHashSystemAndValue;
 			}
 			hashes[i] = hash;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/TokenPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/TokenPredicateBuilder.java
@@ -48,6 +48,7 @@ import ca.uhn.fhir.rest.param.TokenParamModifier;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.util.FhirVersionIndependentConcept;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.healthmarketscience.sqlbuilder.BinaryCondition;
 import com.healthmarketscience.sqlbuilder.Condition;
@@ -109,6 +110,11 @@ public class TokenPredicateBuilder extends BaseSearchParamPredicateBuilder {
 	@Override
 	public DbColumn getColumnHashIdentity() {
 		return myColumnHashIdentity;
+	}
+
+	@VisibleForTesting
+	public void setStorageSettingsForUnitTest(JpaStorageSettings theStorageSettings) {
+		myStorageSettings = theStorageSettings;
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
@@ -78,7 +78,9 @@ public class ResourceHistoryTable extends BaseHasResource implements Serializabl
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@GenericGenerator(name = "SEQ_RESOURCE_HISTORY_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
+	@GenericGenerator(
+			name = "SEQ_RESOURCE_HISTORY_ID",
+			type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESOURCE_HISTORY_ID")
 	@Column(name = "PID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTable.java
@@ -38,13 +38,13 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.OptimisticLock;
 
 import java.io.Serializable;
@@ -78,7 +78,7 @@ public class ResourceHistoryTable extends BaseHasResource implements Serializabl
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_RESOURCE_HISTORY_ID", sequenceName = "SEQ_RESOURCE_HISTORY_ID")
+	@GenericGenerator(name = "SEQ_RESOURCE_HISTORY_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESOURCE_HISTORY_ID")
 	@Column(name = "PID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTag.java
@@ -29,9 +29,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.GenericGenerator;
 
 import java.io.Serializable;
 
@@ -49,7 +49,7 @@ public class ResourceHistoryTag extends BaseTag implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	@SequenceGenerator(name = "SEQ_HISTORYTAG_ID", sequenceName = "SEQ_HISTORYTAG_ID")
+	@GenericGenerator(name = "SEQ_HISTORYTAG_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_HISTORYTAG_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboStringUnique.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboStringUnique.java
@@ -29,7 +29,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.CompareToBuilder;
@@ -37,6 +36,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 import org.hl7.fhir.instance.model.api.IIdType;
 
 /**
@@ -76,7 +76,7 @@ public class ResourceIndexedComboStringUnique extends BaseResourceIndexedCombo
 	public static final String IDX_IDXCMPSTRUNIQ_STRING = "IDX_IDXCMPSTRUNIQ_STRING";
 	public static final String IDX_IDXCMPSTRUNIQ_RESOURCE = "IDX_IDXCMPSTRUNIQ_RESOURCE";
 
-	@SequenceGenerator(name = "SEQ_IDXCMPSTRUNIQ_ID", sequenceName = "SEQ_IDXCMPSTRUNIQ_ID")
+	@GenericGenerator(name = "SEQ_IDXCMPSTRUNIQ_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_IDXCMPSTRUNIQ_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboStringUnique.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboStringUnique.java
@@ -76,7 +76,9 @@ public class ResourceIndexedComboStringUnique extends BaseResourceIndexedCombo
 	public static final String IDX_IDXCMPSTRUNIQ_STRING = "IDX_IDXCMPSTRUNIQ_STRING";
 	public static final String IDX_IDXCMPSTRUNIQ_RESOURCE = "IDX_IDXCMPSTRUNIQ_RESOURCE";
 
-	@GenericGenerator(name = "SEQ_IDXCMPSTRUNIQ_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
+	@GenericGenerator(
+			name = "SEQ_IDXCMPSTRUNIQ_ID",
+			type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_IDXCMPSTRUNIQ_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboTokenNonUnique.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboTokenNonUnique.java
@@ -31,13 +31,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(
@@ -51,7 +51,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class ResourceIndexedComboTokenNonUnique extends BaseResourceIndexedCombo
 		implements Comparable<ResourceIndexedComboTokenNonUnique>, IResourceIndexComboSearchParameter {
 
-	@SequenceGenerator(name = "SEQ_IDXCMBTOKNU_ID", sequenceName = "SEQ_IDXCMBTOKNU_ID")
+	@GenericGenerator(name = "SEQ_IDXCMBTOKNU_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_IDXCMBTOKNU_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboTokenNonUnique.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedComboTokenNonUnique.java
@@ -51,7 +51,9 @@ import org.hibernate.annotations.GenericGenerator;
 public class ResourceIndexedComboTokenNonUnique extends BaseResourceIndexedCombo
 		implements Comparable<ResourceIndexedComboTokenNonUnique>, IResourceIndexComboSearchParameter {
 
-	@GenericGenerator(name = "SEQ_IDXCMBTOKNU_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
+	@GenericGenerator(
+			name = "SEQ_IDXCMBTOKNU_ID",
+			type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_IDXCMBTOKNU_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamCoords.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamCoords.java
@@ -35,12 +35,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 
 @Embeddable
 @EntityListeners(IndexStorageOptimizationListener.class)
@@ -67,7 +67,7 @@ public class ResourceIndexedSearchParamCoords extends BaseResourceIndexedSearchP
 	public Double myLongitude;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_COORDS", sequenceName = "SEQ_SPIDX_COORDS")
+	@GenericGenerator(name = "SEQ_SPIDX_COORDS", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_COORDS")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
@@ -39,7 +39,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -49,6 +48,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hl7.fhir.r4.model.DateTimeType;
 
@@ -107,7 +107,7 @@ public class ResourceIndexedSearchParamDate extends BaseResourceIndexedSearchPar
 	private transient String myOriginalValue;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_DATE", sequenceName = "SEQ_SPIDX_DATE")
+	@GenericGenerator(name = "SEQ_SPIDX_DATE", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_DATE")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamNumber.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamNumber.java
@@ -35,12 +35,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ScaledNumberField;
 import org.hibernate.type.SqlTypes;
@@ -68,7 +68,7 @@ public class ResourceIndexedSearchParamNumber extends BaseResourceIndexedSearchP
 	public BigDecimal myValue;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_NUMBER", sequenceName = "SEQ_SPIDX_NUMBER")
+	@GenericGenerator(name = "SEQ_SPIDX_NUMBER", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_NUMBER")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantity.java
@@ -74,7 +74,9 @@ public class ResourceIndexedSearchParamQuantity extends BaseResourceIndexedSearc
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@GenericGenerator(name = "SEQ_SPIDX_QUANTITY", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
+	@GenericGenerator(
+			name = "SEQ_SPIDX_QUANTITY",
+			type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_QUANTITY")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantity.java
@@ -35,12 +35,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ScaledNumberField;
 
 import java.math.BigDecimal;
@@ -74,7 +74,7 @@ public class ResourceIndexedSearchParamQuantity extends BaseResourceIndexedSearc
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_QUANTITY", sequenceName = "SEQ_SPIDX_QUANTITY")
+	@GenericGenerator(name = "SEQ_SPIDX_QUANTITY", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_QUANTITY")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantityNormalized.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantityNormalized.java
@@ -80,7 +80,9 @@ public class ResourceIndexedSearchParamQuantityNormalized extends BaseResourceIn
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@GenericGenerator(name = "SEQ_SPIDX_QUANTITY_NRML", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
+	@GenericGenerator(
+			name = "SEQ_SPIDX_QUANTITY_NRML",
+			type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_QUANTITY_NRML")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantityNormalized.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamQuantityNormalized.java
@@ -36,13 +36,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.fhir.ucum.Pair;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ScaledNumberField;
 
 import java.math.BigDecimal;
@@ -80,7 +80,7 @@ public class ResourceIndexedSearchParamQuantityNormalized extends BaseResourceIn
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_QUANTITY_NRML", sequenceName = "SEQ_SPIDX_QUANTITY_NRML")
+	@GenericGenerator(name = "SEQ_SPIDX_QUANTITY_NRML", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_QUANTITY_NRML")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -37,7 +37,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamString.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 
 import static ca.uhn.fhir.jpa.model.util.SearchParamHash.hashSearchParam;
 import static org.apache.commons.lang3.StringUtils.defaultString;
@@ -78,7 +79,7 @@ public class ResourceIndexedSearchParamString extends BaseResourceIndexedSearchP
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_STRING", sequenceName = "SEQ_SPIDX_STRING")
+	@GenericGenerator(name = "SEQ_SPIDX_STRING", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_STRING")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamToken.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamToken.java
@@ -39,13 +39,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 
 import static ca.uhn.fhir.jpa.model.util.SearchParamHash.hashSearchParam;
@@ -89,7 +89,7 @@ public class ResourceIndexedSearchParamToken extends BaseResourceIndexedSearchPa
 
 	@SuppressWarnings("unused")
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_TOKEN", sequenceName = "SEQ_SPIDX_TOKEN")
+	@GenericGenerator(name = "SEQ_SPIDX_TOKEN", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_TOKEN")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamUri.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamUri.java
@@ -36,12 +36,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 
 import static ca.uhn.fhir.jpa.model.util.SearchParamHash.hashSearchParam;
@@ -76,7 +76,7 @@ public class ResourceIndexedSearchParamUri extends BaseResourceIndexedSearchPara
 	public String myUri;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_SPIDX_URI", sequenceName = "SEQ_SPIDX_URI")
+	@GenericGenerator(name = "SEQ_SPIDX_URI", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SPIDX_URI")
 	@Column(name = "SP_ID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
@@ -31,7 +31,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -39,6 +38,7 @@ import jakarta.persistence.Transient;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hl7.fhir.instance.model.api.IIdType;
 
@@ -63,7 +63,7 @@ public class ResourceLink extends BaseResourceIndex {
 	public static final int SRC_PATH_LENGTH = 500;
 	private static final long serialVersionUID = 1L;
 
-	@SequenceGenerator(name = "SEQ_RESLINK_ID", sequenceName = "SEQ_RESLINK_ID")
+	@GenericGenerator(name = "SEQ_RESLINK_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESLINK_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTag.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(
@@ -53,7 +54,7 @@ public class ResourceTag extends BaseTag {
 
 	private static final long serialVersionUID = 1L;
 
-	@SequenceGenerator(name = "SEQ_RESTAG_ID", sequenceName = "SEQ_RESTAG_ID")
+	@GenericGenerator(name = "SEQ_RESTAG_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESTAG_ID")
 	@Id
 	@Column(name = "PID")

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTag.java
@@ -29,7 +29,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import org.apache.commons.lang3.builder.EqualsBuilder;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/SearchParamPresentEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/SearchParamPresentEntity.java
@@ -57,7 +57,9 @@ public class SearchParamPresentEntity extends BasePartitionable implements Seria
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@GenericGenerator(name = "SEQ_RESPARMPRESENT_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
+	@GenericGenerator(
+			name = "SEQ_RESPARMPRESENT_ID",
+			type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESPARMPRESENT_ID")
 	@Column(name = "PID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/SearchParamPresentEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/SearchParamPresentEntity.java
@@ -31,7 +31,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import org.apache.commons.lang3.Validate;
@@ -39,6 +38,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 
 import java.io.Serializable;
 
@@ -57,7 +57,7 @@ public class SearchParamPresentEntity extends BasePartitionable implements Seria
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@SequenceGenerator(name = "SEQ_RESPARMPRESENT_ID", sequenceName = "SEQ_RESPARMPRESENT_ID")
+	@GenericGenerator(name = "SEQ_RESPARMPRESENT_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESPARMPRESENT_ID")
 	@Column(name = "PID")
 	private Long myId;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -389,6 +389,8 @@ public abstract class BaseJpaTest extends BaseTest {
 		JpaStorageSettings defaultConfig = new JpaStorageSettings();
 		myStorageSettings.setAdvancedHSearchIndexing(defaultConfig.isAdvancedHSearchIndexing());
 		myStorageSettings.setAllowContainsSearches(defaultConfig.isAllowContainsSearches());
+		myStorageSettings.setIncludeHashIdentityForTokenSearches(defaultConfig.isIncludeHashIdentityForTokenSearches());
+
 	}
 
 	@AfterEach

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/search/builder/predicate/TokenPredicateBuilderTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/search/builder/predicate/TokenPredicateBuilderTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.search.builder.predicate;
 
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.search.builder.sql.SearchQueryBuilder;
@@ -58,6 +59,7 @@ public class TokenPredicateBuilderTest {
 		when(mySearchQueryBuilder.addTable(Mockito.anyString())).thenReturn(table);
 		when(mySearchQueryBuilder.getPartitionSettings()).thenReturn(new PartitionSettings());
 		myTokenPredicateBuilder = new TokenPredicateBuilder(mySearchQueryBuilder);
+		myTokenPredicateBuilder.setStorageSettingsForUnitTest(new JpaStorageSettings());
 	}
 
 	@AfterEach

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.rest.api.SearchTotalModeEnum;
 import ca.uhn.fhir.system.HapiSystemProperties;
 import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.validation.FhirValidator;
+import com.google.common.annotations.Beta;
 import com.google.common.collect.Sets;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -369,6 +370,16 @@ public class JpaStorageSettings extends StorageSettings {
 	private boolean myWriteToLegacyLobColumns = false;
 
 	/**
+	 * If this is enabled (default is {@literal false}), searches on token indexes will
+	 * include the {@literal HASH_IDENTITY} column on all generated FHIR search query SQL.
+	 * This is an experimental flag that may be changed or removed in a future release.
+	 *
+	 * @since 7.6.0
+	 */
+	@Beta
+	private boolean myIncludeHashIdentityForTokenSearches = false;
+
+	/**
 	 * Constructor
 	 */
 	public JpaStorageSettings() {
@@ -394,6 +405,28 @@ public class JpaStorageSettings extends StorageSettings {
 		if (HapiSystemProperties.isPreventInvalidatingConditionalMatchCriteria()) {
 			setPreventInvalidatingConditionalMatchCriteria(true);
 		}
+	}
+
+	/**
+	 * If this is enabled (default is {@literal false}), searches on token indexes will
+	 * include the {@literal HASH_IDENTITY} column on all generated FHIR search query SQL.
+	 * This is an experimental flag that may be changed or removed in a future release.
+	 *
+	 * @since 7.6.0
+	 */
+	public boolean isIncludeHashIdentityForTokenSearches() {
+		return myIncludeHashIdentityForTokenSearches;
+	}
+
+	/**
+	 * If this is enabled (default is {@literal false}), searches on token indexes will
+	 * include the {@literal HASH_IDENTITY} column on all generated FHIR search query SQL.
+	 * This is an experimental flag that may be changed or removed in a future release.
+	 *
+	 * @since 7.6.0
+	 */
+	public void setIncludeHashIdentityForTokenSearches(boolean theIncludeHashIdentityForTokenSearches) {
+		myIncludeHashIdentityForTokenSearches = theIncludeHashIdentityForTokenSearches;
 	}
 
 	/**


### PR DESCRIPTION
This PR adds an experimental new feature to include the HASH_IDENTITY column as a predicate whenever searches against the SPIDX_TOKEN table are performed (for positive searches - does not cover :not searches, etc)