### PR TITLE
Update SearchParameterMap Offset And Count logic to not lose It's values when present

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -2022,7 +2022,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				}
 			}
 
-			final Integer offset = RestfulServerUtils.extractOffsetParameter(theRequest);
+			final Integer offset = theParams.getOffset() != null ? theParams.getOffset() : RestfulServerUtils.extractOffsetParameter(theRequest);
 			if (offset != null || !isPagingProviderDatabaseBacked(theRequest)) {
 				theParams.setLoadSynchronous(true);
 				if (offset != null) {
@@ -2031,7 +2031,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 				theParams.setOffset(offset);
 			}
 
-			Integer count = RestfulServerUtils.extractCountParameter(theRequest);
+			Integer count = theParams.getCount() != null ? theParams.getCount() : RestfulServerUtils.extractCountParameter(theRequest);
 			if (count != null) {
 				Integer maxPageSize = theRequest.getServer().getMaximumPageSize();
 				if (maxPageSize != null && count > maxPageSize) {


### PR DESCRIPTION
When doing a search with a SearchParameterMap and RequestDetails, Don't let the values from the RequestDetails overwrite the values of the SearchParameterMap if they are present already.