### PR TITLE
Fix tests about elementsSubset

### DIFF
--- a/hapi-fhir-client-okhttp/src/test/java/ca/uhn/fhir/okhttp/GenericOkHttpClientDstu2Test.java
+++ b/hapi-fhir-client-okhttp/src/test/java/ca/uhn/fhir/okhttp/GenericOkHttpClientDstu2Test.java
@@ -1357,7 +1357,9 @@ public class GenericOkHttpClientDstu2Test {
 			.returnBundle(Bundle.class)
 			.execute();
 
-		assertEquals(ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=identifier%2Cname", MY_SERVLET.ourRequestUri);
+		assertThat(MY_SERVLET.ourRequestUri).isIn(
+			ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=identifier%2Cname",
+			ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=name%2Cidentifier");
 
 		// assertThat(MY_SERVLET.ourRequestUri,
 		// either(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo(ourServer.getBaseUrl() +
@@ -1391,7 +1393,10 @@ public class GenericOkHttpClientDstu2Test {
 			.execute();
 
 		assertThat(MY_SERVLET.ourRequestUri).contains(ourServer.getBaseUrl() + "/fhir/Patient/_search?");
-		assertThat(MY_SERVLET.ourRequestUri).contains("_elements=identifier%2Cname");
+		assertThat(MY_SERVLET.ourRequestUri).satisfiesAnyOf(
+			s -> assertThat(s).contains("_elements=identifier%2Cname"),
+			s -> assertThat(s).contains("_elements=name%2Cidentifier")
+		);
 		assertThat(MY_SERVLET.ourRequestUri).doesNotContain("_format=json");
 
 		// assertThat(MY_SERVLET.ourRequestUri,

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu2Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu2Test.java
@@ -49,7 +49,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu2Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu2Test.java
@@ -49,6 +49,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -1474,7 +1475,9 @@ public class GenericJaxRsClientDstu2Test {
 			.execute();
 
 
-		assertEquals(ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=identifier%2Cname", CAPTURE_SERVLET.ourRequestUri);
+		assertThat(CAPTURE_SERVLET.ourRequestUri).isIn(
+			ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=identifier%2Cname",
+			ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=name%2Cidentifier");
 
 		//		assertThat(MY_SERVLET.ourRequestUri,
 		//				either(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
@@ -1511,7 +1514,10 @@ public class GenericJaxRsClientDstu2Test {
 
 
 		assertThat(CAPTURE_SERVLET.ourRequestUri).contains(ourServer.getBaseUrl() + "/fhir/Patient/_search?");
-		assertThat(CAPTURE_SERVLET.ourRequestUri).contains("_elements=identifier%2Cname");
+		assertThat(CAPTURE_SERVLET.ourRequestUri).satisfiesAnyOf(
+			s -> assertThat(s).contains("_elements=identifier%2Cname"),
+			s -> assertThat(s).contains("_elements=name%2Cidentifier")
+		);
 
 		//		assertThat(MY_SERVLET.ourRequestUri,
 		//				either(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=identifier%2Cname")));

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu3Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu3Test.java
@@ -53,6 +53,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -1546,7 +1547,9 @@ public class GenericJaxRsClientDstu3Test {
 			.execute();
 		//@formatter:on
 
-		assertEquals(ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=identifier%2Cname", MY_SERVLET.ourRequestUri);
+		assertThat(MY_SERVLET.ourRequestUri).isIn(
+			ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=identifier%2Cname",
+			ourServer.getBaseUrl() + "/fhir/Patient/_search?_elements=name%2Cidentifier");
 
 		//		assertThat(MY_SERVLET.ourRequestUri,
 		//				either(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=identifier%2Cname")));
@@ -1583,7 +1586,10 @@ public class GenericJaxRsClientDstu3Test {
 		//@formatter:on
 
 		assertThat(MY_SERVLET.ourRequestUri).contains(ourServer.getBaseUrl() + "/fhir/Patient/_search?");
-		assertThat(MY_SERVLET.ourRequestUri).contains("_elements=identifier%2Cname");
+		assertThat(MY_SERVLET.ourRequestUri).satisfiesAnyOf(
+			s -> assertThat(s).contains("_elements=identifier%2Cname"),
+			s -> assertThat(s).contains("_elements=name%2Cidentifier")
+		);
 
 		//		assertThat(MY_SERVLET.ourRequestUri,
 		//				either(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo(ourServer.getBaseUrl() + "/fhir/Patient?name=james&_elements=identifier%2Cname")));

--- a/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu3Test.java
+++ b/hapi-fhir-jaxrsserver-base/src/test/java/ca/uhn/fhir/jaxrs/client/GenericJaxRsClientDstu3Test.java
@@ -53,7 +53,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2Test.java
@@ -1878,7 +1878,9 @@ public class GenericClientDstu2Test {
 			.returnBundle(Bundle.class)
 			.execute();
 
-		assertEquals("http://example.com/fhir/Patient/_search?_elements=identifier%2Cname", capt.getValue().getURI().toString());
+		assertThat(capt.getValue().getURI().toString()).isIn(
+				"http://example.com/fhir/Patient/_search?_elements=identifier%2Cname",
+				"http://example.com/fhir/Patient/_search?_elements=name%2Cidentifier");
 
 		// assertThat(capt.getValue().getURI().toString(),
 		// either(equalTo("http://example.com/fhir/Patient?name=james&_elements=name%2Cidentifier")).or(equalTo("http://example.com/fhir/Patient?name=james&_elements=identifier%2Cname")));
@@ -1919,7 +1921,10 @@ public class GenericClientDstu2Test {
 			.execute();
 
 		assertThat(capt.getValue().getURI().toString()).contains("http://example.com/fhir/Patient/_search?");
-		assertThat(capt.getValue().getURI().toString()).contains("_elements=identifier%2Cname");
+		assertThat(capt.getValue().getURI().toString()).satisfiesAnyOf(
+			s -> assertThat(s).contains("_elements=identifier%2Cname"),
+			s -> assertThat(s).contains("_elements=name%2Cidentifier")
+		);
 		assertThat(capt.getValue().getURI().toString()).doesNotContain("_format=json");
 
 		// assertThat(capt.getValue().getURI().toString(),


### PR DESCRIPTION
### Issue
Following Tests all used method "elementsSubset" of class "GenericClient". ElementsSubset used a HashSet to store URL queries. Since HashSet doesn't guarantee the orders of entries. The URL GenericClient prints will have different String in different times.

### Change
I found some tests have the handler for different output String but some test doesn't. I added the handler for these tests missing it.

