### PR TITLE
Contained bug

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -105,7 +105,6 @@ public abstract class BaseParser implements IParser {
 	private static final Set<String> notEncodeForContainedResource =
 			new HashSet<>(Arrays.asList("security", "versionId", "lastUpdated"));
 
-	private FhirTerser.ContainedResources myContainedResources;
 	private boolean myEncodeElementsAppliesToChildResourcesOnly;
 	private final FhirContext myContext;
 	private Collection<String> myDontEncodeElements;
@@ -183,12 +182,12 @@ public abstract class BaseParser implements IParser {
 	}
 
 	private String determineReferenceText(
-			IBaseReference theRef, CompositeChildElement theCompositeChildElement, IBaseResource theResource) {
+			IBaseReference theRef, CompositeChildElement theCompositeChildElement, IBaseResource theResource, EncodeContext theContext) {
 		IIdType ref = theRef.getReferenceElement();
 		if (isBlank(ref.getIdPart())) {
 			String reference = ref.getValue();
 			if (theRef.getResource() != null) {
-				IIdType containedId = getContainedResources().getResourceId(theRef.getResource());
+				IIdType containedId = theContext.getContainedResources().getResourceId(theRef.getResource());
 				if (containedId != null && !containedId.isEmpty()) {
 					if (containedId.isLocal()) {
 						reference = containedId.getValue();
@@ -262,7 +261,7 @@ public abstract class BaseParser implements IParser {
 	@Override
 	public final void encodeResourceToWriter(IBaseResource theResource, Writer theWriter)
 			throws IOException, DataFormatException {
-		EncodeContext encodeContext = new EncodeContext(this, myContext.getParserOptions());
+		EncodeContext encodeContext = new EncodeContext(this, myContext.getParserOptions(), new FhirTerser.ContainedResources());
 		encodeResourceToWriter(theResource, theWriter, encodeContext);
 	}
 
@@ -285,7 +284,7 @@ public abstract class BaseParser implements IParser {
 		} else if (theElement instanceof IPrimitiveType) {
 			theWriter.write(((IPrimitiveType<?>) theElement).getValueAsString());
 		} else {
-			EncodeContext encodeContext = new EncodeContext(this, myContext.getParserOptions());
+			EncodeContext encodeContext = new EncodeContext(this, myContext.getParserOptions(), new FhirTerser.ContainedResources());
 			encodeToWriter(theElement, theWriter, encodeContext);
 		}
 	}
@@ -404,9 +403,6 @@ public abstract class BaseParser implements IParser {
 		return elementId;
 	}
 
-	FhirTerser.ContainedResources getContainedResources() {
-		return myContainedResources;
-	}
 
 	@Override
 	public Set<String> getDontStripVersionsFromReferencesAtPaths() {
@@ -539,10 +535,10 @@ public abstract class BaseParser implements IParser {
 		return mySuppressNarratives;
 	}
 
-	protected boolean isChildContained(BaseRuntimeElementDefinition<?> childDef, boolean theIncludedResource) {
+	protected boolean isChildContained(BaseRuntimeElementDefinition<?> childDef, boolean theIncludedResource, EncodeContext theContext) {
 		return (childDef.getChildType() == ChildTypeEnum.CONTAINED_RESOURCES
 						|| childDef.getChildType() == ChildTypeEnum.CONTAINED_RESOURCE_LIST)
-				&& getContainedResources().isEmpty() == false
+				&&  theContext.getContainedResources().isEmpty() == false
 				&& theIncludedResource == false;
 	}
 
@@ -788,7 +784,7 @@ public abstract class BaseParser implements IParser {
 			 */
 			if (next instanceof IBaseReference) {
 				IBaseReference nextRef = (IBaseReference) next;
-				String refText = determineReferenceText(nextRef, theCompositeChildElement, theResource);
+				String refText = determineReferenceText(nextRef, theCompositeChildElement, theResource, theEncodeContext);
 				if (!StringUtils.equals(refText, nextRef.getReferenceElement().getValue())) {
 
 					if (retVal == theValues) {
@@ -980,7 +976,7 @@ public abstract class BaseParser implements IParser {
 		return true;
 	}
 
-	protected void containResourcesInReferences(IBaseResource theResource) {
+	protected void containResourcesInReferences(IBaseResource theResource, EncodeContext theContext) {
 
 		/*
 		 * If a UUID is present in Bundle.entry.fullUrl but no value is present
@@ -1003,7 +999,7 @@ public abstract class BaseParser implements IParser {
 			}
 		}
 
-		myContainedResources = getContext().newTerser().containResources(theResource);
+		 theContext.setContainedResources(getContext().newTerser().containResources(theResource));
 	}
 
 	static class ChildNameAndDef {
@@ -1034,8 +1030,9 @@ public abstract class BaseParser implements IParser {
 		private final List<EncodeContextPath> myEncodeElementPaths;
 		private final Set<String> myEncodeElementsAppliesToResourceTypes;
 		private final List<EncodeContextPath> myDontEncodeElementPaths;
+		private FhirTerser.ContainedResources myContainedResources;
 
-		public EncodeContext(BaseParser theParser, ParserOptions theParserOptions) {
+		public EncodeContext(BaseParser theParser, ParserOptions theParserOptions, FhirTerser.ContainedResources theContainedResources) {
 			Collection<String> encodeElements = theParser.myEncodeElements;
 			Collection<String> dontEncodeElements = theParser.myDontEncodeElements;
 			if (isSummaryMode()) {
@@ -1058,12 +1055,21 @@ public abstract class BaseParser implements IParser {
 						dontEncodeElements.stream().map(EncodeContextPath::new).collect(Collectors.toList());
 			}
 
+			myContainedResources = theContainedResources;
+
 			myEncodeElementsAppliesToResourceTypes =
 					ParserUtil.determineApplicableResourceTypesForTerserPaths(myEncodeElementPaths);
 		}
 
 		private Map<Key, List<BaseParser.CompositeChildElement>> getCompositeChildrenCache() {
 			return myCompositeChildrenCache;
+		}
+
+		public FhirTerser.ContainedResources getContainedResources() {
+			return myContainedResources;
+		}
+		public void setContainedResources(FhirTerser.ContainedResources theContainedResources) {
+			myContainedResources = theContainedResources;
 		}
 	}
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -182,7 +182,10 @@ public abstract class BaseParser implements IParser {
 	}
 
 	private String determineReferenceText(
-			IBaseReference theRef, CompositeChildElement theCompositeChildElement, IBaseResource theResource, EncodeContext theContext) {
+			IBaseReference theRef,
+			CompositeChildElement theCompositeChildElement,
+			IBaseResource theResource,
+			EncodeContext theContext) {
 		IIdType ref = theRef.getReferenceElement();
 		if (isBlank(ref.getIdPart())) {
 			String reference = ref.getValue();
@@ -261,7 +264,8 @@ public abstract class BaseParser implements IParser {
 	@Override
 	public final void encodeResourceToWriter(IBaseResource theResource, Writer theWriter)
 			throws IOException, DataFormatException {
-		EncodeContext encodeContext = new EncodeContext(this, myContext.getParserOptions(), new FhirTerser.ContainedResources());
+		EncodeContext encodeContext =
+				new EncodeContext(this, myContext.getParserOptions(), new FhirTerser.ContainedResources());
 		encodeResourceToWriter(theResource, theWriter, encodeContext);
 	}
 
@@ -284,7 +288,8 @@ public abstract class BaseParser implements IParser {
 		} else if (theElement instanceof IPrimitiveType) {
 			theWriter.write(((IPrimitiveType<?>) theElement).getValueAsString());
 		} else {
-			EncodeContext encodeContext = new EncodeContext(this, myContext.getParserOptions(), new FhirTerser.ContainedResources());
+			EncodeContext encodeContext =
+					new EncodeContext(this, myContext.getParserOptions(), new FhirTerser.ContainedResources());
 			encodeToWriter(theElement, theWriter, encodeContext);
 		}
 	}
@@ -402,7 +407,6 @@ public abstract class BaseParser implements IParser {
 		}
 		return elementId;
 	}
-
 
 	@Override
 	public Set<String> getDontStripVersionsFromReferencesAtPaths() {
@@ -535,10 +539,11 @@ public abstract class BaseParser implements IParser {
 		return mySuppressNarratives;
 	}
 
-	protected boolean isChildContained(BaseRuntimeElementDefinition<?> childDef, boolean theIncludedResource, EncodeContext theContext) {
+	protected boolean isChildContained(
+			BaseRuntimeElementDefinition<?> childDef, boolean theIncludedResource, EncodeContext theContext) {
 		return (childDef.getChildType() == ChildTypeEnum.CONTAINED_RESOURCES
 						|| childDef.getChildType() == ChildTypeEnum.CONTAINED_RESOURCE_LIST)
-				&&  theContext.getContainedResources().isEmpty() == false
+				&& theContext.getContainedResources().isEmpty() == false
 				&& theIncludedResource == false;
 	}
 
@@ -784,7 +789,8 @@ public abstract class BaseParser implements IParser {
 			 */
 			if (next instanceof IBaseReference) {
 				IBaseReference nextRef = (IBaseReference) next;
-				String refText = determineReferenceText(nextRef, theCompositeChildElement, theResource, theEncodeContext);
+				String refText =
+						determineReferenceText(nextRef, theCompositeChildElement, theResource, theEncodeContext);
 				if (!StringUtils.equals(refText, nextRef.getReferenceElement().getValue())) {
 
 					if (retVal == theValues) {
@@ -999,7 +1005,7 @@ public abstract class BaseParser implements IParser {
 			}
 		}
 
-		 theContext.setContainedResources(getContext().newTerser().containResources(theResource));
+		theContext.setContainedResources(getContext().newTerser().containResources(theResource));
 	}
 
 	static class ChildNameAndDef {
@@ -1032,7 +1038,10 @@ public abstract class BaseParser implements IParser {
 		private final List<EncodeContextPath> myDontEncodeElementPaths;
 		private FhirTerser.ContainedResources myContainedResources;
 
-		public EncodeContext(BaseParser theParser, ParserOptions theParserOptions, FhirTerser.ContainedResources theContainedResources) {
+		public EncodeContext(
+				BaseParser theParser,
+				ParserOptions theParserOptions,
+				FhirTerser.ContainedResources theContainedResources) {
 			Collection<String> encodeElements = theParser.myEncodeElements;
 			Collection<String> dontEncodeElements = theParser.myDontEncodeElements;
 			if (isSummaryMode()) {
@@ -1068,6 +1077,7 @@ public abstract class BaseParser implements IParser {
 		public FhirTerser.ContainedResources getContainedResources() {
 			return myContainedResources;
 		}
+
 		public void setContainedResources(FhirTerser.ContainedResources theContainedResources) {
 			myContainedResources = theContainedResources;
 		}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -387,12 +387,14 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 			}
 			case CONTAINED_RESOURCE_LIST:
 			case CONTAINED_RESOURCES: {
-				List<IBaseResource> containedResources = theEncodeContext.getContainedResources().getContainedResources();
+				List<IBaseResource> containedResources =
+						theEncodeContext.getContainedResources().getContainedResources();
 				if (containedResources.size() > 0) {
 					beginArray(theEventWriter, theChildName);
 
 					for (IBaseResource next : containedResources) {
-						IIdType resourceId = theEncodeContext.getContainedResources().getResourceId(next);
+						IIdType resourceId =
+								theEncodeContext.getContainedResources().getResourceId(next);
 						String value = resourceId.getValue();
 						encodeResourceToJsonStreamWriter(
 								theResDef,
@@ -555,7 +557,8 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 
 				if (nextValue == null || nextValue.isEmpty()) {
 					if (nextValue instanceof BaseContainedDt) {
-						if (theContainedResource || theEncodeContext.getContainedResources().isEmpty()) {
+						if (theContainedResource
+								|| theEncodeContext.getContainedResources().isEmpty()) {
 							continue;
 						}
 					} else {
@@ -839,7 +842,8 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 					+ theResource.getStructureFhirVersionEnum());
 		}
 
-		EncodeContext encodeContext = new EncodeContext(this, getContext().getParserOptions(), new FhirTerser.ContainedResources());
+		EncodeContext encodeContext =
+				new EncodeContext(this, getContext().getParserOptions(), new FhirTerser.ContainedResources());
 		String resourceName = getContext().getResourceType(theResource);
 		encodeContext.pushPath(resourceName, true);
 		doEncodeResourceToJsonLikeWriter(theResource, theJsonLikeWriter, encodeContext);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -54,6 +54,7 @@ import ca.uhn.fhir.parser.json.JsonLikeStructure;
 import ca.uhn.fhir.parser.json.jackson.JacksonStructure;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.util.ElementUtil;
+import ca.uhn.fhir.util.FhirTerser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.text.WordUtils;
@@ -386,12 +387,12 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 			}
 			case CONTAINED_RESOURCE_LIST:
 			case CONTAINED_RESOURCES: {
-				List<IBaseResource> containedResources = getContainedResources().getContainedResources();
+				List<IBaseResource> containedResources = theEncodeContext.getContainedResources().getContainedResources();
 				if (containedResources.size() > 0) {
 					beginArray(theEventWriter, theChildName);
 
 					for (IBaseResource next : containedResources) {
-						IIdType resourceId = getContainedResources().getResourceId(next);
+						IIdType resourceId = theEncodeContext.getContainedResources().getResourceId(next);
 						String value = resourceId.getValue();
 						encodeResourceToJsonStreamWriter(
 								theResDef,
@@ -554,7 +555,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 
 				if (nextValue == null || nextValue.isEmpty()) {
 					if (nextValue instanceof BaseContainedDt) {
-						if (theContainedResource || getContainedResources().isEmpty()) {
+						if (theContainedResource || theEncodeContext.getContainedResources().isEmpty()) {
 							continue;
 						}
 					} else {
@@ -838,7 +839,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 					+ theResource.getStructureFhirVersionEnum());
 		}
 
-		EncodeContext encodeContext = new EncodeContext(this, getContext().getParserOptions());
+		EncodeContext encodeContext = new EncodeContext(this, getContext().getParserOptions(), new FhirTerser.ContainedResources());
 		String resourceName = getContext().getResourceType(theResource);
 		encodeContext.pushPath(resourceName, true);
 		doEncodeResourceToJsonLikeWriter(theResource, theJsonLikeWriter, encodeContext);
@@ -894,7 +895,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 		}
 
 		if (!theContainedResource) {
-			containResourcesInReferences(theResource);
+			containResourcesInReferences(theResource, theEncodeContext);
 		}
 
 		RuntimeResourceDefinition resDef = getContext().getResourceDefinition(theResource);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/RDFParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/RDFParser.java
@@ -191,7 +191,7 @@ public class RDFParser extends BaseParser {
 		}
 
 		if (!containedResource) {
-			containResourcesInReferences(resource);
+			containResourcesInReferences(resource, encodeContext);
 		}
 
 		if (!(resource instanceof IAnyResource)) {
@@ -354,7 +354,7 @@ public class RDFParser extends BaseParser {
 		try {
 
 			if (element == null || element.isEmpty()) {
-				if (!isChildContained(childDef, includedResource)) {
+				if (!isChildContained(childDef, includedResource, theEncodeContext)) {
 					return rdfModel;
 				}
 			}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java
@@ -359,8 +359,10 @@ public class XmlParser extends BaseParser {
 					 * theEventWriter.writeStartElement("contained"); encodeResourceToXmlStreamWriter(next, theEventWriter, true, fixContainedResourceId(next.getId().getValue()));
 					 * theEventWriter.writeEndElement(); }
 					 */
-					for (IBaseResource next : theEncodeContext.getContainedResources().getContainedResources()) {
-						IIdType resourceId = theEncodeContext.getContainedResources().getResourceId(next);
+					for (IBaseResource next :
+							theEncodeContext.getContainedResources().getContainedResources()) {
+						IIdType resourceId =
+								theEncodeContext.getContainedResources().getResourceId(next);
 						theEventWriter.writeStartElement("contained");
 						String value = resourceId.getValue();
 						encodeResourceToXmlStreamWriter(

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java
@@ -295,7 +295,7 @@ public class XmlParser extends BaseParser {
 		try {
 
 			if (theElement == null || theElement.isEmpty()) {
-				if (isChildContained(childDef, theIncludedResource)) {
+				if (isChildContained(childDef, theIncludedResource, theEncodeContext)) {
 					// We still want to go in..
 				} else {
 					return;
@@ -359,8 +359,8 @@ public class XmlParser extends BaseParser {
 					 * theEventWriter.writeStartElement("contained"); encodeResourceToXmlStreamWriter(next, theEventWriter, true, fixContainedResourceId(next.getId().getValue()));
 					 * theEventWriter.writeEndElement(); }
 					 */
-					for (IBaseResource next : getContainedResources().getContainedResources()) {
-						IIdType resourceId = getContainedResources().getResourceId(next);
+					for (IBaseResource next : theEncodeContext.getContainedResources().getContainedResources()) {
+						IIdType resourceId = theEncodeContext.getContainedResources().getResourceId(next);
 						theEventWriter.writeStartElement("contained");
 						String value = resourceId.getValue();
 						encodeResourceToXmlStreamWriter(
@@ -682,7 +682,7 @@ public class XmlParser extends BaseParser {
 		}
 
 		if (!theContainedResource) {
-			containResourcesInReferences(theResource);
+			containResourcesInReferences(theResource, theEncodeContext);
 		}
 
 		theEventWriter.writeStartElement(resDef.getName());

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -84,20 +84,22 @@ public class FhirTerser {
 
 	private static final Pattern COMPARTMENT_MATCHER_PATH =
 			Pattern.compile("([a-zA-Z.]+)\\.where\\(resolve\\(\\) is ([a-zA-Z]+)\\)");
+
 	private static final String USER_DATA_KEY_CONTAIN_RESOURCES_COMPLETED =
 			FhirTerser.class.getName() + "_CONTAIN_RESOURCES_COMPLETED";
+
 	private final FhirContext myContext;
 
 	/**
 	 * This comparator sorts IBaseReferences, and places any that are missing an ID at the end. Those with an ID go to the front.
 	 */
 	private static final Comparator<IBaseReference> REFERENCES_WITH_IDS_FIRST =
-		Comparator.nullsLast(Comparator.comparing(ref -> {
-			if (ref.getResource() == null) return true;
-			if (ref.getResource().getIdElement() == null) return true;
-			if (ref.getResource().getIdElement().getValue() == null) return true;
-			return false;
-		}));
+			Comparator.nullsLast(Comparator.comparing(ref -> {
+				if (ref.getResource() == null) return true;
+				if (ref.getResource().getIdElement() == null) return true;
+				if (ref.getResource().getIdElement().getValue() == null) return true;
+				return false;
+			}));
 
 	public FhirTerser(FhirContext theContext) {
 		super();

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -1803,7 +1803,6 @@ public class FhirTerser {
 
 	public static class ContainedResources {
 		private long myNextContainedId = 1;
-
 		private List<IBaseResource> myResourceList;
 		private IdentityHashMap<IBaseResource, IIdType> myResourceToIdMap;
 		private Map<String, IBaseResource> myExistingIdToContainedResourceMap;
@@ -1869,17 +1868,18 @@ public class FhirTerser {
 				return null;
 			}
 
-			var idFromMap = getResourceToIdMap().get(theNext);
-			if (idFromMap != null) {
-				return idFromMap;
-			} else if (theNext.getIdElement().getIdPart() != null) {
-				return getResourceToIdMap().values().stream()
-						.filter(id -> theNext.getIdElement().getIdPart().equals(id.getIdPart()))
-						.findAny()
-						.orElse(null);
-			} else {
-				return null;
-			}
+			return getResourceToIdMap().get(theNext);
+//			var idFromMap = getResourceToIdMap().get(theNext);
+//			if (idFromMap != null) {
+//				return idFromMap;
+//			} else if (theNext.getIdElement().getIdPart() != null) {
+//				return getResourceToIdMap().values().stream()
+//						.filter(id -> theNext.getIdElement().getIdPart().equals(id.getIdPart()))
+//						.findAny()
+//						.orElse(null);
+//			} else {
+//				return null;
+//			}
 		}
 
 		private List<IBaseResource> getOrCreateResourceList() {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -1804,7 +1804,7 @@ public class FhirTerser {
 		public IIdType addContained(IBaseResource theResource) {
 			if (this.getResourceId(theResource) != null) {
 				// Prevent infinite recursion if there are circular loops in the contained resources
-					return null;
+				return null;
 			}
 
 			IIdType existing = getResourceToIdMap().get(theResource);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -1439,6 +1439,7 @@ public class FhirTerser {
 				if (resource.getIdElement().isEmpty() || resource.getIdElement().isLocal()) {
 					if (theContained.getResourceId(resource) != null) {
 						// Prevent infinite recursion if there are circular loops in the contained resources
+						//TODO GGG: Here is where we drop out of processing the specimen, as the same object that was processed in the previous DR had already placed this specimen in the
 						continue;
 					}
 					IIdType id = theContained.addContained(resource);
@@ -1796,6 +1797,7 @@ public class FhirTerser {
 				if (substring(idPart, 0, 1).equals("#")) {
 					idPart = idPart.substring(1);
 					if (StringUtils.isNumeric(idPart)) {
+						//FIXME GGG START HERE AND TRY TO PRE_PARSE OUT THE STUPID LIST OF CONTAINEDS.
 						myNextContainedId = Long.parseLong(idPart) + 1;
 					}
 				}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -93,10 +93,10 @@ public class FhirTerser {
 	 */
 	private static final Comparator<IBaseReference> REFERENCES_WITH_IDS_FIRST =
 		Comparator.nullsLast(Comparator.comparing(ref -> {
-			if (ref.getResource() == null) return 1;
-			if (ref.getResource().getIdElement() == null) return 1;
-			if (ref.getResource().getIdElement().getValue() == null) return 1;
-			return 0;
+			if (ref.getResource() == null) return true;
+			if (ref.getResource().getIdElement() == null) return true;
+			if (ref.getResource().getIdElement().getValue() == null) return true;
+			return false;
 		}));
 
 	public FhirTerser(FhirContext theContext) {
@@ -1425,13 +1425,6 @@ public class FhirTerser {
 				return true;
 			}
 		});
-	}
-
-	private static Integer hasId(IBaseReference theReference) {
-		if (theReference.getResource() == null) return 1;
-		if (theReference.getResource().getIdElement() == null) return 1;
-		if (theReference.getResource().getIdElement().getValue() == null) return 1;
-		return 0;
 	}
 
 	private void containResourcesForEncoding(

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -1868,18 +1868,17 @@ public class FhirTerser {
 				return null;
 			}
 
-			return getResourceToIdMap().get(theNext);
-//			var idFromMap = getResourceToIdMap().get(theNext);
-//			if (idFromMap != null) {
-//				return idFromMap;
-//			} else if (theNext.getIdElement().getIdPart() != null) {
-//				return getResourceToIdMap().values().stream()
-//						.filter(id -> theNext.getIdElement().getIdPart().equals(id.getIdPart()))
-//						.findAny()
-//						.orElse(null);
-//			} else {
-//				return null;
-//			}
+			var idFromMap = getResourceToIdMap().get(theNext);
+			if (idFromMap != null) {
+				return idFromMap;
+			} else if (theNext.getIdElement().getIdPart() != null) {
+				return getResourceToIdMap().values().stream()
+						.filter(id -> theNext.getIdElement().getIdPart().equals(id.getIdPart()))
+						.findAny()
+						.orElse(null);
+			} else {
+				return null;
+			}
 		}
 
 		private List<IBaseResource> getOrCreateResourceList() {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/FhirTerser.java
@@ -1437,12 +1437,11 @@ public class FhirTerser {
 			IBaseResource resource = next.getResource();
 			if (resource != null) {
 				if (resource.getIdElement().isEmpty() || resource.getIdElement().isLocal()) {
-					if (theContained.getResourceId(resource) != null) {
-						// Prevent infinite recursion if there are circular loops in the contained resources
-						//TODO GGG: Here is where we drop out of processing the specimen, as the same object that was processed in the previous DR had already placed this specimen in the
+
+					IIdType id = theContained.addContained(resource);
+					if (id == null) {
 						continue;
 					}
-					IIdType id = theContained.addContained(resource);
 					if (theModifyResource) {
 						getContainedResourceList(theResource).add(resource);
 						next.setReference(id.getValue());
@@ -1783,6 +1782,14 @@ public class FhirTerser {
 		}
 
 		public IIdType addContained(IBaseResource theResource) {
+			if (this.getResourceId(theResource) != null) {
+				// Prevent infinite recursion if there are circular loops in the contained resources
+				if( this.getResourceToIdMap().get(theResource) == theResource) {
+					System.out.println("WE ARE IN AN INFINITE LOOP, TIME TO DROP OUT!");
+					return null;
+				}
+			}
+
 			IIdType existing = getResourceToIdMap().get(theResource);
 			if (existing != null) {
 				return existing;

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6403-json-parser-bugs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_4_0/6403-json-parser-bugs.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+jira: SMILE-8969
+title: "Fixed a rare bug in the JSON Parser, wherein client-assigned contained resource IDs could collide with server-assigned contained IDs. For example if a 
+resource had a client-assigned contained ID of `#2`, and a contained resource with no ID, then depending on the processing order, the parser could occasionally 
+provide duplicate contained resource IDs, leading to non-deterministic behaviour."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/ColumnTupleObject.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/ColumnTupleObject.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2024 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.search.builder.sql;
 
 import com.healthmarketscience.common.util.AppendableExt;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ContainedTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ContainedTest.java
@@ -49,33 +49,6 @@ public class FhirResourceDaoR4ContainedTest extends BaseJpaR4Test {
 		myStorageSettings.setIndexOnContainedResources(false);
 	}
 
-
-	@Test
-	public void testContainedResourcesGeUniqueIds() {
-		Patient patient = new Patient();
-		patient.setId("Patient/test-patient");
-		myPatientDao.update(patient, mySrd);
-
-		Observation observation = new Observation();
-		Practitioner containedPractitioner = new Practitioner();
-		containedPractitioner.getNameFirstRep().setFamily("zoop").addGiven("woop");
-		Specimen containedSpecimen = new Specimen();
-		containedSpecimen.getType().getCodingFirstRep().setSystem("HL70396").setCode("99UNK").setDisplay("Unknown");
-
-		observation.addContained(containedPractitioner);
-		observation.addContained(containedSpecimen);
-		observation.getPerformerFirstRep().setReference("#1");
-		observation.getSpecimen().setReference("#2");
-		observation.setSubject(new Reference("Patient/test-patient"));
-
-		observation.getCode().getCodingFirstRep().setSystem("LN").setCode("NV");
-		observation.setValue(new StringType("abc123"));
-
-		System.out.println(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(observation));
-		DaoMethodOutcome daoMethodOutcome = myObservationDao.create(observation, mySrd);
-
-		System.out.println(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(daoMethodOutcome.getResource()));
-	}
 	@Test
 	public void testCreateSimpleContainedResourceIndexWithGeneratedId() {
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -263,6 +263,8 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		myStorageSettings.setSearchPreFetchThresholds(new JpaStorageSettings().getSearchPreFetchThresholds());
 	}
 
+
+
 	@Test
 	public void testParameterWithNoValueThrowsError_InvalidChainOnCustomSearch() throws IOException {
 		SearchParameter searchParameter = new SearchParameter();

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
@@ -285,6 +285,45 @@ public class JsonParserR4Test extends BaseTest {
 		String encoded = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(b);
 		ourLog.info(encoded);
 	}
+	@Test
+	public void testAutoAssignedContainedCollision() {
+		Bundle b = new Bundle();
+		Specimen specimen = new Specimen();
+		Practitioner practitioner = new Practitioner();
+		DiagnosticReport report = new DiagnosticReport();
+		report.addSpecimen(new Reference(specimen));
+		b.addEntry().setResource(report).getRequest().setMethod(Bundle.HTTPVerb.POST).setUrl("/DiagnosticReport");
+
+		Observation obs = new Observation();
+		specimen.setId("#1");
+//		practitioner.setId("#1");
+		obs.addPerformer(new Reference(practitioner));
+		obs.setSpecimen(new Reference(specimen));
+
+
+		String encoded = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(obs);
+		ourLog.info(encoded);
+	}
+
+
+	@Test
+	public void testDuplicate() {
+		Bundle b = new Bundle();
+		Specimen specimen = new Specimen();
+		Practitioner practitioner = new Practitioner();
+		DiagnosticReport report = new DiagnosticReport();
+		report.addSpecimen(new Reference(specimen));
+		b.addEntry().setResource(report).getRequest().setMethod(Bundle.HTTPVerb.POST).setUrl("/DiagnosticReport");
+
+		Observation obs = new Observation();
+		obs.setSpecimen(new Reference(specimen));
+		obs.addPerformer(new Reference(practitioner));
+
+		b.addEntry().setResource(obs).getRequest().setMethod(Bundle.HTTPVerb.POST).setUrl("/Observation");
+
+		String encoded = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(b);
+		ourLog.info(encoded);
+	}
 
 	@Test
 	public void testContainedResourcesNotAutoContainedWhenConfiguredNotToDoSo() {

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -1551,10 +1551,9 @@ public class FhirTerserR4Test {
 		params.setId(id);
 		params.addParameter("system-version", new StringType("test2"));
 		var paramsExt = new Extension();
+
 		paramsExt.setUrl("test").setValue(new Reference(id));
-
 		library.addContained(params);
-
 		library.addExtension(paramsExt);
 
 		final var parser = FhirContext.forR4Cached().newJsonParser();
@@ -1565,10 +1564,11 @@ public class FhirTerserR4Test {
 		assertEquals(1, copy.getContained().size());
 
 		var stringifiedCopy = parser.encodeResourceToString(copy);
+
 		System.out.print(stringifiedCopy);
-		var parsedCopy = parser.parseResource(stringifiedCopy);
+		Library parsedCopy = (Library) parser.parseResource(stringifiedCopy);
 		System.out.println(stringifiedCopy);
-		assertEquals(1, ((Library) parsedCopy).getContained().size());
+		assertEquals(1, parsedCopy.getContained().size());
 	}
 
 	/**

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -1545,23 +1545,29 @@ public class FhirTerserR4Test {
 
 	@Test
 	void copyingAndParsingCreatesDuplicateContainedResources() {
-		var input = new Library();
+		var library = new Library();
 		var params = new Parameters();
 		var id = "#expansion-parameters-ecr";
 		params.setId(id);
 		params.addParameter("system-version", new StringType("test2"));
 		var paramsExt = new Extension();
 		paramsExt.setUrl("test").setValue(new Reference(id));
-		input.addContained(params);
-		input.addExtension(paramsExt);
+
+		library.addContained(params);
+
+		library.addExtension(paramsExt);
+
 		final var parser = FhirContext.forR4Cached().newJsonParser();
-		var stringified = parser.encodeResourceToString(input);
+		var stringified = parser.encodeResourceToString(library);
 		var parsed = parser.parseResource(stringified);
 		var copy = ((Library) parsed).copy();
+
 		assertEquals(1, copy.getContained().size());
+
 		var stringifiedCopy = parser.encodeResourceToString(copy);
 		System.out.print(stringifiedCopy);
 		var parsedCopy = parser.parseResource(stringifiedCopy);
+		System.out.println(stringifiedCopy);
 		assertEquals(1, ((Library) parsedCopy).getContained().size());
 	}
 

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -1549,7 +1549,7 @@ public class FhirTerserR4Test {
 	}
 
 	@Test
-	void copyingAndParsingCreatesDuplicateContainedResources() throws JsonProcessingException {
+	void copyingAndParsingCreatesDuplicateContainedResources() {
 		var library = new Library();
 		var params = new Parameters();
 		var id = "#expansion-parameters-ecr";
@@ -1571,59 +1571,7 @@ public class FhirTerserR4Test {
 		assertEquals(1, copy.getContained().size());
 
 		String stringifiedCopy = FhirContext.forR4Cached().newJsonParser().encodeResourceToString(copy);
-		String original = FhirContext.forR4Cached().newJsonParser().encodeResourceToString(parsed);
-		//FIXME GGG WTF IS WRONG WITH COPY!?
-		System.out.println("ORIGINAL PARSE RESULT");
-		System.out.print(original);
-		System.out.println("*********");
-		System.out.println("COPIED PARSE RESULT");
-		System.out.println(stringifiedCopy);
-		System.out.println("*********");
-
 		Library parsedCopy = (Library) parser.parseResource(stringifiedCopy);
-		assertEquals(1, parsedCopy.getContained().size());
-	}
-
-	@Test
-	public void minimalWeirdCopyTest() {
-		Library library = new Library();
-		var params = new Parameters();
-
-		String id = "#expansion-parameters-ecr";
-		params.setId(id);
-		params.addParameter("system-version", new StringType("test2"));
-		Extension paramsExt = new Extension();
-
-		paramsExt.setUrl("test").setValue(new Reference(id));
-		library.addContained(params);
-		library.addExtension(paramsExt);
-
-		assertEquals(1, library.getContained().size());
-		assertEquals(1, library.copy().getContained().size());
-
-		IParser parser = FhirContext.forR4Cached().newJsonParser();
-
-		String stringLibrary = parser.encodeResourceToString(library);
-		Library originalLibrary = parser.parseResource(Library.class, stringLibrary);
-		Library copiedLibrary = originalLibrary.copy();
-
-		assertEquals(1, originalLibrary.getContained().size());
-		assertEquals(1, copiedLibrary.getContained().size());
-
-		String stringifiedOriginal = parser.encodeResourceToString(originalLibrary);
-		String stringifiedCopy = parser.encodeResourceToString(copiedLibrary);
-
-		System.out.println("ORIGINAL PARSE RESULT");
-		System.out.print(stringifiedOriginal);
-		System.out.println("*********");
-
-		System.out.println("COPIED PARSE RESULT");
-		System.out.println(stringifiedCopy);
-		System.out.println("*********");
-
-		Library parsedOriginal = parser.parseResource(Library.class, stringifiedOriginal);
-		Library parsedCopy = parser.parseResource(Library.class, stringifiedCopy);
-		assertEquals(1, parsedOriginal.getContained().size());
 		assertEquals(1, parsedCopy.getContained().size());
 	}
 

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -1560,6 +1560,7 @@ public class FhirTerserR4Test {
 		var copy = ((Library) parsed).copy();
 		assertEquals(1, copy.getContained().size());
 		var stringifiedCopy = parser.encodeResourceToString(copy);
+		System.out.print(stringifiedCopy);
 		var parsedCopy = parser.parseResource(stringifiedCopy);
 		assertEquals(1, ((Library) parsedCopy).getContained().size());
 	}


### PR DESCRIPTION
- Test
- modify algorithm for server-assigned contained IDs.
- Process contained resources which have a client-assigned ID before those that do not in a resource. 
- moved ContainedResources from the Parser, to the EncodeContext object, so we get one per resource processed. 
Closes #6403 