### PR TITLE
Patient/$match: Add remaining parameters

### DIFF
--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderCrossPartitionR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderCrossPartitionR4Test.java
@@ -54,7 +54,7 @@ public class MdmProviderCrossPartitionR4Test extends BaseProviderR4Test{
 		myMdmSettings.setSearchAllPartitionForMatch(true);
 		createPatientOnPartition(buildJanePatient(), RequestPartitionId.fromPartitionId(1));
 
-		Bundle result = (Bundle) myMdmProvider.match(buildJanePatient(), new SystemRequestDetails().setRequestPartitionId(RequestPartitionId.fromPartitionId(2)));
+		Bundle result = (Bundle) myMdmProvider.match(buildJanePatient(), null, null, new SystemRequestDetails().setRequestPartitionId(RequestPartitionId.fromPartitionId(2)));
 		assertThat(result.getEntry()).hasSize(1);
 	}
 
@@ -63,7 +63,7 @@ public class MdmProviderCrossPartitionR4Test extends BaseProviderR4Test{
 		myMdmSettings.setSearchAllPartitionForMatch(false);
 		createPatientOnPartition(buildJanePatient(), RequestPartitionId.fromPartitionId(1));
 
-		Bundle result = (Bundle) myMdmProvider.match(buildJanePatient(), new SystemRequestDetails().setRequestPartitionId(RequestPartitionId.fromPartitionId(2)));
+		Bundle result = (Bundle) myMdmProvider.match(buildJanePatient(), null, null, new SystemRequestDetails().setRequestPartitionId(RequestPartitionId.fromPartitionId(2)));
 		assertThat(result.getEntry()).isEmpty();
 	}
 

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderMatchR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderMatchR4Test.java
@@ -43,7 +43,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 		Patient createdJane = createPatient(jane);
 		Patient newJane = buildJanePatient();
 
-		Bundle result = (Bundle) myMdmProvider.match(newJane, new SystemRequestDetails());
+		Bundle result = (Bundle) myMdmProvider.match(newJane, null, null, new SystemRequestDetails());
 		assertThat(result.getEntry()).hasSize(1);
 
 		Bundle.BundleEntryComponent entry0 = result.getEntry().get(0);
@@ -118,7 +118,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 
 		Patient newJane = buildJanePatient();
 
-		Bundle result = (Bundle) myMdmProvider.match(newJane, new SystemRequestDetails());
+		Bundle result = (Bundle) myMdmProvider.match(newJane, null, null, new SystemRequestDetails());
 		assertThat(result.getEntry()).hasSize(2);
 
 		Bundle.BundleEntryComponent entry0 = result.getEntry().get(0);
@@ -142,7 +142,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 		Patient paul = buildPaulPatient();
 		paul.setActive(true);
 
-		Bundle result = (Bundle) myMdmProvider.match(paul, new SystemRequestDetails());
+		Bundle result = (Bundle) myMdmProvider.match(paul, null, null, new SystemRequestDetails());
 		assertThat(result.getEntry()).isEmpty();
 	}
 
@@ -154,7 +154,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 		Patient createdJane = createPatient(jane);
 		Patient newJane = buildJanePatient();
 
-		Bundle result = (Bundle) myMdmProvider.match(newJane, new SystemRequestDetails());
+		Bundle result = (Bundle) myMdmProvider.match(newJane, null, null, new SystemRequestDetails());
 		assertThat(result.getEntry()).hasSize(1);
 		assertEquals(createdJane.getId(), result.getEntryFirstRep().getResource().getId());
 	}
@@ -226,7 +226,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 			}""";
 
 		IBaseResource coarseResource = myFhirContext.newJsonParser().parseResource(coarsePatient);
-		Bundle result = (Bundle) myMdmProvider.match((Patient) coarseResource, new SystemRequestDetails());
+		Bundle result = (Bundle) myMdmProvider.match((Patient) coarseResource, null, null, new SystemRequestDetails());
 		assertThat(result.getEntry()).hasSize(1);
 	}
 
@@ -268,7 +268,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 		Patient noMatchPatient = (Patient) myFhirContext.newJsonParser().parseResource(noMatchPatientJson);
 		createPatient(noMatchPatient);
 		{
-			Bundle result = (Bundle) myMdmProvider.match(noMatchPatient, new SystemRequestDetails());
+			Bundle result = (Bundle) myMdmProvider.match(noMatchPatient, null, null, new SystemRequestDetails());
 			assertThat(result.getEntry()).isEmpty();
 		}
 
@@ -289,7 +289,7 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 
 		{
 			Patient nickPatient = (Patient) myFhirContext.newJsonParser().parseResource(nickPatientJson);
-			Bundle result = (Bundle) myMdmProvider.match(nickPatient, new SystemRequestDetails());
+			Bundle result = (Bundle) myMdmProvider.match(nickPatient, null, null, new SystemRequestDetails());
 			assertThat(result.getEntry()).hasSize(1);
 		}
 	}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/provider/MdmProviderDstu3Plus.java
@@ -106,6 +106,12 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 	/**
 	 * Searches for matches for the provided patient resource
 	 * @param thePatient - the patient resource
+	 * @param theOnlyCertainMatches - If there are multiple potential matches, then the match should not return the
+	 *        results with this flag set to true. When false, the server may return multiple results with each result
+	 *        graded accordingly.
+	 * @param theCount - The maximum number of records to return. If no value is provided, the server decides how many
+	 *        matches to return. Note that clients should be careful when using this, as it may prevent probable - and
+	 *        valid - matches from being returned.
 	 * @param theRequestDetails - the request details
 	 * @return - any matches to the provided patient resource
 	 */
@@ -113,6 +119,10 @@ public class MdmProviderDstu3Plus extends BaseMdmProvider {
 	public IBaseBundle match(
 			@OperationParam(name = ProviderConstants.MDM_MATCH_RESOURCE, min = 1, max = 1, typeName = "Patient")
 					IAnyResource thePatient,
+            @OperationParam(name = ProviderConstants.MDM_MATCH_ONLY_CERTAIN_MATCHES, min = 0, max = 1, typeName = "boolean")
+                    IPrimitiveType<Boolean> theOnlyCertainMatches,
+            @OperationParam(name = ProviderConstants.MDM_MATCH_COUNT, min = 0, max = 1, typeName = "integer")
+                    IPrimitiveType<Integer> theCount,
 			RequestDetails theRequestDetails) {
 		if (thePatient == null) {
 			throw new InvalidRequestException(Msg.code(1498) + "resource may not be null");

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ProviderConstants.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ProviderConstants.java
@@ -73,6 +73,8 @@ public class ProviderConstants {
 
 	public static final String MDM_MATCH = "$mdm-match";
 	public static final String MDM_MATCH_RESOURCE = "resource";
+	public static final String MDM_MATCH_ONLY_CERTAIN_MATCHES = "onlyCertainMatches";
+	public static final String MDM_MATCH_COUNT = "count";
 	public static final String MDM_RESOURCE_TYPE = "resourceType";
 	public static final String MDM_MERGE_GOLDEN_RESOURCES = "$mdm-merge-golden-resources";
 	public static final String MDM_MERGE_GR_FROM_GOLDEN_RESOURCE_ID = "fromGoldenResourceId";


### PR DESCRIPTION
Even if they are not used, it simplifies using the parameters when overriding the `match` function.