### PR TITLE
Excessive Hibernate warnings when processing conditional create and delete operations on referenced resources in a transaction bundle

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6475-fix-excessive-hibernate-warnings.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6475-fix-excessive-hibernate-warnings.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 6475
+jira: SMILE-8490
+title: "Previously, submitting a transaction bundle containing a conditional delete, a conditional create, and a 
+resource which relied on this conditional create as a reference would lead to excessive Hibernate warnings in the logs. 
+This has been fixed."

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
@@ -31,6 +31,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -97,6 +98,9 @@ public class ResourceLink extends BaseResourceIndex {
 			foreignKey = @ForeignKey(name = "FK_RESLINK_TARGET"))
 	private ResourceTable myTargetResource;
 
+	@Transient
+	private ResourceTable myTransientTargetResource;
+
 	@Column(name = "TARGET_RESOURCE_ID", insertable = true, updatable = true, nullable = true)
 	@FullTextField
 	private Long myTargetResourcePid;
@@ -141,7 +145,7 @@ public class ResourceLink extends BaseResourceIndex {
 	}
 
 	public String getTargetResourceId() {
-		if (myTargetResourceId == null && myTargetResource != null) {
+		if (myTargetResourceId == null && getTargetResource() != null) {
 			myTargetResourceId = getTargetResource().getIdDt().getIdPart();
 		}
 		return myTargetResourceId;
@@ -184,11 +188,21 @@ public class ResourceLink extends BaseResourceIndex {
 		return b.isEquals();
 	}
 
+	/**
+	 * ResourceLink.myTargetResource field is immutable.Transient ResourceLink.myTransientTargetResource property
+	 * is used instead, allowing it to be updated via the ResourceLink#copyMutableValuesFrom method
+	 * when ResourceLink table row is reused.
+	 */
+	@PostLoad
+	public void postLoad() {
+		myTransientTargetResource = myTargetResource;
+	}
+
 	@Override
 	public <T extends BaseResourceIndex> void copyMutableValuesFrom(T theSource) {
 		ResourceLink source = (ResourceLink) theSource;
 		mySourcePath = source.getSourcePath();
-		myTargetResource = source.getTargetResource();
+		myTransientTargetResource = source.getTargetResource();
 		myTargetResourceId = source.getTargetResourceId();
 		myTargetResourcePid = source.getTargetResourcePid();
 		myTargetResourceType = source.getTargetResourceType();
@@ -331,7 +345,7 @@ public class ResourceLink extends BaseResourceIndex {
 	}
 
 	public ResourceTable getTargetResource() {
-		return myTargetResource;
+		return myTransientTargetResource;
 	}
 
 	/**
@@ -348,8 +362,8 @@ public class ResourceLink extends BaseResourceIndex {
 		retVal.myTargetResourceType = myTargetResourceType;
 		if (myTargetResourceId != null) {
 			retVal.myTargetResourceId = myTargetResourceId;
-		} else if (myTargetResource != null) {
-			retVal.myTargetResourceId = myTargetResource.getIdDt().getIdPart();
+		} else if (getTargetResource() != null) {
+			retVal.myTargetResourceId = getTargetResource().getIdDt().getIdPart();
 		}
 		retVal.myTargetResourceUrl = myTargetResourceUrl;
 		retVal.myTargetResourceVersion = myTargetResourceVersion;


### PR DESCRIPTION
- added test
- fixed an issue with redundant log message by introducing additional `myTransientTargetResource` property
- added change-log