### PR TITLE
Change the migrator to avoid table locks when adding an index. 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6489-change-index-add-concurrency-default.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/6489-change-index-add-concurrency-default.yaml
@@ -1,4 +1,4 @@
 ---
 type: perf
-issue: aa
+issue: 6489
 title: "Change the migrator to avoid table locks when adding an index.  This allows systems to continue running during upgrade."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/mb-change-index-add-concurrency-default.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_6_0/mb-change-index-add-concurrency-default.yaml
@@ -1,0 +1,4 @@
+---
+type: perf
+issue: aa
+title: "Change the migrator to avoid table locks when adding an index.  This allows systems to continue running during upgrade."

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -397,7 +397,7 @@ public class Builder {
 				private final String myVersion;
 				private final boolean myUnique;
 				private String[] myIncludeColumns;
-				private boolean myOnline;
+				private boolean myOnline = true;
 
 				public BuilderAddIndexUnique(String theVersion, boolean theUnique) {
 					myVersion = theVersion;


### PR DESCRIPTION
Use "online/concurrently" when adding an index by default to avoid table locks during upgrade.
This enables zero-downtime upgrades.
