### PR TITLE
[6463] FHIR resource validation breaks when server have multiple versions of same profile

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupport.java
@@ -235,7 +235,13 @@ public class JpaPersistedResourceValidationSupport implements IValidationSupport
 				}
 				SearchParameterMap params = new SearchParameterMap();
 				params.setLoadSynchronousUpTo(1);
-				params.add(StructureDefinition.SP_URL, new UriParam(theUri));
+				int versionSeparator = theUri.lastIndexOf('|');
+				if (versionSeparator != -1) {
+					params.add(StructureDefinition.SP_VERSION, new TokenParam(theUri.substring(versionSeparator + 1)));
+					params.add(StructureDefinition.SP_URL, new UriParam(theUri.substring(0, versionSeparator)));
+				} else {
+					params.add(StructureDefinition.SP_URL, new UriParam(theUri));
+				}
 				search = myDaoRegistry.getResourceDao("StructureDefinition").search(params);
 				break;
 			}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupportTest.java
@@ -1,6 +1,26 @@
 
 package ca.uhn.fhir.jpa.dao;
 
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2024 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupportTest.java
@@ -1,0 +1,175 @@
+
+package ca.uhn.fhir.jpa.dao;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.jpa.term.api.ITermReadSvc;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.param.UriParam;
+import ca.uhn.fhir.sl.cache.Cache;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_LOW;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JpaPersistedResourceValidationSupportTest {
+
+	private FhirContext theFhirContext = FhirContext.forR4();
+
+	@Mock private ITermReadSvc myTermReadSvc;
+	@Mock private DaoRegistry myDaoRegistry;
+	@Mock private Cache<String, IBaseResource> myLoadCache;
+	@Mock private IFhirResourceDao<ValueSet> myValueSetResourceDao;
+
+	@InjectMocks
+	private IValidationSupport testedClass =
+		new JpaPersistedResourceValidationSupport(theFhirContext);
+
+	private Class<? extends IBaseResource> myCodeSystemType = CodeSystem.class;
+	private Class<? extends IBaseResource> myValueSetType = ValueSet.class;
+
+
+	@BeforeEach
+	public void setup() {
+		ReflectionTestUtils.setField(testedClass, "myValueSetType", myValueSetType);
+	}
+
+
+	@Nested
+	public class FetchCodeSystemTests {
+
+		@Test
+		void fetchCodeSystemMustUseForcedId() {
+			testedClass.fetchCodeSystem("string-containing-loinc");
+
+			verify(myTermReadSvc, times(1)).readCodeSystemByForcedId(LOINC_LOW);
+			verify(myLoadCache, never()).get(anyString(), isA(Function.class));
+		}
+
+
+		@Test
+		void fetchCodeSystemMustNotUseForcedId() {
+			testedClass.fetchCodeSystem("string-not-containing-l-o-i-n-c");
+
+			verify(myTermReadSvc, never()).readCodeSystemByForcedId(LOINC_LOW);
+			verify(myLoadCache, times(1)).get(anyString(), isA(Function.class));
+		}
+
+	}
+
+
+	@Nested
+	public class FetchValueSetTests {
+
+		@Test
+		void fetchValueSetMustUseForcedId() {
+			final String valueSetId = "string-containing-loinc";
+			assertNull(testedClass.fetchValueSet(valueSetId));
+		}
+
+
+		@Test
+		void fetchValueSetMustNotUseForcedId() {
+			testedClass.fetchValueSet("string-not-containing-l-o-i-n-c");
+
+			verify(myLoadCache, times(1)).get(anyString(), isA(Function.class));
+		}
+
+	}
+
+	@Nested
+	class FetchStructureDefinitionTests {
+
+		@Mock
+		private DaoRegistry myDaoRegistry;
+
+		@InjectMocks
+		private final JpaPersistedResourceValidationSupport testClass = new JpaPersistedResourceValidationSupport(theFhirContext);
+
+		@Captor
+		ArgumentCaptor<SearchParameterMap> searchParameterMapCaptor;
+		@Test
+		@DisplayName("fetch StructureDefinition by version less url")
+		void fetchStructureDefinitionForUrl() {
+			final String profileUrl = "http://example.com/fhir/StructureDefinition/exampleProfile";
+			IFhirResourceDao mockDao = mock(IFhirResourceDao.class);
+			when(mockDao.search(any())).thenReturn(mock(IBundleProvider.class));
+			when(myDaoRegistry.getResourceDao(anyString())).thenReturn(mockDao);
+
+			testClass.fetchResource(StructureDefinition.class, profileUrl);
+
+			verify(mockDao).search(searchParameterMapCaptor.capture());
+			SearchParameterMap searchParams = searchParameterMapCaptor.getValue();
+			String uriParam = searchParams.get(StructureDefinition.SP_URL)
+				.get(0)
+				.stream()
+				.map(UriParam.class::cast)
+				.map(UriParam::getValue)
+				.findFirst()
+				.orElse(null);
+			assertThat(uriParam).isEqualTo(profileUrl);
+		}
+
+		@Test
+		@DisplayName("fetch StructureDefinition by versioned url")
+		void fetchStructureDefinitionForVersionedUrl() {
+			final String profileUrl = "http://example.com/fhir/StructureDefinition/exampleProfile|1.1.0";
+			IFhirResourceDao mockDao = mock(IFhirResourceDao.class);
+			when(mockDao.search(any())).thenReturn(mock(IBundleProvider.class));
+			when(myDaoRegistry.getResourceDao(anyString())).thenReturn(mockDao);
+
+			testClass.fetchResource(StructureDefinition.class, profileUrl);
+
+			verify(mockDao).search(searchParameterMapCaptor.capture());
+			SearchParameterMap searchParams = searchParameterMapCaptor.getValue();
+			String uriParam = searchParams.get(StructureDefinition.SP_URL)
+				.get(0)
+				.stream()
+				.map(UriParam.class::cast)
+				.map(UriParam::getValue)
+				.findFirst()
+				.orElse(null);
+			assertThat(uriParam).isEqualTo("http://example.com/fhir/StructureDefinition/exampleProfile");
+
+			String versionParam = searchParams.get(StructureDefinition.SP_VERSION)
+				.get(0)
+				.stream()
+				.map(TokenParam.class::cast)
+				.map(TokenParam::getValue)
+				.findFirst()
+				.orElse(null);
+			assertThat(versionParam).isEqualTo("1.1.0");
+		}
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/JpaPersistedResourceValidationSupportTest.java
@@ -26,16 +26,10 @@ import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
-import ca.uhn.fhir.jpa.term.api.ITermReadSvc;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
-import ca.uhn.fhir.sl.cache.Cache;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.StructureDefinition;
-import org.hl7.fhir.r4.model.ValueSet;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,20 +39,11 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.function.Function;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_LOW;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,67 +51,6 @@ import static org.mockito.Mockito.when;
 class JpaPersistedResourceValidationSupportTest {
 
 	private FhirContext theFhirContext = FhirContext.forR4();
-
-	@Mock private ITermReadSvc myTermReadSvc;
-	@Mock private DaoRegistry myDaoRegistry;
-	@Mock private Cache<String, IBaseResource> myLoadCache;
-	@Mock private IFhirResourceDao<ValueSet> myValueSetResourceDao;
-
-	@InjectMocks
-	private IValidationSupport testedClass =
-		new JpaPersistedResourceValidationSupport(theFhirContext);
-
-	private Class<? extends IBaseResource> myCodeSystemType = CodeSystem.class;
-	private Class<? extends IBaseResource> myValueSetType = ValueSet.class;
-
-
-	@BeforeEach
-	public void setup() {
-		ReflectionTestUtils.setField(testedClass, "myValueSetType", myValueSetType);
-	}
-
-
-	@Nested
-	public class FetchCodeSystemTests {
-
-		@Test
-		void fetchCodeSystemMustUseForcedId() {
-			testedClass.fetchCodeSystem("string-containing-loinc");
-
-			verify(myTermReadSvc, times(1)).readCodeSystemByForcedId(LOINC_LOW);
-			verify(myLoadCache, never()).get(anyString(), isA(Function.class));
-		}
-
-
-		@Test
-		void fetchCodeSystemMustNotUseForcedId() {
-			testedClass.fetchCodeSystem("string-not-containing-l-o-i-n-c");
-
-			verify(myTermReadSvc, never()).readCodeSystemByForcedId(LOINC_LOW);
-			verify(myLoadCache, times(1)).get(anyString(), isA(Function.class));
-		}
-
-	}
-
-
-	@Nested
-	public class FetchValueSetTests {
-
-		@Test
-		void fetchValueSetMustUseForcedId() {
-			final String valueSetId = "string-containing-loinc";
-			assertNull(testedClass.fetchValueSet(valueSetId));
-		}
-
-
-		@Test
-		void fetchValueSetMustNotUseForcedId() {
-			testedClass.fetchValueSet("string-not-containing-l-o-i-n-c");
-
-			verify(myLoadCache, times(1)).get(anyString(), isA(Function.class));
-		}
-
-	}
 
 	@Nested
 	class FetchStructureDefinitionTests {
@@ -139,6 +63,7 @@ class JpaPersistedResourceValidationSupportTest {
 
 		@Captor
 		ArgumentCaptor<SearchParameterMap> searchParameterMapCaptor;
+
 		@Test
 		@DisplayName("fetch StructureDefinition by version less url")
 		void fetchStructureDefinitionForUrl() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
@@ -224,8 +224,9 @@ public class RemoteTerminologyServiceJpaR4Test extends BaseJpaR4Test {
 		assertThat(ourCodeSystemProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
 			"http://hl7.org/fhir/administrative-gender"
 		);
-		assertThat(ourCodeSystemProvider.myValidatedCodes).asList().isEmpty();
-
+		assertThat(ourCodeSystemProvider.myValidatedCodes).asList().containsExactlyInAnyOrder(
+			"http://hl7.org/fhir/administrative-gender#female#null"
+		);
 		// Test 2 (should rely on caches)
 		ourCodeSystemProvider.clearCalls();
 		ourValueSetProvider.clearCalls();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
@@ -123,8 +123,8 @@ public class RemoteTerminologyServiceJpaR4Test extends BaseJpaR4Test {
 		// Verify 1
 		Assertions.assertEquals(2, myCaptureQueriesListener.countGetConnections());
 		assertThat(ourValueSetProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
-			"http://hl7.org/fhir/ValueSet/administrative-gender",
-			"http://hl7.org/fhir/ValueSet/administrative-gender"
+			"http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1",
+			"http://hl7.org/fhir/ValueSet/administrative-gender","http://hl7.org/fhir/ValueSet/administrative-gender"
 		);
 		assertThat(ourCodeSystemProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
 			"http://hl7.org/fhir/administrative-gender",
@@ -162,7 +162,7 @@ public class RemoteTerminologyServiceJpaR4Test extends BaseJpaR4Test {
 		// Verify 1
 		Assertions.assertEquals(0, myCaptureQueriesListener.countGetConnections());
 		assertThat(ourValueSetProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
-			"http://hl7.org/fhir/ValueSet/administrative-gender",
+			"http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1",
 			"http://hl7.org/fhir/ValueSet/administrative-gender"
 		);
 		assertThat(ourValueSetProvider.myValidatedCodes).asList().containsExactlyInAnyOrder(
@@ -215,13 +215,15 @@ public class RemoteTerminologyServiceJpaR4Test extends BaseJpaR4Test {
 		// Verify 1
 		Assertions.assertEquals(0, myCaptureQueriesListener.countGetConnections());
 		assertThat(ourValueSetProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
-			"http://hl7.org/fhir/ValueSet/administrative-gender",
+			"http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1",
 			"http://hl7.org/fhir/ValueSet/administrative-gender"
 		);
 		assertThat(ourValueSetProvider.myValidatedCodes).asList().containsExactlyInAnyOrder(
-			"http://hl7.org/fhir/ValueSet/administrative-gender#null#female"
+			"http://hl7.org/fhir/ValueSet/administrative-gender#http://hl7.org/fhir/administrative-gender#female"
 		);
-		assertThat(ourCodeSystemProvider.mySearchUrls).asList().isEmpty();
+		assertThat(ourCodeSystemProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
+			"http://hl7.org/fhir/administrative-gender"
+		);
 		assertThat(ourCodeSystemProvider.myValidatedCodes).asList().isEmpty();
 
 		// Test 2 (should rely on caches)

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/ValidateWithRemoteTerminologyTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/ValidateWithRemoteTerminologyTest.java
@@ -94,7 +94,7 @@ public class ValidateWithRemoteTerminologyTest extends BaseResourceProviderR4Tes
 		final String classSystem = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
 		final String identifierTypeSystem = "http://terminology.hl7.org/CodeSystem/v2-0203";
 
-		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/encounter-status", "http://hl7.org/fhir/encounter-status", statusCode, "validation/encounter/validateCode-ValueSet-encounter-status.json");
+		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/encounter-status", "4.0.1", "http://hl7.org/fhir/encounter-status", statusCode, "validation/encounter/validateCode-ValueSet-encounter-status.json");
 		setupValueSetValidateCode("http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", "http://terminology.hl7.org/CodeSystem/v3-ActCode", classCode, "validation/encounter/validateCode-ValueSet-v3-ActEncounterCode.json");
 		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/identifier-type", "http://hl7.org/fhir/identifier-type", identifierTypeCode, "validation/encounter/validateCode-ValueSet-identifier-type.json");
 
@@ -138,7 +138,7 @@ public class ValidateWithRemoteTerminologyTest extends BaseResourceProviderR4Tes
 		final String loincSystem = "http://loinc.org";
 		final String system = "http://fhir.infoway-inforoute.ca/io/psca/CodeSystem/ICD9CM";
 
-		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/observation-status", statusSystem, statusCode, "validation/observation/validateCode-ValueSet-observation-status.json");
+		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/observation-status", "4.0.1", statusSystem, statusCode, "validation/observation/validateCode-ValueSet-observation-status.json");
 		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/observation-codes", loincSystem, statusCode, "validation/observation/validateCode-ValueSet-codes.json");
 
 		setupCodeSystemValidateCode(statusSystem, statusCode, "validation/observation/validateCode-CodeSystem-observation-status.json");
@@ -171,7 +171,7 @@ public class ValidateWithRemoteTerminologyTest extends BaseResourceProviderR4Tes
 		final String statusSystem = "http://hl7.org/fhir/event-status";
 		final String snomedSystem = "http://snomed.info/sct";
 
-		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/event-status", statusSystem, statusCode, "validation/procedure/validateCode-ValueSet-event-status.json");
+		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/event-status", "4.0.1", statusSystem, statusCode, "validation/procedure/validateCode-ValueSet-event-status.json");
 		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/procedure-code", snomedSystem, procedureCode1, "validation/procedure/validateCode-ValueSet-procedure-code-valid.json");
 		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/procedure-code", snomedSystem, procedureCode2, "validation/procedure/validateCode-ValueSet-procedure-code-invalid.json");
 
@@ -213,7 +213,7 @@ public class ValidateWithRemoteTerminologyTest extends BaseResourceProviderR4Tes
 		final String snomedSystem = "http://snomed.info/sct";
 		final String absentUnknownSystem = "http://hl7.org/fhir/uv/ips/CodeSystem/absent-unknown-uv-ips";
 
-		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/event-status", statusSystem, statusCode, "validation/procedure/validateCode-ValueSet-event-status.json");
+		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/event-status", "4.0.1", statusSystem, statusCode, "validation/procedure/validateCode-ValueSet-event-status.json");
 		setupValueSetValidateCode("http://hl7.org/fhir/ValueSet/procedure-code", snomedSystem, procedureCode, "validation/procedure/validateCode-ValueSet-procedure-code-invalid-slice.json");
 		setupValueSetValidateCode("http://hl7.org/fhir/uv/ips/ValueSet/absent-or-unknown-procedures-uv-ips", absentUnknownSystem, procedureCode, "validation/procedure/validateCode-ValueSet-absent-or-unknown-procedure.json");
 
@@ -244,6 +244,15 @@ public class ValidateWithRemoteTerminologyTest extends BaseResourceProviderR4Tes
 		// that is necessary because VersionSpecificWorkerContextWrapper#validateCodeInValueSet
 		// which also attempts a validateCode against the CodeSystem after the validateCode against the ValueSet
 	}
+
+	private void setupValueSetValidateCode(String theUrl, String theVersion, String theSystem, String theCode, String theTerminologyResponseFile) {
+		ValueSet valueSet = myValueSetProvider.addTerminologyResource(theUrl, theVersion);
+		myValueSetProvider.addTerminologyResource(theSystem, theVersion);
+		myValueSetProvider.addTerminologyResponse(OPERATION_VALIDATE_CODE, valueSet.getUrl(), theCode, ourCtx, theTerminologyResponseFile);
+
+		valueSet.getCompose().addInclude().setSystem(theSystem);
+	}
+
 
 	private void setupCodeSystemValidateCode(String theUrl, String theCode, String theTerminologyResponseFile) {
 		CodeSystem codeSystem = myCodeSystemProvider.addTerminologyResource(theUrl);

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/provider/r5/ResourceProviderR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/provider/r5/ResourceProviderR5Test.java
@@ -284,8 +284,7 @@ public class ResourceProviderR5Test extends BaseResourceProviderR5Test {
 						    "lastUpdated": "2024-03-27T19:20:25.200+00:00",
 						    "source": "#384dd6bccaeafa6c"
 						  },
-						  "url": "https://health.gov.on.ca/idms/fhir/SearchParameter/MedicinalProductDefinition-SearchableString",
-						  "version": "1.0.0",
+						  "url": "https://health.gov.on.ca/idms/fhir/SearchParameter/MedicinalProductDefinition-SearchableString",						  
 						  "name": "MedicinalProductDefinitionSearchableString",
 						  "status": "active",
 						  "publisher": "MOH-IDMS",

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/validation/IValidationProviders.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/validation/IValidationProviders.java
@@ -84,8 +84,13 @@ public interface IValidationProviders {
 		protected void addTerminologyResource(String theUrl, T theResource) {
 			myTerminologyResourceMap.put(theUrl, theResource);
 		}
+		protected void addVersionedTerminologyResource(String theUrl, String theVersion, T theResource) {
+			myTerminologyResourceMap.put(theUrl + "|" + theVersion, theResource);
+		}
 
 		public abstract T addTerminologyResource(String theUrl);
+
+		public abstract T addTerminologyResource(String theUrl, String theVersion);
 
 		protected IBaseParameters getTerminologyResponse(String theOperation, String theUrl, String theCode) throws Exception {
 			String inputKey = getInputKey(theOperation, theUrl, theCode);

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/validation/IValidationProvidersDstu3.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/validation/IValidationProvidersDstu3.java
@@ -95,6 +95,11 @@ public interface IValidationProvidersDstu3 {
 			addTerminologyResource(theUrl, codeSystem);
 			return codeSystem;
 		}
+
+		@Override
+		public CodeSystem addTerminologyResource(String theUrl, String theVersion) {
+			return addTerminologyResource(theUrl);
+		}
 	}
 
 	@SuppressWarnings("unused")
@@ -132,6 +137,11 @@ public interface IValidationProvidersDstu3 {
 			valueSet.setUrl(theUrl);
 			addTerminologyResource(theUrl, valueSet);
 			return valueSet;
+		}
+
+		@Override
+		public ValueSet addTerminologyResource(String theUrl, String theVersion) {
+			return addTerminologyResource(theUrl);
 		}
 	}
 }

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/validation/IValidationProvidersR4.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/validation/IValidationProvidersR4.java
@@ -99,6 +99,14 @@ public interface IValidationProvidersR4 {
 			addTerminologyResource(theUrl, codeSystem);
 			return codeSystem;
 		}
+
+		@Override
+		public CodeSystem addTerminologyResource(String theUrl, String theVersion) {
+			CodeSystem codeSystem = addTerminologyResource(theUrl);
+			codeSystem.setVersion(theVersion);
+			addVersionedTerminologyResource(theUrl, theVersion, codeSystem);
+			return codeSystem;
+		}
 	}
 
 	@SuppressWarnings("unused")
@@ -130,12 +138,20 @@ public interface IValidationProvidersR4 {
 		Class<Parameters> getParameterType() {
 			return Parameters.class;
 		}
+
 		@Override
 		public ValueSet addTerminologyResource(String theUrl) {
 			ValueSet valueSet = new ValueSet();
 			valueSet.setId(theUrl.substring(0, theUrl.lastIndexOf("/")));
 			valueSet.setUrl(theUrl);
 			addTerminologyResource(theUrl, valueSet);
+			return valueSet;
+		}
+
+		@Override
+		public ValueSet addTerminologyResource(String theUrl, String theVersion) {
+			ValueSet valueSet = addTerminologyResource(theUrl);
+			addVersionedTerminologyResource(theUrl, theVersion, valueSet);
 			return valueSet;
 		}
 	}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
@@ -88,7 +88,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	 * the converted version gets cached too.
 	 */
 	private static final String CANONICAL_USERDATA_KEY =
-			VersionSpecificWorkerContextWrapper.class.getName() + "_CANONICAL_USERDATA_KEY";
+		VersionSpecificWorkerContextWrapper.class.getName() + "_CANONICAL_USERDATA_KEY";
 
 	public static final FhirContext FHIR_CONTEXT_R5 = FhirContext.forR5();
 	private final ValidationSupportContext myValidationSupportContext;
@@ -99,7 +99,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	private volatile FHIRPathEngine myFHIRPathEngine;
 
 	public VersionSpecificWorkerContextWrapper(
-			ValidationSupportContext theValidationSupportContext, VersionCanonicalizer theVersionCanonicalizer) {
+		ValidationSupportContext theValidationSupportContext, VersionCanonicalizer theVersionCanonicalizer) {
 		myValidationSupportContext = theValidationSupportContext;
 		myVersionCanonicalizer = theVersionCanonicalizer;
 
@@ -128,13 +128,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader, List<String> types)
-			throws FileNotFoundException, IOException, FHIRException {
+		throws FileNotFoundException, IOException, FHIRException {
 		throw new UnsupportedOperationException(Msg.code(653));
 	}
 
 	@Override
 	public int loadFromPackageAndDependencies(NpmPackage pi, IContextResourceLoader loader, BasePackageCacheManager pcm)
-			throws FHIRException {
+		throws FHIRException {
 		throw new UnsupportedOperationException(Msg.code(654));
 	}
 
@@ -185,7 +185,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public PEBuilder getProfiledElementBuilder(
-			PEBuilder.PEElementPropertiesPolicy thePEElementPropertiesPolicy, boolean theB) {
+		PEBuilder.PEElementPropertiesPolicy thePEElementPropertiesPolicy, boolean theB) {
 		throw new UnsupportedOperationException(Msg.code(2264));
 	}
 
@@ -213,7 +213,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		List<StructureDefinition> retVal = myAllStructures;
 		if (retVal == null) {
 			List<IBaseResource> allStructureDefinitions =
-					myValidationSupportContext.getRootValidationSupport().fetchAllStructureDefinitions();
+				myValidationSupportContext.getRootValidationSupport().fetchAllStructureDefinitions();
 			assert allStructureDefinitions != null;
 
 			/*
@@ -233,8 +233,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			 * generate useful error messages for the user.
 			 */
 			retVal = allStructureDefinitions.stream()
-					.map(t -> myVersionCanonicalizer.structureDefinitionToCanonical(t))
-					.collect(Collectors.toList());
+				.map(t -> myVersionCanonicalizer.structureDefinitionToCanonical(t))
+				.collect(Collectors.toList());
 			myAllStructures = retVal;
 
 			try {
@@ -263,7 +263,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Nonnull
 	private ValidationResult convertValidationResult(
-			String theSystem, @Nullable IValidationSupport.CodeValidationResult theResult) {
+		String theSystem, @Nullable IValidationSupport.CodeValidationResult theResult) {
 		ValidationResult retVal = null;
 		if (theResult != null) {
 			String code = theResult.getCode();
@@ -281,18 +281,18 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			CodeSystem.ConceptDefinitionComponent conceptDefinitionComponent = null;
 			if (code != null) {
 				conceptDefinitionComponent = new CodeSystem.ConceptDefinitionComponent()
-						.setCode(code)
-						.setDisplay(display);
+					.setCode(code)
+					.setDisplay(display);
 			}
 
 			retVal = new ValidationResult(
-					issueSeverity,
-					message,
-					theSystem,
-					theResult.getCodeSystemVersion(),
-					conceptDefinitionComponent,
-					display,
-					getIssuesForCodeValidation(theResult.getIssues()));
+				issueSeverity,
+				message,
+				theSystem,
+				theResult.getCodeSystemVersion(),
+				conceptDefinitionComponent,
+				display,
+				getIssuesForCodeValidation(theResult.getIssues()));
 		}
 
 		if (retVal == null) {
@@ -303,33 +303,33 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private List<OperationOutcome.OperationOutcomeIssueComponent> getIssuesForCodeValidation(
-			List<IValidationSupport.CodeValidationIssue> theIssues) {
+		List<IValidationSupport.CodeValidationIssue> theIssues) {
 		List<OperationOutcome.OperationOutcomeIssueComponent> issueComponents = new ArrayList<>();
 
 		for (IValidationSupport.CodeValidationIssue issue : theIssues) {
 			OperationOutcome.IssueSeverity severity =
-					OperationOutcome.IssueSeverity.fromCode(issue.getSeverity().getCode());
+				OperationOutcome.IssueSeverity.fromCode(issue.getSeverity().getCode());
 			OperationOutcome.IssueType issueType =
-					OperationOutcome.IssueType.fromCode(issue.getType().getCode());
+				OperationOutcome.IssueType.fromCode(issue.getType().getCode());
 			String diagnostics = issue.getDiagnostics();
 
 			IValidationSupport.CodeValidationIssueDetails details = issue.getDetails();
 			CodeableConcept codeableConcept = new CodeableConcept().setText(details.getText());
 			details.getCodings().forEach(detailCoding -> codeableConcept
-					.addCoding()
-					.setSystem(detailCoding.getSystem())
-					.setCode(detailCoding.getCode()));
+				.addCoding()
+				.setSystem(detailCoding.getSystem())
+				.setCode(detailCoding.getCode()));
 
 			OperationOutcome.OperationOutcomeIssueComponent issueComponent =
-					new OperationOutcome.OperationOutcomeIssueComponent()
-							.setSeverity(severity)
-							.setCode(issueType)
-							.setDetails(codeableConcept)
-							.setDiagnostics(diagnostics);
+				new OperationOutcome.OperationOutcomeIssueComponent()
+					.setSeverity(severity)
+					.setCode(issueType)
+					.setDetails(codeableConcept)
+					.setDiagnostics(diagnostics);
 			issueComponent
-					.addExtension()
-					.setUrl("http://hl7.org/fhir/StructureDefinition/operationoutcome-message-id")
-					.setValue(new StringType("Terminology_PassThrough_TX_Message"));
+				.addExtension()
+				.setUrl("http://hl7.org/fhir/StructureDefinition/operationoutcome-message-id")
+				.setValue(new StringType("Terminology_PassThrough_TX_Message"));
 			issueComponents.add(issueComponent);
 		}
 		return issueComponents;
@@ -344,8 +344,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			throw new InternalErrorException(Msg.code(661) + e);
 		}
 		IValidationSupport.ValueSetExpansionOutcome expanded = myValidationSupportContext
-				.getRootValidationSupport()
-				.expandValueSet(myValidationSupportContext, null, convertedSource);
+			.getRootValidationSupport()
+			.expandValueSet(myValidationSupportContext, null, convertedSource);
 
 		ValueSet convertedResult = null;
 		if (expanded.getValueSet() != null) {
@@ -364,27 +364,27 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public ValueSetExpansionOutcome expandVS(
-			Resource src,
-			ElementDefinition.ElementDefinitionBindingComponent binding,
-			boolean cacheOk,
-			boolean Hierarchical) {
+		Resource src,
+		ElementDefinition.ElementDefinitionBindingComponent binding,
+		boolean cacheOk,
+		boolean Hierarchical) {
 		ValueSet valueSet = fetchResource(ValueSet.class, binding.getValueSet(), src);
 		return expandVS(valueSet, cacheOk, Hierarchical);
 	}
 
 	@Override
 	public ValueSetExpansionOutcome expandVS(ValueSet.ConceptSetComponent inc, boolean hierarchical, boolean noInactive)
-			throws TerminologyServiceException {
+		throws TerminologyServiceException {
 		throw new UnsupportedOperationException(Msg.code(664));
 	}
 
 	@Override
 	public Locale getLocale() {
 		return myValidationSupportContext
-				.getRootValidationSupport()
-				.getFhirContext()
-				.getLocalizer()
-				.getLocale();
+			.getRootValidationSupport()
+			.getFhirContext()
+			.getLocalizer()
+			.getLocale();
 	}
 
 	@Override
@@ -395,7 +395,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public CodeSystem fetchCodeSystem(String system) {
 		IBaseResource fetched =
-				myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
+			myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
 		if (fetched == null) {
 			return null;
 		}
@@ -409,7 +409,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public CodeSystem fetchCodeSystem(String system, String verison) {
 		IBaseResource fetched =
-				myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
+			myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
 		if (fetched == null) {
 			return null;
 		}
@@ -487,7 +487,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		T retVal = fetchResource(class_, uri);
 		if (retVal == null) {
 			throw new FHIRException(
-					Msg.code(667) + "Can not find resource of type " + class_.getSimpleName() + " with uri " + uri);
+				Msg.code(667) + "Can not find resource of type " + class_.getSimpleName() + " with uri " + uri);
 		}
 		return retVal;
 	}
@@ -504,7 +504,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public <T extends Resource> T fetchResource(
-			Class<T> class_, String uri, String version, FhirPublication fhirVersion) {
+		Class<T> class_, String uri, String version, FhirPublication fhirVersion) {
 		return null;
 	}
 
@@ -520,16 +520,16 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public <T extends Resource> T fetchResourceWithException(Class<T> class_, String uri, Resource sourceOfReference)
-			throws FHIRException {
+		throws FHIRException {
 		throw new UnsupportedOperationException(Msg.code(2214));
 	}
 
 	@Override
 	public List<String> getResourceNames() {
 		return new ArrayList<>(myValidationSupportContext
-				.getRootValidationSupport()
-				.getFhirContext()
-				.getResourceTypes());
+			.getRootValidationSupport()
+			.getFhirContext()
+			.getResourceTypes());
 	}
 
 	@Override
@@ -540,9 +540,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public Set<String> getResourceNamesAsSet() {
 		return myValidationSupportContext
-				.getRootValidationSupport()
-				.getFhirContext()
-				.getResourceTypes();
+			.getRootValidationSupport()
+			.getFhirContext()
+			.getResourceTypes();
 	}
 
 	@Override
@@ -562,7 +562,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public List<StructureDefinition> fetchTypeDefinitions(String theTypeName) {
-		List<StructureDefinition> allStructures = new ArrayList<>(allStructures());
+		List<StructureDefinition> allStructures = new ArrayList<>(allStructureDefinitions());
 		allStructures.removeIf(sd -> !sd.hasType() || !sd.getType().equals(theTypeName));
 		return allStructures;
 	}
@@ -581,12 +581,12 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		Set<String> retVal = myAllPrimitiveTypes;
 		if (retVal == null) {
 			// Collector may be changed to Collectors.toUnmodifiableSet() when switching to Android API level >= 33
-			retVal = allStructures().stream()
-					.filter(structureDefinition ->
-							structureDefinition.getKind() == StructureDefinition.StructureDefinitionKind.PRIMITIVETYPE)
-					.map(StructureDefinition::getName)
-					.filter(Objects::nonNull)
-					.collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
+			retVal = allStructureDefinitions().stream()
+				.filter(structureDefinition ->
+					structureDefinition.getKind() == StructureDefinition.StructureDefinitionKind.PRIMITIVETYPE)
+				.map(StructureDefinition::getName)
+				.filter(Objects::nonNull)
+				.collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
 			myAllPrimitiveTypes = retVal;
 		}
 
@@ -611,11 +611,11 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public String getVersion() {
 		return myValidationSupportContext
-				.getRootValidationSupport()
-				.getFhirContext()
-				.getVersion()
-				.getVersion()
-				.getFhirVersionString();
+			.getRootValidationSupport()
+			.getFhirContext()
+			.getVersion()
+			.getVersion()
+			.getFhirVersionString();
 	}
 
 	@Override
@@ -678,8 +678,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public boolean supportsSystem(String system) {
 		return myValidationSupportContext
-				.getRootValidationSupport()
-				.isCodeSystemSupported(myValidationSupportContext, system);
+			.getRootValidationSupport()
+			.isCodeSystemSupported(myValidationSupportContext, system);
 	}
 
 	@Override
@@ -689,25 +689,25 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public ValueSetExpansionOutcome expandVS(
-			ValueSet source, boolean cacheOk, boolean heiarchical, boolean incompleteOk) {
+		ValueSet source, boolean cacheOk, boolean heiarchical, boolean incompleteOk) {
 		return null;
 	}
 
 	@Override
 	public ValidationResult validateCode(
-			ValidationOptions theOptions, String system, String version, String code, String display) {
+		ValidationOptions theOptions, String system, String version, String code, String display) {
 		ConceptValidationOptions validationOptions = convertConceptValidationOptions(theOptions);
 		return doValidation(null, validationOptions, system, code, display);
 	}
 
 	@Override
 	public ValidationResult validateCode(
-			ValidationOptions theOptions,
-			String theSystem,
-			String version,
-			String theCode,
-			String display,
-			ValueSet theValueSet) {
+		ValidationOptions theOptions,
+		String theSystem,
+		String version,
+		String theCode,
+		String display,
+		ValueSet theValueSet) {
 		IBaseResource convertedVs = null;
 
 		try {
@@ -737,7 +737,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		String system = ValidationSupportUtils.extractCodeSystemForCode(theValueSet, code);
 
 		ConceptValidationOptions validationOptions =
-				convertConceptValidationOptions(theOptions).setInferSystem(true);
+			convertConceptValidationOptions(theOptions).setInferSystem(true);
 
 		return doValidation(convertedVs, validationOptions, system, code, null);
 	}
@@ -764,13 +764,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public ValidationResult validateCode(
-			ValidationOptions options, Coding code, ValueSet vs, ValidationContextCarrier ctxt) {
+		ValidationOptions options, Coding code, ValueSet vs, ValidationContextCarrier ctxt) {
 		return validateCode(options, code, vs);
 	}
 
 	@Override
 	public void validateCodeBatch(
-			ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs) {
+		ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs) {
 		for (CodingValidationRequest next : codes) {
 			ValidationResult outcome = validateCode(options, next.getCoding(), vs);
 			next.setResult(outcome);
@@ -779,18 +779,18 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public void validateCodeBatchByRef(
-			ValidationOptions validationOptions, List<? extends CodingValidationRequest> list, String s) {
+		ValidationOptions validationOptions, List<? extends CodingValidationRequest> list, String s) {
 		ValueSet valueSet = fetchResource(ValueSet.class, s);
 		validateCodeBatch(validationOptions, list, valueSet);
 	}
 
 	@Nonnull
 	private ValidationResult doValidation(
-			IBaseResource theValueSet,
-			ConceptValidationOptions theValidationOptions,
-			String theSystem,
-			String theCode,
-			String theDisplay) {
+		IBaseResource theValueSet,
+		ConceptValidationOptions theValidationOptions,
+		String theSystem,
+		String theCode,
+		String theDisplay) {
 		IValidationSupport.CodeValidationResult result;
 		if (theValueSet != null) {
 			result = validateCodeInValueSet(theValueSet, theValidationOptions, theSystem, theCode, theDisplay);
@@ -801,24 +801,24 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private IValidationSupport.CodeValidationResult validateCodeInValueSet(
-			IBaseResource theValueSet,
-			ConceptValidationOptions theValidationOptions,
-			String theSystem,
-			String theCode,
-			String theDisplay) {
+		IBaseResource theValueSet,
+		ConceptValidationOptions theValidationOptions,
+		String theSystem,
+		String theCode,
+		String theDisplay) {
 		IValidationSupport.CodeValidationResult result = myValidationSupportContext
-				.getRootValidationSupport()
-				.validateCodeInValueSet(
-						myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, theValueSet);
-		if (result != null && theSystem != null) {
+			.getRootValidationSupport()
+			.validateCodeInValueSet(
+				myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, theValueSet);
+		if (result != null && isNotBlank(theSystem)) {
 			/* We got a value set result, which could be successful, or could contain errors/warnings. The code
 			might also be invalid in the code system, so we will check that as well and add those issues
 			to our result.
 			*/
 			IValidationSupport.CodeValidationResult codeSystemResult =
-					validateCodeInCodeSystem(theValidationOptions, theSystem, theCode, theDisplay);
+				validateCodeInCodeSystem(theValidationOptions, theSystem, theCode, theDisplay);
 			final boolean valueSetResultContainsInvalidDisplay = result.getIssues().stream()
-					.anyMatch(VersionSpecificWorkerContextWrapper::hasInvalidDisplayDetailCode);
+				.anyMatch(VersionSpecificWorkerContextWrapper::hasInvalidDisplayDetailCode);
 			if (codeSystemResult != null) {
 				for (IValidationSupport.CodeValidationIssue codeValidationIssue : codeSystemResult.getIssues()) {
 					/* Value set validation should already have checked the display name. If we get INVALID_DISPLAY
@@ -838,10 +838,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private IValidationSupport.CodeValidationResult validateCodeInCodeSystem(
-			ConceptValidationOptions theValidationOptions, String theSystem, String theCode, String theDisplay) {
+		ConceptValidationOptions theValidationOptions, String theSystem, String theCode, String theDisplay) {
 		return myValidationSupportContext
-				.getRootValidationSupport()
-				.validateCode(myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, null);
+			.getRootValidationSupport()
+			.validateCode(myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, null);
 	}
 
 	@Override
@@ -852,13 +852,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		for (Coding next : code.getCoding()) {
 			if (!next.hasSystem()) {
 				String message =
-						"Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided";
+					"Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided";
 				OperationOutcome.OperationOutcomeIssueComponent issue =
-						new OperationOutcome.OperationOutcomeIssueComponent()
-								.setSeverity(OperationOutcome.IssueSeverity.WARNING)
-								.setCode(OperationOutcome.IssueType.NOTFOUND)
-								.setDiagnostics(message)
-								.setDetails(new CodeableConcept().setText(message));
+					new OperationOutcome.OperationOutcomeIssueComponent()
+						.setSeverity(OperationOutcome.IssueSeverity.WARNING)
+						.setCode(OperationOutcome.IssueType.NOTFOUND)
+						.setDiagnostics(message)
+						.setDetails(new CodeableConcept().setText(message));
 
 				issues.add(issue);
 			}
@@ -873,7 +873,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		}
 
 		if (code.getCoding().size() > 0) {
-			if (!myValidationSupportContext.isEnabledValidationForCodingsLogicalAnd()) {
+			if (!myValidationSupportContext.isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid()) {
 				if (validationResultsOk.size() == code.getCoding().size()) {
 					return validationResultsOk.get(0);
 				}
@@ -888,10 +888,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private static OperationOutcome.OperationOutcomeIssueComponent getOperationOutcomeTxIssueComponent(
-			String message, OperationOutcome.IssueType issueCode, String txIssueTypeCode) {
+		String message, OperationOutcome.IssueType issueCode, String txIssueTypeCode) {
 		OperationOutcome.OperationOutcomeIssueComponent issue = new OperationOutcome.OperationOutcomeIssueComponent()
-				.setSeverity(OperationOutcome.IssueSeverity.ERROR)
-				.setDiagnostics(message);
+			.setSeverity(OperationOutcome.IssueSeverity.ERROR)
+			.setDiagnostics(message);
 		issue.getDetails().setText(message);
 
 		issue.setCode(issueCode);
@@ -900,13 +900,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	public void invalidateCaches() {
-		myFetchResourceCache.invalidateAll();
+		// nothing for now
 	}
 
 	@Override
 	public <T extends Resource> List<T> fetchResourcesByType(Class<T> theClass) {
 		if (theClass.equals(StructureDefinition.class)) {
-			return (List<T>) allStructures();
+			return (List<T>) allStructureDefinitions();
 		}
 		throw new UnsupportedOperationException(Msg.code(650) + "Unable to fetch resources of type: " + theClass);
 	}
@@ -967,10 +967,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Nonnull
 	public static VersionSpecificWorkerContextWrapper newVersionSpecificWorkerContextWrapper(
-			IValidationSupport theValidationSupport) {
+		IValidationSupport theValidationSupport) {
 		VersionCanonicalizer versionCanonicalizer = new VersionCanonicalizer(theValidationSupport.getFhirContext());
 		return new VersionSpecificWorkerContextWrapper(
-				new ValidationSupportContext(theValidationSupport), versionCanonicalizer);
+			new ValidationSupportContext(theValidationSupport), versionCanonicalizer);
 	}
 
 	private static class ResourceKey {
@@ -982,9 +982,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			myResourceName = theResourceName;
 			myUri = theUri;
 			myHashCode = new HashCodeBuilder(17, 37)
-					.append(myResourceName)
-					.append(myUri)
-					.toHashCode();
+				.append(myResourceName)
+				.append(myUri)
+				.toHashCode();
 		}
 
 		@Override
@@ -1000,9 +1000,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			ResourceKey that = (ResourceKey) theO;
 
 			return new EqualsBuilder()
-					.append(myResourceName, that.myResourceName)
-					.append(myUri, that.myUri)
-					.isEquals();
+				.append(myResourceName, that.myResourceName)
+				.append(myUri, that.myUri)
+				.isEquals();
 		}
 
 		public String getResourceName() {
@@ -1032,11 +1032,11 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	private IBaseResource fetchResource(String theResourceType, String theUrl) {
 		String fetchResourceName = theResourceType;
 		if (myValidationSupportContext
-						.getRootValidationSupport()
-						.getFhirContext()
-						.getVersion()
-						.getVersion()
-				== FhirVersionEnum.DSTU2) {
+			.getRootValidationSupport()
+			.getFhirContext()
+			.getVersion()
+			.getVersion()
+			== FhirVersionEnum.DSTU2) {
 			if ("CodeSystem".equals(fetchResourceName)) {
 				fetchResourceName = "ValueSet";
 			}
@@ -1047,14 +1047,14 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			fetchResourceType = null;
 		} else {
 			fetchResourceType = myValidationSupportContext
-					.getRootValidationSupport()
-					.getFhirContext()
-					.getResourceDefinition(fetchResourceName)
-					.getImplementingClass();
+				.getRootValidationSupport()
+				.getFhirContext()
+				.getResourceDefinition(fetchResourceName)
+				.getImplementingClass();
 		}
 
 		IBaseResource fetched =
-				myValidationSupportContext.getRootValidationSupport().fetchResource(fetchResourceType, theUrl);
+			myValidationSupportContext.getRootValidationSupport().fetchResource(fetchResourceType, theUrl);
 
 		if (fetched == null) {
 			return null;
@@ -1064,7 +1064,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private Resource convertToCanonicalVersionAndGenerateSnapshot(
-			@Nonnull IBaseResource theResource, boolean thePropagateSnapshotException) {
+		@Nonnull IBaseResource theResource, boolean thePropagateSnapshotException) {
 		Resource canonical;
 		synchronized (theResource) {
 			canonical = (Resource) theResource.getUserData(CANONICAL_USERDATA_KEY);
@@ -1080,16 +1080,16 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 						try {
 
 							FhirContext fhirContext = myValidationSupportContext
-									.getRootValidationSupport()
-									.getFhirContext();
+								.getRootValidationSupport()
+								.getFhirContext();
 							SnapshotGeneratingValidationSupport snapshotGenerator =
-									new SnapshotGeneratingValidationSupport(fhirContext, this, getFHIRPathEngine());
+								new SnapshotGeneratingValidationSupport(fhirContext, this, getFHIRPathEngine());
 							resource = snapshotGenerator.generateSnapshot(
-									myValidationSupportContext, resource, "", null, "");
+								myValidationSupportContext, resource, "", null, "");
 							Validate.isTrue(
-									resource != null,
-									"StructureDefinition %s has no snapshot, and no snapshot generator is configured",
-									canonicalSd.getUrl());
+								resource != null,
+								"StructureDefinition %s has no snapshot, and no snapshot generator is configured",
+								canonicalSd.getUrl());
 
 						} catch (BaseServerResponseException e) {
 							if (thePropagateSnapshotException) {
@@ -1101,9 +1101,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 								message = rootCause.getMessage();
 							}
 							ourLog.warn(
-									"Failed to generate snapshot for profile with URL[{}]: {}",
-									canonicalSd.getUrl(),
-									message);
+								"Failed to generate snapshot for profile with URL[{}]: {}",
+								canonicalSd.getUrl(),
+								message);
 							storeCanonical = false;
 						}
 
@@ -1112,7 +1112,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 				}
 
 				String sourcePackageId =
-						(String) theResource.getUserData(DefaultProfileValidationSupport.SOURCE_PACKAGE_ID);
+					(String) theResource.getUserData(DefaultProfileValidationSupport.SOURCE_PACKAGE_ID);
 				if (sourcePackageId != null) {
 					canonical.setSourcePackage(new PackageInformation(sourcePackageId, null, null, new Date()));
 				}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
@@ -12,6 +12,7 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -72,7 +73,6 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import org.apache.commons.lang3.StringUtils;
 
 public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWorkerContext {
 	private static final Logger ourLog = LoggerFactory.getLogger(VersionSpecificWorkerContextWrapper.class);
@@ -88,7 +88,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	 * the converted version gets cached too.
 	 */
 	private static final String CANONICAL_USERDATA_KEY =
-		VersionSpecificWorkerContextWrapper.class.getName() + "_CANONICAL_USERDATA_KEY";
+			VersionSpecificWorkerContextWrapper.class.getName() + "_CANONICAL_USERDATA_KEY";
 
 	public static final FhirContext FHIR_CONTEXT_R5 = FhirContext.forR5();
 	private final ValidationSupportContext myValidationSupportContext;
@@ -99,7 +99,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	private volatile FHIRPathEngine myFHIRPathEngine;
 
 	public VersionSpecificWorkerContextWrapper(
-		ValidationSupportContext theValidationSupportContext, VersionCanonicalizer theVersionCanonicalizer) {
+			ValidationSupportContext theValidationSupportContext, VersionCanonicalizer theVersionCanonicalizer) {
 		myValidationSupportContext = theValidationSupportContext;
 		myVersionCanonicalizer = theVersionCanonicalizer;
 
@@ -128,13 +128,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader, List<String> types)
-		throws FileNotFoundException, IOException, FHIRException {
+			throws FileNotFoundException, IOException, FHIRException {
 		throw new UnsupportedOperationException(Msg.code(653));
 	}
 
 	@Override
 	public int loadFromPackageAndDependencies(NpmPackage pi, IContextResourceLoader loader, BasePackageCacheManager pcm)
-		throws FHIRException {
+			throws FHIRException {
 		throw new UnsupportedOperationException(Msg.code(654));
 	}
 
@@ -185,7 +185,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public PEBuilder getProfiledElementBuilder(
-		PEBuilder.PEElementPropertiesPolicy thePEElementPropertiesPolicy, boolean theB) {
+			PEBuilder.PEElementPropertiesPolicy thePEElementPropertiesPolicy, boolean theB) {
 		throw new UnsupportedOperationException(Msg.code(2264));
 	}
 
@@ -213,7 +213,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		List<StructureDefinition> retVal = myAllStructures;
 		if (retVal == null) {
 			List<IBaseResource> allStructureDefinitions =
-				myValidationSupportContext.getRootValidationSupport().fetchAllStructureDefinitions();
+					myValidationSupportContext.getRootValidationSupport().fetchAllStructureDefinitions();
 			assert allStructureDefinitions != null;
 
 			/*
@@ -233,8 +233,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			 * generate useful error messages for the user.
 			 */
 			retVal = allStructureDefinitions.stream()
-				.map(t -> myVersionCanonicalizer.structureDefinitionToCanonical(t))
-				.collect(Collectors.toList());
+					.map(t -> myVersionCanonicalizer.structureDefinitionToCanonical(t))
+					.collect(Collectors.toList());
 			myAllStructures = retVal;
 
 			try {
@@ -263,7 +263,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Nonnull
 	private ValidationResult convertValidationResult(
-		String theSystem, @Nullable IValidationSupport.CodeValidationResult theResult) {
+			String theSystem, @Nullable IValidationSupport.CodeValidationResult theResult) {
 		ValidationResult retVal = null;
 		if (theResult != null) {
 			String code = theResult.getCode();
@@ -281,18 +281,18 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			CodeSystem.ConceptDefinitionComponent conceptDefinitionComponent = null;
 			if (code != null) {
 				conceptDefinitionComponent = new CodeSystem.ConceptDefinitionComponent()
-					.setCode(code)
-					.setDisplay(display);
+						.setCode(code)
+						.setDisplay(display);
 			}
 
 			retVal = new ValidationResult(
-				issueSeverity,
-				message,
-				theSystem,
-				theResult.getCodeSystemVersion(),
-				conceptDefinitionComponent,
-				display,
-				getIssuesForCodeValidation(theResult.getIssues()));
+					issueSeverity,
+					message,
+					theSystem,
+					theResult.getCodeSystemVersion(),
+					conceptDefinitionComponent,
+					display,
+					getIssuesForCodeValidation(theResult.getIssues()));
 		}
 
 		if (retVal == null) {
@@ -303,33 +303,33 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private List<OperationOutcome.OperationOutcomeIssueComponent> getIssuesForCodeValidation(
-		List<IValidationSupport.CodeValidationIssue> theIssues) {
+			List<IValidationSupport.CodeValidationIssue> theIssues) {
 		List<OperationOutcome.OperationOutcomeIssueComponent> issueComponents = new ArrayList<>();
 
 		for (IValidationSupport.CodeValidationIssue issue : theIssues) {
 			OperationOutcome.IssueSeverity severity =
-				OperationOutcome.IssueSeverity.fromCode(issue.getSeverity().getCode());
+					OperationOutcome.IssueSeverity.fromCode(issue.getSeverity().getCode());
 			OperationOutcome.IssueType issueType =
-				OperationOutcome.IssueType.fromCode(issue.getType().getCode());
+					OperationOutcome.IssueType.fromCode(issue.getType().getCode());
 			String diagnostics = issue.getDiagnostics();
 
 			IValidationSupport.CodeValidationIssueDetails details = issue.getDetails();
 			CodeableConcept codeableConcept = new CodeableConcept().setText(details.getText());
 			details.getCodings().forEach(detailCoding -> codeableConcept
-				.addCoding()
-				.setSystem(detailCoding.getSystem())
-				.setCode(detailCoding.getCode()));
+					.addCoding()
+					.setSystem(detailCoding.getSystem())
+					.setCode(detailCoding.getCode()));
 
 			OperationOutcome.OperationOutcomeIssueComponent issueComponent =
-				new OperationOutcome.OperationOutcomeIssueComponent()
-					.setSeverity(severity)
-					.setCode(issueType)
-					.setDetails(codeableConcept)
-					.setDiagnostics(diagnostics);
+					new OperationOutcome.OperationOutcomeIssueComponent()
+							.setSeverity(severity)
+							.setCode(issueType)
+							.setDetails(codeableConcept)
+							.setDiagnostics(diagnostics);
 			issueComponent
-				.addExtension()
-				.setUrl("http://hl7.org/fhir/StructureDefinition/operationoutcome-message-id")
-				.setValue(new StringType("Terminology_PassThrough_TX_Message"));
+					.addExtension()
+					.setUrl("http://hl7.org/fhir/StructureDefinition/operationoutcome-message-id")
+					.setValue(new StringType("Terminology_PassThrough_TX_Message"));
 			issueComponents.add(issueComponent);
 		}
 		return issueComponents;
@@ -344,8 +344,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			throw new InternalErrorException(Msg.code(661) + e);
 		}
 		IValidationSupport.ValueSetExpansionOutcome expanded = myValidationSupportContext
-			.getRootValidationSupport()
-			.expandValueSet(myValidationSupportContext, null, convertedSource);
+				.getRootValidationSupport()
+				.expandValueSet(myValidationSupportContext, null, convertedSource);
 
 		ValueSet convertedResult = null;
 		if (expanded.getValueSet() != null) {
@@ -364,27 +364,27 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public ValueSetExpansionOutcome expandVS(
-		Resource src,
-		ElementDefinition.ElementDefinitionBindingComponent binding,
-		boolean cacheOk,
-		boolean Hierarchical) {
+			Resource src,
+			ElementDefinition.ElementDefinitionBindingComponent binding,
+			boolean cacheOk,
+			boolean Hierarchical) {
 		ValueSet valueSet = fetchResource(ValueSet.class, binding.getValueSet(), src);
 		return expandVS(valueSet, cacheOk, Hierarchical);
 	}
 
 	@Override
 	public ValueSetExpansionOutcome expandVS(ValueSet.ConceptSetComponent inc, boolean hierarchical, boolean noInactive)
-		throws TerminologyServiceException {
+			throws TerminologyServiceException {
 		throw new UnsupportedOperationException(Msg.code(664));
 	}
 
 	@Override
 	public Locale getLocale() {
 		return myValidationSupportContext
-			.getRootValidationSupport()
-			.getFhirContext()
-			.getLocalizer()
-			.getLocale();
+				.getRootValidationSupport()
+				.getFhirContext()
+				.getLocalizer()
+				.getLocale();
 	}
 
 	@Override
@@ -395,7 +395,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public CodeSystem fetchCodeSystem(String system) {
 		IBaseResource fetched =
-			myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
+				myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
 		if (fetched == null) {
 			return null;
 		}
@@ -409,7 +409,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public CodeSystem fetchCodeSystem(String system, String verison) {
 		IBaseResource fetched =
-			myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
+				myValidationSupportContext.getRootValidationSupport().fetchCodeSystem(system);
 		if (fetched == null) {
 			return null;
 		}
@@ -487,7 +487,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		T retVal = fetchResource(class_, uri);
 		if (retVal == null) {
 			throw new FHIRException(
-				Msg.code(667) + "Can not find resource of type " + class_.getSimpleName() + " with uri " + uri);
+					Msg.code(667) + "Can not find resource of type " + class_.getSimpleName() + " with uri " + uri);
 		}
 		return retVal;
 	}
@@ -504,7 +504,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public <T extends Resource> T fetchResource(
-		Class<T> class_, String uri, String version, FhirPublication fhirVersion) {
+			Class<T> class_, String uri, String version, FhirPublication fhirVersion) {
 		return null;
 	}
 
@@ -520,16 +520,16 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public <T extends Resource> T fetchResourceWithException(Class<T> class_, String uri, Resource sourceOfReference)
-		throws FHIRException {
+			throws FHIRException {
 		throw new UnsupportedOperationException(Msg.code(2214));
 	}
 
 	@Override
 	public List<String> getResourceNames() {
 		return new ArrayList<>(myValidationSupportContext
-			.getRootValidationSupport()
-			.getFhirContext()
-			.getResourceTypes());
+				.getRootValidationSupport()
+				.getFhirContext()
+				.getResourceTypes());
 	}
 
 	@Override
@@ -540,9 +540,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public Set<String> getResourceNamesAsSet() {
 		return myValidationSupportContext
-			.getRootValidationSupport()
-			.getFhirContext()
-			.getResourceTypes();
+				.getRootValidationSupport()
+				.getFhirContext()
+				.getResourceTypes();
 	}
 
 	@Override
@@ -582,11 +582,11 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		if (retVal == null) {
 			// Collector may be changed to Collectors.toUnmodifiableSet() when switching to Android API level >= 33
 			retVal = allStructureDefinitions().stream()
-				.filter(structureDefinition ->
-					structureDefinition.getKind() == StructureDefinition.StructureDefinitionKind.PRIMITIVETYPE)
-				.map(StructureDefinition::getName)
-				.filter(Objects::nonNull)
-				.collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
+					.filter(structureDefinition ->
+							structureDefinition.getKind() == StructureDefinition.StructureDefinitionKind.PRIMITIVETYPE)
+					.map(StructureDefinition::getName)
+					.filter(Objects::nonNull)
+					.collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
 			myAllPrimitiveTypes = retVal;
 		}
 
@@ -611,11 +611,11 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public String getVersion() {
 		return myValidationSupportContext
-			.getRootValidationSupport()
-			.getFhirContext()
-			.getVersion()
-			.getVersion()
-			.getFhirVersionString();
+				.getRootValidationSupport()
+				.getFhirContext()
+				.getVersion()
+				.getVersion()
+				.getFhirVersionString();
 	}
 
 	@Override
@@ -678,8 +678,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	@Override
 	public boolean supportsSystem(String system) {
 		return myValidationSupportContext
-			.getRootValidationSupport()
-			.isCodeSystemSupported(myValidationSupportContext, system);
+				.getRootValidationSupport()
+				.isCodeSystemSupported(myValidationSupportContext, system);
 	}
 
 	@Override
@@ -689,25 +689,25 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public ValueSetExpansionOutcome expandVS(
-		ValueSet source, boolean cacheOk, boolean heiarchical, boolean incompleteOk) {
+			ValueSet source, boolean cacheOk, boolean heiarchical, boolean incompleteOk) {
 		return null;
 	}
 
 	@Override
 	public ValidationResult validateCode(
-		ValidationOptions theOptions, String system, String version, String code, String display) {
+			ValidationOptions theOptions, String system, String version, String code, String display) {
 		ConceptValidationOptions validationOptions = convertConceptValidationOptions(theOptions);
 		return doValidation(null, validationOptions, system, code, display);
 	}
 
 	@Override
 	public ValidationResult validateCode(
-		ValidationOptions theOptions,
-		String theSystem,
-		String version,
-		String theCode,
-		String display,
-		ValueSet theValueSet) {
+			ValidationOptions theOptions,
+			String theSystem,
+			String version,
+			String theCode,
+			String display,
+			ValueSet theValueSet) {
 		IBaseResource convertedVs = null;
 
 		try {
@@ -737,7 +737,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		String system = ValidationSupportUtils.extractCodeSystemForCode(theValueSet, code);
 
 		ConceptValidationOptions validationOptions =
-			convertConceptValidationOptions(theOptions).setInferSystem(true);
+				convertConceptValidationOptions(theOptions).setInferSystem(true);
 
 		return doValidation(convertedVs, validationOptions, system, code, null);
 	}
@@ -764,13 +764,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public ValidationResult validateCode(
-		ValidationOptions options, Coding code, ValueSet vs, ValidationContextCarrier ctxt) {
+			ValidationOptions options, Coding code, ValueSet vs, ValidationContextCarrier ctxt) {
 		return validateCode(options, code, vs);
 	}
 
 	@Override
 	public void validateCodeBatch(
-		ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs) {
+			ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs) {
 		for (CodingValidationRequest next : codes) {
 			ValidationResult outcome = validateCode(options, next.getCoding(), vs);
 			next.setResult(outcome);
@@ -779,18 +779,18 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Override
 	public void validateCodeBatchByRef(
-		ValidationOptions validationOptions, List<? extends CodingValidationRequest> list, String s) {
+			ValidationOptions validationOptions, List<? extends CodingValidationRequest> list, String s) {
 		ValueSet valueSet = fetchResource(ValueSet.class, s);
 		validateCodeBatch(validationOptions, list, valueSet);
 	}
 
 	@Nonnull
 	private ValidationResult doValidation(
-		IBaseResource theValueSet,
-		ConceptValidationOptions theValidationOptions,
-		String theSystem,
-		String theCode,
-		String theDisplay) {
+			IBaseResource theValueSet,
+			ConceptValidationOptions theValidationOptions,
+			String theSystem,
+			String theCode,
+			String theDisplay) {
 		IValidationSupport.CodeValidationResult result;
 		if (theValueSet != null) {
 			result = validateCodeInValueSet(theValueSet, theValidationOptions, theSystem, theCode, theDisplay);
@@ -801,24 +801,24 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private IValidationSupport.CodeValidationResult validateCodeInValueSet(
-		IBaseResource theValueSet,
-		ConceptValidationOptions theValidationOptions,
-		String theSystem,
-		String theCode,
-		String theDisplay) {
+			IBaseResource theValueSet,
+			ConceptValidationOptions theValidationOptions,
+			String theSystem,
+			String theCode,
+			String theDisplay) {
 		IValidationSupport.CodeValidationResult result = myValidationSupportContext
-			.getRootValidationSupport()
-			.validateCodeInValueSet(
-				myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, theValueSet);
+				.getRootValidationSupport()
+				.validateCodeInValueSet(
+						myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, theValueSet);
 		if (result != null && isNotBlank(theSystem)) {
 			/* We got a value set result, which could be successful, or could contain errors/warnings. The code
 			might also be invalid in the code system, so we will check that as well and add those issues
 			to our result.
 			*/
 			IValidationSupport.CodeValidationResult codeSystemResult =
-				validateCodeInCodeSystem(theValidationOptions, theSystem, theCode, theDisplay);
+					validateCodeInCodeSystem(theValidationOptions, theSystem, theCode, theDisplay);
 			final boolean valueSetResultContainsInvalidDisplay = result.getIssues().stream()
-				.anyMatch(VersionSpecificWorkerContextWrapper::hasInvalidDisplayDetailCode);
+					.anyMatch(VersionSpecificWorkerContextWrapper::hasInvalidDisplayDetailCode);
 			if (codeSystemResult != null) {
 				for (IValidationSupport.CodeValidationIssue codeValidationIssue : codeSystemResult.getIssues()) {
 					/* Value set validation should already have checked the display name. If we get INVALID_DISPLAY
@@ -838,10 +838,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private IValidationSupport.CodeValidationResult validateCodeInCodeSystem(
-		ConceptValidationOptions theValidationOptions, String theSystem, String theCode, String theDisplay) {
+			ConceptValidationOptions theValidationOptions, String theSystem, String theCode, String theDisplay) {
 		return myValidationSupportContext
-			.getRootValidationSupport()
-			.validateCode(myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, null);
+				.getRootValidationSupport()
+				.validateCode(myValidationSupportContext, theValidationOptions, theSystem, theCode, theDisplay, null);
 	}
 
 	@Override
@@ -852,13 +852,13 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 		for (Coding next : code.getCoding()) {
 			if (!next.hasSystem()) {
 				String message =
-					"Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided";
+						"Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided";
 				OperationOutcome.OperationOutcomeIssueComponent issue =
-					new OperationOutcome.OperationOutcomeIssueComponent()
-						.setSeverity(OperationOutcome.IssueSeverity.WARNING)
-						.setCode(OperationOutcome.IssueType.NOTFOUND)
-						.setDiagnostics(message)
-						.setDetails(new CodeableConcept().setText(message));
+						new OperationOutcome.OperationOutcomeIssueComponent()
+								.setSeverity(OperationOutcome.IssueSeverity.WARNING)
+								.setCode(OperationOutcome.IssueType.NOTFOUND)
+								.setDiagnostics(message)
+								.setDetails(new CodeableConcept().setText(message));
 
 				issues.add(issue);
 			}
@@ -888,10 +888,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private static OperationOutcome.OperationOutcomeIssueComponent getOperationOutcomeTxIssueComponent(
-		String message, OperationOutcome.IssueType issueCode, String txIssueTypeCode) {
+			String message, OperationOutcome.IssueType issueCode, String txIssueTypeCode) {
 		OperationOutcome.OperationOutcomeIssueComponent issue = new OperationOutcome.OperationOutcomeIssueComponent()
-			.setSeverity(OperationOutcome.IssueSeverity.ERROR)
-			.setDiagnostics(message);
+				.setSeverity(OperationOutcome.IssueSeverity.ERROR)
+				.setDiagnostics(message);
 		issue.getDetails().setText(message);
 
 		issue.setCode(issueCode);
@@ -967,10 +967,10 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 
 	@Nonnull
 	public static VersionSpecificWorkerContextWrapper newVersionSpecificWorkerContextWrapper(
-		IValidationSupport theValidationSupport) {
+			IValidationSupport theValidationSupport) {
 		VersionCanonicalizer versionCanonicalizer = new VersionCanonicalizer(theValidationSupport.getFhirContext());
 		return new VersionSpecificWorkerContextWrapper(
-			new ValidationSupportContext(theValidationSupport), versionCanonicalizer);
+				new ValidationSupportContext(theValidationSupport), versionCanonicalizer);
 	}
 
 	private static class ResourceKey {
@@ -982,9 +982,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			myResourceName = theResourceName;
 			myUri = theUri;
 			myHashCode = new HashCodeBuilder(17, 37)
-				.append(myResourceName)
-				.append(myUri)
-				.toHashCode();
+					.append(myResourceName)
+					.append(myUri)
+					.toHashCode();
 		}
 
 		@Override
@@ -1000,9 +1000,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			ResourceKey that = (ResourceKey) theO;
 
 			return new EqualsBuilder()
-				.append(myResourceName, that.myResourceName)
-				.append(myUri, that.myUri)
-				.isEquals();
+					.append(myResourceName, that.myResourceName)
+					.append(myUri, that.myUri)
+					.isEquals();
 		}
 
 		public String getResourceName() {
@@ -1032,11 +1032,11 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	private IBaseResource fetchResource(String theResourceType, String theUrl) {
 		String fetchResourceName = theResourceType;
 		if (myValidationSupportContext
-			.getRootValidationSupport()
-			.getFhirContext()
-			.getVersion()
-			.getVersion()
-			== FhirVersionEnum.DSTU2) {
+						.getRootValidationSupport()
+						.getFhirContext()
+						.getVersion()
+						.getVersion()
+				== FhirVersionEnum.DSTU2) {
 			if ("CodeSystem".equals(fetchResourceName)) {
 				fetchResourceName = "ValueSet";
 			}
@@ -1047,14 +1047,14 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			fetchResourceType = null;
 		} else {
 			fetchResourceType = myValidationSupportContext
-				.getRootValidationSupport()
-				.getFhirContext()
-				.getResourceDefinition(fetchResourceName)
-				.getImplementingClass();
+					.getRootValidationSupport()
+					.getFhirContext()
+					.getResourceDefinition(fetchResourceName)
+					.getImplementingClass();
 		}
 
 		IBaseResource fetched =
-			myValidationSupportContext.getRootValidationSupport().fetchResource(fetchResourceType, theUrl);
+				myValidationSupportContext.getRootValidationSupport().fetchResource(fetchResourceType, theUrl);
 
 		if (fetched == null) {
 			return null;
@@ -1064,7 +1064,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 	}
 
 	private Resource convertToCanonicalVersionAndGenerateSnapshot(
-		@Nonnull IBaseResource theResource, boolean thePropagateSnapshotException) {
+			@Nonnull IBaseResource theResource, boolean thePropagateSnapshotException) {
 		Resource canonical;
 		synchronized (theResource) {
 			canonical = (Resource) theResource.getUserData(CANONICAL_USERDATA_KEY);
@@ -1080,16 +1080,16 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 						try {
 
 							FhirContext fhirContext = myValidationSupportContext
-								.getRootValidationSupport()
-								.getFhirContext();
+									.getRootValidationSupport()
+									.getFhirContext();
 							SnapshotGeneratingValidationSupport snapshotGenerator =
-								new SnapshotGeneratingValidationSupport(fhirContext, this, getFHIRPathEngine());
+									new SnapshotGeneratingValidationSupport(fhirContext, this, getFHIRPathEngine());
 							resource = snapshotGenerator.generateSnapshot(
-								myValidationSupportContext, resource, "", null, "");
+									myValidationSupportContext, resource, "", null, "");
 							Validate.isTrue(
-								resource != null,
-								"StructureDefinition %s has no snapshot, and no snapshot generator is configured",
-								canonicalSd.getUrl());
+									resource != null,
+									"StructureDefinition %s has no snapshot, and no snapshot generator is configured",
+									canonicalSd.getUrl());
 
 						} catch (BaseServerResponseException e) {
 							if (thePropagateSnapshotException) {
@@ -1101,9 +1101,9 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 								message = rootCause.getMessage();
 							}
 							ourLog.warn(
-								"Failed to generate snapshot for profile with URL[{}]: {}",
-								canonicalSd.getUrl(),
-								message);
+									"Failed to generate snapshot for profile with URL[{}]: {}",
+									canonicalSd.getUrl(),
+									message);
 							storeCanonical = false;
 						}
 
@@ -1112,7 +1112,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 				}
 
 				String sourcePackageId =
-					(String) theResource.getUserData(DefaultProfileValidationSupport.SOURCE_PACKAGE_ID);
+						(String) theResource.getUserData(DefaultProfileValidationSupport.SOURCE_PACKAGE_ID);
 				if (sourcePackageId != null) {
 					canonical.setSourcePackage(new PackageInformation(sourcePackageId, null, null, new Date()));
 				}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
@@ -12,6 +12,7 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -460,11 +461,8 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			return null;
 		}
 
-		if (theUri.contains("|")) {
-			String[] parts = theUri.split("\\|");
-			if (parts.length != 2) {
-				ourLog.warn("Unrecognized profile uri: {}", theUri);
-			}
+		if (StringUtils.countMatches(theUri, "|") > 1) {
+			ourLog.warn("Unrecognized profile uri: {}", theUri);
 		}
 
 		String resourceType = getResourceType(class_);

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
@@ -12,7 +12,6 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -73,6 +72,7 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import org.apache.commons.lang3.StringUtils;
 
 public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWorkerContext {
 	private static final Logger ourLog = LoggerFactory.getLogger(VersionSpecificWorkerContextWrapper.class);


### PR DESCRIPTION
- version in canonical url is used to search StructureDefinition
- remain the version of a Resource to identify it properly