### PR TITLE
Add composite interceptor registry

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/IBaseInterceptorBroadcaster.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/IBaseInterceptorBroadcaster.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.interceptor.api;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 public interface IBaseInterceptorBroadcaster<POINTCUT extends IPointcut> {
@@ -73,4 +74,15 @@ public interface IBaseInterceptorBroadcaster<POINTCUT extends IPointcut> {
 	 * @since 4.0.0
 	 */
 	boolean hasHooks(POINTCUT thePointcut);
+
+	List<IInvoker> getInvokersForPointcut(POINTCUT thePointcut);
+
+	interface IInvoker extends Comparable<IInvoker> {
+
+		Object invoke(HookParams theParams);
+
+		int getOrder();
+
+		Object getInterceptor();
+	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/executor/BaseInterceptorService.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/executor/BaseInterceptorService.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.interceptor.executor;
 
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IBaseInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.IBaseInterceptorService;
@@ -57,7 +58,6 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -72,14 +72,14 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 			AttributeKey.stringKey("hapifhir.interceptor.class_name");
 	private static final AttributeKey<String> OTEL_INTERCEPTOR_METHOD_NAME_ATT_KEY =
 			AttributeKey.stringKey("hapifhir.interceptor.method_name");
+	public static final Class<Boolean> BOOLEAN_RETURN_TYPE = boolean.class;
 
 	private final List<Object> myInterceptors = new ArrayList<>();
-	private final ListMultimap<POINTCUT, BaseInvoker> myGlobalInvokers = ArrayListMultimap.create();
-	private final ListMultimap<POINTCUT, BaseInvoker> myAnonymousInvokers = ArrayListMultimap.create();
+	private final ListMultimap<POINTCUT, IInvoker> myGlobalInvokers = ArrayListMultimap.create();
+	private final ListMultimap<POINTCUT, IInvoker> myAnonymousInvokers = ArrayListMultimap.create();
 	private final Object myRegistryMutex = new Object();
 	private final Class<POINTCUT> myPointcutType;
 	private volatile EnumSet<POINTCUT> myRegisteredPointcuts;
-	private String myName;
 	private boolean myWarnOnInterceptorWithNoHooks = true;
 
 	/**
@@ -93,10 +93,11 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 	 * Constructor
 	 *
 	 * @param theName The name for this registry (useful for troubleshooting)
+	 * @deprecated The name parameter is not used for anything
 	 */
+	@Deprecated(since = "8.0.0", forRemoval = true)
 	public BaseInterceptorService(Class<POINTCUT> thePointcutType, String theName) {
 		super();
-		myName = theName;
 		myPointcutType = thePointcutType;
 		rebuildRegisteredPointcutSet();
 	}
@@ -113,13 +114,17 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 		return myInterceptors;
 	}
 
-	public void setName(String theName) {
-		myName = theName;
+	/**
+	 * @deprecated This value is not used anywhere
+	 */
+	@Deprecated(since = "8.0.0", forRemoval = true)
+	public void setName(@SuppressWarnings("unused") String theName) {
+		// nothing
 	}
 
 	protected void registerAnonymousInterceptor(POINTCUT thePointcut, Object theInterceptor, BaseInvoker theInvoker) {
-		Validate.notNull(thePointcut);
-		Validate.notNull(theInterceptor);
+		Validate.notNull(thePointcut, "thePointcut must not be null");
+		Validate.notNull(theInterceptor, "theInterceptor must not be null");
 		synchronized (myRegistryMutex) {
 			myAnonymousInvokers.put(thePointcut, theInvoker);
 			if (!isInterceptorAlreadyRegistered(theInterceptor)) {
@@ -179,9 +184,9 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 	}
 
 	private void unregisterInterceptorsIf(
-			Predicate<Object> theShouldUnregisterFunction, ListMultimap<POINTCUT, BaseInvoker> theGlobalInvokers) {
+			Predicate<Object> theShouldUnregisterFunction, ListMultimap<POINTCUT, IInvoker> theGlobalInvokers) {
 		synchronized (myRegistryMutex) {
-			for (Map.Entry<POINTCUT, BaseInvoker> nextInvoker : new ArrayList<>(theGlobalInvokers.entries())) {
+			for (Map.Entry<POINTCUT, IInvoker> nextInvoker : new ArrayList<>(theGlobalInvokers.entries())) {
 				if (theShouldUnregisterFunction.test(nextInvoker.getValue().getInterceptor())) {
 					unregisterInterceptor(nextInvoker.getValue().getInterceptor());
 				}
@@ -265,7 +270,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 		assert haveAppropriateParams(thePointcut, theParams);
 		assert thePointcut.getReturnType() != void.class;
 
-		return doCallHooks(thePointcut, theParams, null);
+		return doCallHooks(thePointcut, theParams);
 	}
 
 	@Override
@@ -273,125 +278,51 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 		return myRegisteredPointcuts.contains(thePointcut);
 	}
 
-	protected Class<?> getBooleanReturnType() {
-		return boolean.class;
-	}
-
 	@Override
 	public boolean callHooks(POINTCUT thePointcut, HookParams theParams) {
 		assert haveAppropriateParams(thePointcut, theParams);
-		assert thePointcut.getReturnType() == void.class || thePointcut.getReturnType() == getBooleanReturnType();
+		assert thePointcut.getReturnType() == void.class || thePointcut.getReturnType() == BOOLEAN_RETURN_TYPE;
 
-		Object retValObj = doCallHooks(thePointcut, theParams, true);
+		Object retValObj = doCallHooks(thePointcut, theParams);
 		return (Boolean) retValObj;
 	}
 
-	private Object doCallHooks(POINTCUT thePointcut, HookParams theParams, Object theRetVal) {
-		// use new list for loop to avoid ConcurrentModificationException in case invoker gets added while looping
-		List<BaseInvoker> invokers = new ArrayList<>(getInvokersForPointcut(thePointcut));
-
-		/*
-		 * Call each hook in order
-		 */
-		for (BaseInvoker nextInvoker : invokers) {
-			Object nextOutcome = nextInvoker.invoke(theParams);
-			Class<?> pointcutReturnType = thePointcut.getReturnType();
-			if (pointcutReturnType.equals(getBooleanReturnType())) {
-				Boolean nextOutcomeAsBoolean = (Boolean) nextOutcome;
-				if (Boolean.FALSE.equals(nextOutcomeAsBoolean)) {
-					ourLog.trace("callHooks({}) for invoker({}) returned false", thePointcut, nextInvoker);
-					theRetVal = false;
-					break;
-				} else {
-					theRetVal = true;
-				}
-			} else if (!pointcutReturnType.equals(void.class)) {
-				if (nextOutcome != null) {
-					theRetVal = nextOutcome;
-					break;
-				}
-			}
-		}
-
-		return theRetVal;
+	private Object doCallHooks(POINTCUT thePointcut, HookParams theParams) {
+		List<IInvoker> invokers = getInvokersForPointcut(thePointcut);
+		return callInvokers(thePointcut, theParams, invokers);
 	}
 
 	@VisibleForTesting
 	List<Object> getInterceptorsWithInvokersForPointcut(POINTCUT thePointcut) {
 		return getInvokersForPointcut(thePointcut).stream()
-				.map(BaseInvoker::getInterceptor)
+				.map(IInvoker::getInterceptor)
 				.collect(Collectors.toList());
 	}
 
 	/**
-	 * Returns an ordered list of invokers for the given pointcut. Note that
-	 * a new and stable list is returned to.. do whatever you want with it.
+	 * Returns a list of all invokers registered for the given pointcut. The list
+	 * is ordered by the invoker order (specified on the {@link Interceptor#order()}
+	 * and {@link Hook#order()} values.
+	 *
+	 * @return The list returned by this method will always be a newly created list, so it will be stable and can be modified.
 	 */
-	private List<BaseInvoker> getInvokersForPointcut(POINTCUT thePointcut) {
-		List<BaseInvoker> invokers;
+	@Override
+	public List<IInvoker> getInvokersForPointcut(POINTCUT thePointcut) {
+		List<IInvoker> invokers;
 
 		synchronized (myRegistryMutex) {
-			List<BaseInvoker> globalInvokers = myGlobalInvokers.get(thePointcut);
-			List<BaseInvoker> anonymousInvokers = myAnonymousInvokers.get(thePointcut);
-			List<BaseInvoker> threadLocalInvokers = null;
-			invokers = union(globalInvokers, anonymousInvokers, threadLocalInvokers);
+			List<IInvoker> globalInvokers = myGlobalInvokers.get(thePointcut);
+			List<IInvoker> anonymousInvokers = myAnonymousInvokers.get(thePointcut);
+			invokers = union(Arrays.asList(globalInvokers, anonymousInvokers));
 		}
 
 		return invokers;
 	}
 
 	/**
-	 * First argument must be the global invoker list!!
-	 */
-	@SafeVarargs
-	private List<BaseInvoker> union(List<BaseInvoker>... theInvokersLists) {
-		List<BaseInvoker> haveOne = null;
-		boolean haveMultiple = false;
-		for (List<BaseInvoker> nextInvokerList : theInvokersLists) {
-			if (nextInvokerList == null || nextInvokerList.isEmpty()) {
-				continue;
-			}
-
-			if (haveOne == null) {
-				haveOne = nextInvokerList;
-			} else {
-				haveMultiple = true;
-			}
-		}
-
-		if (haveOne == null) {
-			return Collections.emptyList();
-		}
-
-		List<BaseInvoker> retVal;
-
-		if (!haveMultiple) {
-
-			// The global list doesn't need to be sorted every time since it's sorted on
-			// insertion each time. Doing so is a waste of cycles..
-			if (haveOne == theInvokersLists[0]) {
-				retVal = haveOne;
-			} else {
-				retVal = new ArrayList<>(haveOne);
-				retVal.sort(Comparator.naturalOrder());
-			}
-
-		} else {
-
-			retVal = Arrays.stream(theInvokersLists)
-					.filter(Objects::nonNull)
-					.flatMap(Collection::stream)
-					.sorted()
-					.collect(Collectors.toList());
-		}
-
-		return retVal;
-	}
-
-	/**
 	 * Only call this when assertions are enabled, it's expensive
 	 */
-	final boolean haveAppropriateParams(POINTCUT thePointcut, HookParams theParams) {
+	public static boolean haveAppropriateParams(IPointcut thePointcut, HookParams theParams) {
 		if (theParams.getParamsForType().values().size()
 				!= thePointcut.getParameterTypes().size()) {
 			throw new IllegalArgumentException(Msg.code(1909)
@@ -430,7 +361,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 	}
 
 	private List<HookInvoker> scanInterceptorAndAddToInvokerMultimap(
-			Object theInterceptor, ListMultimap<POINTCUT, BaseInvoker> theInvokers) {
+			Object theInterceptor, ListMultimap<POINTCUT, IInvoker> theInvokers) {
 		Class<?> interceptorClass = theInterceptor.getClass();
 		int typeOrder = determineOrder(interceptorClass);
 
@@ -452,7 +383,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 
 		// Make sure we're always sorted according to the order declared in @Order
 		for (POINTCUT nextPointcut : theInvokers.keys()) {
-			List<BaseInvoker> nextInvokerList = theInvokers.get(nextPointcut);
+			List<IInvoker> nextInvokerList = theInvokers.get(nextPointcut);
 			nextInvokerList.sort(Comparator.naturalOrder());
 		}
 
@@ -483,6 +414,108 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 
 	protected abstract Optional<HookDescriptor> scanForHook(Method nextMethod);
 
+	public static Object callInvokers(IPointcut thePointcut, HookParams theParams, List<IInvoker> invokers) {
+
+		Object retVal = null;
+
+		/*
+		 * Call each hook in order
+		 */
+		for (IInvoker nextInvoker : invokers) {
+			Object nextOutcome = nextInvoker.invoke(theParams);
+			Class<?> pointcutReturnType = thePointcut.getReturnType();
+			if (pointcutReturnType.equals(BOOLEAN_RETURN_TYPE)) {
+				Boolean nextOutcomeAsBoolean = (Boolean) nextOutcome;
+				if (Boolean.FALSE.equals(nextOutcomeAsBoolean)) {
+					ourLog.trace("callHooks({}) for invoker({}) returned false", thePointcut, nextInvoker);
+					retVal = false;
+					break;
+				} else {
+					retVal = true;
+				}
+			} else if (!pointcutReturnType.equals(void.class)) {
+				if (nextOutcome != null) {
+					retVal = nextOutcome;
+					break;
+				}
+			}
+		}
+
+		return retVal;
+	}
+
+	/**
+	 * First argument must be the global invoker list!!
+	 */
+	public static List<IInvoker> union(List<List<IInvoker>> theInvokersLists) {
+		List<IInvoker> haveOne = null;
+		boolean haveMultiple = false;
+		for (List<IInvoker> nextInvokerList : theInvokersLists) {
+			if (nextInvokerList == null || nextInvokerList.isEmpty()) {
+				continue;
+			}
+
+			if (haveOne == null) {
+				haveOne = nextInvokerList;
+			} else {
+				haveMultiple = true;
+			}
+		}
+
+		if (haveOne == null) {
+			return Collections.emptyList();
+		}
+
+		List<IInvoker> retVal;
+
+		if (!haveMultiple) {
+
+			// The global list doesn't need to be sorted every time since it's sorted on
+			// insertion each time. Doing so is a waste of cycles..
+			if (haveOne == theInvokersLists.get(0)) {
+				retVal = haveOne;
+			} else {
+				retVal = new ArrayList<>(haveOne);
+				retVal.sort(Comparator.naturalOrder());
+			}
+
+		} else {
+
+			int totalSize = 0;
+			for (List<IInvoker> list : theInvokersLists) {
+				totalSize += list.size();
+			}
+			retVal = new ArrayList<>(totalSize);
+			for (List<IInvoker> list : theInvokersLists) {
+				retVal.addAll(list);
+			}
+			retVal.sort(Comparator.naturalOrder());
+		}
+
+		return retVal;
+	}
+
+	protected static <T extends Annotation> Optional<T> findAnnotation(
+			AnnotatedElement theObject, Class<T> theHookClass) {
+		T annotation;
+		if (theObject instanceof Method) {
+			annotation = MethodUtils.getAnnotation((Method) theObject, theHookClass, true, true);
+		} else {
+			annotation = theObject.getAnnotation(theHookClass);
+		}
+		return Optional.ofNullable(annotation);
+	}
+
+	private static int determineOrder(Class<?> theInterceptorClass) {
+		return findAnnotation(theInterceptorClass, Interceptor.class)
+				.map(Interceptor::order)
+				.orElse(Interceptor.DEFAULT_ORDER);
+	}
+
+	private static String toErrorString(List<String> theParameterTypes) {
+		return theParameterTypes.stream().sorted().collect(Collectors.joining(","));
+	}
+
 	private class HookInvoker extends BaseInvoker {
 
 		private final Method myMethod;
@@ -501,9 +534,9 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 			myMethod = theHookMethod;
 
 			Class<?> returnType = theHookMethod.getReturnType();
-			if (myPointcut.getReturnType().equals(getBooleanReturnType())) {
+			if (myPointcut.getReturnType().equals(BOOLEAN_RETURN_TYPE)) {
 				Validate.isTrue(
-						getBooleanReturnType().equals(returnType) || void.class.equals(returnType),
+						BOOLEAN_RETURN_TYPE.equals(returnType) || void.class.equals(returnType),
 						"Method does not return boolean or void: %s",
 						theHookMethod);
 			} else if (myPointcut.getReturnType().equals(void.class)) {
@@ -541,7 +574,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 		 * @return Returns true/false if the hook method returns a boolean, returns true otherwise
 		 */
 		@Override
-		Object invoke(HookParams theParams) {
+		public Object invoke(HookParams theParams) {
 
 			Object[] args = new Object[myParameterTypes.length];
 			for (int i = 0; i < myParameterTypes.length; i++) {
@@ -610,7 +643,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 		}
 	}
 
-	protected abstract static class BaseInvoker implements Comparable<BaseInvoker> {
+	public abstract static class BaseInvoker implements IInvoker {
 
 		private final int myOrder;
 		private final Object myInterceptor;
@@ -620,36 +653,19 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 			myOrder = theOrder;
 		}
 
+		@Override
 		public Object getInterceptor() {
 			return myInterceptor;
 		}
 
-		abstract Object invoke(HookParams theParams);
+		@Override
+		public int getOrder() {
+			return myOrder;
+		}
 
 		@Override
-		public int compareTo(BaseInvoker theInvoker) {
-			return myOrder - theInvoker.myOrder;
+		public int compareTo(IInvoker theInvoker) {
+			return myOrder - theInvoker.getOrder();
 		}
-	}
-
-	protected static <T extends Annotation> Optional<T> findAnnotation(
-			AnnotatedElement theObject, Class<T> theHookClass) {
-		T annotation;
-		if (theObject instanceof Method) {
-			annotation = MethodUtils.getAnnotation((Method) theObject, theHookClass, true, true);
-		} else {
-			annotation = theObject.getAnnotation(theHookClass);
-		}
-		return Optional.ofNullable(annotation);
-	}
-
-	private static int determineOrder(Class<?> theInterceptorClass) {
-		return findAnnotation(theInterceptorClass, Interceptor.class)
-				.map(Interceptor::order)
-				.orElse(Interceptor.DEFAULT_ORDER);
-	}
-
-	private static String toErrorString(List<String> theParameterTypes) {
-		return theParameterTypes.stream().sorted().collect(Collectors.joining(","));
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/executor/InterceptorService.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/executor/InterceptorService.java
@@ -64,8 +64,8 @@ public class InterceptorService extends BaseInterceptorService<Pointcut>
 
 	@Override
 	public void registerAnonymousInterceptor(Pointcut thePointcut, int theOrder, IAnonymousInterceptor theInterceptor) {
-		Validate.notNull(thePointcut);
-		Validate.notNull(theInterceptor);
+		Validate.notNull(thePointcut, "thePointcut must not be null");
+		Validate.notNull(theInterceptor, "theInterceptor must not be null");
 		BaseInvoker invoker = new AnonymousLambdaInvoker(thePointcut, theInterceptor, theOrder);
 		registerAnonymousInterceptor(thePointcut, theInterceptor, invoker);
 	}
@@ -81,7 +81,7 @@ public class InterceptorService extends BaseInterceptorService<Pointcut>
 		}
 
 		@Override
-		Object invoke(HookParams theParams) {
+		public Object invoke(HookParams theParams) {
 			myHook.invoke(myPointcut, theParams);
 			return true;
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/SearchConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/SearchConfig.java
@@ -25,7 +25,6 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
-import ca.uhn.fhir.jpa.api.dao.IDao;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.api.svc.ISearchCoordinatorSvc;
 import ca.uhn.fhir.jpa.dao.ISearchBuilder;
@@ -158,10 +157,8 @@ public class SearchConfig {
 
 	@Bean(name = ISearchBuilder.SEARCH_BUILDER_BEAN_NAME)
 	@Scope("prototype")
-	public ISearchBuilder newSearchBuilder(
-			IDao theDao, String theResourceName, Class<? extends IBaseResource> theResourceType) {
+	public ISearchBuilder newSearchBuilder(String theResourceName, Class<? extends IBaseResource> theResourceType) {
 		return new SearchBuilder(
-				theDao,
 				theResourceName,
 				myStorageSettings,
 				myEntityManagerFactory,

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -1057,8 +1057,9 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 
 			// Interceptor broadcast: JPA_PERFTRACE_INFO
 			if (!presenceCount.isEmpty()) {
-				if (CompositeInterceptorBroadcaster.hasHooks(
-						Pointcut.JPA_PERFTRACE_INFO, myInterceptorBroadcaster, theRequest)) {
+				IInterceptorBroadcaster compositeBroadcaster =
+						CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+				if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_INFO)) {
 					StorageProcessingMessage message = new StorageProcessingMessage();
 					message.setMessage(
 							"For " + entity.getIdDt().toUnqualifiedVersionless().getValue() + " added "
@@ -1068,8 +1069,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 							.add(RequestDetails.class, theRequest)
 							.addIfMatchesType(ServletRequestDetails.class, theRequest)
 							.add(StorageProcessingMessage.class, message);
-					CompositeInterceptorBroadcaster.doCallHooks(
-							myInterceptorBroadcaster, theRequest, Pointcut.JPA_PERFTRACE_INFO, params);
+					compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_INFO, params);
 				}
 			}
 		}
@@ -1092,8 +1092,10 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 
 				// Interceptor broadcast: JPA_PERFTRACE_INFO
 				if (!searchParamAddRemoveCount.isEmpty()) {
-					if (CompositeInterceptorBroadcaster.hasHooks(
-							Pointcut.JPA_PERFTRACE_INFO, myInterceptorBroadcaster, theRequest)) {
+					IInterceptorBroadcaster compositeBroadcaster =
+							CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+									myInterceptorBroadcaster, theRequest);
+					if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_INFO)) {
 						StorageProcessingMessage message = new StorageProcessingMessage();
 						message.setMessage("For "
 								+ entity.getIdDt().toUnqualifiedVersionless().getValue() + " added "
@@ -1104,8 +1106,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 								.add(RequestDetails.class, theRequest)
 								.addIfMatchesType(ServletRequestDetails.class, theRequest)
 								.add(StorageProcessingMessage.class, message);
-						CompositeInterceptorBroadcaster.doCallHooks(
-								myInterceptorBroadcaster, theRequest, Pointcut.JPA_PERFTRACE_INFO, params);
+						compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_INFO, params);
 					}
 				}
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -226,15 +226,15 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	@Nullable
 	public static <T extends IBaseResource> T invokeStoragePreShowResources(
 			IInterceptorBroadcaster theInterceptorBroadcaster, RequestDetails theRequest, T retVal) {
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_PRESHOW_RESOURCES, theInterceptorBroadcaster, theRequest)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(theInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
 			SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(retVal);
 			HookParams params = new HookParams()
 					.add(IPreResourceShowDetails.class, showDetails)
 					.add(RequestDetails.class, theRequest)
 					.addIfMatchesType(ServletRequestDetails.class, theRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					theInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PRESHOW_RESOURCES, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
 			//noinspection unchecked
 			retVal = (T) showDetails.getResource(
 					0); // TODO GGG/JA : getting resource 0 is interesting. We apparently allow null values in the list.
@@ -1584,15 +1584,15 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	}
 
 	private Optional<T> invokeStoragePreAccessResources(RequestDetails theRequest, T theResource) {
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_PREACCESS_RESOURCES, myInterceptorBroadcaster, theRequest)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
 			SimplePreResourceAccessDetails accessDetails = new SimplePreResourceAccessDetails(theResource);
 			HookParams params = new HookParams()
 					.add(IPreResourceAccessDetails.class, accessDetails)
 					.add(RequestDetails.class, theRequest)
 					.addIfMatchesType(ServletRequestDetails.class, theRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
 			if (accessDetails.isDontReturnResourceAtIndex(0)) {
 				return Optional.empty();
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -250,15 +250,15 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			RequestDetails theRequest,
 			IIdType theId,
 			IBaseResource theResource) {
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_PREACCESS_RESOURCES, theInterceptorBroadcaster, theRequest)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(theInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
 			SimplePreResourceAccessDetails accessDetails = new SimplePreResourceAccessDetails(theResource);
 			HookParams params = new HookParams()
 					.add(IPreResourceAccessDetails.class, accessDetails)
 					.add(RequestDetails.class, theRequest)
 					.addIfMatchesType(ServletRequestDetails.class, theRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					theInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
 			if (accessDetails.isDontReturnResourceAtIndex(0)) {
 				throw new ResourceNotFoundException(Msg.code(1995) + "Resource " + theId + " is not known");
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
@@ -516,8 +516,9 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 	 */
 	@SuppressWarnings("rawtypes")
 	private void logQuery(SearchQueryOptionsStep theQuery, RequestDetails theRequestDetails) {
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.JPA_PERFTRACE_INFO, myInterceptorBroadcaster, theRequestDetails)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_INFO)) {
 			StorageProcessingMessage storageProcessingMessage = new StorageProcessingMessage();
 			String queryString = theQuery.toQuery().queryString();
 			storageProcessingMessage.setMessage(queryString);
@@ -525,8 +526,7 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 					.add(RequestDetails.class, theRequestDetails)
 					.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
 					.add(StorageProcessingMessage.class, storageProcessingMessage);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequestDetails, Pointcut.JPA_PERFTRACE_INFO, params);
+			compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_INFO, params);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
@@ -124,12 +124,15 @@ public class ExpungeEverythingService implements IExpungeEverythingService {
 		final AtomicInteger counter = new AtomicInteger();
 
 		// Notify Interceptors about pre-action call
-		HookParams hooks = new HookParams()
-				.add(AtomicInteger.class, counter)
-				.add(RequestDetails.class, theRequest)
-				.addIfMatchesType(ServletRequestDetails.class, theRequest);
-		CompositeInterceptorBroadcaster.doCallHooks(
-				myInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PRESTORAGE_EXPUNGE_EVERYTHING, hooks);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESTORAGE_EXPUNGE_EVERYTHING)) {
+			HookParams hooks = new HookParams()
+					.add(AtomicInteger.class, counter)
+					.add(RequestDetails.class, theRequest)
+					.addIfMatchesType(ServletRequestDetails.class, theRequest);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESTORAGE_EXPUNGE_EVERYTHING, hooks);
+		}
 
 		ourLog.info("BEGINNING GLOBAL $expunge");
 		Propagation propagation = Propagation.REQUIRES_NEW;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
@@ -256,8 +256,9 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 			ResourceHistoryTable theVersion,
 			IdDt theId) {
 		final AtomicInteger counter = new AtomicInteger();
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_PRESTORAGE_EXPUNGE_RESOURCE, myInterceptorBroadcaster, theRequestDetails)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESTORAGE_EXPUNGE_RESOURCE)) {
 			IBaseResource resource = myJpaStorageResourceParser.toResource(theVersion, false);
 			HookParams params = new HookParams()
 					.add(AtomicInteger.class, counter)
@@ -265,8 +266,7 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 					.add(IBaseResource.class, resource)
 					.add(RequestDetails.class, theRequestDetails)
 					.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequestDetails, Pointcut.STORAGE_PRESTORAGE_EXPUNGE_RESOURCE, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESTORAGE_EXPUNGE_RESOURCE, params);
 		}
 		theRemainingCount.addAndGet(-1 * counter.get());
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/DeleteConflictService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/DeleteConflictService.java
@@ -106,13 +106,15 @@ public class DeleteConflictService {
 		}
 
 		// Notify Interceptors about pre-action call
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
 		HookParams hooks = new HookParams()
 				.add(DeleteConflictList.class, theDeleteConflicts)
 				.add(RequestDetails.class, theRequest)
 				.addIfMatchesType(ServletRequestDetails.class, theRequest)
 				.add(TransactionDetails.class, theTransactionDetails);
-		return (DeleteConflictOutcome) CompositeInterceptorBroadcaster.doCallHooksAndReturnObject(
-				myInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PRESTORAGE_DELETE_CONFLICTS, hooks);
+		return (DeleteConflictOutcome)
+				compositeBroadcaster.callHooksAndReturnObject(Pointcut.STORAGE_PRESTORAGE_DELETE_CONFLICTS, hooks);
 	}
 
 	private void addConflictsToList(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/ThreadSafeResourceDeleterSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/ThreadSafeResourceDeleterSvc.java
@@ -155,17 +155,19 @@ public class ThreadSafeResourceDeleterSvc {
 			TransactionDetails theTransactionDetails,
 			IdDt nextSource,
 			IFhirResourceDao<?> dao) {
-		// Interceptor call: STORAGE_CASCADE_DELETE
 
 		// Remove the version so we grab the latest version to delete
 		IBaseResource resource = dao.read(nextSource.toVersionless(), theRequest);
+
+		// Interceptor call: STORAGE_CASCADE_DELETE
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
 		HookParams params = new HookParams()
 				.add(RequestDetails.class, theRequest)
 				.addIfMatchesType(ServletRequestDetails.class, theRequest)
 				.add(DeleteConflictList.class, theConflictList)
 				.add(IBaseResource.class, resource);
-		CompositeInterceptorBroadcaster.doCallHooks(
-				myInterceptorBroadcaster, theRequest, Pointcut.STORAGE_CASCADE_DELETE, params);
+		compositeBroadcaster.callHooks(Pointcut.STORAGE_CASCADE_DELETE, params);
 
 		return dao.delete(resource.getIdElement(), theConflictList, theRequest, theTransactionDetails);
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
@@ -189,15 +189,17 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 			retVal.add(myJpaStorageResourceParser.toResource(resource, true));
 		}
 
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, myRequest);
+
 		// Interceptor call: STORAGE_PREACCESS_RESOURCES
-		{
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
 			SimplePreResourceAccessDetails accessDetails = new SimplePreResourceAccessDetails(retVal);
 			HookParams params = new HookParams()
 					.add(IPreResourceAccessDetails.class, accessDetails)
 					.add(RequestDetails.class, myRequest)
 					.addIfMatchesType(ServletRequestDetails.class, myRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, myRequest, Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
 
 			for (int i = retVal.size() - 1; i >= 0; i--) {
 				if (accessDetails.isDontReturnResourceAtIndex(i)) {
@@ -207,14 +209,13 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 		}
 
 		// Interceptor broadcast: STORAGE_PRESHOW_RESOURCES
-		{
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
 			SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(retVal);
 			HookParams params = new HookParams()
 					.add(IPreResourceShowDetails.class, showDetails)
 					.add(RequestDetails.class, myRequest)
 					.addIfMatchesType(ServletRequestDetails.class, myRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, myRequest, Pointcut.STORAGE_PRESHOW_RESOURCES, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
 			retVal = showDetails.toList();
 		}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SearchCoordinatorSvcImpl.java
@@ -599,17 +599,18 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc<JpaPid> {
 				.withRequest(theRequestDetails)
 				.withRequestPartitionId(theRequestPartitionId)
 				.execute(() -> {
+					IInterceptorBroadcaster compositeBroadcaster =
+							CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+									myInterceptorBroadcaster, theRequestDetails);
 
 					// Interceptor call: STORAGE_PRECHECK_FOR_CACHED_SEARCH
+
 					HookParams params = new HookParams()
 							.add(SearchParameterMap.class, theParams)
 							.add(RequestDetails.class, theRequestDetails)
 							.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
-					Object outcome = CompositeInterceptorBroadcaster.doCallHooksAndReturnObject(
-							myInterceptorBroadcaster,
-							theRequestDetails,
-							Pointcut.STORAGE_PRECHECK_FOR_CACHED_SEARCH,
-							params);
+					Object outcome = compositeBroadcaster.callHooksAndReturnObject(
+							Pointcut.STORAGE_PRECHECK_FOR_CACHED_SEARCH, params);
 					if (Boolean.FALSE.equals(outcome)) {
 						return null;
 					}
@@ -626,11 +627,7 @@ public class SearchCoordinatorSvcImpl implements ISearchCoordinatorSvc<JpaPid> {
 							.add(SearchParameterMap.class, theParams)
 							.add(RequestDetails.class, theRequestDetails)
 							.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
-					CompositeInterceptorBroadcaster.doCallHooks(
-							myInterceptorBroadcaster,
-							theRequestDetails,
-							Pointcut.JPA_PERFTRACE_SEARCH_REUSING_CACHED,
-							params);
+					compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_SEARCH_REUSING_CACHED, params);
 
 					return myPersistedJpaBundleProviderFactory.newInstance(theRequestDetails, searchToUse.getUuid());
 				});

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SynchronousSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SynchronousSearchSvcImpl.java
@@ -181,12 +181,16 @@ public class SynchronousSearchSvcImpl implements ISynchronousSearchSvc {
 					}
 
 					JpaPreResourceAccessDetails accessDetails = new JpaPreResourceAccessDetails(pids, () -> theSb);
-					HookParams params = new HookParams()
-							.add(IPreResourceAccessDetails.class, accessDetails)
-							.add(RequestDetails.class, theRequestDetails)
-							.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
-					CompositeInterceptorBroadcaster.doCallHooks(
-							myInterceptorBroadcaster, theRequestDetails, Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+					IInterceptorBroadcaster compositeBroadcaster =
+							CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+									myInterceptorBroadcaster, theRequestDetails);
+					if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
+						HookParams params = new HookParams()
+								.add(IPreResourceAccessDetails.class, accessDetails)
+								.add(RequestDetails.class, theRequestDetails)
+								.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
+						compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+					}
 
 					for (int i = pids.size() - 1; i >= 0; i--) {
 						if (accessDetails.isDontReturnResourceAtIndex(i)) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/StorageInterceptorHooksFacade.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/StorageInterceptorHooksFacade.java
@@ -53,14 +53,17 @@ public class StorageInterceptorHooksFacade {
 			SearchParameterMap theParams,
 			Search search,
 			RequestPartitionId theRequestPartitionId) {
-		HookParams params = new HookParams()
-				.add(ICachedSearchDetails.class, search)
-				.add(RequestDetails.class, theRequestDetails)
-				.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
-				.add(SearchParameterMap.class, theParams)
-				.add(RequestPartitionId.class, theRequestPartitionId);
-		CompositeInterceptorBroadcaster.doCallHooks(
-				myInterceptorBroadcaster, theRequestDetails, Pointcut.STORAGE_PRESEARCH_REGISTERED, params);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESEARCH_REGISTERED)) {
+			HookParams params = new HookParams()
+					.add(ICachedSearchDetails.class, search)
+					.add(RequestDetails.class, theRequestDetails)
+					.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
+					.add(SearchParameterMap.class, theParams)
+					.add(RequestPartitionId.class, theRequestPartitionId);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESEARCH_REGISTERED, params);
+		}
 	}
 	// private IInterceptorBroadcaster myInterceptorBroadcaster;
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceLinkPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceLinkPredicateBuilder.java
@@ -407,12 +407,16 @@ public class ResourceLinkPredicateBuilder extends BaseJoiningPredicateBuilder im
 		}
 		String message = builder.toString();
 		StorageProcessingMessage msg = new StorageProcessingMessage().setMessage(message);
-		HookParams params = new HookParams()
-				.add(RequestDetails.class, theRequest)
-				.addIfMatchesType(ServletRequestDetails.class, theRequest)
-				.add(StorageProcessingMessage.class, msg);
-		CompositeInterceptorBroadcaster.doCallHooks(
-				myInterceptorBroadcaster, theRequest, Pointcut.JPA_PERFTRACE_WARNING, params);
+
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_WARNING)) {
+			HookParams params = new HookParams()
+					.add(RequestDetails.class, theRequest)
+					.addIfMatchesType(ServletRequestDetails.class, theRequest)
+					.add(StorageProcessingMessage.class, msg);
+			compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_WARNING, params);
+		}
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/UriPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/UriPredicateBuilder.java
@@ -109,15 +109,18 @@ public class UriPredicateBuilder extends BaseSearchParamPredicateBuilder {
 							+ "] param[" + theParamName + "]";
 					ourLog.info(msg);
 
-					StorageProcessingMessage message = new StorageProcessingMessage();
-					ourLog.warn(msg);
-					message.setMessage(msg);
-					HookParams params = new HookParams()
-							.add(RequestDetails.class, theRequestDetails)
-							.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
-							.add(StorageProcessingMessage.class, message);
-					CompositeInterceptorBroadcaster.doCallHooks(
-							myInterceptorBroadcaster, theRequestDetails, Pointcut.JPA_PERFTRACE_WARNING, params);
+					IInterceptorBroadcaster compositeBroadcaster =
+							CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+									myInterceptorBroadcaster, theRequestDetails);
+					if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_WARNING)) {
+						StorageProcessingMessage message = new StorageProcessingMessage();
+						message.setMessage(msg);
+						HookParams params = new HookParams()
+								.add(RequestDetails.class, theRequestDetails)
+								.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
+								.add(StorageProcessingMessage.class, message);
+						compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_WARNING, params);
+					}
 
 					long hashIdentity = BaseResourceIndexedSearchParam.calculateHashIdentity(
 							getPartitionSettings(), getRequestPartitionId(), getResourceType(), theParamName);

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionMatcherInterceptor.java
@@ -118,12 +118,15 @@ public class SubscriptionMatcherInterceptor {
 		ResourceModifiedMessage msg = createResourceModifiedMessage(theNewResource, theOperationType, theRequest);
 
 		// Interceptor call: SUBSCRIPTION_RESOURCE_MODIFIED
-		HookParams params = new HookParams().add(ResourceModifiedMessage.class, msg);
-		boolean outcome = CompositeInterceptorBroadcaster.doCallHooks(
-				myInterceptorBroadcaster, theRequest, Pointcut.SUBSCRIPTION_RESOURCE_MODIFIED, params);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.SUBSCRIPTION_RESOURCE_MODIFIED)) {
+			HookParams params = new HookParams().add(ResourceModifiedMessage.class, msg);
+			boolean outcome = compositeBroadcaster.callHooks(Pointcut.SUBSCRIPTION_RESOURCE_MODIFIED, params);
 
-		if (!outcome) {
-			return;
+			if (!outcome) {
+				return;
+			}
 		}
 
 		processResourceModifiedMessage(msg);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/SystemRequestDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/SystemRequestDetails.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Objects.nonNull;
@@ -240,6 +241,11 @@ public class SystemRequestDetails extends RequestDetails {
 		@Override
 		public boolean hasHooks(Pointcut thePointcut) {
 			return false;
+		}
+
+		@Override
+		public List<IInvoker> getInvokersForPointcut(Pointcut thePointcut) {
+			return Collections.emptyList();
 		}
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ServerInterceptorUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ServerInterceptorUtil.java
@@ -54,17 +54,20 @@ public class ServerInterceptorUtil {
 		// Interceptor call: STORAGE_PRESHOW_RESOURCE
 		// This can be used to remove results from the search result details before
 		// the user has a chance to know that they were in the results
-		if (retVal.size() > 0) {
-			SimplePreResourceShowDetails accessDetails = new SimplePreResourceShowDetails(retVal);
-			HookParams params = new HookParams()
-					.add(IPreResourceShowDetails.class, accessDetails)
-					.add(RequestDetails.class, theRequest)
-					.addIfMatchesType(ServletRequestDetails.class, theRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					theInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PRESHOW_RESOURCES, params);
+		if (!retVal.isEmpty()) {
+			IInterceptorBroadcaster compositeBroadcaster =
+					CompositeInterceptorBroadcaster.newCompositeBroadcaster(theInterceptorBroadcaster, theRequest);
+			if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
+				SimplePreResourceShowDetails accessDetails = new SimplePreResourceShowDetails(retVal);
+				HookParams params = new HookParams()
+						.add(IPreResourceShowDetails.class, accessDetails)
+						.add(RequestDetails.class, theRequest)
+						.addIfMatchesType(ServletRequestDetails.class, theRequest);
+				theInterceptorBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
 
-			retVal = accessDetails.toList();
-			retVal.removeIf(Objects::isNull);
+				retVal = accessDetails.toList();
+				retVal.removeIf(Objects::isNull);
+			}
 		}
 
 		return retVal;

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/CompositeInterceptorBroadcaster.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/CompositeInterceptorBroadcaster.java
@@ -19,97 +19,97 @@
  */
 package ca.uhn.fhir.rest.server.util;
 
+import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.executor.BaseInterceptorService;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
-public class CompositeInterceptorBroadcaster {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * This is an {@link IInterceptorBroadcaster} which combines multiple interceptor
+ * broadcasters. Hook methods are called across all broadcasters, respecting
+ * the {@link Hook#order()} across all broadcasters.
+ */
+public class CompositeInterceptorBroadcaster implements IInterceptorBroadcaster {
+
+	private final Collection<IInterceptorBroadcaster> myServices;
 
 	/**
-	 * Non instantiable
+	 * Constructor
 	 */
-	private CompositeInterceptorBroadcaster() {
-		// nothing
+	private CompositeInterceptorBroadcaster(Collection<IInterceptorBroadcaster> theServices) {
+		myServices = theServices;
+	}
+
+	@Override
+	public boolean callHooks(Pointcut thePointcut, HookParams theParams) {
+		assert BaseInterceptorService.haveAppropriateParams(thePointcut, theParams);
+		assert thePointcut.getReturnType() == void.class
+				|| thePointcut.getReturnType() == BaseInterceptorService.BOOLEAN_RETURN_TYPE;
+
+		List<IInvoker> invokers = getInvokersForPointcut(thePointcut);
+		Object retVal = BaseInterceptorService.callInvokers(thePointcut, theParams, invokers);
+		return (Boolean) retVal;
+	}
+
+	@Override
+	public Object callHooksAndReturnObject(Pointcut thePointcut, HookParams theParams) {
+		assert BaseInterceptorService.haveAppropriateParams(thePointcut, theParams);
+		assert thePointcut.getReturnType() != void.class;
+
+		List<IInvoker> invokers = getInvokersForPointcut(thePointcut);
+		return BaseInterceptorService.callInvokers(thePointcut, theParams, invokers);
+	}
+
+	@Override
+	@Nonnull
+	public List<IInvoker> getInvokersForPointcut(Pointcut thePointcut) {
+		List<IInvoker> invokers = new ArrayList<>();
+		for (IInterceptorBroadcaster services : myServices) {
+			List<IInvoker> serviceInvokers = services.getInvokersForPointcut(thePointcut);
+			invokers.addAll(serviceInvokers);
+		}
+		invokers.sort(Comparator.naturalOrder());
+		return invokers;
+	}
+
+	@Override
+	public boolean hasHooks(Pointcut thePointcut) {
+		for (IInterceptorBroadcaster service : myServices) {
+			if (service.hasHooks(thePointcut)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
-	 * Broadcast hooks to both the interceptor service associated with the request, as well
-	 * as the one associated with the JPA module.
+	 * @since 8.0.0
 	 */
-	public static boolean doCallHooks(
-			IInterceptorBroadcaster theInterceptorBroadcaster,
-			@Nullable RequestDetails theRequestDetails,
-			Pointcut thePointcut,
-			HookParams theParams) {
-		return newCompositeBroadcaster(theInterceptorBroadcaster, theRequestDetails)
-				.callHooks(thePointcut, theParams);
-	}
-
-	/**
-	 * Broadcast hooks to both the interceptor service associated with the request, as well
-	 * as the one associated with the JPA module.
-	 */
-	public static Object doCallHooksAndReturnObject(
-			IInterceptorBroadcaster theInterceptorBroadcaster,
-			RequestDetails theRequestDetails,
-			Pointcut thePointcut,
-			HookParams theParams) {
-		return newCompositeBroadcaster(theInterceptorBroadcaster, theRequestDetails)
-				.callHooksAndReturnObject(thePointcut, theParams);
-	}
-
-	// TODO: JA - Refactor to make thePointcut the last argument in order to be consistent with thr other methods here
-	public static boolean hasHooks(
-			Pointcut thePointcut, IInterceptorBroadcaster theInterceptorBroadcaster, RequestDetails theRequestDetails) {
-		return newCompositeBroadcaster(theInterceptorBroadcaster, theRequestDetails)
-				.hasHooks(thePointcut);
+	public static IInterceptorBroadcaster newCompositeBroadcaster(Collection<IInterceptorBroadcaster> theServices) {
+		return new CompositeInterceptorBroadcaster(theServices);
 	}
 
 	/**
 	 * @since 5.5.0
 	 */
 	public static IInterceptorBroadcaster newCompositeBroadcaster(
-			IInterceptorBroadcaster theInterceptorBroadcaster, RequestDetails theRequestDetails) {
-		return new IInterceptorBroadcaster() {
-			@Override
-			public boolean callHooks(Pointcut thePointcut, HookParams theParams) {
-				boolean retVal = true;
-				if (theInterceptorBroadcaster != null) {
-					retVal = theInterceptorBroadcaster.callHooks(thePointcut, theParams);
-				}
-				if (theRequestDetails != null && theRequestDetails.getInterceptorBroadcaster() != null && retVal) {
-					IInterceptorBroadcaster interceptorBroadcaster = theRequestDetails.getInterceptorBroadcaster();
-					interceptorBroadcaster.callHooks(thePointcut, theParams);
-				}
-				return retVal;
+			@Nonnull IInterceptorBroadcaster theInterceptorBroadcaster, @Nullable RequestDetails theRequestDetails) {
+		if (theRequestDetails != null) {
+			IInterceptorBroadcaster requestBroadcaster = theRequestDetails.getInterceptorBroadcaster();
+			if (requestBroadcaster != null) {
+				return new CompositeInterceptorBroadcaster(List.of(theInterceptorBroadcaster, requestBroadcaster));
 			}
+		}
 
-			@Override
-			public Object callHooksAndReturnObject(Pointcut thePointcut, HookParams theParams) {
-				Object retVal = true;
-				if (theInterceptorBroadcaster != null) {
-					retVal = theInterceptorBroadcaster.callHooksAndReturnObject(thePointcut, theParams);
-				}
-				if (theRequestDetails != null
-						&& theRequestDetails.getInterceptorBroadcaster() != null
-						&& retVal == null) {
-					IInterceptorBroadcaster interceptorBroadcaster = theRequestDetails.getInterceptorBroadcaster();
-					retVal = interceptorBroadcaster.callHooksAndReturnObject(thePointcut, theParams);
-				}
-				return retVal;
-			}
-
-			@Override
-			public boolean hasHooks(Pointcut thePointcut) {
-				if (theInterceptorBroadcaster != null && theInterceptorBroadcaster.hasHooks(thePointcut)) {
-					return true;
-				}
-				return theRequestDetails != null
-						&& theRequestDetails.getInterceptorBroadcaster() != null
-						&& theRequestDetails.getInterceptorBroadcaster().hasHooks(thePointcut);
-			}
-		};
+		return new CompositeInterceptorBroadcaster(List.of(theInterceptorBroadcaster));
 	}
 }

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/util/CompositeInterceptorBroadcasterTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/util/CompositeInterceptorBroadcasterTest.java
@@ -1,0 +1,114 @@
+package ca.uhn.fhir.rest.server.util;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.HookParams;
+import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.executor.InterceptorService;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompositeInterceptorBroadcasterTest {
+
+	private List<Integer> myOrders = new ArrayList<>();
+
+	@ParameterizedTest
+	@CsvSource({
+		"0, 1, 2",
+		"1, 0, 2",
+		"2, 0, 1"
+	})
+	public void testCompositeBroadcasterBroadcastsInOrder(int theIndex0, int theIndex1, int theIndex2) {
+		// Setup
+		InterceptorService svc0 = new InterceptorService();
+		svc0.registerInterceptor(new Interceptor0());
+		InterceptorService svc1 = new InterceptorService();
+		svc1.registerInterceptor(new Interceptor1());
+		InterceptorService svc2 = new InterceptorService();
+		svc2.registerInterceptor(new Interceptor2());
+		InterceptorService[] services = new InterceptorService[] {svc0, svc1, svc2};
+
+		List<IInterceptorBroadcaster> serviceList = List.of(
+			services[theIndex0], services[theIndex1], services[theIndex2]
+		);
+		IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(serviceList);
+
+		assertTrue(compositeBroadcaster.hasHooks(Pointcut.TEST_RO));
+		assertFalse(compositeBroadcaster.hasHooks(Pointcut.TEST_RB));
+
+		// Test
+		HookParams hookParams = new HookParams()
+			.add(String.class, "PARAM_A")
+			.add(String.class, "PARAM_B");
+		Object outcome = compositeBroadcaster.callHooksAndReturnObject(Pointcut.TEST_RO, hookParams);
+
+		// Verify
+		assertNull(outcome);
+		assertThat(myOrders).asList().containsExactly(
+			-2, -1, 0, 1, 2, 3
+		);
+	}
+
+
+	@Interceptor
+	private class Interceptor0 {
+
+		@Hook(value=Pointcut.TEST_RO, order = 0)
+		public BaseServerResponseException hook0() {
+			myOrders.add(0);
+			return null;
+		}
+
+		@Hook(value=Pointcut.TEST_RO, order = 2)
+		public BaseServerResponseException hook2() {
+			myOrders.add(2);
+			return null;
+		}
+
+	}
+
+	@Interceptor
+	private class Interceptor1 {
+
+		@Hook(value=Pointcut.TEST_RO, order = 1)
+		public BaseServerResponseException hook1() {
+			myOrders.add(1);
+			return null;
+		}
+
+		@Hook(value=Pointcut.TEST_RO, order = 3)
+		public BaseServerResponseException hook3() {
+			myOrders.add(3);
+			return null;
+		}
+
+	}
+
+	@Interceptor
+	private class Interceptor2 {
+
+		@Hook(value=Pointcut.TEST_RO, order = -1)
+		public BaseServerResponseException hookMinus1() {
+			myOrders.add(-1);
+			return null;
+		}
+
+		@Hook(value=Pointcut.TEST_RO, order = -2)
+		public BaseServerResponseException hookMinus2() {
+			myOrders.add(-2);
+			return null;
+		}
+
+	}
+
+}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -173,15 +173,15 @@ public class BulkDataExportProvider {
 		expandParameters(theRequestDetails, theOptions);
 
 		// permission check
-		HookParams initiateBulkExportHookParams = (new HookParams())
-				.add(BulkExportJobParameters.class, theOptions)
-				.add(RequestDetails.class, theRequestDetails)
-				.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
-		CompositeInterceptorBroadcaster.doCallHooks(
-				this.myInterceptorBroadcaster,
-				theRequestDetails,
-				Pointcut.STORAGE_INITIATE_BULK_EXPORT,
-				initiateBulkExportHookParams);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_INITIATE_BULK_EXPORT)) {
+			HookParams initiateBulkExportHookParams = (new HookParams())
+					.add(BulkExportJobParameters.class, theOptions)
+					.add(RequestDetails.class, theRequestDetails)
+					.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_INITIATE_BULK_EXPORT, initiateBulkExportHookParams);
+		}
 
 		// get cache boolean
 		boolean useCache = shouldUseCache(theRequestDetails);
@@ -220,15 +220,15 @@ public class BulkDataExportProvider {
 		theOptions.setPartitionId(partitionId);
 
 		// call hook so any other parameter manipulation can be done
-		HookParams preInitiateBulkExportHookParams = new HookParams();
-		preInitiateBulkExportHookParams.add(BulkExportJobParameters.class, theOptions);
-		preInitiateBulkExportHookParams.add(RequestDetails.class, theRequestDetails);
-		preInitiateBulkExportHookParams.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
-		CompositeInterceptorBroadcaster.doCallHooks(
-				myInterceptorBroadcaster,
-				theRequestDetails,
-				Pointcut.STORAGE_PRE_INITIATE_BULK_EXPORT,
-				preInitiateBulkExportHookParams);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRE_INITIATE_BULK_EXPORT)) {
+			HookParams preInitiateBulkExportHookParams = new HookParams();
+			preInitiateBulkExportHookParams.add(BulkExportJobParameters.class, theOptions);
+			preInitiateBulkExportHookParams.add(RequestDetails.class, theRequestDetails);
+			preInitiateBulkExportHookParams.addIfMatchesType(ServletRequestDetails.class, theRequestDetails);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_PRE_INITIATE_BULK_EXPORT, preInitiateBulkExportHookParams);
+		}
 	}
 
 	private boolean shouldUseCache(ServletRequestDetails theRequestDetails) {

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/expunge/DeleteExpungeJobSubmitterImpl.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/expunge/DeleteExpungeJobSubmitterImpl.java
@@ -78,13 +78,16 @@ public class DeleteExpungeJobSubmitterImpl implements IDeleteExpungeJobSubmitter
 					Msg.code(820) + "Delete Expunge not allowed:  " + myStorageSettings.cannotDeleteExpungeReason());
 		}
 
-		for (String url : theUrlsToDeleteExpunge) {
-			HookParams params = new HookParams()
-					.add(RequestDetails.class, theRequestDetails)
-					.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
-					.add(String.class, url);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequestDetails, Pointcut.STORAGE_PRE_DELETE_EXPUNGE, params);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRE_DELETE_EXPUNGE)) {
+			for (String url : theUrlsToDeleteExpunge) {
+				HookParams params = new HookParams()
+						.add(RequestDetails.class, theRequestDetails)
+						.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
+						.add(String.class, url);
+				compositeBroadcaster.callHooks(Pointcut.STORAGE_PRE_DELETE_EXPUNGE, params);
+			}
 		}
 
 		DeleteExpungeJobParameters deleteExpungeJobParameters = new DeleteExpungeJobParameters();

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
@@ -274,12 +274,15 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 	 * @return A string, which will be used to prefix the blob ID. May be null.
 	 */
 	private String invokeAssignBinaryContentPrefix(RequestDetails theRequest, IBaseResource theResource) {
-		// TODO: to be removed when pointcut STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX has exceeded the grace period
-		boolean hasStorageBinaryAssignBlobIdPrefixHooks = CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX, myInterceptorBroadcaster, theRequest);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
 
-		boolean hasStorageBinaryAssignBinaryContentIdPrefixHooks = CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_BINARY_ASSIGN_BINARY_CONTENT_ID_PREFIX, myInterceptorBroadcaster, theRequest);
+		// TODO: to be removed when pointcut STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX has exceeded the grace period
+		boolean hasStorageBinaryAssignBlobIdPrefixHooks =
+				compositeBroadcaster.hasHooks(Pointcut.STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX);
+
+		boolean hasStorageBinaryAssignBinaryContentIdPrefixHooks =
+				compositeBroadcaster.hasHooks(Pointcut.STORAGE_BINARY_ASSIGN_BINARY_CONTENT_ID_PREFIX);
 
 		if (!(hasStorageBinaryAssignBlobIdPrefixHooks || hasStorageBinaryAssignBinaryContentIdPrefixHooks)) {
 			return null;
@@ -297,8 +300,7 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 			pointcutToInvoke = Pointcut.STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX;
 		}
 
-		return (String) CompositeInterceptorBroadcaster.doCallHooksAndReturnObject(
-				myInterceptorBroadcaster, theRequest, pointcutToInvoke, params);
+		return (String) compositeBroadcaster.callHooksAndReturnObject(pointcutToInvoke, params);
 	}
 
 	@Nonnull

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/svc/BaseBinaryStorageSvcImpl.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/svc/BaseBinaryStorageSvcImpl.java
@@ -174,13 +174,16 @@ public abstract class BaseBinaryStorageSvcImpl implements IBinaryStorageSvc {
 	@Nullable
 	private String callBinaryContentIdPointcut(
 			byte[] theBytes, RequestDetails theRequestDetails, String theContentType) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+
 		// TODO: to be removed when pointcut STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX has exceeded the grace period.
 		// Deprecated in 7.2.0.
-		boolean hasStorageBinaryAssignBlobIdPrefixHooks = CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX, myInterceptorBroadcaster, theRequestDetails);
+		boolean hasStorageBinaryAssignBlobIdPrefixHooks =
+				compositeBroadcaster.hasHooks(Pointcut.STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX);
 
-		boolean hasStorageBinaryAssignBinaryContentIdPrefixHooks = CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_BINARY_ASSIGN_BINARY_CONTENT_ID_PREFIX, myInterceptorBroadcaster, theRequestDetails);
+		boolean hasStorageBinaryAssignBinaryContentIdPrefixHooks =
+				compositeBroadcaster.hasHooks(Pointcut.STORAGE_BINARY_ASSIGN_BINARY_CONTENT_ID_PREFIX);
 
 		if (!(hasStorageBinaryAssignBlobIdPrefixHooks || hasStorageBinaryAssignBinaryContentIdPrefixHooks)) {
 			return null;
@@ -201,8 +204,7 @@ public abstract class BaseBinaryStorageSvcImpl implements IBinaryStorageSvc {
 			pointcutToInvoke = Pointcut.STORAGE_BINARY_ASSIGN_BLOB_ID_PREFIX;
 		}
 
-		return (String) CompositeInterceptorBroadcaster.doCallHooksAndReturnObject(
-				myInterceptorBroadcaster, theRequestDetails, pointcutToInvoke, hookParams);
+		return (String) compositeBroadcaster.callHooksAndReturnObject(pointcutToInvoke, hookParams);
 	}
 
 	@Override

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseStorageDao.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseStorageDao.java
@@ -335,14 +335,14 @@ public abstract class BaseStorageDao {
 		// Interceptor broadcast: STORAGE_PREACCESS_RESOURCES
 		if (outcome.getResource() != null) {
 			SimplePreResourceAccessDetails accessDetails = new SimplePreResourceAccessDetails(outcome.getResource());
-			IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+			IInterceptorBroadcaster compositeBroadcaster =
+					CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
 			if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
 				HookParams params = new HookParams()
-					.add(IPreResourceAccessDetails.class, accessDetails)
-					.add(RequestDetails.class, theRequest)
-					.addIfMatchesType(ServletRequestDetails.class, theRequest);
-				compositeBroadcaster.callHooks(
-					Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+						.add(IPreResourceAccessDetails.class, accessDetails)
+						.add(RequestDetails.class, theRequest)
+						.addIfMatchesType(ServletRequestDetails.class, theRequest);
+				compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
 				if (accessDetails.isDontReturnResourceAtIndex(0)) {
 					outcome.setResource(null);
 				}
@@ -355,13 +355,14 @@ public abstract class BaseStorageDao {
 		// outcome.fireResourceViewCallback())
 		outcome.registerResourceViewCallback(() -> {
 			if (outcome.getResource() != null) {
-				IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+				IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+						getInterceptorBroadcaster(), theRequest);
 				if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
 					SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(outcome.getResource());
 					HookParams params = new HookParams()
-						.add(IPreResourceShowDetails.class, showDetails)
-						.add(RequestDetails.class, theRequest)
-						.addIfMatchesType(ServletRequestDetails.class, theRequest);
+							.add(IPreResourceShowDetails.class, showDetails)
+							.add(RequestDetails.class, theRequest)
+							.addIfMatchesType(ServletRequestDetails.class, theRequest);
 					compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
 					outcome.setResource(showDetails.getResource(0));
 				}
@@ -383,14 +384,15 @@ public abstract class BaseStorageDao {
 		outcome.setEntitySupplierUseCallback(() -> {
 			// Interceptor broadcast: STORAGE_PREACCESS_RESOURCES
 			if (outcome.getResource() != null) {
-				IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+				IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+						getInterceptorBroadcaster(), theRequest);
 				if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
 					SimplePreResourceAccessDetails accessDetails =
-						new SimplePreResourceAccessDetails(outcome.getResource());
+							new SimplePreResourceAccessDetails(outcome.getResource());
 					HookParams params = new HookParams()
-						.add(IPreResourceAccessDetails.class, accessDetails)
-						.add(RequestDetails.class, theRequest)
-						.addIfMatchesType(ServletRequestDetails.class, theRequest);
+							.add(IPreResourceAccessDetails.class, accessDetails)
+							.add(RequestDetails.class, theRequest)
+							.addIfMatchesType(ServletRequestDetails.class, theRequest);
 					compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
 					if (accessDetails.isDontReturnResourceAtIndex(0)) {
 						outcome.setResource(null);
@@ -404,13 +406,16 @@ public abstract class BaseStorageDao {
 			// outcome.fireResourceViewCallback())
 			outcome.registerResourceViewCallback(() -> {
 				if (outcome.getResource() != null) {
-					IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+					IInterceptorBroadcaster compositeBroadcaster =
+							CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+									getInterceptorBroadcaster(), theRequest);
 					if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
-						SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(outcome.getResource());
+						SimplePreResourceShowDetails showDetails =
+								new SimplePreResourceShowDetails(outcome.getResource());
 						HookParams params = new HookParams()
-							.add(IPreResourceShowDetails.class, showDetails)
-							.add(RequestDetails.class, theRequest)
-							.addIfMatchesType(ServletRequestDetails.class, theRequest);
+								.add(IPreResourceShowDetails.class, showDetails)
+								.add(RequestDetails.class, theRequest)
+								.addIfMatchesType(ServletRequestDetails.class, theRequest);
 						compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
 						outcome.setResource(showDetails.getResource(0));
 					}
@@ -429,7 +434,8 @@ public abstract class BaseStorageDao {
 		if (theTransactionDetails.isAcceptingDeferredInterceptorBroadcasts(thePointcut)) {
 			theTransactionDetails.addDeferredInterceptorBroadcast(thePointcut, theParams);
 		} else {
-			IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequestDetails);
+			IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+					getInterceptorBroadcaster(), theRequestDetails);
 			compositeBroadcaster.callHooks(thePointcut, theParams);
 		}
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseStorageDao.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseStorageDao.java
@@ -335,14 +335,17 @@ public abstract class BaseStorageDao {
 		// Interceptor broadcast: STORAGE_PREACCESS_RESOURCES
 		if (outcome.getResource() != null) {
 			SimplePreResourceAccessDetails accessDetails = new SimplePreResourceAccessDetails(outcome.getResource());
-			HookParams params = new HookParams()
+			IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+			if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
+				HookParams params = new HookParams()
 					.add(IPreResourceAccessDetails.class, accessDetails)
 					.add(RequestDetails.class, theRequest)
 					.addIfMatchesType(ServletRequestDetails.class, theRequest);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					getInterceptorBroadcaster(), theRequest, Pointcut.STORAGE_PREACCESS_RESOURCES, params);
-			if (accessDetails.isDontReturnResourceAtIndex(0)) {
-				outcome.setResource(null);
+				compositeBroadcaster.callHooks(
+					Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+				if (accessDetails.isDontReturnResourceAtIndex(0)) {
+					outcome.setResource(null);
+				}
 			}
 		}
 
@@ -352,14 +355,16 @@ public abstract class BaseStorageDao {
 		// outcome.fireResourceViewCallback())
 		outcome.registerResourceViewCallback(() -> {
 			if (outcome.getResource() != null) {
-				SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(outcome.getResource());
-				HookParams params = new HookParams()
+				IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+				if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
+					SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(outcome.getResource());
+					HookParams params = new HookParams()
 						.add(IPreResourceShowDetails.class, showDetails)
 						.add(RequestDetails.class, theRequest)
 						.addIfMatchesType(ServletRequestDetails.class, theRequest);
-				CompositeInterceptorBroadcaster.doCallHooks(
-						getInterceptorBroadcaster(), theRequest, Pointcut.STORAGE_PRESHOW_RESOURCES, params);
-				outcome.setResource(showDetails.getResource(0));
+					compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
+					outcome.setResource(showDetails.getResource(0));
+				}
 			}
 		});
 
@@ -378,16 +383,18 @@ public abstract class BaseStorageDao {
 		outcome.setEntitySupplierUseCallback(() -> {
 			// Interceptor broadcast: STORAGE_PREACCESS_RESOURCES
 			if (outcome.getResource() != null) {
-				SimplePreResourceAccessDetails accessDetails =
+				IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+				if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PREACCESS_RESOURCES)) {
+					SimplePreResourceAccessDetails accessDetails =
 						new SimplePreResourceAccessDetails(outcome.getResource());
-				HookParams params = new HookParams()
+					HookParams params = new HookParams()
 						.add(IPreResourceAccessDetails.class, accessDetails)
 						.add(RequestDetails.class, theRequest)
 						.addIfMatchesType(ServletRequestDetails.class, theRequest);
-				CompositeInterceptorBroadcaster.doCallHooks(
-						getInterceptorBroadcaster(), theRequest, Pointcut.STORAGE_PREACCESS_RESOURCES, params);
-				if (accessDetails.isDontReturnResourceAtIndex(0)) {
-					outcome.setResource(null);
+					compositeBroadcaster.callHooks(Pointcut.STORAGE_PREACCESS_RESOURCES, params);
+					if (accessDetails.isDontReturnResourceAtIndex(0)) {
+						outcome.setResource(null);
+					}
 				}
 			}
 
@@ -397,14 +404,16 @@ public abstract class BaseStorageDao {
 			// outcome.fireResourceViewCallback())
 			outcome.registerResourceViewCallback(() -> {
 				if (outcome.getResource() != null) {
-					SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(outcome.getResource());
-					HookParams params = new HookParams()
+					IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequest);
+					if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
+						SimplePreResourceShowDetails showDetails = new SimplePreResourceShowDetails(outcome.getResource());
+						HookParams params = new HookParams()
 							.add(IPreResourceShowDetails.class, showDetails)
 							.add(RequestDetails.class, theRequest)
 							.addIfMatchesType(ServletRequestDetails.class, theRequest);
-					CompositeInterceptorBroadcaster.doCallHooks(
-							getInterceptorBroadcaster(), theRequest, Pointcut.STORAGE_PRESHOW_RESOURCES, params);
-					outcome.setResource(showDetails.getResource(0));
+						compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
+						outcome.setResource(showDetails.getResource(0));
+					}
 				}
 			});
 		});
@@ -420,8 +429,8 @@ public abstract class BaseStorageDao {
 		if (theTransactionDetails.isAcceptingDeferredInterceptorBroadcasts(thePointcut)) {
 			theTransactionDetails.addDeferredInterceptorBroadcast(thePointcut, theParams);
 		} else {
-			CompositeInterceptorBroadcaster.doCallHooks(
-					getInterceptorBroadcaster(), theRequestDetails, thePointcut, theParams);
+			IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(getInterceptorBroadcaster(), theRequestDetails);
+			compositeBroadcaster.callHooks(thePointcut, theParams);
 		}
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -359,14 +359,14 @@ public abstract class BaseTransactionProcessor {
 		try {
 
 			// Interceptor call: STORAGE_TRANSACTION_PROCESSING
-			if (CompositeInterceptorBroadcaster.hasHooks(
-					Pointcut.STORAGE_TRANSACTION_PROCESSING, myInterceptorBroadcaster, theRequestDetails)) {
+			IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+					myInterceptorBroadcaster, theRequestDetails);
+			if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_TRANSACTION_PROCESSING)) {
 				HookParams params = new HookParams()
 						.add(RequestDetails.class, theRequestDetails)
 						.addIfMatchesType(ServletRequestDetails.class, theRequest)
 						.add(IBaseBundle.class, theRequest);
-				CompositeInterceptorBroadcaster.doCallHooks(
-						myInterceptorBroadcaster, theRequestDetails, Pointcut.STORAGE_TRANSACTION_PROCESSING, params);
+				compositeBroadcaster.callHooks(Pointcut.STORAGE_TRANSACTION_PROCESSING, params);
 			}
 
 			return processTransaction(theRequestDetails, theRequest, theActionName, theNestedMode);
@@ -561,8 +561,9 @@ public abstract class BaseTransactionProcessor {
 				theRequestDetails, response, getEntries, originalRequestOrder, transactionStopWatch, theNestedMode);
 
 		// Interceptor broadcast: JPA_PERFTRACE_INFO
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.JPA_PERFTRACE_INFO, myInterceptorBroadcaster, theRequestDetails)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_INFO)) {
 			String taskDurations = transactionStopWatch.formatTaskDurations();
 			StorageProcessingMessage message = new StorageProcessingMessage();
 			message.setMessage("Transaction timing:\n" + taskDurations);
@@ -570,8 +571,7 @@ public abstract class BaseTransactionProcessor {
 					.add(RequestDetails.class, theRequestDetails)
 					.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
 					.add(StorageProcessingMessage.class, message);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequestDetails, Pointcut.JPA_PERFTRACE_INFO, params);
+			compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_INFO, params);
 		}
 
 		return response;
@@ -821,12 +821,10 @@ public abstract class BaseTransactionProcessor {
 	}
 
 	private boolean haveWriteOperationsHooks(RequestDetails theRequestDetails) {
-		return CompositeInterceptorBroadcaster.hasHooks(
-						Pointcut.STORAGE_TRANSACTION_WRITE_OPERATIONS_PRE, myInterceptorBroadcaster, theRequestDetails)
-				|| CompositeInterceptorBroadcaster.hasHooks(
-						Pointcut.STORAGE_TRANSACTION_WRITE_OPERATIONS_POST,
-						myInterceptorBroadcaster,
-						theRequestDetails);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		return compositeBroadcaster.hasHooks(Pointcut.STORAGE_TRANSACTION_WRITE_OPERATIONS_PRE)
+				|| compositeBroadcaster.hasHooks(Pointcut.STORAGE_TRANSACTION_WRITE_OPERATIONS_POST);
 	}
 
 	private void callWriteOperationsHook(
@@ -834,10 +832,14 @@ public abstract class BaseTransactionProcessor {
 			RequestDetails theRequestDetails,
 			TransactionDetails theTransactionDetails,
 			TransactionWriteOperationsDetails theWriteOperationsDetails) {
-		HookParams params = new HookParams()
-				.add(TransactionDetails.class, theTransactionDetails)
-				.add(TransactionWriteOperationsDetails.class, theWriteOperationsDetails);
-		CompositeInterceptorBroadcaster.doCallHooks(myInterceptorBroadcaster, theRequestDetails, thePointcut, params);
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequestDetails);
+		if (compositeBroadcaster.hasHooks(thePointcut)) {
+			HookParams params = new HookParams()
+					.add(TransactionDetails.class, theTransactionDetails)
+					.add(TransactionWriteOperationsDetails.class, theWriteOperationsDetails);
+			compositeBroadcaster.callHooks(thePointcut, params);
+		}
 	}
 
 	@SuppressWarnings("unchecked")
@@ -967,18 +969,16 @@ public abstract class BaseTransactionProcessor {
 									+ " as it contained a duplicate conditional " + verb;
 							ourLog.info(msg);
 							// Interceptor broadcast: JPA_PERFTRACE_INFO
-							if (CompositeInterceptorBroadcaster.hasHooks(
-									Pointcut.JPA_PERFTRACE_WARNING, myInterceptorBroadcaster, theRequestDetails)) {
+							IInterceptorBroadcaster compositeBroadcaster =
+									CompositeInterceptorBroadcaster.newCompositeBroadcaster(
+											myInterceptorBroadcaster, theRequestDetails);
+							if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_WARNING)) {
 								StorageProcessingMessage message = new StorageProcessingMessage().setMessage(msg);
 								HookParams params = new HookParams()
 										.add(RequestDetails.class, theRequestDetails)
 										.addIfMatchesType(ServletRequestDetails.class, theRequestDetails)
 										.add(StorageProcessingMessage.class, message);
-								CompositeInterceptorBroadcaster.doCallHooks(
-										myInterceptorBroadcaster,
-										theRequestDetails,
-										Pointcut.JPA_PERFTRACE_INFO,
-										params);
+								compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_INFO, params);
 							}
 
 							theEntries.remove(index);
@@ -1475,13 +1475,14 @@ public abstract class BaseTransactionProcessor {
 				}
 			}
 
+			IInterceptorBroadcaster compositeBroadcaster =
+					CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
 			ListMultimap<Pointcut, HookParams> deferredBroadcastEvents =
 					theTransactionDetails.endAcceptingDeferredInterceptorBroadcasts();
 			for (Map.Entry<Pointcut, HookParams> nextEntry : deferredBroadcastEvents.entries()) {
 				Pointcut nextPointcut = nextEntry.getKey();
 				HookParams nextParams = nextEntry.getValue();
-				CompositeInterceptorBroadcaster.doCallHooks(
-						myInterceptorBroadcaster, theRequest, nextPointcut, nextParams);
+				compositeBroadcaster.callHooks(nextPointcut, nextParams);
 			}
 
 			DeferredInterceptorBroadcasts deferredInterceptorBroadcasts =
@@ -1492,8 +1493,7 @@ public abstract class BaseTransactionProcessor {
 					.add(DeferredInterceptorBroadcasts.class, deferredInterceptorBroadcasts)
 					.add(TransactionDetails.class, theTransactionDetails)
 					.add(IBaseBundle.class, theResponse);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequest, Pointcut.STORAGE_TRANSACTION_PROCESSED, params);
+			compositeBroadcaster.callHooks(Pointcut.STORAGE_TRANSACTION_PROCESSED, params);
 
 			theTransactionDetails.deferredBroadcastProcessingFinished();
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlService.java
@@ -135,8 +135,9 @@ public class MatchResourceUrlService<T extends IResourcePersistentId> {
 		}
 
 		// Interceptor broadcast: STORAGE_PRESHOW_RESOURCES
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.STORAGE_PRESHOW_RESOURCES, myInterceptorBroadcaster, theRequest)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.STORAGE_PRESHOW_RESOURCES)) {
 			Map<IBaseResource, T> resourceToPidMap = new HashMap<>();
 
 			IFhirResourceDao<R> dao = getResourceDao(theResourceType);
@@ -152,8 +153,7 @@ public class MatchResourceUrlService<T extends IResourcePersistentId> {
 					.addIfMatchesType(ServletRequestDetails.class, theRequest);
 
 			try {
-				CompositeInterceptorBroadcaster.doCallHooks(
-						myInterceptorBroadcaster, theRequest, Pointcut.STORAGE_PRESHOW_RESOURCES, params);
+				compositeBroadcaster.callHooks(Pointcut.STORAGE_PRESHOW_RESOURCES, params);
 
 				retVal = accessDetails.toList().stream()
 						.map(resourceToPidMap::get)
@@ -222,16 +222,16 @@ public class MatchResourceUrlService<T extends IResourcePersistentId> {
 		List<T> retVal = dao.searchForIds(theParamMap, theRequest, theConditionalOperationTargetOrNull);
 
 		// Interceptor broadcast: JPA_PERFTRACE_INFO
-		if (CompositeInterceptorBroadcaster.hasHooks(
-				Pointcut.JPA_PERFTRACE_INFO, myInterceptorBroadcaster, theRequest)) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(myInterceptorBroadcaster, theRequest);
+		if (compositeBroadcaster.hasHooks(Pointcut.JPA_PERFTRACE_INFO)) {
 			StorageProcessingMessage message = new StorageProcessingMessage();
 			message.setMessage("Processed conditional resource URL with " + retVal.size() + " result(s) in " + sw);
 			HookParams params = new HookParams()
 					.add(RequestDetails.class, theRequest)
 					.addIfMatchesType(ServletRequestDetails.class, theRequest)
 					.add(StorageProcessingMessage.class, message);
-			CompositeInterceptorBroadcaster.doCallHooks(
-					myInterceptorBroadcaster, theRequest, Pointcut.JPA_PERFTRACE_INFO, params);
+			compositeBroadcaster.callHooks(Pointcut.JPA_PERFTRACE_INFO, params);
 		}
 
 		return new HashSet<>(retVal);


### PR DESCRIPTION
Interceptors can be defines against the registry on the RestfulServer, or on the registry in the JPA repository. Because these are separate registries, the `order()` attribute on the `Hook` annotation isn't correctly processed today across the two registries. This PR fixes that.