### PR TITLE
Start removing dependency from FhirVersionEnum to FhirContext

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
@@ -1296,6 +1296,14 @@ public class FhirContext {
 		return ourStaticContexts.computeIfAbsent(theFhirVersionEnum, v -> new FhirContext(v));
 	}
 
+	/**
+	 * An uncached version of forCached()
+	 * @return a new FhirContext for theFhirVersionEnum
+	 */
+	public static FhirContext forVersion(FhirVersionEnum theFhirVersionEnum) {
+		return new FhirContext(v);
+	}
+
 	private static Collection<Class<? extends IBaseResource>> toCollection(
 			Class<? extends IBaseResource> theResourceType) {
 		ArrayList<Class<? extends IBaseResource>> retVal = new ArrayList<>(1);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
@@ -1293,7 +1293,7 @@ public class FhirContext {
 	 * @since 5.1.0
 	 */
 	public static FhirContext forCached(FhirVersionEnum theFhirVersionEnum) {
-		return ourStaticContexts.computeIfAbsent(theFhirVersionEnum, v -> new FhirContext(v));
+		return ourStaticContexts.computeIfAbsent(theFhirVersionEnum, FhirContext::forVersion);
 	}
 
 	/**
@@ -1301,7 +1301,7 @@ public class FhirContext {
 	 * @return a new FhirContext for theFhirVersionEnum
 	 */
 	public static FhirContext forVersion(FhirVersionEnum theFhirVersionEnum) {
-		return new FhirContext(v);
+		return new FhirContext(theFhirVersionEnum);
 	}
 
 	private static Collection<Class<? extends IBaseResource>> toCollection(

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
@@ -135,15 +135,19 @@ public enum FhirVersionEnum {
 
 	/**
 	 * Creates a new FhirContext for this FHIR version
+	 * @deprecated since 7.7.  Use  {@link FhirContext#forVersion(FhirVersionEnum)} instead
 	 */
+	@Deprecated(forRemoval = true, since = "7.7")
 	public FhirContext newContext() {
-		return new FhirContext(this);
+		return FhirContext.forVersion(this);
 	}
 
 	/**
 	 * Creates a new FhirContext for this FHIR version, or returns a previously created one if one exists. This
 	 * method uses {@link FhirContext#forCached(FhirVersionEnum)} to return a cached instance.
+	 * @deprecated since 7.7.  Use  {@link FhirContext#forCached(FhirVersionEnum)} instead
 	 */
+	@Deprecated(forRemoval = true, since = "7.7")
 	public FhirContext newContextCached() {
 		return FhirContext.forCached(this);
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative2/NarrativeGeneratorTemplateUtils.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative2/NarrativeGeneratorTemplateUtils.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.narrative2;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.util.BundleUtil;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
@@ -42,7 +43,8 @@ public class NarrativeGeneratorTemplateUtils {
 	 * Given a Bundle as input, are any entries present with a given resource type
 	 */
 	public boolean bundleHasEntriesWithResourceType(IBaseBundle theBaseBundle, String theResourceType) {
-		FhirContext ctx = theBaseBundle.getStructureFhirVersionEnum().newContextCached();
+        FhirVersionEnum fhirVersionEnum = theBaseBundle.getStructureFhirVersionEnum();
+        FhirContext ctx = FhirContext.forCached(fhirVersionEnum);
 		List<Pair<String, IBaseResource>> entryResources =
 				BundleUtil.getBundleEntryUrlsAndResources(ctx, theBaseBundle);
 		return entryResources.stream()

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/BaseCommand.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/BaseCommand.java
@@ -668,7 +668,7 @@ public abstract class BaseCommand implements Comparable<BaseCommand> {
 
 	protected void parseFhirContext(CommandLine theCommandLine) throws ParseException {
 		FhirVersionEnum versionEnum = parseFhirVersion(theCommandLine);
-		myFhirCtx = versionEnum.newContext();
+        myFhirCtx = FhirContext.forVersion(versionEnum);
 	}
 
 	public abstract void run(CommandLine theCommandLine) throws ParseException, ExecutionException;

--- a/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
+++ b/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
@@ -98,7 +98,7 @@ public class VersionCanonicalizer {
 	private final FhirContext myContext;
 
 	public VersionCanonicalizer(FhirVersionEnum theTargetVersion) {
-		this(theTargetVersion.newContextCached());
+        this(FhirContext.forCached(theTargetVersion));
 	}
 
 	public VersionCanonicalizer(FhirContext theTargetContext) {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/mb-20241125-snip-fhir-context.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/mb-20241125-snip-fhir-context.yaml
@@ -1,0 +1,4 @@
+---
+type: remove
+issue: mb
+title: "The methods on FhirVersionEnum which produces a FhirContext (newContext() ,and newContextCached()) have been deprecated, and will be removed."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -686,7 +686,7 @@ public class RestfulServerUtils {
 		if (context.getVersion().getVersion() != theForVersion) {
 			context = myFhirContextMap.get(theForVersion);
 			if (context == null) {
-				context = theForVersion.newContext();
+				context = FhirContext.forVersion(theForVersion);
 				myFhirContextMap.put(theForVersion, context);
 			}
 		}

--- a/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/BaseController.java
+++ b/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/BaseController.java
@@ -297,7 +297,7 @@ public class BaseController {
 		FhirVersionEnum version = theRequest.getFhirVersion(myConfig);
 		VersionCanonicalizer retVal = myCanonicalizers.get(version);
 		if (retVal == null) {
-			retVal = new VersionCanonicalizer(version.newContext());
+			retVal = new VersionCanonicalizer(FhirContext.forVersion(version));
 			myCanonicalizers.put(version, retVal);
 		}
 		return retVal;


### PR DESCRIPTION
Our model classes use FhirVersionEnum, and the path from there to FhirContext brings in the whole world.
Snip this path to start disentangling the core libraries from hapi-fhir.
