### PR TITLE
fix: extensions in patient doesn't ensure orders

### DIFF
--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/validation/ResourceValidatorDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/validation/ResourceValidatorDstu2Test.java
@@ -298,7 +298,7 @@ public class ResourceValidatorDstu2Test {
 		ourLog.info(messageString);
 
 		//@formatter:off
-		assertThat(messageString).containsSubsequence(
+		assertThat(messageString).contains(
 			"meta",
 			"String Extension",
 			"Organization/2.25.79433498044103547197447759549862032393",
@@ -342,7 +342,7 @@ public class ResourceValidatorDstu2Test {
 		ourLog.info(messageString);
 
 		//@formatter:off
-		assertThat(messageString).containsSubsequence(
+		assertThat(messageString).contains(
 			"meta",
 			"Organization/2.25.79433498044103547197447759549862032393",
 			"furry-grey",

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu2016may/hapi/validation/ResourceValidatorDstu2_1Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu2016may/hapi/validation/ResourceValidatorDstu2_1Test.java
@@ -94,7 +94,7 @@ public class ResourceValidatorDstu2_1Test extends BaseValidationTestWithInlineMo
 		ourLog.info(messageString);
 
 		//@formatter:off
-		assertThat(messageString).containsSubsequence(
+		assertThat(messageString).contains(
 			"meta",
 			"Organization/2.25.79433498044103547197447759549862032393",
 			"furry-grey",
@@ -160,7 +160,7 @@ public class ResourceValidatorDstu2_1Test extends BaseValidationTestWithInlineMo
 		ourLog.info(messageString);
 
 		//@formatter:off
-		assertThat(messageString).containsSubsequence(
+		assertThat(messageString).contains(
 			"meta",
 			"String Extension",
 			"Organization/2.25.79433498044103547197447759549862032393",

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/ResourceValidatorDstu3Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/ResourceValidatorDstu3Test.java
@@ -412,7 +412,7 @@ public class ResourceValidatorDstu3Test extends BaseValidationTestWithInlineMock
 		String messageString = p.encodeResourceToString(myPatient);
 //		ourLog.info(messageString);
 
-		assertThat(messageString).containsSubsequence(
+		assertThat(messageString).contains(
 			"meta",
 			"String Extension",
 			"Organization/2.25.79433498044103547197447759549862032393",
@@ -457,7 +457,7 @@ public class ResourceValidatorDstu3Test extends BaseValidationTestWithInlineMock
 		ourLog.info(messageString);
 
 		//@formatter:off
-		assertThat(messageString).containsSubsequence(
+		assertThat(messageString).contains(
 			"meta",
 			"Organization/2.25.79433498044103547197447759549862032393",
 			"furry-grey",


### PR DESCRIPTION
### Issues
The methods testValidateWithExtensionsJson and testValidateWithExtensionsXml in ResourceValidatorDstu2_1Test and ResourceValidatorDstu3Test may encounter potential issues due to the usage of assertThat(messageString).containsSubsequence(). This assertion could fail in certain environments.

![090d6cb6b43555534530c0e4d00959f](https://github.com/user-attachments/assets/09f0bad8-6d06-495c-b443-c94c3dc152a0)


### Reason
The fields "Organization/2.25.79433498044103547197447759549862032393", "furry-grey", and "furry-white" are extension fields in PatientProfileDstu2_1. These fields do not have an explicit order annotation in PatientProfileDstu2_1. (like order=9)

![image](https://github.com/user-attachments/assets/4e01798e-cdf5-4a48-b222-2e3f7a0f2591)

In this context, BaseRuntimeElementCompositeDefinition relies on the default field order provided by getDeclaredFields. However, the order of fields returned by getDeclaredFields is not guaranteed and can vary between different JVM implementations.

Due to this, the test assertion using containsSubsequence is unable to reliably ensure the order of the fields, leading to potential inconsistencies.

![image](https://github.com/user-attachments/assets/bfc91bbc-ca5a-4e2f-b928-9a8e0acc95d1)

### Change
instead of introducing explicit order annotations for these fields, I have updated the test to use contains instead of containsSubsequence. Please let me know if further adjustments are needed. Thank you!