### PR TITLE
Concurrent batch reduction

### DIFF
--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2FinalizationConcurrencyIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2FinalizationConcurrencyIT.java
@@ -1,0 +1,93 @@
+package ca.uhn.fhir.jpa.batch2;
+
+import ca.uhn.fhir.batch2.api.ChunkExecutionDetails;
+import ca.uhn.fhir.batch2.api.IJobDataSink;
+import ca.uhn.fhir.batch2.api.IReductionStepWorker;
+import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
+import ca.uhn.fhir.batch2.api.RunOutcome;
+import ca.uhn.fhir.batch2.api.StepExecutionDetails;
+import ca.uhn.fhir.batch2.api.VoidModel;
+import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
+import ca.uhn.fhir.batch2.model.ChunkOutcome;
+import ca.uhn.fhir.batch2.model.JobDefinition;
+import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
+import ca.uhn.fhir.jpa.batch.models.Batch2JobStartResponse;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.jpa.test.Batch2JobHelper;
+import ca.uhn.hapi.fhir.batch2.test.support.TestJobParameters;
+import ca.uhn.hapi.fhir.batch2.test.support.TestJobStep2InputType;
+import ca.uhn.hapi.fhir.batch2.test.support.TestJobStep3InputType;
+import jakarta.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static ca.uhn.fhir.jpa.batch2.Batch2CoordinatorIT.FIRST_STEP_ID;
+import static ca.uhn.fhir.jpa.batch2.Batch2CoordinatorIT.LAST_STEP_ID;
+import static ca.uhn.fhir.jpa.batch2.Batch2CoordinatorIT.SECOND_STEP_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Batch2FinalizationConcurrencyIT extends BaseJpaR4Test {
+	private static final String CONCURRENT_FINAL_TEST = "CONCURRENT_FINAL_TEST";
+	@Autowired
+	JobDefinitionRegistry myJobDefinitionRegistry;
+	@Autowired
+	Batch2JobHelper myBatch2JobHelper;
+	private JobDefinition<TestJobParameters> myJobDefinition;
+
+	@BeforeEach
+	public void before() {
+		if (myJobDefinition == null) {
+			myJobDefinition = buildJobDefinition();
+			myJobDefinitionRegistry.addJobDefinition(myJobDefinition);
+		}
+	}
+
+	@Test
+	public void testTwoRuns() {
+		TestJobParameters params = new TestJobParameters();
+		params.setParam1("foo");
+		params.setParam1("bar");
+		JobInstanceStartRequest startRequest1 = new JobInstanceStartRequest(CONCURRENT_FINAL_TEST, params.setParam1("a").setParam2("100000"));
+		JobInstanceStartRequest startRequest2 = new JobInstanceStartRequest(CONCURRENT_FINAL_TEST, params.setParam1("b").setParam2("200000"));
+
+		Batch2JobStartResponse response1 = myJobCoordinator.startInstance(mySrd, startRequest1);
+		Batch2JobStartResponse response2 = myJobCoordinator.startInstance(mySrd, startRequest2);
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(CONCURRENT_FINAL_TEST);
+
+		TestReducer reductionStep = (TestReducer) myJobDefinition.getStepById(LAST_STEP_ID).getJobStepWorker();
+		assertThat(reductionStep.counter).hasValue(1);
+	}
+
+	private JobDefinition<TestJobParameters> buildJobDefinition() {
+		JobDefinition.Builder<TestJobParameters, ?> builder = JobDefinition.newBuilder()
+			.setJobDefinitionId(CONCURRENT_FINAL_TEST)
+			.setJobDefinitionVersion(1)
+			.gatedExecution()
+			.setJobDescription("A job description")
+			.setParametersType(TestJobParameters.class)
+			.addFirstStep(FIRST_STEP_ID, "the first step", TestJobStep2InputType.class, (theStepExecutionDetails, theDataSink) -> new RunOutcome(0))
+			.addIntermediateStep(SECOND_STEP_ID, "the second step", TestJobStep3InputType.class, (theStepExecutionDetails, theDataSink) -> new RunOutcome(0))
+			.addFinalReducerStep(LAST_STEP_ID, "reduction step", VoidModel.class, new TestReducer());
+		return builder.build();
+	}
+
+	private class TestReducer implements IReductionStepWorker<TestJobParameters, TestJobStep3InputType, VoidModel> {
+		AtomicInteger counter = new AtomicInteger();
+
+		@Nonnull
+		@Override
+		public ChunkOutcome consume(ChunkExecutionDetails<TestJobParameters, TestJobStep3InputType> theChunkDetails) {
+			return ChunkOutcome.SUCCESS();
+		}
+
+		@Nonnull
+		@Override
+		public RunOutcome run(@Nonnull StepExecutionDetails<TestJobParameters, TestJobStep3InputType> theStepExecutionDetails, @Nonnull IJobDataSink<VoidModel> theDataSink) throws JobExecutionFailedException {
+			counter.incrementAndGet();
+			return RunOutcome.SUCCESS;
+		}
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2FinalizationConcurrencyIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2FinalizationConcurrencyIT.java
@@ -63,7 +63,7 @@ public class Batch2FinalizationConcurrencyIT extends BaseJpaR4Test {
 			.setParametersType(TestJobParameters.class)
 			.addFirstStep(FIRST_STEP_ID, "the first step", TestJobStep2InputType.class, (theStepExecutionDetails, theDataSink) -> new RunOutcome(0))
 			.addIntermediateStep(SECOND_STEP_ID, "the second step", TestJobStep3InputType.class, (theStepExecutionDetails, theDataSink) -> new RunOutcome(0))
-			.addFinalReducerStep(LAST_STEP_ID, "reduction step", TestResults.class, new TestReducer());
+			.addFinalReducerStep(LAST_STEP_ID, "reduction step", TestResults.class, TestReducer::new);
 		return builder.build();
 	}
 

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportAppCtx.java
@@ -30,7 +30,6 @@ import ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters;
 import ca.uhn.fhir.util.Batch2JobDefinitionConstants;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 
 @Configuration
 public class BulkExportAppCtx {
@@ -69,7 +68,7 @@ public class BulkExportAppCtx {
 						CREATE_REPORT_STEP,
 						"Creates the output report from a bulk export job",
 						BulkExportJobResults.class,
-						createReportStep())
+					() -> new BulkExportCreateReportStep())
 				.build();
 
 		return def;
@@ -104,7 +103,7 @@ public class BulkExportAppCtx {
 						"create-report-step",
 						"Creates the output report from a bulk export job",
 						BulkExportJobResults.class,
-						createReportStep())
+					() -> new BulkExportCreateReportStep())
 				.build();
 
 		return def;
@@ -142,11 +141,5 @@ public class BulkExportAppCtx {
 	@Bean
 	public ExpandResourceAndWriteBinaryStep expandResourceAndWriteBinaryStep() {
 		return new ExpandResourceAndWriteBinaryStep();
-	}
-
-	@Bean
-	@Scope("prototype")
-	public BulkExportCreateReportStep createReportStep() {
-		return new BulkExportCreateReportStep();
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/termcodesystem/TermCodeSystemJobConfig.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/termcodesystem/TermCodeSystemJobConfig.java
@@ -51,15 +51,12 @@ public class TermCodeSystemJobConfig {
 	 */
 	public static final String TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME = "termCodeSystemVersionDeleteJob";
 
-	@Autowired
-	private ITermCodeSystemDeleteJobSvc myITermCodeSystemSvc;
-
 	/**
 	 * Delete code system version job.
 	 * Deletes only a specific code system version
 	 */
 	@Bean
-	public JobDefinition<TermCodeSystemDeleteVersionJobParameters> termCodeSystemVersionDeleteJobDefinition() {
+	public JobDefinition<TermCodeSystemDeleteVersionJobParameters> termCodeSystemVersionDeleteJobDefinition(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
 		return JobDefinition.newBuilder()
 				.setJobDefinitionId(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME)
 				.setJobDescription("Term code system version job delete")
@@ -71,13 +68,13 @@ public class TermCodeSystemJobConfig {
 						"DeleteCodeSystemVersionFirstStep",
 						"A first step for deleting code system versions; deletes the concepts for a provided code system version",
 						CodeSystemVersionPIDResult.class,
-						deleteCodeSystemVersionFirstStep())
+						deleteCodeSystemVersionFirstStep(theTermCodeSystemSvc))
 				.addLastStep(
 						"DeleteCodeSystemVersionFinalStep",
 						"Deletes the code system version",
-						deleteCodeSystemVersionFinalStep())
-				.completionHandler(deleteCodeSystemVersionCompletionHandler())
-				.errorHandler(deleteCodeSystemVersionCompletionHandler())
+						deleteCodeSystemVersionFinalStep(theTermCodeSystemSvc))
+				.completionHandler(deleteCodeSystemVersionCompletionHandler(theTermCodeSystemSvc))
+				.errorHandler(deleteCodeSystemVersionCompletionHandler(theTermCodeSystemSvc))
 				.build();
 	}
 
@@ -86,7 +83,7 @@ public class TermCodeSystemJobConfig {
 	 * Deletes all code system versions, before deleting the code system itself
 	 */
 	@Bean
-	public JobDefinition<TermCodeSystemDeleteJobParameters> termCodeSystemDeleteJobDefinition() {
+	public JobDefinition<TermCodeSystemDeleteJobParameters> termCodeSystemDeleteJobDefinition(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
 		return JobDefinition.newBuilder()
 				.setJobDefinitionId(TERM_CODE_SYSTEM_DELETE_JOB_NAME)
 				.setJobDescription("Term code system job delete")
@@ -98,24 +95,24 @@ public class TermCodeSystemJobConfig {
 						"FetchVersionsStep",
 						"Fetches all term code system version PIDs for given Code System PID",
 						CodeSystemVersionPIDResult.class,
-						readCodeSystemVersionsStep())
+						readCodeSystemVersionsStep(theTermCodeSystemSvc))
 				.addIntermediateStep(
 						"DeleteCodeSystemConceptsByVersionPidStep",
 						"Deletes the concept links, concept properties, concept designations, and concepts associated with a given code system version PID",
 						CodeSystemVersionPIDResult.class,
-						deleteCodeSystemConceptsStep())
+						deleteCodeSystemConceptsStep(theTermCodeSystemSvc))
 				.addIntermediateStep(
 						"DeleteCodeSystemVersionStep",
 						"Deletes the specified code system version",
 						CodeSystemVersionPIDResult.class,
-						deleteCodeSystemVersionsStep())
+						deleteCodeSystemVersionsStep(theTermCodeSystemSvc))
 				.addFinalReducerStep(
 						"DeleteCodeSystemStep",
 						"Deletes the code system itself",
 						VoidModel.class,
-						deleteCodeSystemFinalStep())
-				.completionHandler(deleteCodeSystemCompletionHandler())
-				.errorHandler(deleteCodeSystemCompletionHandler())
+					() -> new DeleteCodeSystemStep(theTermCodeSystemSvc))
+				.completionHandler(deleteCodeSystemCompletionHandler(theTermCodeSystemSvc))
+				.errorHandler(deleteCodeSystemCompletionHandler(theTermCodeSystemSvc))
 				.build();
 	}
 
@@ -126,28 +123,23 @@ public class TermCodeSystemJobConfig {
 	}
 
 	@Bean
-	public ReadTermConceptVersionsStep readCodeSystemVersionsStep() {
-		return new ReadTermConceptVersionsStep(myITermCodeSystemSvc);
+	public ReadTermConceptVersionsStep readCodeSystemVersionsStep(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new ReadTermConceptVersionsStep(theTermCodeSystemSvc);
 	}
 
 	@Bean
-	public DeleteCodeSystemConceptsByVersionStep deleteCodeSystemConceptsStep() {
-		return new DeleteCodeSystemConceptsByVersionStep(myITermCodeSystemSvc);
+	public DeleteCodeSystemConceptsByVersionStep deleteCodeSystemConceptsStep(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new DeleteCodeSystemConceptsByVersionStep(theTermCodeSystemSvc);
 	}
 
 	@Bean
-	public DeleteCodeSystemVersionStep deleteCodeSystemVersionsStep() {
-		return new DeleteCodeSystemVersionStep(myITermCodeSystemSvc);
+	public DeleteCodeSystemVersionStep deleteCodeSystemVersionsStep(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new DeleteCodeSystemVersionStep(theTermCodeSystemSvc);
 	}
 
 	@Bean
-	public DeleteCodeSystemStep deleteCodeSystemFinalStep() {
-		return new DeleteCodeSystemStep(myITermCodeSystemSvc);
-	}
-
-	@Bean
-	public DeleteCodeSystemCompletionHandler deleteCodeSystemCompletionHandler() {
-		return new DeleteCodeSystemCompletionHandler(myITermCodeSystemSvc);
+	public DeleteCodeSystemCompletionHandler deleteCodeSystemCompletionHandler(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new DeleteCodeSystemCompletionHandler(theTermCodeSystemSvc);
 	}
 
 	/** Delete code system version job **/
@@ -157,17 +149,17 @@ public class TermCodeSystemJobConfig {
 	}
 
 	@Bean
-	public DeleteCodeSystemVersionFirstStep deleteCodeSystemVersionFirstStep() {
-		return new DeleteCodeSystemVersionFirstStep(myITermCodeSystemSvc);
+	public DeleteCodeSystemVersionFirstStep deleteCodeSystemVersionFirstStep(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new DeleteCodeSystemVersionFirstStep(theTermCodeSystemSvc);
 	}
 
 	@Bean
-	public DeleteCodeSystemVersionFinalStep deleteCodeSystemVersionFinalStep() {
-		return new DeleteCodeSystemVersionFinalStep(myITermCodeSystemSvc);
+	public DeleteCodeSystemVersionFinalStep deleteCodeSystemVersionFinalStep(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new DeleteCodeSystemVersionFinalStep(theTermCodeSystemSvc);
 	}
 
 	@Bean
-	public DeleteCodeSystemVersionCompletionHandler deleteCodeSystemVersionCompletionHandler() {
-		return new DeleteCodeSystemVersionCompletionHandler(myITermCodeSystemSvc);
+	public DeleteCodeSystemVersionCompletionHandler deleteCodeSystemVersionCompletionHandler(ITermCodeSystemDeleteJobSvc theTermCodeSystemSvc) {
+		return new DeleteCodeSystemVersionCompletionHandler(theTermCodeSystemSvc);
 	}
 }

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/AbstractIJobPersistenceSpecificationTest.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/AbstractIJobPersistenceSpecificationTest.java
@@ -110,7 +110,7 @@ public abstract class AbstractIJobPersistenceSpecificationTest
 			.setParametersType(TestJobParameters.class)
 			.addFirstStep(FIRST_STEP_ID, "the first step", TestJobStep2InputType.class, (theStepExecutionDetails, theDataSink) -> new RunOutcome(0))
 			.addIntermediateStep(SECOND_STEP_ID, "the second step", TestJobStep3InputType.class, (theStepExecutionDetails, theDataSink) -> new RunOutcome(0))
-			.addFinalReducerStep(LAST_STEP_ID, "reduction step", VoidModel.class, new IReductionStepWorker<TestJobParameters, TestJobStep3InputType, VoidModel>() {
+			.addFinalReducerStep(LAST_STEP_ID, "reduction step", VoidModel.class, () -> new IReductionStepWorker<TestJobParameters, TestJobStep3InputType, VoidModel>() {
 				@Nonnull
 				@Override
 				public ChunkOutcome consume(ChunkExecutionDetails<TestJobParameters, TestJobStep3InputType> theChunkDetails) {

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepExecutorServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepExecutorServiceImpl.java
@@ -146,6 +146,7 @@ public class ReductionStepExecutorServiceImpl implements IReductionStepExecutorS
 					String instanceId = instanceIds[0];
 					myCurrentlyFinalizingInstanceId.set(instanceId);
 					JobWorkCursor<?, ?, ?> jobWorkCursor = myInstanceIdToJobWorkCursor.get(instanceId);
+					// TODO KHS executeReductionStep can return failure. Should we do anything with this information?
 					executeReductionStep(instanceId, jobWorkCursor);
 
 					// If we get here, this succeeded. Purge the instance from the work queue

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class JobDefinition<PT extends IModelJson> {
@@ -311,13 +312,13 @@ public class JobDefinition<PT extends IModelJson> {
 				String theStepId,
 				String theStepDescription,
 				Class<OT> theOutputType,
-				IReductionStepWorker<PT, NIT, OT> theStepWorker) {
+				Supplier<IReductionStepWorker<PT, NIT, OT>> theStepWorkerSupplier) {
 			if (!myGatedExecution) {
 				throw new ConfigurationException(Msg.code(2106)
 						+ String.format("Job Definition %s has a reducer step but is not gated", myJobDefinitionId));
 			}
 			mySteps.add(new JobDefinitionReductionStep<>(
-					theStepId, theStepDescription, theStepWorker, myNextInputType, theOutputType));
+					theStepId, theStepDescription, theStepWorkerSupplier, myNextInputType, theOutputType));
 			return new Builder<>(
 					mySteps,
 					myJobDefinitionId,

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinitionReductionStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinitionReductionStep.java
@@ -24,19 +24,21 @@ import ca.uhn.fhir.batch2.api.IReductionStepWorker;
 import ca.uhn.fhir.model.api.IModelJson;
 import jakarta.annotation.Nonnull;
 
+import java.util.function.Supplier;
+
 public class JobDefinitionReductionStep<PT extends IModelJson, IT extends IModelJson, OT extends IModelJson>
 		extends JobDefinitionStep<PT, IT, OT> {
 
 	public JobDefinitionReductionStep(
 			@Nonnull String theStepId,
 			@Nonnull String theStepDescription,
-			@Nonnull IReductionStepWorker<PT, IT, OT> theJobStepWorker,
+			@Nonnull Supplier<IReductionStepWorker<PT, IT, OT>> theJobStepWorkerSupplier,
 			@Nonnull Class<IT> theInputType,
 			@Nonnull Class<OT> theOutputType) {
 		super(
 				theStepId,
 				theStepDescription,
-				(IJobStepWorker<PT, IT, OT>) theJobStepWorker,
+				theJobStepWorkerSupplier,
 				theInputType,
 				theOutputType);
 	}


### PR DESCRIPTION
A batch2 reduction step likely holds state. This state is currently shared between jobs which is incorrect.

Proposed solution: reduction step in job definition should be a factory that creates a reducer rather than thes same stateful reducer instance shared by all runs.