### PR TITLE
Drop tag definition constraint

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6582-drop-tag-fk-constraint.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6582-drop-tag-fk-constraint.yaml
@@ -1,4 +1,4 @@
 ---
 type: perf
 issue: 6582
-title: "Under heavy load, a foreign key constraint in the Tag Definition table (used for Tags, Security Labels, and Profile Definitions) can cause serious slowdowns when writing large numbers of resources (particularly if many resources contain the same tags/labels, or if the resources are being written individually or in smaller batches). This has been corrected."
+title: "Under heavy load, a foreign key constraint in the Tag Definition table (used for Tags, Security Labels, and Profile Definitions) can cause serious slowdowns when writing large numbers of resources (particularly if many resources contain the same tags/labels, or if the resources are being written individually or in smaller batches). This has been corrected. Also, a foreign key constraint on the Resource Link table has been dropped. This will significantly improve performance when writing resource collections with many links to resources not also in the same Bundle."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6582-drop-tag-fk-constraint.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6582-drop-tag-fk-constraint.yaml
@@ -1,0 +1,4 @@
+---
+type: perf
+issue: 6582
+title: "Under heavy load, a foreign key constraint in the Tag Definition table (used for Tags, Security Labels, and Profile Definitions) can cause serious slowdowns when writing large numbers of resources (particularly if many resources contain the same tags/labels, or if the resources are being written individually or in smaller batches). This has been corrected."

--- a/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/DatabasePartitionModeIdFilteringMappingContributor.java
+++ b/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/DatabasePartitionModeIdFilteringMappingContributor.java
@@ -196,10 +196,10 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 				Value value = property.getValue();
 				if (value instanceof ToOne) {
 					ToOne toOne = (ToOne) value;
-					filterPropertiesFromToOneRelationship(theClassLoaderService, theMetadata, table, entityPersistentClass.getClassName(), toOne);
+					filterPropertiesFromToOneRelationship(
+							theClassLoaderService, theMetadata, table, entityPersistentClass.getClassName(), toOne);
 				}
 			}
-
 
 			for (UniqueKey uniqueKey : table.getUniqueKeys().values()) {
 				// Adjust UniqueKey constraints, which are uniqueness
@@ -355,7 +355,8 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 		Value value = theForeignKey.getColumn(0).getValue();
 		if (value instanceof ToOne) {
 			ToOne manyToOne = (ToOne) value;
-			Set<String> columnNamesToRemoveFromFks = filterPropertiesFromToOneRelationship(theClassLoaderService, theMetadata, theTable, theEntityTypeName, manyToOne);
+			Set<String> columnNamesToRemoveFromFks = filterPropertiesFromToOneRelationship(
+					theClassLoaderService, theMetadata, theTable, theEntityTypeName, manyToOne);
 			removeColumns(theForeignKey.getColumns(), t1 -> columnNamesToRemoveFromFks.contains(t1.getName()));
 		} else {
 
@@ -367,7 +368,12 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 	}
 
 	@Nonnull
-	private Set<String> filterPropertiesFromToOneRelationship(ClassLoaderService theClassLoaderService, InFlightMetadataCollector theMetadata, Table theTable, String theEntityTypeName, ToOne manyToOne) {
+	private Set<String> filterPropertiesFromToOneRelationship(
+			ClassLoaderService theClassLoaderService,
+			InFlightMetadataCollector theMetadata,
+			Table theTable,
+			String theEntityTypeName,
+			ToOne manyToOne) {
 		String targetTableName = theMetadata
 				.getEntityBindingMap()
 				.get(manyToOne.getReferencedEntityName())

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -563,10 +563,14 @@
 						<dialect>
 							<className>ca.uhn.fhir.jpa.model.dialect.HapiFhirOracleDialect</className>
 							<targetFileName>oracle.sql</targetFileName>
+							<!-- We may be able to do this in a cleaner way once this is resolved: https://hibernate.atlassian.net/browse/HHH-19046 -->
+							<dropStatementsContainingRegex>add constraint FK_RESLINK_TARGET</dropStatementsContainingRegex>
 						</dialect>
 						<dialect>
 							<className>ca.uhn.fhir.jpa.model.dialect.HapiFhirSQLServerDialect</className>
 							<targetFileName>sqlserver.sql</targetFileName>
+							<!-- We may be able to do this in a cleaner way once this is resolved: https://hibernate.atlassian.net/browse/HHH-19046 -->
+							<dropStatementsContainingRegex>add constraint FK_RESLINK_TARGET</dropStatementsContainingRegex>
 						</dialect>
 						<dialect>
 							<className>ca.uhn.fhir.jpa.model.dialect.HapiFhirCockroachDialect</className>
@@ -580,6 +584,8 @@
 							<className>ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect</className>
 							<targetFileName>postgres.sql</targetFileName>
 							<appendFile>classpath:ca/uhn/fhir/jpa/docs/database/hapifhirpostgres94-init01.sql</appendFile>
+							<!-- We may be able to do this in a cleaner way once this is resolved: https://hibernate.atlassian.net/browse/HHH-19046 -->
+							<dropStatementsContainingRegex>add constraint FK_RESLINK_TARGET</dropStatementsContainingRegex>
 						</dialect>
 					</dialects>
 				</configuration>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -766,6 +766,9 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 	 * @return Returns <code>true</code> if the tag should be removed
 	 */
 	protected boolean shouldDroppedTagBeRemovedOnUpdate(RequestDetails theRequest, ResourceTag theTag) {
+		if (theTag.getTag() == null) {
+			return true;
+		}
 
 		Set<TagTypeEnum> metaSnapshotModeTokens = null;
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -681,8 +681,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			if (tagDefinition != null && !allResourceTagsFromTheResource.contains(tag)) {
 				if (shouldDroppedTagBeRemovedOnUpdate(theRequest, tag)) {
 					theEntity.getTags().remove(tag);
-				} else if (HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY.equals(
-						tagDefinition.getSystem())) {
+				} else if (HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY.equals(tagDefinition.getSystem())) {
 					theEntity.getTags().remove(tag);
 				}
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -671,17 +671,18 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 
 		allResourceTagsNewAndOldFromTheEntity.forEach(tag -> {
 
-			// Don't keep duplicate tags
-			if (!allTagDefinitionsPresent.add(tag.getTag())) {
+			// Don't keep duplicate tags or tags with a missing definition
+			TagDefinition tagDefinition = tag.getTag();
+			if (tagDefinition == null || !allTagDefinitionsPresent.add(tagDefinition)) {
 				theEntity.getTags().remove(tag);
 			}
 
 			// Drop any tags that have been removed
-			if (!allResourceTagsFromTheResource.contains(tag)) {
+			if (tagDefinition != null && !allResourceTagsFromTheResource.contains(tag)) {
 				if (shouldDroppedTagBeRemovedOnUpdate(theRequest, tag)) {
 					theEntity.getTags().remove(tag);
 				} else if (HapiExtensions.EXT_SUBSCRIPTION_MATCHING_STRATEGY.equals(
-						tag.getTag().getSystem())) {
+						tagDefinition.getSystem())) {
 					theEntity.getTags().remove(tag);
 				}
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
@@ -490,7 +490,17 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 			res.getMeta().getTag().clear();
 			res.getMeta().getProfile().clear();
 			res.getMeta().getSecurity().clear();
+
+			boolean haveWarnedForMissingTag = false;
 			for (BaseTag next : theTagList) {
+				if (next.getTag() == null) {
+					if (!haveWarnedForMissingTag) {
+						ourLog.warn("Tag definition HFJ_TAG_DEF#{} is missing, returned Resource.meta may not be complete", next.getTagId());
+						haveWarnedForMissingTag = true;
+					}
+					continue;
+				}
+
 				switch (next.getTag().getTagType()) {
 					case PROFILE:
 						res.getMeta().addProfile(next.getTag().getCode());

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaStorageResourceParser.java
@@ -495,7 +495,9 @@ public class JpaStorageResourceParser implements IJpaStorageResourceParser {
 			for (BaseTag next : theTagList) {
 				if (next.getTag() == null) {
 					if (!haveWarnedForMissingTag) {
-						ourLog.warn("Tag definition HFJ_TAG_DEF#{} is missing, returned Resource.meta may not be complete", next.getTagId());
+						ourLog.warn(
+								"Tag definition HFJ_TAG_DEF#{} is missing, returned Resource.meta may not be complete",
+								next.getTagId());
 						haveWarnedForMissingTag = true;
 					}
 					continue;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -384,11 +384,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		 * These two constraints were the last two that we had that used
 		 * hibernate-generated names. Yay!
 		 */
-		version.onTable("HFJ_RES_TAG")
-			.dropForeignKey("20250102.10", "FKbfcjbaftmiwr3rxkwsy23vneo", "HFJ_TAG_DEF");
-		version.onTable("HFJ_HISTORY_TAG")
-			.dropForeignKey("20250102.20", "FKtderym7awj6q8iq5c51xv4ndw", "HFJ_TAG_DEF");
-
+		version.onTable("HFJ_RES_TAG").dropForeignKey("20250102.10", "FKbfcjbaftmiwr3rxkwsy23vneo", "HFJ_TAG_DEF");
+		version.onTable("HFJ_HISTORY_TAG").dropForeignKey("20250102.20", "FKtderym7awj6q8iq5c51xv4ndw", "HFJ_TAG_DEF");
 	}
 
 	protected void init780_afterPartitionChanges() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -387,7 +387,21 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable("HFJ_RES_TAG").dropForeignKey("20250115.10", "FKbfcjbaftmiwr3rxkwsy23vneo", "HFJ_TAG_DEF");
 		version.onTable("HFJ_HISTORY_TAG").dropForeignKey("20250115.20", "FKtderym7awj6q8iq5c51xv4ndw", "HFJ_TAG_DEF");
 
-		version.onTable("HFJ_RES_LINK").dropForeignKey("20250115.30", "FK_RESLINK_TARGET", "HFJ_RESOURCE");
+		/*
+		 * This migration drops a constraint from ResourceLink#myTargetResource. Not having this
+		 * constraint is a significant performance improvement in some cases, and the column is
+		 * nullable anyhow already because we also have the possibility of having a logical reference
+		 * instead of a hard one. We still keep the constraint present on the ResourceLink
+		 * entity for two reasons:
+		 * 1. We want to leave it in place on H2 to ensure that it helps to catch any bugs.
+		 * 2. We can't drop it as of 2025-01-16 because of this Hibernate bug:
+		 *    https://hibernate.atlassian.net/browse/HHH-19046
+		 */
+		version.onTable("HFJ_RES_LINK")
+				.dropForeignKey("20250115.30", "FK_RESLINK_TARGET", "HFJ_RESOURCE")
+				.runEvenDuringSchemaInitialization()
+				.onlyAppliesToPlatforms(
+						DriverTypeEnum.POSTGRES_9_4, DriverTypeEnum.MSSQL_2012, DriverTypeEnum.ORACLE_12C);
 	}
 
 	protected void init780_afterPartitionChanges() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -384,8 +384,10 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		 * These two constraints were the last two that we had that used
 		 * hibernate-generated names. Yay!
 		 */
-		version.onTable("HFJ_RES_TAG").dropForeignKey("20250102.10", "FKbfcjbaftmiwr3rxkwsy23vneo", "HFJ_TAG_DEF");
-		version.onTable("HFJ_HISTORY_TAG").dropForeignKey("20250102.20", "FKtderym7awj6q8iq5c51xv4ndw", "HFJ_TAG_DEF");
+		version.onTable("HFJ_RES_TAG").dropForeignKey("20250115.10", "FKbfcjbaftmiwr3rxkwsy23vneo", "HFJ_TAG_DEF");
+		version.onTable("HFJ_HISTORY_TAG").dropForeignKey("20250115.20", "FKtderym7awj6q8iq5c51xv4ndw", "HFJ_TAG_DEF");
+
+		version.onTable("HFJ_RES_LINK").dropForeignKey("20250115.30", "FK_RESLINK_TARGET", "HFJ_RESOURCE");
 	}
 
 	protected void init780_afterPartitionChanges() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -379,6 +379,16 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.nullable()
 				.withType(ColumnTypeEnum.TINYINT)
 				.heavyweightSkipByDefault();
+
+		/*
+		 * These two constraints were the last two that we had that used
+		 * hibernate-generated names. Yay!
+		 */
+		version.onTable("HFJ_RES_TAG")
+			.dropForeignKey("20250102.10", "FKbfcjbaftmiwr3rxkwsy23vneo", "HFJ_TAG_DEF");
+		version.onTable("HFJ_HISTORY_TAG")
+			.dropForeignKey("20250102.20", "FKtderym7awj6q8iq5c51xv4ndw", "HFJ_TAG_DEF");
+
 	}
 
 	protected void init780_afterPartitionChanges() {

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/BaseTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/BaseTag.java
@@ -20,9 +20,13 @@
 package ca.uhn.fhir.jpa.model.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 
 import java.io.Serializable;
 
@@ -31,9 +35,15 @@ public abstract class BaseTag extends BasePartitionable implements Serializable 
 
 	private static final long serialVersionUID = 1L;
 
-	// many baseTags -> one tag definition
+	/**
+	 * Every tag has a reference to the tag definition. Note that this field
+	 * must not have a FK constraint! In this case, Postgres (and maybe others)
+	 * are horribly slow writing to the table if there's an FK constraint.
+	 * See https://pganalyze.com/blog/5mins-postgres-multiXact-ids-foreign-keys-performance
+	 */
 	@ManyToOne(cascade = {})
-	@JoinColumn(name = "TAG_ID", nullable = false)
+	@JoinColumn(name = "TAG_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+	@NotFound(action = NotFoundAction.IGNORE)
 	private TagDefinition myTag;
 
 	@Column(name = "TAG_ID", insertable = false, updatable = false)

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/BaseTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/BaseTag.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.fhir.jpa.model.entity;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.ForeignKey;
@@ -53,6 +54,12 @@ public abstract class BaseTag extends BasePartitionable implements Serializable 
 		return myTagId;
 	}
 
+	/**
+	 * This can be null if the tag definition has been deleted. This
+	 * should never happen unless someone has manually messed with
+	 * the database, but it could happen.
+	 */
+	@Nullable
 	public TagDefinition getTag() {
 		return myTag;
 	}

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceHistoryTag.java
@@ -154,12 +154,12 @@ public class ResourceHistoryTag extends BaseTag implements Serializable {
 	public String toString() {
 		ToStringBuilder b = new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE);
 		b.append("id", getId());
-		if (getPartitionId() != null) {
+		if (getPartitionId().getPartitionId() != null) {
 			b.append("partId", getPartitionId().getPartitionId());
 		}
 		b.append("versionId", myResourceHistoryPid);
 		b.append("resId", getResourceId());
-		b.append("tag", getTag().getId());
+		b.append("tag", getTagId());
 		return b.build();
 	}
 }

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.model.entity;
 
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
@@ -68,7 +69,6 @@ public class ResourceLink extends BaseResourceIndex {
 	private static final long serialVersionUID = 1L;
 	public static final String TARGET_RES_PARTITION_ID = "TARGET_RES_PARTITION_ID";
 	public static final String TARGET_RESOURCE_ID = "TARGET_RESOURCE_ID";
-	public static final String FK_RESLINK_TARGET = "FK_RESLINK_TARGET";
 
 	@GenericGenerator(name = "SEQ_RESLINK_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESLINK_ID")
@@ -124,7 +124,7 @@ public class ResourceLink extends BaseResourceIndex {
 						insertable = false,
 						updatable = false),
 			},
-			foreignKey = @ForeignKey(name = FK_RESLINK_TARGET))
+			foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private ResourceTable myTargetResource;
 
 	@Transient

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceLink.java
@@ -21,7 +21,6 @@ package ca.uhn.fhir.jpa.model.entity;
 
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
@@ -69,6 +68,7 @@ public class ResourceLink extends BaseResourceIndex {
 	private static final long serialVersionUID = 1L;
 	public static final String TARGET_RES_PARTITION_ID = "TARGET_RES_PARTITION_ID";
 	public static final String TARGET_RESOURCE_ID = "TARGET_RESOURCE_ID";
+	public static final String FK_RESLINK_TARGET = "FK_RESLINK_TARGET";
 
 	@GenericGenerator(name = "SEQ_RESLINK_ID", type = ca.uhn.fhir.jpa.model.dialect.HapiSequenceStyleGenerator.class)
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_RESLINK_ID")
@@ -124,7 +124,13 @@ public class ResourceLink extends BaseResourceIndex {
 						insertable = false,
 						updatable = false),
 			},
-			foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+			/*
+			 * TODO: We need to drop this constraint because it affects performance in pretty
+			 *  terrible ways on a lot of platforms. But a Hibernate bug present in Hibernate 6.6.4
+			 *  makes it impossible.
+			 *  See: https://hibernate.atlassian.net/browse/HHH-19046
+			 */
+			foreignKey = @ForeignKey(name = FK_RESLINK_TARGET))
 	private ResourceTable myTargetResource;
 
 	@Transient

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTag.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTag.java
@@ -175,7 +175,7 @@ public class ResourceTag extends BaseTag {
 			b.append("partition", getPartitionId().getPartitionId());
 		}
 		b.append("resId", getResourceId());
-		b.append("tag", getTag().getId());
+		b.append("tag", getTagId());
 		return b.build();
 	}
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
@@ -198,9 +199,22 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 	 * definitions get deleted. This test makes sure we act sanely when that happens.
 	 */
 	@ParameterizedTest
-	@ValueSource(strings = {"read", "vread", "search", "history", "update"})
-	public void testTagDefinitionDeleted(String theOperation) {
+	@CsvSource(value = {
+		"NONVERSIONED, read",
+		"NONVERSIONED, vread",
+		"NONVERSIONED, search",
+		"NONVERSIONED, history",
+		"NONVERSIONED, update",
+		"VERSIONED, read",
+		"VERSIONED, vread",
+		"VERSIONED, search",
+		"VERSIONED, history",
+		"VERSIONED, update"
+	})
+	public void testTagDefinitionDeleted(JpaStorageSettings.TagStorageModeEnum theTagStorageMode, String theOperation) {
 		// Setup
+		myStorageSettings.setTagStorageMode(theTagStorageMode);
+
 		Patient patient = new Patient();
 		patient.setId("Patient/A");
 		patient.getMeta().addProfile("http://profile0");
@@ -209,6 +223,9 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 		patient.getMeta().addTag("http://tag", "tag1", "display1");
 		patient.getMeta().addSecurity("http://security", "security0", "display0");
 		patient.getMeta().addSecurity("http://security", "security1", "display1");
+		myPatientDao.update(patient, mySrd);
+
+		patient.setActive(false);
 		myPatientDao.update(patient, mySrd);
 
 		// Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
@@ -2,17 +2,12 @@ package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
-import ca.uhn.fhir.jpa.dao.JpaStorageResourceParser;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.gclient.TokenClientParam;
 import ca.uhn.fhir.util.BundleBuilder;
-import ca.uhn.test.util.LogbackTestExtension;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Enumerations;
@@ -22,11 +17,8 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.SearchParameter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,9 +31,6 @@ import static org.mockito.Mockito.when;
 public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(FhirResourceDaoR4TagsTest.class);
-
-	@RegisterExtension
-	private LogbackTestExtension myLogbackTestExtension = new LogbackTestExtension(JpaStorageResourceParser.class, Level.WARN);
 
 	@Override
 	@AfterEach
@@ -192,83 +181,6 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 		assertThat(toTags(patient)).as(toTags(patient).toString()).containsExactlyInAnyOrder("http://tag1|vtag1|dtag1", "http://tag2|vtag2|dtag2");
 
 	}
-
-	/**
-	 * We have removed the FK constraint from {@link ca.uhn.fhir.jpa.model.entity.ResourceTag}
-	 * to {@link ca.uhn.fhir.jpa.model.entity.TagDefinition} so it's possible that tag
-	 * definitions get deleted. This test makes sure we act sanely when that happens.
-	 */
-	@ParameterizedTest
-	@CsvSource(value = {
-		"NON_VERSIONED, read",
-		"NON_VERSIONED, vread",
-		"NON_VERSIONED, search",
-		"NON_VERSIONED, history",
-		"NON_VERSIONED, update",
-		"VERSIONED,     read",
-		"VERSIONED,     vread",
-		"VERSIONED,     search",
-		"VERSIONED,     history",
-		"VERSIONED,     update"
-	})
-	public void testTagDefinitionDeleted(JpaStorageSettings.TagStorageModeEnum theTagStorageMode, String theOperation) {
-		// Setup
-		myStorageSettings.setTagStorageMode(theTagStorageMode);
-
-		Patient patient = new Patient();
-		patient.setId("Patient/A");
-		patient.getMeta().addProfile("http://profile0");
-		patient.getMeta().addProfile("http://profile1");
-		patient.getMeta().addTag("http://tag", "tag0", "display0");
-		patient.getMeta().addTag("http://tag", "tag1", "display1");
-		patient.getMeta().addSecurity("http://security", "security0", "display0");
-		patient.getMeta().addSecurity("http://security", "security1", "display1");
-		myPatientDao.update(patient, mySrd);
-
-		patient.setActive(false);
-		myPatientDao.update(patient, mySrd);
-
-		// Test
-
-		runInTransaction(() -> {
-			assertEquals(6, myTagDefinitionDao.count());
-			myTagDefinitionDao.deleteAll();
-			assertEquals(0, myTagDefinitionDao.count());
-		});
-		Patient actualPatient;
-		switch (theOperation) {
-			case "read":
-				actualPatient = myPatientDao.read(new IdType("Patient/A"), mySrd);
-				break;
-			case "vread":
-				actualPatient = myPatientDao.read(new IdType("Patient/A/_history/1"), mySrd);
-				break;
-			case "search":
-				actualPatient = (Patient) myPatientDao.search(SearchParameterMap.newSynchronous(), mySrd).getResources(0, 1).get(0);
-				break;
-			case "history":
-				actualPatient = (Patient) mySystemDao.history(null, null, null, mySrd).getResources(0, 1).get(0);
-				break;
-			case "update":
-				Patient updatePatient = new Patient();
-				updatePatient.setId("Patient/A");
-				updatePatient.setActive(true);
-				actualPatient = (Patient) myPatientDao.update(updatePatient, mySrd).getResource();
-				break;
-			default:
-				throw new IllegalArgumentException("Unknown operation: " + theOperation);
-		}
-
-		// Verify
-
-		assertEquals(0, actualPatient.getMeta().getProfile().size());
-		assertEquals(0, actualPatient.getMeta().getTag().size());
-		assertEquals(0, actualPatient.getMeta().getSecurity().size());
-
-		List<ILoggingEvent> logEvents = myLogbackTestExtension.getLogEvents(t -> t.getMessage().contains("Tag definition HFJ_TAG_DEF#{} is missing"));
-		assertThat(logEvents).as(() -> myLogbackTestExtension.getLogEvents().toString()).hasSize(1);
-	}
-
 
 	/**
 	 * Make sure tags are preserved
@@ -598,6 +510,21 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 		validatePatientSearchResultsForInlineTags(outcome);
 	}
 
+	@Nonnull
+	public static SearchParameter createSecuritySearchParameter(FhirContext fhirContext) {
+		SearchParameter searchParameter = new SearchParameter();
+		searchParameter.setId("SearchParameter/resource-security");
+		for (String next : fhirContext.getResourceTypes().stream().sorted().collect(Collectors.toList())) {
+			searchParameter.addBase(next);
+		}
+		searchParameter.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		searchParameter.setType(Enumerations.SearchParamType.TOKEN);
+		searchParameter.setCode("_security");
+		searchParameter.setName("Security");
+		searchParameter.setExpression("meta.security");
+		return searchParameter;
+	}
+
 	private void validatePatientSearchResultsForInlineTags(Bundle outcome) {
 		Patient patient;
 		patient = (Patient) outcome.getEntry().get(0).getResource();
@@ -670,21 +597,6 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 		patient.getMeta().addTag("http://tag2", "vtag2", "dtag2");
 		patient.setActive(false);
 		assertEquals("2", myPatientDao.update(patient, mySrd).getId().getVersionIdPart());
-	}
-
-	@Nonnull
-	public static SearchParameter createSecuritySearchParameter(FhirContext fhirContext) {
-		SearchParameter searchParameter = new SearchParameter();
-		searchParameter.setId("SearchParameter/resource-security");
-		for (String next : fhirContext.getResourceTypes().stream().sorted().collect(Collectors.toList())) {
-			searchParameter.addBase(next);
-		}
-		searchParameter.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		searchParameter.setType(Enumerations.SearchParamType.TOKEN);
-		searchParameter.setCode("_security");
-		searchParameter.setName("Security");
-		searchParameter.setExpression("meta.security");
-		return searchParameter;
 	}
 
 	@Nonnull

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TagsTest.java
@@ -200,16 +200,16 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 	 */
 	@ParameterizedTest
 	@CsvSource(value = {
-		"NONVERSIONED, read",
-		"NONVERSIONED, vread",
-		"NONVERSIONED, search",
-		"NONVERSIONED, history",
-		"NONVERSIONED, update",
-		"VERSIONED, read",
-		"VERSIONED, vread",
-		"VERSIONED, search",
-		"VERSIONED, history",
-		"VERSIONED, update"
+		"NON_VERSIONED, read",
+		"NON_VERSIONED, vread",
+		"NON_VERSIONED, search",
+		"NON_VERSIONED, history",
+		"NON_VERSIONED, update",
+		"VERSIONED,     read",
+		"VERSIONED,     vread",
+		"VERSIONED,     search",
+		"VERSIONED,     history",
+		"VERSIONED,     update"
 	})
 	public void testTagDefinitionDeleted(JpaStorageSettings.TagStorageModeEnum theTagStorageMode, String theOperation) {
 		// Setup
@@ -229,6 +229,7 @@ public class FhirResourceDaoR4TagsTest extends BaseResourceProviderR4Test {
 		myPatientDao.update(patient, mySrd);
 
 		// Test
+
 		runInTransaction(() -> {
 			assertEquals(6, myTagDefinitionDao.count());
 			myTagDefinitionDao.deleteAll();

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DeletedDatabaseRowsR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/DeletedDatabaseRowsR5Test.java
@@ -1,0 +1,159 @@
+package ca.uhn.fhir.jpa.dao.r5;
+
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.IDao;
+import ca.uhn.fhir.jpa.dao.JpaStorageResourceParser;
+import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTable;
+import ca.uhn.fhir.jpa.model.entity.ResourceLink;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.test.util.LogbackTestExtension;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.IdType;
+import org.hl7.fhir.r5.model.Organization;
+import org.hl7.fhir.r5.model.Patient;
+import org.hl7.fhir.r5.model.Reference;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DeletedDatabaseRowsR5Test extends BaseJpaR5Test{
+
+	@RegisterExtension
+	private LogbackTestExtension myLogbackTestExtension = new LogbackTestExtension(JpaStorageResourceParser.class, Level.WARN);
+
+
+	/**
+	 * We have removed the FK constraint from {@link ca.uhn.fhir.jpa.model.entity.ResourceTag}
+	 * to {@link ca.uhn.fhir.jpa.model.entity.TagDefinition} so it's possible that tag
+	 * definitions get deleted. This test makes sure we act sanely when that happens.
+	 */
+	@ParameterizedTest
+	@CsvSource(value = {
+		"NON_VERSIONED, read",
+		"NON_VERSIONED, vread",
+		"NON_VERSIONED, search",
+		"NON_VERSIONED, history",
+		"NON_VERSIONED, update",
+		"VERSIONED,     read",
+		"VERSIONED,     vread",
+		"VERSIONED,     search",
+		"VERSIONED,     history",
+		"VERSIONED,     update"
+	})
+	public void testTagDefinitionDeleted(JpaStorageSettings.TagStorageModeEnum theTagStorageMode, String theOperation) {
+		// Setup
+		myStorageSettings.setTagStorageMode(theTagStorageMode);
+
+		Patient patient = new Patient();
+		patient.setId("Patient/A");
+		patient.getMeta().addProfile("http://profile0");
+		patient.getMeta().addProfile("http://profile1");
+		patient.getMeta().addTag("http://tag", "tag0", "display0");
+		patient.getMeta().addTag("http://tag", "tag1", "display1");
+		patient.getMeta().addSecurity(new Coding("http://security", "security0", "display0"));
+		patient.getMeta().addSecurity(new Coding("http://security", "security1", "display1"));
+		myPatientDao.update(patient, mySrd);
+
+		patient.setActive(false);
+		myPatientDao.update(patient, mySrd);
+
+		// Test
+
+		runInTransaction(() -> {
+			assertEquals(6, myTagDefinitionDao.count());
+			myTagDefinitionDao.deleteAll();
+			assertEquals(0, myTagDefinitionDao.count());
+		});
+		Patient actualPatient;
+		switch (theOperation) {
+			case "read":
+				actualPatient = myPatientDao.read(new IdType("Patient/A"), mySrd);
+				break;
+			case "vread":
+				actualPatient = myPatientDao.read(new IdType("Patient/A/_history/1"), mySrd);
+				break;
+			case "search":
+				actualPatient = (Patient) myPatientDao.search(SearchParameterMap.newSynchronous(), mySrd).getResources(0, 1).get(0);
+				break;
+			case "history":
+				actualPatient = (Patient) mySystemDao.history(null, null, null, mySrd).getResources(0, 1).get(0);
+				break;
+			case "update":
+				Patient updatePatient = new Patient();
+				updatePatient.setId("Patient/A");
+				updatePatient.setActive(true);
+				actualPatient = (Patient) myPatientDao.update(updatePatient, mySrd).getResource();
+				break;
+			default:
+				throw new IllegalArgumentException("Unknown operation: " + theOperation);
+		}
+
+		// Verify
+
+		assertEquals(0, actualPatient.getMeta().getProfile().size());
+		assertEquals(0, actualPatient.getMeta().getTag().size());
+		assertEquals(0, actualPatient.getMeta().getSecurity().size());
+
+		List<ILoggingEvent> logEvents = myLogbackTestExtension.getLogEvents(t -> t.getMessage().contains("Tag definition HFJ_TAG_DEF#{} is missing"));
+		assertThat(logEvents).as(() -> myLogbackTestExtension.getLogEvents().toString()).hasSize(1);
+	}
+
+	/**
+	 * There is no FK constraint on {@link ResourceLink#getTargetResource()} so this can be
+	 * nulled out even if a value is present. This is a test to make sure we behave if the
+	 * target row is deleted.
+	 */
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testReferenceWithTargetExpunged(boolean theSynchronous) {
+		// Test
+		Organization org = new Organization();
+		org.setId("Organization/O");
+		JpaPid orgPid = IDao.RESOURCE_PID.get(myOrganizationDao.update(org, mySrd).getResource());
+
+		Patient patient = new Patient();
+		patient.setId("Patient/P");
+		patient.setManagingOrganization(new Reference("Organization/O"));
+		myPatientDao.update(patient, mySrd);
+
+		// Delete the Organization resource
+		runInTransaction(()->{
+			List<ResourceHistoryTable> historyEntities = myResourceHistoryTableDao.findAllVersionsForResourceIdInOrder(orgPid.toFk());
+			myResourceHistoryTableDao.deleteAll(historyEntities);
+		});
+
+		logAllResources();
+		logAllResourceVersions();
+
+		runInTransaction(()->{
+			myResourceTableDao.deleteByPid(orgPid);
+		});
+
+		// Make sure that the Org was deleted
+		assertThrows(ResourceNotFoundException.class, ()->myOrganizationDao.read(new IdType("Organization/O"), mySrd));
+
+		// Test
+		SearchParameterMap params = new SearchParameterMap().addInclude(new Include("*"));
+		params.setLoadSynchronous(theSynchronous);
+		IBundleProvider result = myPatientDao.search(params, mySrd);
+
+		// Verify
+		List<String> values = toUnqualifiedVersionlessIdValues(result);
+		assertThat(values).asList().containsExactly("Patient/P");
+
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/search/reindex/InstanceReindexServiceImplR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/search/reindex/InstanceReindexServiceImplR5Test.java
@@ -183,10 +183,12 @@ public class InstanceReindexServiceImplR5Test extends BaseJpaR5Test {
 		IIdType id = createObservation(withSubject("Patient/A"));
 
 		runInTransaction(() -> {
-			assertEquals(2, myEntityManager.createNativeQuery("update HFJ_RES_LINK set TARGET_RESOURCE_ID = null").executeUpdate());
+			assertEquals(2, myEntityManager.createNativeQuery("update HFJ_RES_LINK set (TARGET_RESOURCE_ID,TARGET_RES_PARTITION_ID) = (null, null)").executeUpdate());
 			assertEquals(2, myEntityManager.createNativeQuery("update HFJ_RES_LINK set TARGET_RESOURCE_URL = 'http://foo'").executeUpdate());
 			assertEquals(2, myEntityManager.createNativeQuery("update HFJ_RES_LINK set TARGET_RESOURCE_VERSION = 1").executeUpdate());
 		});
+
+		myEntityManager.clear();
 
 		Parameters outcome = (Parameters) mySvc.reindexDryRun(new SystemRequestDetails(), id, null);
 		ourLog.info("Output:{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/JdbcUtils.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/JdbcUtils.java
@@ -276,7 +276,8 @@ public class JdbcUtils {
 	}
 
 	/**
-	 * Retrieve all index names
+	 * Retrieve all index names. The returned names will be in upper case
+	 * always.
 	 */
 	public static Set<String> getForeignKeys(
 			DriverTypeEnum.ConnectionProperties theConnectionProperties,
@@ -588,9 +589,9 @@ public class JdbcUtils {
 		}
 	}
 
-	private static String massageIdentifier(DatabaseMetaData theMetadata, String theCatalog) throws SQLException {
-		String retVal = theCatalog;
-		if (theCatalog == null) {
+	public static String massageIdentifier(DatabaseMetaData theMetadata, String theIdentifier) throws SQLException {
+		String retVal = theIdentifier;
+		if (theIdentifier == null) {
 			return null;
 		} else if (theMetadata.storesLowerCaseIdentifiers()) {
 			retVal = retVal.toLowerCase();

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropForeignKeyTask.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropForeignKeyTask.java
@@ -26,12 +26,15 @@ import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -92,14 +95,18 @@ public class DropForeignKeyTask extends BaseTableTask {
 	public void doExecute() throws SQLException {
 
 		Set<String> existing = JdbcUtils.getForeignKeys(getConnectionProperties(), myParentTableName, getTableName());
-		if (!existing.contains(myConstraintName)) {
+		if (!existing.contains(myConstraintName.toUpperCase(Locale.US))) {
 			logInfo(ourLog, "Don't have constraint named {} - No action performed", myConstraintName);
 			return;
 		}
 
-		List<String> sqls = generateSql(getTableName(), myConstraintName, getDriverType());
+		List<String> sqlStatements;
+		try (Connection connection = getConnectionProperties().getDataSource().getConnection()) {
+			String constraintName = JdbcUtils.massageIdentifier(connection.getMetaData(), myConstraintName);
+			sqlStatements = generateSql(getTableName(), constraintName, getDriverType());
+		}
 
-		for (String next : sqls) {
+		for (@Language("SQL") String next : sqlStatements) {
 			executeSql(getTableName(), next);
 		}
 	}

--- a/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-sql-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -334,12 +334,13 @@ public class Builder {
 		 * @param theFkName          the name of the foreign key
 		 * @param theParentTableName the name of the table that exports the foreign key
 		 */
-		public void dropForeignKey(String theVersion, String theFkName, String theParentTableName) {
+		public BuilderCompleteTask dropForeignKey(String theVersion, String theFkName, String theParentTableName) {
 			DropForeignKeyTask task = new DropForeignKeyTask(myRelease, theVersion);
 			task.setConstraintName(theFkName);
 			task.setTableName(getTableName());
 			task.setParentTableName(theParentTableName);
 			addTask(task);
+			return new BuilderCompleteTask(task);
 		}
 
 		public BuilderCompleteTask renameTable(String theVersion, String theNewTableName) {

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ddl/GenerateDdlMojo.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ddl/GenerateDdlMojo.java
@@ -113,6 +113,7 @@ public class GenerateDdlMojo extends AbstractMojo {
 		private String targetFileName;
 		private String prependFile;
 		private String appendFile;
+		private List<String> dropStatementsContainingRegex;
 
 		public Dialect() {
 			super();
@@ -122,6 +123,14 @@ public class GenerateDdlMojo extends AbstractMojo {
 			super();
 			setClassName(theClassName);
 			setTargetFileName(theTargetFileName);
+		}
+
+		public List<String> getDropStatementsContainingRegex() {
+			return dropStatementsContainingRegex;
+		}
+
+		public void setDropStatementsContainingRegex(List<String> theDropStatementsContainingRegex) {
+			dropStatementsContainingRegex = theDropStatementsContainingRegex;
 		}
 
 		public String getAppendFile() {

--- a/pom.xml
+++ b/pom.xml
@@ -3016,60 +3016,6 @@
 		</plugins>
 	</build>
 
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-changes-plugin</artifactId>
-				<version>${maven_changes_version}</version>
-				<inherited>false</inherited>
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>changes-report</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-				<configuration>
-					<feedType>atom_1.0</feedType>
-					<issueLinkTemplatePerSystem>
-						<default>https://github.com/hapifhir/hapi-fhir/issues/%ISSUE%</default>
-					</issueLinkTemplatePerSystem>
-					<escapeHTML>false</escapeHTML>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>${surefire_version}</version>
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>failsafe-report-only</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-				<configuration>
-					<reportsDirectories>
-						<reportDirectory>${project.basedir}/hapi-fhir-base/target/surefire-reports/</reportDirectory>
-						<reportDirectory>${project.basedir}/hapi-fhir-structures-dstu/target/surefire-reports/
-						</reportDirectory>
-						<reportDirectory>${project.basedir}/hapi-fhir-structures-dstu2/target/surefire-reports/
-						</reportDirectory>
-						<reportDirectory>${project.basedir}/hapi-fhir-jpaserver-base/target/surefire-reports/
-						</reportDirectory>
-					</reportsDirectories>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.0.0</version>
-				<inherited>false</inherited>
-			</plugin>
-		</plugins>
-	</reporting>
-
 	<profiles>
 		<profile>
 			<id>ERRORPRONE</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2529,6 +2529,11 @@
 					<version>3.8.1</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.1.3</version>
+				</plugin>
+				<plugin>
 					<groupId>org.sonatype.plugins</groupId>
 					<artifactId>nexus-staging-maven-plugin</artifactId>
 					<version>1.7.0</version>


### PR DESCRIPTION
Under heavy load, a foreign key constraint in the Tag Definition table (used for Tags, Security Labels, and Profile Definitions) can cause serious slowdowns when writing large numbers of resources (particularly if many resources contain the same tags/labels, or if the resources are being written individually or in smaller batches). This has been corrected.