### PR TITLE
Fix batch2 intermittent failure

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -548,8 +548,7 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 		 * we fetch it and then refresh-lock it so that we don't fail if someone
 		 * else has touched it.
 		 */
-		Batch2JobInstanceEntity instanceEntity =
-				myEntityManager.find(Batch2JobInstanceEntity.class, theInstanceId);
+		Batch2JobInstanceEntity instanceEntity = myEntityManager.find(Batch2JobInstanceEntity.class, theInstanceId);
 		myEntityManager.refresh(instanceEntity, LockModeType.PESSIMISTIC_WRITE);
 
 		if (null == instanceEntity) {


### PR DESCRIPTION
When processing a batch2 job under heavy load, a race condition meant that the final reducer step would occasionally fail if it started immediately following a batch2 maintenance task.