### PR TITLE
fix replace references small batch test

### DIFF
--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -146,6 +146,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 			int numberOfEntriesInCurrentBundle = patchResultBundle.getEntry().size();
 			// validate
 			totalPatchResultEntriesSeen += numberOfEntriesInCurrentBundle;
+			assertThat(numberOfEntriesInCurrentBundle).isBetween(1, ReplaceReferencesTestHelper.SMALL_BATCH_SIZE);
 			ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, numberOfEntriesInCurrentBundle, List.of(
 				"Observation",
 				"Encounter", "CarePlan"));

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.jpa.provider.ReplaceReferencesSvcImpl.RESOURCE_TYPES_SYSTEM;
 import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper.EXPECTED_SMALL_BATCHES;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,8 +124,11 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 			.element(0)
 			.isInstanceOf(Bundle.class);
 
-		int entriesLeft = ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES;
-		for (int i = 1; i < EXPECTED_SMALL_BATCHES; i++) {
+		// for each batch, there should be a corresponding patch result bundle in the task as a contained resource.
+		// The loop below validates the patch result bundles, and counts total number of bundle entries seen
+		// to ensure that all patch results are accounted for.
+		int totalPatchResultEntriesSeen = 0;
+		for (int i = 0; i < EXPECTED_SMALL_BATCHES; i++) {
 
 			Task.TaskOutputComponent taskOutput = taskWithOutput.getOutput().get(i);
 
@@ -139,12 +143,15 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 			patchResultBundle = (Bundle) outputRef.getResource();
 			assertTrue(containedBundle.equalsDeep(patchResultBundle));
 
+			int numberOfEntriesInCurrentBundle = patchResultBundle.getEntry().size();
 			// validate
-			entriesLeft -= ReplaceReferencesTestHelper.SMALL_BATCH_SIZE;
-			int expectedNumberOfEntries = Math.min(entriesLeft, ReplaceReferencesTestHelper.SMALL_BATCH_SIZE);
-			ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, expectedNumberOfEntries, List.of("Observation",
+			totalPatchResultEntriesSeen += numberOfEntriesInCurrentBundle;
+			ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, numberOfEntriesInCurrentBundle, List.of(
+				"Observation",
 				"Encounter", "CarePlan"));
 		}
+
+		assertThat(totalPatchResultEntriesSeen).isEqualTo(TOTAL_EXPECTED_PATCHES);
 
 		// Check that the linked resources were updated
 


### PR DESCRIPTION
This PR fixes the small batch test for replace references operation.

For async replace-references operation, a task resource is generated. And the task resource is expected to contain a patch result bundle for each batch processed. The test had a loop to validate the result bundles in the task per batch. But the loop had 2 problems: 
- The test was assuming that the result bundle for the smallest batch is always returned last. Meaning that for 23 resources that are patched in batches of 5, the test expecting result bundle sizes to be 5,5,5,5,3 ( in this strict order)  in the task output. However, it is not guaranteed that the bundle with the smallest size (3 in this case) will be the last one, it could appear anywhere. 
- The second issue was that the loop index variable was starting at 1 instead of 0, so it was actually not going through the all bundles. 

This MR fixes these issues.  