### PR TITLE
tests fail on new version of derby

### DIFF
--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -54,13 +54,15 @@
 			<groupId>org.apache.derby</groupId>
 			<artifactId>derby</artifactId>
 			<scope>test</scope>
-			<version>10.17.1.0</version>
+			<version>10.16.1.1</version>
+			<!--	Don't bump this, they drop support for JRE 17	-->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.derby</groupId>
 			<artifactId>derbytools</artifactId>
 			<scope>test</scope>
-			<version>10.17.1.0</version>
+			<version>10.16.1.1</version>
+			<!--	Don't bump this, they drop support for JRE 17	-->
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>


### PR DESCRIPTION
The version of Derby was bumped [here](https://github.com/hapifhir/hapi-fhir/pull/6449).

The new version dropped support for JRE 17, and required JRE 19+. We need to revert the dependency.

This is only for migration testing and does not introduce any vulnerabilities into HAPI otherwise.