### PR TITLE
remove package-mode from poetry

### DIFF
--- a/.github/workflows/cdr_check/pyproject.toml
+++ b/.github/workflows/cdr_check/pyproject.toml
@@ -3,6 +3,7 @@ name = "tester"
 version = "0.1.0"
 description = ""
 authors = ["Tadgh <garygrantgraham@gmail.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
poetry 2.x exits with code 1 if we do not set package-mode to false when setting up