### PR TITLE
create provenance resource for replace-references and merge operations

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -3168,6 +3168,23 @@ public enum Pointcut implements IPointcut {
 	 */
 	BATCH2_CHUNK_PROCESS_FILTER(
 			IInterceptorFilterHook.class, "ca.uhn.fhir.batch2.model.JobInstance", "ca.uhn.fhir.batch2.model.WorkChunk"),
+
+	/**
+	 * <b>Provenance Agent Hook:</b>
+	 * This pointcut is called to retrieve the data for populating the agent element of a Provenance resource that need to be created
+	 * as a result of a request, such as $merge and $hapi.fhir.replace-references operations.
+	 * <p> Hooks should accept the following parameter:</p>
+	 * <ul>
+	 *     <li>ca.uhn.fhir.jpa.model.ProvenanceAgentPointcutParameters - an object containing the parameters for the hook. It contains:</li>
+	 *     <ul>
+	 *         <li>ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is about to be processed.</li>
+	 *         <li>List of ca.uhn.fhir.model.api.IProvenanceAgent - This is an output parameter. The interceptor should add the agent information to this list</li>
+	 *     </ul>
+	 * </ul>
+	 * Hooks should return <code>void</code>, and use the parameter object to add the agent information.
+	 */
+	PROVENANCE_AGENTS(void.class, "ca.uhn.fhir.jpa.model.IProvenanceAgentsPointcutParameter"),
+
 	/**
 	 * This pointcut is used only for unit tests. Do not use in production code as it may be changed or
 	 * removed at any time.

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -3170,18 +3170,18 @@ public enum Pointcut implements IPointcut {
 			IInterceptorFilterHook.class, "ca.uhn.fhir.batch2.model.JobInstance", "ca.uhn.fhir.batch2.model.WorkChunk"),
 
 	/**
-	 * <b>Provenance Agent Hook:</b>
-	 * This pointcut is called to retrieve the data for populating the agent element of a Provenance resource that need to be created
-	 * as a result of a request, such as $merge and $hapi.fhir.replace-references operations.
+	 * <b>Provenance Agents Pointcut:</b>
+	 * This is a pointcut to retrieve data for populating the agent element of a Provenance resource that needs to be created
+	 * as a result of a request, such as a $merge or a $hapi.fhir.replace-references operation.
 	 * <p> Hooks should accept the following parameter:</p>
 	 * <ul>
-	 *     <li>ca.uhn.fhir.jpa.model.ProvenanceAgentPointcutParameters - an object containing the parameters for the hook. It contains:</li>
+	 *     <li>ca.uhn.fhir.jpa.model.ProvenanceAgentPointcutParameters - an object containing the parameters for the hook, including:</li>
 	 *     <ul>
-	 *         <li>ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is about to be processed.</li>
-	 *         <li>List of ca.uhn.fhir.model.api.IProvenanceAgent - This is an output parameter. The interceptor should add the agent information to this list</li>
+	 *         <li>ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is being processed.</li>
+	 *         <li>List of ca.uhn.fhir.model.api.IProvenanceAgent - This is an output parameter; the hook should add the agent information to this list</li>
 	 *     </ul>
 	 * </ul>
-	 * Hooks should return <code>void</code>, and use the parameter object to add the agent information.
+	 * Hooks should return <code>void</code> and use the parameter object to add the agent information.
 	 */
 	PROVENANCE_AGENTS(void.class, "ca.uhn.fhir.jpa.model.IProvenanceAgentsPointcutParameter"),
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/IProvenanceAgent.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/IProvenanceAgent.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * HAPI FHIR - Core Library
  * %%
@@ -17,31 +17,14 @@
  * limitations under the License.
  * #L%
  */
-package org.hl7.fhir.instance.model.api;
+package ca.uhn.fhir.model.api;
 
-public interface IBaseReference extends ICompositeType {
+import org.hl7.fhir.instance.model.api.IBaseReference;
 
-	IBaseResource getResource();
+import java.io.Serializable;
 
-	IBaseReference setResource(IBaseResource theResource);
+public interface IProvenanceAgent extends Serializable {
+	IBaseReference getWho();
 
-	IIdType getReferenceElement();
-
-	IBaseReference setReference(String theReference);
-
-	IBase setDisplay(String theValue);
-
-	IPrimitiveType<String> getDisplayElement();
-
-	default boolean hasIdentifier() {
-		return false;
-	}
-
-	default IBaseReference setIdentifier(ICompositeType theIdentifier) {
-		throw new UnsupportedOperationException("This reference does not support identifiers");
-	}
-
-	default ICompositeType getIdentifier() {
-		return null;
-	}
+	IBaseReference getOnBehalfOf();
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/ProvenanceAgent.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/ProvenanceAgent.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * HAPI FHIR - Core Library
  * %%
@@ -17,31 +17,34 @@
  * limitations under the License.
  * #L%
  */
-package org.hl7.fhir.instance.model.api;
+package ca.uhn.fhir.model.api;
 
-public interface IBaseReference extends ICompositeType {
+import org.hl7.fhir.instance.model.api.IBaseReference;
 
-	IBaseResource getResource();
+public class ProvenanceAgent implements IProvenanceAgent {
 
-	IBaseReference setResource(IBaseResource theResource);
+	private static final long serialVersionUID = 1L;
 
-	IIdType getReferenceElement();
+	IBaseReference myWho;
+	IBaseReference myOnBehalfOf;
 
-	IBaseReference setReference(String theReference);
-
-	IBase setDisplay(String theValue);
-
-	IPrimitiveType<String> getDisplayElement();
-
-	default boolean hasIdentifier() {
-		return false;
+	@Override
+	public IBaseReference getWho() {
+		return myWho;
 	}
 
-	default IBaseReference setIdentifier(ICompositeType theIdentifier) {
-		throw new UnsupportedOperationException("This reference does not support identifiers");
+	public IProvenanceAgent setWho(IBaseReference theWho) {
+		myWho = theWho;
+		return this;
 	}
 
-	default ICompositeType getIdentifier() {
-		return null;
+	@Override
+	public IBaseReference getOnBehalfOf() {
+		return myOnBehalfOf;
+	}
+
+	public IProvenanceAgent setOnBehalfOf(IBaseReference theOnBehalfOf) {
+		myOnBehalfOf = theOnBehalfOf;
+		return this;
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7037-replace-references-not-existing-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7037-replace-references-not-existing-resources.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7037
+title: "The $hapi.fhir.replace-references operation now returns a 404 ResourceNotFound response when the 
+`source-reference-id` or `target-reference-id` parameter refers to a non-existent resource. 
+Previously, it returned a success response with an empty Bundle in these cases."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7037-replace-references-not-existing-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7037-replace-references-not-existing-resources.yaml
@@ -1,6 +1,6 @@
 ---
 type: fix
 issue: 7037
-title: "The $hapi.fhir.replace-references operation now returns a 404 ResourceNotFound response when the 
-`source-reference-id` or `target-reference-id` parameter refers to a non-existent resource. 
-Previously, it returned a success response with an empty Bundle in these cases."
+title: "Previously, the $hapi.fhir.replace-references operation returned a success response with an empty Bundle when 
+the source-reference-id or target-reference-id parameter referred to a non-existent resource. 
+Now, it returns a 404 ResourceNotFound response in these cases."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7038-provenance-for-replace-references-and-merge.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7038-provenance-for-replace-references-and-merge.yaml
@@ -1,0 +1,5 @@
+--- 
+type: add
+issue: 7038
+title: "$hapi.fhir.replace-references and $merge operations now create a Provenance resource upon successful 
+completion."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -187,6 +187,7 @@ import ca.uhn.fhir.jpa.validation.ResourceLoaderImpl;
 import ca.uhn.fhir.jpa.validation.ValidationSettings;
 import ca.uhn.fhir.model.api.IPrimitiveDatatype;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesPatchBundleSvc;
+import ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IDeleteExpungeJobSubmitter;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
@@ -999,7 +1000,8 @@ public class JpaConfig {
 			IJobCoordinator theJobCoordinator,
 			ReplaceReferencesPatchBundleSvc theReplaceReferencesPatchBundle,
 			Batch2TaskHelper theBatch2TaskHelper,
-			JpaStorageSettings theStorageSettings) {
+			JpaStorageSettings theStorageSettings,
+			ReplaceReferencesProvenanceSvc theProvenanceSvc) {
 		return new ReplaceReferencesSvcImpl(
 				theDaoRegistry,
 				theHapiTransactionService,
@@ -1007,7 +1009,13 @@ public class JpaConfig {
 				theJobCoordinator,
 				theReplaceReferencesPatchBundle,
 				theBatch2TaskHelper,
-				theStorageSettings);
+				theStorageSettings,
+				theProvenanceSvc);
+	}
+
+	@Bean
+	public ReplaceReferencesProvenanceSvc replaceReferencesProvenanceSvc(DaoRegistry theDaoRegistry) {
+		return new ReplaceReferencesProvenanceSvc(theDaoRegistry);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/r4/JpaR4Config.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/r4/JpaR4Config.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.batch2.api.IJobCoordinator;
 import ca.uhn.fhir.batch2.util.Batch2TaskHelper;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.jpa.api.IDaoRegistry;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
@@ -128,7 +129,12 @@ public class JpaR4Config {
 
 	@Bean
 	public PatientMergeProvider patientMergeProvider(
-			FhirContext theFhirContext, DaoRegistry theDaoRegistry, ResourceMergeService theResourceMergeService) {
-		return new PatientMergeProvider(theFhirContext, theDaoRegistry, theResourceMergeService);
+			FhirContext theFhirContext,
+			DaoRegistry theDaoRegistry,
+			ResourceMergeService theResourceMergeService,
+			IInterceptorBroadcaster theInterceptorBroadcaster) {
+
+		return new PatientMergeProvider(
+				theFhirContext, theDaoRegistry, theResourceMergeService, theInterceptorBroadcaster);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/ProvenanceAgentsPointcutUtil.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/ProvenanceAgentsPointcutUtil.java
@@ -1,0 +1,65 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.interceptor;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.HookParams;
+import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.model.IProvenanceAgentsPointcutParameter;
+import ca.uhn.fhir.jpa.model.ProvenanceAgentsPointcutParameter;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *  Utility class for PROVENANCE_AGENTS pointcut.
+ */
+public class ProvenanceAgentsPointcutUtil {
+
+	private ProvenanceAgentsPointcutUtil() {}
+
+	public static List<IProvenanceAgent> ifHasCallHooks(
+			RequestDetails theRequestDetails, IInterceptorBroadcaster theInterceptorBroadcaster) {
+		IInterceptorBroadcaster compositeBroadcaster =
+				CompositeInterceptorBroadcaster.newCompositeBroadcaster(theInterceptorBroadcaster, theRequestDetails);
+
+		if (compositeBroadcaster.hasHooks(Pointcut.PROVENANCE_AGENTS)) {
+
+			ProvenanceAgentsPointcutParameter agentParam = new ProvenanceAgentsPointcutParameter();
+			agentParam.setRequestDetails(theRequestDetails);
+
+			HookParams hookParams = new HookParams().add(IProvenanceAgentsPointcutParameter.class, agentParam);
+			compositeBroadcaster.callHooks(Pointcut.PROVENANCE_AGENTS, hookParams);
+
+			List<IProvenanceAgent> agents = agentParam.getProvenanceAgents();
+			if (agents.isEmpty()) {
+				throw new InternalErrorException(Msg.code(2723)
+						+ "No Provenance Agent was provided by any interceptor for Pointcut.PROVENANCE_AGENTS");
+			}
+			return agents;
+		}
+		return Collections.emptyList();
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/model/IProvenanceAgentsPointcutParameter.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/model/IProvenanceAgentsPointcutParameter.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.model;
+
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+
+import java.util.List;
+
+/**
+ * This interface is used to pass parameters to the {@link Pointcut#PROVENANCE_AGENTS} pointcut.
+ * It allows interceptors to retrieve input parameters and provide provenance agents as an output parameter.
+ */
+public interface IProvenanceAgentsPointcutParameter {
+	List<IProvenanceAgent> getProvenanceAgents();
+
+	IProvenanceAgentsPointcutParameter setProvenanceAgents(List<IProvenanceAgent> theProvenanceAgents);
+
+	void addProvenanceAgent(IProvenanceAgent theProvenanceAgent);
+
+	RequestDetails getRequestDetails();
+
+	IProvenanceAgentsPointcutParameter setRequestDetails(RequestDetails myRequestDetails);
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/model/ProvenanceAgentsPointcutParameter.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/model/ProvenanceAgentsPointcutParameter.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.model;
+
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is used to pass parameters to the {@link ca.uhn.fhir.interceptor.api.Pointcut#PROVENANCE_AGENTS} pointcut.
+ */
+public class ProvenanceAgentsPointcutParameter implements IProvenanceAgentsPointcutParameter {
+	private List<IProvenanceAgent> myProvenanceAgents = new ArrayList<>();
+	private RequestDetails myRequestDetails;
+
+	public List<IProvenanceAgent> getProvenanceAgents() {
+		return myProvenanceAgents;
+	}
+
+	public ProvenanceAgentsPointcutParameter setProvenanceAgents(List<IProvenanceAgent> theProvenanceAgents) {
+		this.myProvenanceAgents = theProvenanceAgents;
+		return this;
+	}
+
+	public void addProvenanceAgent(IProvenanceAgent theProvenanceAgent) {
+		myProvenanceAgents.add(theProvenanceAgent);
+	}
+
+	public RequestDetails getRequestDetails() {
+		return myRequestDetails;
+	}
+
+	public ProvenanceAgentsPointcutParameter setRequestDetails(RequestDetails myRequestDetails) {
+		this.myRequestDetails = myRequestDetails;
+		return this;
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaSystemProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaSystemProvider.java
@@ -21,11 +21,14 @@ package ca.uhn.fhir.jpa.provider;
 
 import ca.uhn.fhir.batch2.jobs.merge.MergeResourceHelper;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.model.ReadPartitionIdRequestDetails;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
+import ca.uhn.fhir.jpa.interceptor.ProvenanceAgentsPointcutUtil;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.model.api.annotation.Description;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesRequest;
@@ -46,6 +49,7 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -59,6 +63,9 @@ import static software.amazon.awssdk.utils.StringUtils.isBlank;
 public final class JpaSystemProvider<T, MT> extends BaseJpaSystemProvider<T, MT> {
 	@Autowired
 	private IRequestPartitionHelperSvc myRequestPartitionHelperSvc;
+
+	@Autowired
+	private IInterceptorBroadcaster myInterceptorBroadcaster;
 
 	@Description(
 			"Marks all currently existing resources of a given type, or all resources of all types, for reindexing.")
@@ -190,8 +197,12 @@ public final class JpaSystemProvider<T, MT> extends BaseJpaSystemProvider<T, MT>
 			IdDt targetId = new IdDt(theTargetId.getValue());
 			RequestPartitionId partitionId = myRequestPartitionHelperSvc.determineReadPartitionForRequest(
 					theServletRequest, ReadPartitionIdRequestDetails.forRead(targetId));
-			ReplaceReferencesRequest replaceReferencesRequest =
-					new ReplaceReferencesRequest(sourceId, targetId, resourceLimit, partitionId);
+
+			List<IProvenanceAgent> provenanceAgents =
+					ProvenanceAgentsPointcutUtil.ifHasCallHooks(theServletRequest, myInterceptorBroadcaster);
+
+			ReplaceReferencesRequest replaceReferencesRequest = new ReplaceReferencesRequest(
+					sourceId, targetId, resourceLimit, partitionId, true, provenanceAgents);
 			IBaseParameters retval =
 					getReplaceReferencesSvc().replaceReferences(replaceReferencesRequest, theServletRequest);
 			if (ParametersUtil.getNamedParameter(getContext(), retval, OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_TASK)

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/ReplaceReferencesSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/ReplaceReferencesSvcImpl.java
@@ -20,21 +20,26 @@
 package ca.uhn.fhir.jpa.provider;
 
 import ca.uhn.fhir.batch2.api.IJobCoordinator;
+import ca.uhn.fhir.batch2.jobs.replacereferences.ProvenanceAgentJson;
 import ca.uhn.fhir.batch2.jobs.replacereferences.ReplaceReferencesJobParameters;
 import ca.uhn.fhir.batch2.util.Batch2TaskHelper;
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceLinkDao;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesPatchBundleSvc;
+import ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesRequest;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.util.StopLimitAccumulator;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Parameters;
@@ -42,6 +47,8 @@ import org.hl7.fhir.r4.model.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static ca.uhn.fhir.batch2.jobs.replacereferences.ReplaceReferencesAppCtx.JOB_REPLACE_REFERENCES;
@@ -58,6 +65,8 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 	private final ReplaceReferencesPatchBundleSvc myReplaceReferencesPatchBundleSvc;
 	private final Batch2TaskHelper myBatch2TaskHelper;
 	private final JpaStorageSettings myStorageSettings;
+	private final ReplaceReferencesProvenanceSvc myReplaceReferencesProvenanceSvc;
+	private final FhirContext myFhirContext;
 
 	public ReplaceReferencesSvcImpl(
 			DaoRegistry theDaoRegistry,
@@ -66,7 +75,8 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 			IJobCoordinator theJobCoordinator,
 			ReplaceReferencesPatchBundleSvc theReplaceReferencesPatchBundleSvc,
 			Batch2TaskHelper theBatch2TaskHelper,
-			JpaStorageSettings theStorageSettings) {
+			JpaStorageSettings theStorageSettings,
+			ReplaceReferencesProvenanceSvc theReplaceReferencesProvenanceSvc) {
 		myDaoRegistry = theDaoRegistry;
 		myHapiTransactionService = theHapiTransactionService;
 		myResourceLinkDao = theResourceLinkDao;
@@ -74,6 +84,8 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 		myReplaceReferencesPatchBundleSvc = theReplaceReferencesPatchBundleSvc;
 		myBatch2TaskHelper = theBatch2TaskHelper;
 		myStorageSettings = theStorageSettings;
+		myReplaceReferencesProvenanceSvc = theReplaceReferencesProvenanceSvc;
+		myFhirContext = theDaoRegistry.getFhirContext();
 	}
 
 	@Override
@@ -81,10 +93,18 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 			ReplaceReferencesRequest theReplaceReferencesRequest, RequestDetails theRequestDetails) {
 		theReplaceReferencesRequest.validateOrThrowInvalidParameterException();
 
+		// Read the source and target resources, this is done for two reasons:
+		// 1. To ensure that the resources exist
+		// 2. To find out the current versions of the resources, which is needed for creating the Provenance resource
+		IBaseResource sourceResource = readResource(theReplaceReferencesRequest.sourceId, theRequestDetails);
+		IBaseResource targetResource = readResource(theReplaceReferencesRequest.targetId, theRequestDetails);
+
 		if (theRequestDetails.isPreferAsync()) {
-			return replaceReferencesPreferAsync(theReplaceReferencesRequest, theRequestDetails);
+			return replaceReferencesPreferAsync(
+					theReplaceReferencesRequest, theRequestDetails, sourceResource, targetResource);
 		} else {
-			return replaceReferencesPreferSync(theReplaceReferencesRequest, theRequestDetails);
+			return replaceReferencesPreferSync(
+					theReplaceReferencesRequest, theRequestDetails, sourceResource, targetResource);
 		}
 	}
 
@@ -97,15 +117,24 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 	}
 
 	private IBaseParameters replaceReferencesPreferAsync(
-			ReplaceReferencesRequest theReplaceReferencesRequest, RequestDetails theRequestDetails) {
+			ReplaceReferencesRequest theReplaceReferencesRequest,
+			RequestDetails theRequestDetails,
+			IBaseResource theSourceResource,
+			IBaseResource theTargetResource) {
+
+		ReplaceReferencesJobParameters jobParams = new ReplaceReferencesJobParameters(
+				theReplaceReferencesRequest,
+				myStorageSettings.getDefaultTransactionEntriesForWrite(),
+				theSourceResource.getIdElement().getVersionIdPart(),
+				theTargetResource.getIdElement().getVersionIdPart(),
+				ProvenanceAgentJson.from(theReplaceReferencesRequest.provenanceAgents, myFhirContext));
 
 		Task task = myBatch2TaskHelper.startJobAndCreateAssociatedTask(
 				myDaoRegistry.getResourceDao(Task.class),
 				theRequestDetails,
 				myJobCoordinator,
 				JOB_REPLACE_REFERENCES,
-				new ReplaceReferencesJobParameters(
-						theReplaceReferencesRequest, myStorageSettings.getDefaultTransactionEntriesForWrite()));
+				jobParams);
 
 		Parameters retval = new Parameters();
 		task.setIdElement(task.getIdElement().toUnqualifiedVersionless());
@@ -117,15 +146,21 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 	}
 
 	/**
-	 * Try to perform the operation synchronously. However if there is more than a page of results, fall back to asynchronous operation
+	 * Try to perform the operation synchronously. If there are more resources to process than the specified resource limit,
+	 * throws a PreconditionFailedException.
 	 */
 	@Nonnull
 	private IBaseParameters replaceReferencesPreferSync(
-			ReplaceReferencesRequest theReplaceReferencesRequest, RequestDetails theRequestDetails) {
+			ReplaceReferencesRequest theReplaceReferencesRequest,
+			RequestDetails theRequestDetails,
+			IBaseResource theSourceResource,
+			IBaseResource theTargetResource) {
 
-		// TODO KHS get partition from request
+		Date startTime = new Date();
+
 		StopLimitAccumulator<IdDt> accumulator = myHapiTransactionService
 				.withRequest(theRequestDetails)
+				.withRequestPartitionId(theReplaceReferencesRequest.partitionId)
 				.execute(() -> getAllPidsWithLimit(theReplaceReferencesRequest));
 
 		if (accumulator.isTruncated()) {
@@ -138,6 +173,17 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 
 		Bundle result = myReplaceReferencesPatchBundleSvc.patchReferencingResources(
 				theReplaceReferencesRequest, accumulator.getItemList(), theRequestDetails);
+
+		if (theReplaceReferencesRequest.createProvenance) {
+			myReplaceReferencesProvenanceSvc.createProvenance(
+					// we need to use versioned ids for the Provenance resource
+					theTargetResource.getIdElement().toUnqualified(),
+					theSourceResource.getIdElement().toUnqualified(),
+					List.of(result),
+					startTime,
+					theRequestDetails,
+					theReplaceReferencesRequest.provenanceAgents);
+		}
 
 		Parameters retval = new Parameters();
 		retval.addParameter()
@@ -155,5 +201,11 @@ public class ReplaceReferencesSvcImpl implements IReplaceReferencesSvc {
 		StopLimitAccumulator<IdDt> accumulator =
 				StopLimitAccumulator.fromStreamAndLimit(idStream, theReplaceReferencesRequest.resourceLimit);
 		return accumulator;
+	}
+
+	private IBaseResource readResource(IIdType theId, RequestDetails theRequestDetails) {
+		String resourceType = theId.getResourceType();
+		IFhirResourceDao<IBaseResource> resourceDao = myDaoRegistry.getResourceDao(resourceType);
+		return resourceDao.read(theId, theRequestDetails);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/merge/BaseMergeOperationInputParameters.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/merge/BaseMergeOperationInputParameters.java
@@ -21,9 +21,11 @@ package ca.uhn.fhir.jpa.provider.merge;
 
 import ca.uhn.fhir.batch2.jobs.chunk.FhirIdJson;
 import ca.uhn.fhir.batch2.jobs.merge.MergeJobParameters;
+import ca.uhn.fhir.batch2.jobs.replacereferences.ProvenanceAgentJson;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.util.CanonicalIdentifier;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -44,6 +46,8 @@ public abstract class BaseMergeOperationInputParameters {
 	private boolean myDeleteSource;
 	private IBaseResource myResultResource;
 	private final int myResourceLimit;
+	private List<IProvenanceAgent> myProvenanceAgents;
+	private boolean myCreateProvenance = true;
 
 	protected BaseMergeOperationInputParameters(int theResourceLimit) {
 		myResourceLimit = theResourceLimit;
@@ -127,6 +131,22 @@ public abstract class BaseMergeOperationInputParameters {
 		return myResourceLimit;
 	}
 
+	public boolean getCreateProvenance() {
+		return myCreateProvenance;
+	}
+
+	public void setCreateProvenance(boolean theCreateProvenance) {
+		this.myCreateProvenance = theCreateProvenance;
+	}
+
+	public List<IProvenanceAgent> getProvenanceAgents() {
+		return myProvenanceAgents;
+	}
+
+	public void setProvenanceAgents(List<IProvenanceAgent> theProvenanceAgents) {
+		this.myProvenanceAgents = theProvenanceAgents;
+	}
+
 	public MergeJobParameters asMergeJobParameters(
 			FhirContext theFhirContext,
 			JpaStorageSettings theStorageSettings,
@@ -142,6 +162,8 @@ public abstract class BaseMergeOperationInputParameters {
 		retval.setSourceId(new FhirIdJson(theSourceResource.getIdElement().toVersionless()));
 		retval.setTargetId(new FhirIdJson(theTargetResource.getIdElement().toVersionless()));
 		retval.setPartitionId(thePartitionId);
+		retval.setProvenanceAgents(ProvenanceAgentJson.from(myProvenanceAgents, theFhirContext));
+		retval.setCreateProvenance(myCreateProvenance);
 		return retval;
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeService.java
@@ -32,21 +32,29 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.provider.IReplaceReferencesSvc;
+import ca.uhn.fhir.merge.MergeProvenanceSvc;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesRequest;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.util.OperationOutcomeUtil;
+import ca.uhn.fhir.util.ParametersUtil;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
+import java.util.List;
+
 import static ca.uhn.fhir.batch2.jobs.merge.MergeAppCtx.JOB_MERGE;
 import static ca.uhn.fhir.rest.api.Constants.STATUS_HTTP_200_OK;
 import static ca.uhn.fhir.rest.api.Constants.STATUS_HTTP_202_ACCEPTED;
 import static ca.uhn.fhir.rest.api.Constants.STATUS_HTTP_500_INTERNAL_ERROR;
+import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME;
 
 /**
  * Service for the FHIR $merge operation. Currently only supports Patient/$merge. The plan is to expand to other resource types.
@@ -65,6 +73,7 @@ public class ResourceMergeService {
 	private final MergeResourceHelper myMergeResourceHelper;
 	private final Batch2TaskHelper myBatch2TaskHelper;
 	private final MergeValidationService myMergeValidationService;
+	private final MergeProvenanceSvc myMergeProvenanceSvc;
 
 	public ResourceMergeService(
 			JpaStorageSettings theStorageSettings,
@@ -84,13 +93,18 @@ public class ResourceMergeService {
 		myBatch2TaskHelper = theBatch2TaskHelper;
 		myFhirContext = myPatientDao.getContext();
 		myHapiTransactionService = theHapiTransactionService;
-		myMergeResourceHelper = new MergeResourceHelper(myPatientDao);
+		myMergeProvenanceSvc = new MergeProvenanceSvc(theDaoRegistry);
+		myMergeResourceHelper = new MergeResourceHelper(theDaoRegistry, myMergeProvenanceSvc);
 		myMergeValidationService = new MergeValidationService(myFhirContext, theDaoRegistry);
 	}
 
 	/**
-	 * Perform the $merge operation. If the number of resources to be changed exceeds the provided batch size,
-	 * then switch to async mode.  See the <a href="https://build.fhir.org/patient-operation-merge.html">Patient $merge spec</a>
+	 * Perform the $merge operation. Operation can be performed synchronously or asynchronously depending on
+	 * the prefer-async request header.
+	 * If the operation is requested to be performed synchronously and the number of
+	 * resources to be changed exceeds the provided batch size,
+	 * and error is returned indicating that operation needs to be performed asynchronously. See the
+	 * <a href="https://build.fhir.org/patient-operation-merge.html">Patient $merge spec</a>
 	 * for details on what the difference is between synchronous and asynchronous mode.
 	 *
 	 * @param theMergeOperationParameters the merge operation parameters
@@ -211,22 +225,45 @@ public class ResourceMergeService {
 			MergeOperationOutcome theMergeOutcome,
 			RequestPartitionId partitionId) {
 
+		Date startTime = new Date();
 		ReplaceReferencesRequest replaceReferencesRequest = new ReplaceReferencesRequest(
 				theSourceResource.getIdElement(),
 				theTargetResource.getIdElement(),
 				theMergeOperationParameters.getResourceLimit(),
-				partitionId);
+				partitionId,
+				// don't create provenance as part of replace-references,
+				// we create it after updating source and target for merge
+				false,
+				null);
 
-		myReplaceReferencesSvc.replaceReferences(replaceReferencesRequest, theRequestDetails);
+		IBaseParameters outParams =
+				myReplaceReferencesSvc.replaceReferences(replaceReferencesRequest, theRequestDetails);
 
-		Patient updatedTarget = myMergeResourceHelper.updateMergedResourcesAfterReferencesReplaced(
-				myHapiTransactionService,
-				theSourceResource,
-				theTargetResource,
-				(Patient) theMergeOperationParameters.getResultResource(),
-				theMergeOperationParameters.getDeleteSource(),
-				theRequestDetails);
-		theMergeOutcome.setUpdatedTargetResource(updatedTarget);
+		Bundle patchResultBundle = (Bundle) ParametersUtil.getNamedParameterResource(
+						myFhirContext, outParams, OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME)
+				.orElseThrow();
+
+		myHapiTransactionService.withRequest(theRequestDetails).execute(() -> {
+			Patient updatedTarget = myMergeResourceHelper.updateMergedResourcesAfterReferencesReplaced(
+					theSourceResource,
+					theTargetResource,
+					(Patient) theMergeOperationParameters.getResultResource(),
+					theMergeOperationParameters.getDeleteSource(),
+					theRequestDetails);
+
+			theMergeOutcome.setUpdatedTargetResource(updatedTarget);
+
+			if (theMergeOperationParameters.getCreateProvenance()) {
+				myMergeResourceHelper.createProvenance(
+						theSourceResource,
+						updatedTarget,
+						List.of(patchResultBundle),
+						theMergeOperationParameters.getDeleteSource(),
+						theRequestDetails,
+						startTime,
+						theMergeOperationParameters.getProvenanceAgents());
+			}
+		});
 
 		String detailsText = "Merge operation completed successfully.";
 		addInfoToOperationOutcome(theMergeOutcome.getOperationOutcome(), null, detailsText);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeServiceTest.java
@@ -23,11 +23,15 @@ import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.util.CanonicalIdentifier;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Task;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +46,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.OngoingStubbing;
 import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 
@@ -90,6 +96,9 @@ public class ResourceMergeServiceTest {
 	IFhirResourceDaoPatient<Task> myTaskDaoMock;
 
 	@Mock
+	IFhirResourceDaoPatient<Provenance> myProvenanceDaoMock;
+
+	@Mock
 	IReplaceReferencesSvc myReplaceReferencesSvcMock;
 
 	@Mock
@@ -125,6 +134,7 @@ public class ResourceMergeServiceTest {
 	void setup() {
 		when(myDaoRegistryMock.getResourceDao(eq(Patient.class))).thenReturn(myPatientDaoMock);
 		when(myDaoRegistryMock.getResourceDao(eq(Task.class))).thenReturn(myTaskDaoMock);
+		when(myDaoRegistryMock.getResourceDao(eq("Provenance"))).thenReturn(myProvenanceDaoMock);
 		when(myPatientDaoMock.getContext()).thenReturn(myFhirContext);
 		myResourceMergeService = new ResourceMergeService(
 			myStorageSettingsMock,
@@ -154,8 +164,8 @@ public class ResourceMergeServiceTest {
 		targetPatient.addIdentifier(new Identifier().setSystem("sysTarget").setValue("valT1"));
 		setupDaoMockForSuccessfulRead(sourcePatient);
 		setupDaoMockForSuccessfulRead(targetPatient);
-		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, new Patient());
-		Patient patientReturnedFromDaoAfterTargetUpdate = new Patient();
+		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, createPatient(SOURCE_PATIENT_TEST_ID_WITH_VERSION_2));
+		Patient patientReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(targetPatient, patientReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -173,7 +183,8 @@ public class ResourceMergeServiceTest {
 			new Identifier().setSystem("sysSource").setValue("valS1").setUse(Identifier.IdentifierUse.OLD),
 			new Identifier().setSystem("sysSource").setValue("valS2").setUse(Identifier.IdentifierUse.OLD));
 		verifyUpdatedTargetPatient(true, expectedIdentifiers);
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(false);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -188,8 +199,8 @@ public class ResourceMergeServiceTest {
 		targetPatient.setActive(true);
 		setupDaoMockForSuccessfulRead(sourcePatient);
 		setupDaoMockForSuccessfulRead(targetPatient);
-		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, new Patient());
-		Patient patientReturnedFromDaoAfterTargetUpdate = new Patient();
+		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, createPatient(SOURCE_PATIENT_TEST_ID_WITH_VERSION_2));
+		Patient patientReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(targetPatient, patientReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -201,7 +212,8 @@ public class ResourceMergeServiceTest {
 		verifySuccessfulOutcomeForSync(mergeOutcome, patientReturnedFromDaoAfterTargetUpdate);
 		verifyUpdatedSourcePatient();
 		verifyUpdatedTargetPatient(true, Collections.emptyList());
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(false);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@Test
@@ -222,8 +234,8 @@ public class ResourceMergeServiceTest {
 		setupDaoMockForSuccessfulRead(sourcePatient);
 		setupDaoMockForSuccessfulRead(targetPatient);
 
-		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, new Patient());
-		Patient patientToBeReturnedFromDaoAfterTargetUpdate = new Patient();
+		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, createPatient(SOURCE_PATIENT_TEST_ID_WITH_VERSION_2));
+		Patient patientToBeReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(resultPatient, patientToBeReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -235,7 +247,8 @@ public class ResourceMergeServiceTest {
 		verifySuccessfulOutcomeForSync(mergeOutcome, patientToBeReturnedFromDaoAfterTargetUpdate);
 		verifyUpdatedSourcePatient();
 		verifyUpdatedTargetPatient(true, Collections.emptyList());
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(false);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -259,8 +272,8 @@ public class ResourceMergeServiceTest {
 		setupDaoMockForSuccessfulRead(sourcePatient);
 		setupDaoMockSearchForIdentifiers(List.of(List.of(targetPatient)));
 
-		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, new Patient());
-		Patient patientToBeReturnedFromDaoAfterTargetUpdate = new Patient();
+		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, createPatient(SOURCE_PATIENT_TEST_ID_WITH_VERSION_2));
+		Patient patientToBeReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(resultPatient, patientToBeReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -277,7 +290,8 @@ public class ResourceMergeServiceTest {
 			new Identifier().setSystem("sys").setValue("val2")
 		);
 		verifyUpdatedTargetPatient(true, expectedIdentifiers);
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(false);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@Test
@@ -293,7 +307,7 @@ public class ResourceMergeServiceTest {
 		setupDaoMockForSuccessfulRead(targetPatient);
 
 		when(myPatientDaoMock.delete(new IdType(SOURCE_PATIENT_TEST_ID_WITH_VERSION_1), myRequestDetailsMock)).thenReturn(new DaoMethodOutcome());
-		Patient patientToBeReturnedFromDaoAfterTargetUpdate = new Patient();
+		Patient patientToBeReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(targetPatient, patientToBeReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -305,7 +319,8 @@ public class ResourceMergeServiceTest {
 		// Then
 		verifySuccessfulOutcomeForSync(mergeOutcome, patientToBeReturnedFromDaoAfterTargetUpdate);
 		verifyUpdatedTargetPatient(false, Collections.emptyList());
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(true);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -324,7 +339,7 @@ public class ResourceMergeServiceTest {
 		setupDaoMockForSuccessfulRead(targetPatient);
 
 		when(myPatientDaoMock.delete(new IdType(SOURCE_PATIENT_TEST_ID_WITH_VERSION_1), myRequestDetailsMock)).thenReturn(new DaoMethodOutcome());
-		Patient patientToBeReturnedFromDaoAfterTargetUpdate = new Patient();
+		Patient patientToBeReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(resultPatient, patientToBeReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -336,7 +351,8 @@ public class ResourceMergeServiceTest {
 		// Then
 		verifySuccessfulOutcomeForSync(mergeOutcome, patientToBeReturnedFromDaoAfterTargetUpdate);
 		verifyUpdatedTargetPatient(false, Collections.emptyList());
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(true);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@Test
@@ -367,7 +383,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDetails().getText()).contains("Preview only merge operation - no issues detected");
 		assertThat(issue.getDiagnostics()).contains("Merge would update 12 resources");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@Test
@@ -380,8 +396,8 @@ public class ResourceMergeServiceTest {
 		Patient targetPatient = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulRead(sourcePatient);
 		setupDaoMockForSuccessfulRead(targetPatient);
-		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, new Patient());
-		Patient patientToBeReturnedFromDaoAfterTargetUpdate = new Patient();
+		setupDaoMockForSuccessfulSourcePatientUpdate(sourcePatient, createPatient(SOURCE_PATIENT_TEST_ID_WITH_VERSION_2));
+		Patient patientToBeReturnedFromDaoAfterTargetUpdate = createPatient(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
 		setupDaoMockForSuccessfulTargetPatientUpdate(targetPatient, patientToBeReturnedFromDaoAfterTargetUpdate);
 		setupTransactionServiceMock();
 		setupReplaceReferencesForSuccessForSync();
@@ -393,7 +409,8 @@ public class ResourceMergeServiceTest {
 		verifySuccessfulOutcomeForSync(mergeOutcome, patientToBeReturnedFromDaoAfterTargetUpdate);
 		verifyUpdatedSourcePatient();
 		verifyUpdatedTargetPatient(true, Collections.emptyList());
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyProvenanceCreated(false);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -431,10 +448,10 @@ public class ResourceMergeServiceTest {
 
 		verifySuccessfulOutcomeForAsync(mergeOutcome, task);
 		verifyBatch2JobTaskHelperMockInvocation(resultResource, theWithDeleteSource);
-
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
+	//  ERROR CASES
 	@ParameterizedTest
 	@CsvSource({
 		"true, false",
@@ -442,8 +459,8 @@ public class ResourceMergeServiceTest {
 		"true, true",
 		"false, false"
 	})
-	void testMerge_AsyncBecauseOfLargeNumberOfRefs_Success(boolean theWithResultResource,
-														   boolean theWithDeleteSource) {
+	void testMerge_SyncRequest_ReplaceReferencesThrowsPreconditionFailedException_TheExceptionReturnedToClientInOutcome(boolean theWithResultResource,
+																														boolean theWithDeleteSource) {
 		// Given
 		BaseMergeOperationInputParameters mergeOperationParameters = new PatientMergeOperationInputParameters(PAGE_SIZE);
 		mergeOperationParameters.setSourceResource(new Reference(SOURCE_PATIENT_TEST_ID));
@@ -466,7 +483,7 @@ public class ResourceMergeServiceTest {
 		MergeOperationOutcome mergeOutcome = myResourceMergeService.merge(mergeOperationParameters, myRequestDetailsMock);
 
 		verifyFailedOutcome(mergeOutcome);
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	private void verifyFailedOutcome(MergeOperationOutcome theMergeOutcome) {
@@ -476,7 +493,6 @@ public class ResourceMergeServiceTest {
 		assertThat(operationOutcome.getIssueFirstRep().getDiagnostics()).isEqualTo(PRECONDITION_FAILED_MESSAGE);
 	}
 
-	//  ERROR CASES
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
 	void testMerge_UnhandledServerResponseExceptionThrown_UsesStatusCodeOfTheException(boolean thePreview) {
@@ -501,7 +517,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("this is the exception message");
 		assertThat(issue.getCode().toCode()).isEqualTo("exception");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -528,7 +544,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("this is the exception message");
 		assertThat(issue.getCode().toCode()).isEqualTo("exception");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -552,7 +568,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains(MISSING_SOURCE_PARAMS_MSG);
 		assertThat(issue.getCode().toCode()).isEqualTo("required");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -578,7 +594,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains(MISSING_TARGET_PARAMS_MSG);
 		assertThat(issue.getCode().toCode()).isEqualTo("required");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -605,7 +621,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue2.getDiagnostics()).contains(MISSING_TARGET_PARAMS_MSG);
 		assertThat(issue2.getCode().toCode()).isEqualTo("required");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -632,7 +648,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getCode().toCode()).isEqualTo("required");
 
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -659,7 +675,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains(BOTH_TARGET_PARAMS_PROVIDED_MSG);
 		assertThat(issue.getCode().toCode()).isEqualTo("required");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -686,7 +702,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("Reference specified in 'source-patient' parameter does not have a reference element.");
 		assertThat(issue.getCode().toCode()).isEqualTo("required");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -714,7 +730,7 @@ public class ResourceMergeServiceTest {
 			"a reference element.");
 		assertThat(issue.getCode().toCode()).isEqualTo("required");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -740,7 +756,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("Resource not found for the reference specified in 'source-patient'");
 		assertThat(issue.getCode().toCode()).isEqualTo("not-found");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -768,7 +784,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("Resource not found for the reference specified in 'target-patient'");
 		assertThat(issue.getCode().toCode()).isEqualTo("not-found");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -798,7 +814,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("No resources found matching the identifier(s) specified in 'source-patient-identifier'");
 		assertThat(issue.getCode().toCode()).isEqualTo("not-found");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -832,7 +848,7 @@ public class ResourceMergeServiceTest {
 			" 'source-patient-identifier'");
 		assertThat(issue.getCode().toCode()).isEqualTo("multiple-matches");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -866,7 +882,7 @@ public class ResourceMergeServiceTest {
 			"'target-patient-identifier'");
 		assertThat(issue.getCode().toCode()).isEqualTo("not-found");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -901,7 +917,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("Multiple resources found matching the identifier(s) specified in 'target-patient-identifier'");
 		assertThat(issue.getCode().toCode()).isEqualTo("multiple-matches");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -929,7 +945,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("The reference in 'source-patient' parameter has a version specified, but it is not the latest version of the resource");
 		assertThat(issue.getCode().toCode()).isEqualTo("conflict");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -960,7 +976,7 @@ public class ResourceMergeServiceTest {
 			"specified, but it is not the latest version of the resource");
 		assertThat(issue.getCode().toCode()).isEqualTo("conflict");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -989,8 +1005,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("Source and target resources are the same resource.");
 
-		//TODO: enable this
-		//verifyNoMoreInteractions(myDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1019,7 +1034,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("Target resource is not active, it must be active to be the target of a merge operation");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1050,7 +1065,7 @@ public class ResourceMergeServiceTest {
 			"reference 'Patient/replacing-res-id', it is " +
 			"not a suitable target for merging.");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1080,7 +1095,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getDiagnostics()).contains("Source resource was previously replaced by a resource with " +
 			"reference 'Patient/replacing-res-id', it is not a suitable source for merging.");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1114,7 +1129,7 @@ public class ResourceMergeServiceTest {
 			"as the actual" +
 			" resolved target resource 'Patient/not-the-target-id'. The actual resolved target resource's id is: '" + TARGET_PATIENT_TEST_ID +"'");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -1153,7 +1168,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("'result-patient' must have all the identifiers provided in target-patient-identifier");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 
@@ -1185,7 +1200,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("'result-patient' must have a 'replaces' link to the source resource.");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1218,7 +1233,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("'result-patient' must have a 'replaces' link to the source resource.");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1251,7 +1266,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("'result-patient' must not have a 'replaces' link to the source resource when the source resource will be deleted, as the link may prevent deleting the source resource.");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	@ParameterizedTest
@@ -1286,7 +1301,7 @@ public class ResourceMergeServiceTest {
 		assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
 		assertThat(issue.getDiagnostics()).contains("'result-patient' has multiple 'replaces' links to the source resource. There should be only one.");
 
-		verifyNoMoreInteractions(myPatientDaoMock);
+		verifyNoMoreInteractions(myPatientDaoMock, myTaskDaoMock, myProvenanceDaoMock, myBatch2TaskHelperMock);
 	}
 
 	private void verifySuccessfulOutcomeForSync(MergeOperationOutcome theMergeOutcome, Patient theExpectedTargetResource) {
@@ -1391,6 +1406,7 @@ public class ResourceMergeServiceTest {
 
 				DaoMethodOutcome outcome = new DaoMethodOutcome();
 				outcome.setResource(thePatientToReturnInDaoOutcome);
+				thePatientExpectedAsInput.setId(thePatientToReturnInDaoOutcome.getIdElement());
 				return outcome;
 			});
 	}
@@ -1415,10 +1431,58 @@ public class ResourceMergeServiceTest {
 
 	}
 
+	private void verifyProvenanceCreated(boolean theDeleteSource) {
+
+		ArgumentCaptor<Provenance> captor = ArgumentCaptor.forClass(Provenance.class);
+		verify(myProvenanceDaoMock).create(captor.capture(), eq(myRequestDetailsMock));
+
+		Provenance provenance = captor.getValue();
+		//assert targets
+		assertThat(provenance.getTarget()).hasSize(theDeleteSource ? 1 : 2);
+		// the first target reference should be the target patient
+		String targetPatientReference = provenance.getTarget().get(0).getReference();
+		assertThat(targetPatientReference).isEqualTo(TARGET_PATIENT_TEST_ID_WITH_VERSION_2);
+		if (!theDeleteSource) {
+			// the second target reference should be the source patient, if it wasn't deleted
+			String sourcePatientReference = provenance.getTarget().get(1).getReference();
+			assertThat(sourcePatientReference).isEqualTo(SOURCE_PATIENT_TEST_ID_WITH_VERSION_2);
+		}
+
+		Instant now = Instant.now();
+		Instant oneMinuteAgo = now.minus(1, ChronoUnit.MINUTES);
+		assertThat(provenance.getRecorded()).isBetween(oneMinuteAgo, now, true, true);
+
+		Period period = provenance.getOccurredPeriod();
+		// since this is unit test and the test runs fast, the start time could be same as the end time
+		assertThat(period.getStart()).isBeforeOrEqualTo(period.getEnd());
+		assertThat(period.getStart()).isBetween(oneMinuteAgo, now, true, true);
+		assertThat(period.getEnd()).isEqualTo(provenance.getRecorded());
+
+		// validate provenance.reason
+		assertThat(provenance.getReason()).hasSize(1);
+		Coding reasonCoding = provenance.getReason().get(0).getCodingFirstRep();
+		assertThat(reasonCoding).isNotNull();
+		assertThat(reasonCoding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v3-ActReason");
+		assertThat(reasonCoding.getCode()).isEqualTo("PATADMIN");
+
+		//validate provenance.activity
+		Coding activityCoding = provenance.getActivity().getCodingFirstRep();
+		assertThat(activityCoding).isNotNull();
+		assertThat(activityCoding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle");
+		assertThat(activityCoding.getCode()).isEqualTo("merge");
+	}
+
+
+
 	private void setupReplaceReferencesForSuccessForSync() {
-		// set the count to less that the page size for sync processing
+		Parameters parameters = new Parameters();
+		Parameters.ParametersParameterComponent outcomeParameter = new Parameters.ParametersParameterComponent();
+		outcomeParameter.setName("outcome");
+		outcomeParameter.setResource(new Bundle());
+		parameters.addParameter(outcomeParameter);
+
 		when(myReplaceReferencesSvcMock.replaceReferences(isA(ReplaceReferencesRequest.class),
-			eq(myRequestDetailsMock))).thenReturn(new Parameters());
+			eq(myRequestDetailsMock))).thenReturn(parameters);
 	}
 
 	private void setupBatch2JobTaskHelperMock(Task theTaskToReturn) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMergeR4Test.java
@@ -215,7 +215,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		// validate:
 		// the result will contain the input parameters, the outcome,
 		// and in sync and preview modes the resulting patient
-		// or  in async mode the task resource instead of the resulting patient
+		// or in async mode the task resource instead of the resulting patient
 		assertThat(outParams.getParameter()).hasSize(3);
 
 		// Assert input

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMergeR4Test.java
@@ -4,14 +4,18 @@ import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper;
 import ca.uhn.fhir.jpa.test.Batch2JobHelper;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.parser.StrictErrorHandler;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletResponse;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Encounter;
@@ -32,6 +36,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -78,12 +84,96 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		myStorageSettings.setReuseCachedSearchResultsForMillis(null);
 		myStorageSettings.setAllowMultipleDelete(true);
 		myFhirContext.setParserErrorHandler(new StrictErrorHandler());
-
+		// we need to keep the version on Provenance.target fields to
+		// verify that Provenance resources were saved with versioned target references
+		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
 		myTestHelper = new ReplaceReferencesTestHelper(myFhirContext, myDaoRegistry);
 		myTestHelper.beforeEach();
 	}
 
-	@ParameterizedTest
+	private void waitForAsyncTaskCompletion(Parameters theOutParams) {
+		assertThat(getLastHttpStatusCode()).isEqualTo(HttpServletResponse.SC_ACCEPTED);
+		Task task = (Task) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_TASK).getResource();
+		assertNull(task.getIdElement().getVersionIdPart());
+		ourLog.info("Got task {}", task.getId());
+		String jobId = myTestHelper.getJobIdFromTask(task);
+		myBatch2JobHelper.awaitJobCompletion(jobId);
+	}
+
+	private void validateTaskOutput(Parameters theOutParams) {
+		Task task = (Task) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_TASK).getResource();
+		Task taskWithOutput = myTaskDao.read(task.getIdElement(), mySrd);
+		assertThat(taskWithOutput.getStatus()).isEqualTo(Task.TaskStatus.COMPLETED);
+		ourLog.info("Complete Task: {}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(taskWithOutput));
+
+		Task.TaskOutputComponent taskOutput = taskWithOutput.getOutputFirstRep();
+
+		// Assert on the output type
+		Coding taskType = taskOutput.getType().getCodingFirstRep();
+		assertEquals(RESOURCE_TYPES_SYSTEM, taskType.getSystem());
+		assertEquals("Bundle", taskType.getCode());
+
+		List<Resource> containedResources = taskWithOutput.getContained();
+		assertThat(containedResources)
+			.hasSize(1)
+			.element(0)
+			.isInstanceOf(Bundle.class);
+
+		Bundle containedBundle = (Bundle) containedResources.get(0);
+
+		Reference outputRef = (Reference) taskOutput.getValue();
+		Bundle patchResultBundle = (Bundle) outputRef.getResource();
+		assertTrue(containedBundle.equalsDeep(patchResultBundle));
+		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
+			ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES,
+			List.of("Observation", "Encounter", "CarePlan"));
+
+
+		OperationOutcome outcome = (OperationOutcome) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_OUTCOME).getResource();
+		assertThat(outcome.getIssue())
+			.hasSize(1)
+			.element(0)
+			.satisfies(issue -> {
+				assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
+				assertThat(issue.getDetails().getText()).isEqualTo("Merge request is accepted, and will be " +
+					"processed asynchronously. See task resource returned in this response for details.");
+			});
+	}
+
+	private void validateSyncOutcome(Parameters theOutParams) {
+		// Assert outcome
+		OperationOutcome outcome = (OperationOutcome) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_OUTCOME).getResource();
+		assertThat(outcome.getIssue())
+			.hasSize(1)
+			.element(0)
+			.satisfies(issue -> {
+				assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
+				assertThat(issue.getDetails().getText()).isEqualTo("Merge operation completed successfully.");
+			});
+
+		// In sync mode, the result patient is returned in the output,
+		// assert what is returned is the same as the one in the db
+		Patient targetPatientInOutput = (Patient) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_RESULT).getResource();
+		Patient targetPatientReadFromDB = myTestHelper.readTargetPatient();
+		IParser parser = myFhirContext.newJsonParser();
+		assertThat(parser.encodeResourceToString(targetPatientInOutput)).isEqualTo(parser.encodeResourceToString(targetPatientReadFromDB));
+	}
+
+
+	private void validatePreviewModeOutcome(Parameters theOutParams) {
+		OperationOutcome outcome = (OperationOutcome) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_OUTCOME).getResource();
+		assertThat(outcome.getIssue())
+			.hasSize(1)
+			.element(0)
+			.satisfies(issue -> {
+				assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
+				assertThat(issue.getDetails().getText()).isEqualTo("Preview only merge operation - no issues detected");
+				assertThat(issue.getDiagnostics()).isEqualTo("Merge would update 25 resources");
+			});
+	}
+
+
+	@ParameterizedTest(name = "{index}: deleteSource={0}, resultPatient={1}, preview={2}, async={3}")
 	@CsvSource({
 		// withDelete, withInputResultPatient, withPreview, isAsync
 		"true, true, true, false",
@@ -122,9 +212,11 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		// exec
 		Parameters outParams = callMergeOperation(inParameters, isAsync);
 
-		// validate
-		// in async mode, there will be an additional task resource in the output params
-		assertThat(outParams.getParameter()).hasSizeBetween(3, 4);
+		// validate:
+		// the result will contain the input parameters, the outcome,
+		// and in sync and preview modes the resulting patient
+		// or  in async mode the task resource instead of the resulting patient
+		assertThat(outParams.getParameter()).hasSize(3);
 
 		// Assert input
 		Parameters input = (Parameters) outParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_INPUT).getResource();
@@ -136,97 +228,93 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		}
 		assertTrue(input.equalsDeep(inParameters));
 
-
 		List<Identifier> expectedIdentifiersOnTargetAfterMerge =
 			myTestHelper.getExpectedIdentifiersForTargetAfterMerge(withInputResultPatient);
 
-		// Assert Task inAsync mode, unless it is preview in which case we don't return a task
-		if (isAsync && !withPreview) {
-			assertThat(getLastHttpStatusCode()).isEqualTo(HttpServletResponse.SC_ACCEPTED);
 
-			Task task = (Task) outParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_TASK).getResource();
-			assertNull(task.getIdElement().getVersionIdPart());
-			ourLog.info("Got task {}", task.getId());
-			String jobId = myTestHelper.getJobIdFromTask(task);
-			myBatch2JobHelper.awaitJobCompletion(jobId);
+		if (withPreview) {
+			validatePreviewModeOutcome(outParams);
+			myTestHelper.assertNothingChanged();
+			//no more validation is needed in preview mode, so we can return early
+			return;
+		}
 
-			Task taskWithOutput = myTaskDao.read(task.getIdElement(), mySrd);
-			assertThat(taskWithOutput.getStatus()).isEqualTo(Task.TaskStatus.COMPLETED);
-			ourLog.info("Complete Task: {}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(taskWithOutput));
-
-			Task.TaskOutputComponent taskOutput = taskWithOutput.getOutputFirstRep();
-
-			// Assert on the output type
-			Coding taskType = taskOutput.getType().getCodingFirstRep();
-			assertEquals(RESOURCE_TYPES_SYSTEM, taskType.getSystem());
-			assertEquals("Bundle", taskType.getCode());
-
-			List<Resource> containedResources = taskWithOutput.getContained();
-			assertThat(containedResources)
-				.hasSize(1)
-				.element(0)
-				.isInstanceOf(Bundle.class);
-
-			Bundle containedBundle = (Bundle) containedResources.get(0);
-
-			Reference outputRef = (Reference) taskOutput.getValue();
-			Bundle patchResultBundle = (Bundle) outputRef.getResource();
-			assertTrue(containedBundle.equalsDeep(patchResultBundle));
-			ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
-				ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES,
-				List.of("Observation", "Encounter", "CarePlan"));
-
-			OperationOutcome outcome = (OperationOutcome) outParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_OUTCOME).getResource();
-			assertThat(outcome.getIssue())
-				.hasSize(1)
-				.element(0)
-				.satisfies(issue -> {
-					assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
-					assertThat(issue.getDetails().getText()).isEqualTo("Merge request is accepted, and will be " +
-						"processed asynchronously. See task resource returned in this response for details.");
-				});
-
+		if (isAsync) {
+			waitForAsyncTaskCompletion(outParams);
+			validateTaskOutput(outParams);
 		} else { // Synchronous case
-			// Assert outcome
-			OperationOutcome outcome = (OperationOutcome) outParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_OUTCOME).getResource();
-
-			if (withPreview) {
-				assertThat(outcome.getIssue())
-					.hasSize(1)
-					.element(0)
-					.satisfies(issue -> {
-						assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
-						assertThat(issue.getDetails().getText()).isEqualTo("Preview only merge operation - no issues detected");
-						assertThat(issue.getDiagnostics()).isEqualTo("Merge would update 25 resources");
-					});
-			} else {
-				assertThat(outcome.getIssue())
-					.hasSize(1)
-					.element(0)
-					.satisfies(issue -> {
-						assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
-						assertThat(issue.getDetails().getText()).isEqualTo("Merge operation completed successfully.");
-					});
-			}
-
-			// Assert Merged Patient
-			Patient mergedPatient = (Patient) outParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_RESULT).getResource();
-			List<Identifier> identifiers = mergedPatient.getIdentifier();
-
-			// TODO ED We can also validate that result patient returned here has the same id as the target patient.
-			// And maybe in not preview case, we should also read the target patient from the db and assert it equals to the result returned.
-			myTestHelper.assertIdentifiers(identifiers, expectedIdentifiersOnTargetAfterMerge);
+			validateSyncOutcome(outParams);
 		}
 
 		// Check that the linked resources were updated
-		if (withPreview) {
-			myTestHelper.assertNothingChanged();
-		} else {
-			myTestHelper.assertAllReferencesUpdated(withDelete);
-			myTestHelper.assertSourcePatientUpdatedOrDeleted(withDelete);
-			myTestHelper.assertTargetPatientUpdated(withDelete, expectedIdentifiersOnTargetAfterMerge);
-		}
+		myTestHelper.assertAllReferencesUpdated(withDelete);
+		myTestHelper.assertSourcePatientUpdatedOrDeletedAfterMerge(withDelete);
+		myTestHelper.assertTargetPatientUpdatedAfterMerge(withDelete, expectedIdentifiersOnTargetAfterMerge);
+		myTestHelper.assertMergeProvenance(withDelete, null);
 	}
+
+
+
+	@ParameterizedTest(name = "{index}: isAsync={0}, theAgentInterceptorReturnsMultipleAgents={1}")
+	@CsvSource (value = {
+		"false, false",
+		"false, true",
+		"true, false",
+		"true, true",
+	})
+	void testMerge_withProvenanceAgentInterceptor_Success(boolean theIsAsync, boolean theAgentInterceptorReturnsMultipleAgents) {
+
+		List<IProvenanceAgent> agents = new ArrayList<>();
+		agents.add(myTestHelper.createTestProvenanceAgent());
+		if (theAgentInterceptorReturnsMultipleAgents) {
+			agents.add(myTestHelper.createTestProvenanceAgent());
+		}
+		// this interceptor will be unregistered in @AfterEach of the base class, which unregisters all interceptors
+		ReplaceReferencesTestHelper.registerProvenanceAgentInterceptor(myServer.getRestfulServer(), agents);
+
+		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
+		myTestHelper.setSourceAndTarget(inParams);
+
+		Parameters inParameters = inParams.asParametersResource();
+
+		// exec
+		Parameters outParams = callMergeOperation(inParameters, theIsAsync);
+
+		if (theIsAsync) {
+			waitForAsyncTaskCompletion(outParams);
+			validateTaskOutput(outParams);
+		}
+		else { // Synchronous case
+			validateSyncOutcome(outParams);
+		}
+
+		myTestHelper.assertMergeProvenance(false, agents);
+	}
+
+	@ParameterizedTest(name = "{index}: isAsync={0}")
+	@CsvSource (value = {
+		"false",
+		"true"
+	})
+	void testMerge_withProvenanceAgentInterceptor_InterceptorReturnsNoAgent_ReturnsInternalError(boolean theIsAsync) {
+
+		// this interceptor will be unregistered in @AfterEach of the base class, which unregisters all interceptors
+		ReplaceReferencesTestHelper.registerProvenanceAgentInterceptor(myServer.getRestfulServer(), Collections.emptyList());
+
+		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
+		myTestHelper.setSourceAndTarget(inParams);
+
+		Parameters inParameters = inParams.asParametersResource();
+
+		assertThatThrownBy(() -> callMergeOperation(inParameters, theIsAsync)
+		).isInstanceOf(InternalErrorException.class)
+			.hasMessageContaining("HAPI-2723: No Provenance Agent was provided by any interceptor for Pointcut.PROVENANCE_AGENTS")
+			.extracting(InternalErrorException.class::cast)
+			.extracting(BaseServerResponseException::getStatusCode)
+			.isEqualTo(500);
+	}
+
+
 
 	@Test
 	void testMerge_smallResourceLimit() {
@@ -241,6 +329,61 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 			.isInstanceOf(PreconditionFailedException.class)
 			.satisfies(ex -> assertThat(extractFailureMessage((BaseServerResponseException) ex)).isEqualTo("HAPI-2597: Number of resources with references to "+ myTestHelper.getSourcePatientId() + " exceeds the resource-limit 5. Submit the request asynchronsly by adding the HTTP Header 'Prefer: respond-async'."));
 	}
+
+	@ParameterizedTest(name = "{index}: deleteSource={0}, async={1}")
+	@CsvSource({
+		"true, false",
+		"false, false",
+		"true, true",
+		"false, true",
+	})
+	void testMerge_sourceResourceWithoutAnyReference(boolean theDeleteSource, boolean theAsync) {
+
+		Patient sourcePatient = new Patient();
+		sourcePatient = (Patient) myPatientDao.create(sourcePatient, mySrd).getResource();
+
+		Patient targetPatient = new Patient();
+		targetPatient = (Patient) myPatientDao.create(targetPatient, mySrd).getResource();
+
+		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
+		inParams.sourcePatient = new Reference(sourcePatient.getIdElement().toVersionless());
+		inParams.targetPatient = new Reference(targetPatient.getIdElement().toVersionless());
+		if (theDeleteSource) {
+			inParams.deleteSource = true;
+		}
+
+		Parameters outParams = callMergeOperation(inParams.asParametersResource(), theAsync);
+
+		if (theAsync) {
+			waitForAsyncTaskCompletion(outParams);
+		}
+
+		IIdType theExpectedTargetIdWithVersion = targetPatient.getIdElement().withVersion("2");
+		if (theDeleteSource) {
+			// the source resource is being deleted and there is no identifiers to copy over to the target,
+			// so, in this version of the test, the target is not actually updated. Its version will remain the same.
+			theExpectedTargetIdWithVersion = targetPatient.getIdElement().withVersion("1");
+		}
+
+		myTestHelper.assertTargetPatientUpdatedAfterMerge(
+			targetPatient.getIdElement(),
+			sourcePatient.getIdElement(),
+			theDeleteSource,
+			Collections.emptyList()
+		);
+
+		myTestHelper.assertSourcePatientUpdatedOrDeletedAfterMerge(sourcePatient.getIdElement(),
+			targetPatient.getIdElement(),
+			theDeleteSource);
+
+		myTestHelper.assertMergeProvenance(theDeleteSource,
+			sourcePatient.getIdElement().withVersion("2"),
+			theExpectedTargetIdWithVersion,
+			0,
+			Collections.EMPTY_SET,
+			null);
+	}
+
 
 	@Test
 	void testMerge_SourceResourceCannotBeDeletedBecauseAnotherResourceReferencingSourceWasAddedWhileJobIsRunning_JobFails() {
@@ -280,7 +423,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		assertThat(taskAfterJobFailure.getStatus()).isEqualTo(Task.TaskStatus.FAILED);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTest(name = "{index}: deleteSource={0}, resultPatient={1}, preview={2}")
 	@CsvSource({
 		// withDelete, withInputResultPatient, withPreview
 		"true, true, true",
@@ -301,7 +444,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 	}
 
 
-	@ParameterizedTest
+	@ParameterizedTest(name = "{index}: deleteSource={0}, resultPatient={1}, preview={2}")
 	@CsvSource({
 		// withDelete, withInputResultPatient, withPreview
 		"true, true, true",
@@ -323,7 +466,8 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	void test_MissingRequiredParameters_Returns400BadRequest() {
-		assertThatThrownBy(() -> callMergeOperation(new Parameters())
+		Parameters params = new Parameters();
+		assertThatThrownBy(() -> callMergeOperation(params)
 		).isInstanceOf(InvalidRequestException.class)
 			.extracting(InvalidRequestException.class::cast)
 			.extracting(BaseServerResponseException::getStatusCode)
@@ -361,8 +505,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 	class MyExceptionHandler implements TestExecutionExceptionHandler {
 		@Override
 		public void handleTestExecutionException(ExtensionContext theExtensionContext, Throwable theThrowable) throws Throwable {
-			if (theThrowable instanceof BaseServerResponseException) {
-				BaseServerResponseException ex = (BaseServerResponseException) theThrowable;
+			if (theThrowable instanceof BaseServerResponseException ex) {
 				String message = extractFailureMessage(ex);
 				throw ex.getClass().getDeclaredConstructor(String.class, Throwable.class).newInstance(message, ex);
 			}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/interceptor/ex/ProvenanceAgentTestInterceptor.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/interceptor/ex/ProvenanceAgentTestInterceptor.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.interceptor.ex;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.model.IProvenanceAgentsPointcutParameter;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+
+import java.util.List;
+
+/**
+ * A test interceptor that allows you return ProvenanceAgents you provide
+ */
+public class ProvenanceAgentTestInterceptor {
+	private final List<IProvenanceAgent> myAgents;
+
+	public ProvenanceAgentTestInterceptor(List<IProvenanceAgent> theAgents) {
+		myAgents = theAgents;
+	}
+
+	@Hook(Pointcut.PROVENANCE_AGENTS)
+	public void getProvenanceAgent(IProvenanceAgentsPointcutParameter params) {
+		myAgents.forEach(params::addProvenanceAgent);
+	}
+}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/merge/MergeAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/merge/MergeAppCtx.java
@@ -33,6 +33,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
+import ca.uhn.fhir.merge.MergeProvenanceSvc;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesPatchBundleSvc;
 import org.hl7.fhir.r4.model.Task;
 import org.springframework.context.annotation.Bean;
@@ -86,9 +87,25 @@ public class MergeAppCtx {
 	}
 
 	@Bean
+	public MergeProvenanceSvc mergeProvenanceSvc(DaoRegistry theDaoRegistry) {
+		return new MergeProvenanceSvc(theDaoRegistry);
+	}
+
+	@Bean
+	public MergeResourceHelper mergeResourceHelper(
+			DaoRegistry theDaoRegistry, MergeProvenanceSvc theMergeProvenanceSvc) {
+
+		return new MergeResourceHelper(theDaoRegistry, theMergeProvenanceSvc);
+	}
+
+	@Bean
 	public MergeUpdateTaskReducerStep mergeUpdateTaskStep(
-			DaoRegistry theDaoRegistry, IHapiTransactionService theHapiTransactionService) {
-		return new MergeUpdateTaskReducerStep(theDaoRegistry, theHapiTransactionService);
+			DaoRegistry theDaoRegistry,
+			IHapiTransactionService theHapiTransactionService,
+			MergeResourceHelper theMergeResourceHelper,
+			MergeProvenanceSvc theMergeProvenanceSvc) {
+		return new MergeUpdateTaskReducerStep(
+				theDaoRegistry, theHapiTransactionService, theMergeResourceHelper, theMergeProvenanceSvc);
 	}
 
 	@Bean

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/merge/MergeResourceHelper.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/merge/MergeResourceHelper.java
@@ -20,20 +20,23 @@
 package ca.uhn.fhir.batch2.jobs.merge;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
-import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
+import ca.uhn.fhir.merge.MergeProvenanceSvc;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import jakarta.annotation.Nullable;
-import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 
+import java.util.Date;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
@@ -44,9 +47,11 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 public class MergeResourceHelper {
 
 	private final IFhirResourceDao<Patient> myPatientDao;
+	private final MergeProvenanceSvc myProvenanceSvc;
 
-	public MergeResourceHelper(IFhirResourceDao<Patient> theDao) {
-		myPatientDao = theDao;
+	public MergeResourceHelper(DaoRegistry theDaoRegistry, MergeProvenanceSvc theMergeProvenanceSvc) {
+		myPatientDao = theDaoRegistry.getResourceDao(Patient.class);
+		myProvenanceSvc = theMergeProvenanceSvc;
 	}
 
 	public static int setResourceLimitFromParameter(
@@ -60,49 +65,44 @@ public class MergeResourceHelper {
 		return retval;
 	}
 
-	public void updateMergedResourcesAfterReferencesReplaced(
-			IHapiTransactionService myHapiTransactionService,
-			IIdType theSourceResourceId,
-			IIdType theTargetResourceId,
-			@Nullable Patient theResultResource,
-			boolean theDeleteSource,
-			RequestDetails theRequestDetails) {
-		Patient sourceResource = myPatientDao.read(theSourceResourceId, theRequestDetails);
-		Patient targetResource = myPatientDao.read(theTargetResourceId, theRequestDetails);
-
-		updateMergedResourcesAfterReferencesReplaced(
-				myHapiTransactionService,
-				sourceResource,
-				targetResource,
-				theResultResource,
-				theDeleteSource,
-				theRequestDetails);
-	}
-
 	public Patient updateMergedResourcesAfterReferencesReplaced(
-			IHapiTransactionService myHapiTransactionService,
 			Patient theSourceResource,
 			Patient theTargetResource,
 			@Nullable Patient theResultResource,
 			boolean theDeleteSource,
 			RequestDetails theRequestDetails) {
 
-		AtomicReference<Patient> targetPatientAfterUpdate = new AtomicReference<>();
-		myHapiTransactionService.withRequest(theRequestDetails).execute(() -> {
-			Patient patientToUpdate = prepareTargetPatientForUpdate(
-					theTargetResource, theSourceResource, theResultResource, theDeleteSource);
+		Patient targetToUpdate =
+				prepareTargetPatientForUpdate(theTargetResource, theSourceResource, theResultResource, theDeleteSource);
 
-			targetPatientAfterUpdate.set(updateResource(patientToUpdate, theRequestDetails));
+		Patient updatedTarget = updateResource(targetToUpdate, theRequestDetails);
+		myPatientDao.update(targetToUpdate, theRequestDetails);
+		if (theDeleteSource) {
+			deleteResource(theSourceResource, theRequestDetails);
+		} else {
+			prepareSourcePatientForUpdate(theSourceResource, theTargetResource);
+			updateResource(theSourceResource, theRequestDetails);
+		}
 
-			if (theDeleteSource) {
-				deleteResource(theSourceResource, theRequestDetails);
-			} else {
-				prepareSourcePatientForUpdate(theSourceResource, theTargetResource);
-				updateResource(theSourceResource, theRequestDetails);
-			}
-		});
+		return updatedTarget;
+	}
 
-		return targetPatientAfterUpdate.get();
+	public void createProvenance(
+			IBaseResource theSourceResource,
+			IBaseResource theTargetResource,
+			List<Bundle> thePatchResultBundles,
+			boolean theDeleteSource,
+			RequestDetails theRequestDetails,
+			Date theStartTime,
+			List<IProvenanceAgent> theProvenanceAgents) {
+
+		myProvenanceSvc.createProvenance(
+				theTargetResource.getIdElement(),
+				theDeleteSource ? null : theSourceResource.getIdElement(),
+				thePatchResultBundles,
+				theStartTime,
+				theRequestDetails,
+				theProvenanceAgents);
 	}
 
 	public Patient prepareTargetPatientForUpdate(

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/merge/MergeResourceHelper.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/merge/MergeResourceHelper.java
@@ -69,15 +69,15 @@ public class MergeResourceHelper {
 			Patient theSourceResource,
 			Patient theTargetResource,
 			@Nullable Patient theResultResource,
-			boolean theDeleteSource,
+			boolean theIsDeleteSource,
 			RequestDetails theRequestDetails) {
 
-		Patient targetToUpdate =
-				prepareTargetPatientForUpdate(theTargetResource, theSourceResource, theResultResource, theDeleteSource);
+		Patient targetToUpdate = prepareTargetPatientForUpdate(
+				theTargetResource, theSourceResource, theResultResource, theIsDeleteSource);
 
 		Patient updatedTarget = updateResource(targetToUpdate, theRequestDetails);
 		myPatientDao.update(targetToUpdate, theRequestDetails);
-		if (theDeleteSource) {
+		if (theIsDeleteSource) {
 			deleteResource(theSourceResource, theRequestDetails);
 		} else {
 			prepareSourcePatientForUpdate(theSourceResource, theTargetResource);
@@ -91,14 +91,14 @@ public class MergeResourceHelper {
 			IBaseResource theSourceResource,
 			IBaseResource theTargetResource,
 			List<Bundle> thePatchResultBundles,
-			boolean theDeleteSource,
+			boolean theIsDeleteSource,
 			RequestDetails theRequestDetails,
 			Date theStartTime,
 			List<IProvenanceAgent> theProvenanceAgents) {
 
 		myProvenanceSvc.createProvenance(
 				theTargetResource.getIdElement(),
-				theDeleteSource ? null : theSourceResource.getIdElement(),
+				theIsDeleteSource ? null : theSourceResource.getIdElement(),
 				thePatchResultBundles,
 				theStartTime,
 				theRequestDetails,
@@ -109,7 +109,7 @@ public class MergeResourceHelper {
 			Patient theTargetResource,
 			Patient theSourceResource,
 			@Nullable Patient theResultResource,
-			boolean theDeleteSource) {
+			boolean theIsDeleteSource) {
 
 		// if the client provided a result resource as input then use it to update the target resource
 		if (theResultResource != null) {
@@ -118,7 +118,7 @@ public class MergeResourceHelper {
 
 		// client did not provide a result resource, we should update the target resource,
 		// add the replaces link to the target resource, if the source resource is not to be deleted
-		if (!theDeleteSource) {
+		if (!theIsDeleteSource) {
 			theTargetResource
 					.addLink()
 					.setType(Patient.LinkType.REPLACES)

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ProvenanceAgentJson.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ProvenanceAgentJson.java
@@ -1,0 +1,116 @@
+/*-
+ * #%L
+ * hapi-fhir-storage-batch2-jobs
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.batch2.jobs.replacereferences;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.model.api.ProvenanceAgent;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.util.TerserUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * ProvenanceAgentJson is a JSON representation of an IProvenanceAgent.
+ * It is used to serialize and deserialize provenance agent information
+ * in the context of batch jobs.
+ */
+public class ProvenanceAgentJson {
+	@JsonProperty("who")
+	private String myWho;
+
+	@JsonProperty("onBehalfOf")
+	private String myOnBehalfOf;
+
+	public String getWho() {
+		return myWho;
+	}
+
+	public void setWho(String theWho) {
+		this.myWho = theWho;
+	}
+
+	public String getOnBehalfOf() {
+		return myOnBehalfOf;
+	}
+
+	public void setOnBehalfOf(String theOnBehalfOf) {
+		this.myOnBehalfOf = theOnBehalfOf;
+	}
+
+	public static ProvenanceAgentJson from(IProvenanceAgent theProvenanceAgent, FhirContext theFhirContext) {
+		if (theProvenanceAgent == null) {
+			return null;
+		}
+		IParser parser = theFhirContext.newJsonParser();
+		ProvenanceAgentJson retVal = new ProvenanceAgentJson();
+		if (theProvenanceAgent.getWho() != null) {
+			retVal.myWho = parser.encodeToString(theProvenanceAgent.getWho());
+		}
+		if (theProvenanceAgent.getOnBehalfOf() != null) {
+			retVal.myOnBehalfOf = parser.encodeToString(theProvenanceAgent.getOnBehalfOf());
+		}
+		return retVal;
+	}
+
+	public static List<ProvenanceAgentJson> from(
+			@Nullable List<IProvenanceAgent> theProvenanceAgents, FhirContext theFhirContext) {
+		if (theProvenanceAgents == null) {
+			return null;
+		}
+		return theProvenanceAgents.stream()
+				.map(agent -> from(agent, theFhirContext))
+				.collect(Collectors.toList());
+	}
+
+	public static IProvenanceAgent toIProvenanceAgent(
+			ProvenanceAgentJson theProvenanceAgentJson, FhirContext theFhirContext) {
+		if (theProvenanceAgentJson == null) {
+			return null;
+		}
+		IParser parser = theFhirContext.newJsonParser();
+		ProvenanceAgent provAgent = new ProvenanceAgent();
+		if (theProvenanceAgentJson.myWho != null) {
+			IBaseReference who = TerserUtil.newElement(theFhirContext, "Reference");
+			parser.parseInto(theProvenanceAgentJson.myWho, who);
+			provAgent.setWho(who);
+		}
+		if (theProvenanceAgentJson.myOnBehalfOf != null) {
+			IBaseReference onBehalfOf = TerserUtil.newElement(theFhirContext, "Reference");
+			parser.parseInto(theProvenanceAgentJson.myOnBehalfOf, onBehalfOf);
+			provAgent.setOnBehalfOf(onBehalfOf);
+		}
+		return provAgent;
+	}
+
+	public static List<IProvenanceAgent> toIProvenanceAgents(
+			List<ProvenanceAgentJson> theProvenanceAgentJsons, FhirContext theFhirContext) {
+		if (theProvenanceAgentJsons == null) {
+			return null;
+		}
+		return theProvenanceAgentJsons.stream()
+				.map(agentJson -> toIProvenanceAgent(agentJson, theFhirContext))
+				.collect(Collectors.toList());
+	}
+}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ReplaceReferenceUpdateStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ReplaceReferenceUpdateStep.java
@@ -57,7 +57,7 @@ public class ReplaceReferenceUpdateStep<PT extends ReplaceReferencesJobParameter
 			throws JobExecutionFailedException {
 
 		ReplaceReferencesJobParameters params = theStepExecutionDetails.getParameters();
-		ReplaceReferencesRequest replaceReferencesRequest = params.asReplaceReferencesRequest();
+		ReplaceReferencesRequest replaceReferencesRequest = params.asReplaceReferencesRequest(myFhirContext);
 		List<IdDt> fhirIds = theStepExecutionDetails.getData().getFhirIds().stream()
 				.map(FhirIdJson::asIdDt)
 				.collect(Collectors.toList());

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ReplaceReferencesAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ReplaceReferencesAppCtx.java
@@ -28,9 +28,11 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.svc.IBatch2DaoSvc;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesPatchBundleSvc;
+import ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc;
 import org.hl7.fhir.r4.model.Task;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class ReplaceReferencesAppCtx {
@@ -82,8 +84,8 @@ public class ReplaceReferencesAppCtx {
 
 	@Bean
 	public ReplaceReferenceUpdateTaskReducerStep<ReplaceReferencesJobParameters> replaceReferenceUpdateTaskStep(
-			DaoRegistry theDaoRegistry) {
-		return new ReplaceReferenceUpdateTaskReducerStep<>(theDaoRegistry);
+			DaoRegistry theDaoRegistry, ReplaceReferencesProvenanceSvc theReplaceReferencesProvenanceSvc) {
+		return new ReplaceReferenceUpdateTaskReducerStep<>(theDaoRegistry, theReplaceReferencesProvenanceSvc);
 	}
 
 	@Bean
@@ -91,5 +93,11 @@ public class ReplaceReferencesAppCtx {
 			DaoRegistry theDaoRegistry, Batch2TaskHelper theBatch2TaskHelper) {
 		IFhirResourceDao<Task> taskDao = theDaoRegistry.getResourceDao(Task.class);
 		return new ReplaceReferencesErrorHandler<>(theBatch2TaskHelper, taskDao);
+	}
+
+	@Primary
+	@Bean
+	public ReplaceReferencesProvenanceSvc replaceReferencesProvenanceSvc(DaoRegistry theDaoRegistry) {
+		return new ReplaceReferencesProvenanceSvc(theDaoRegistry);
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ReplaceReferencesJobParameters.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/replacereferences/ReplaceReferencesJobParameters.java
@@ -21,11 +21,15 @@ package ca.uhn.fhir.batch2.jobs.replacereferences;
 
 import ca.uhn.fhir.batch2.jobs.chunk.FhirIdJson;
 import ca.uhn.fhir.batch2.jobs.parameters.BatchJobParametersWithTaskId;
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesRequest;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
+
+import java.util.List;
 
 public class ReplaceReferencesJobParameters extends BatchJobParametersWithTaskId {
 
@@ -44,15 +48,51 @@ public class ReplaceReferencesJobParameters extends BatchJobParametersWithTaskId
 	@JsonProperty("partitionId")
 	private RequestPartitionId myPartitionId;
 
+	/**
+	 * If true, a Provenance resource will be created at the end of the job.
+	 */
+	@JsonProperty(value = "createProvenance", defaultValue = "true", required = false)
+	private boolean myCreateProvenance;
+
+	/**
+	 * The version of the source resource that should be used in the Provenance resource.
+	 * The $merge operation populates this after the source resource is updated as a result of the merge.
+	 */
+	@JsonProperty("sourceVersionForProvenance")
+	private String mySourceVersionForProvenance;
+
+	/**
+	 * The version of the target resource that should be used in the Provenance resource.
+	 * The $merge operation populates this after the target resource is updated as a result of the merge.
+	 */
+	@JsonProperty("targetVersionForProvenance")
+	private String myTargetVersionForProvenance;
+
+	/**
+	 * The agents to be used in the Provenance resource.
+	 */
+	@JsonProperty("provenanceAgents")
+	private List<ProvenanceAgentJson> myProvenanceAgents;
+
 	public ReplaceReferencesJobParameters() {}
 
-	public ReplaceReferencesJobParameters(ReplaceReferencesRequest theReplaceReferencesRequest, int theBatchSize) {
+	public ReplaceReferencesJobParameters(
+			ReplaceReferencesRequest theReplaceReferencesRequest,
+			int theBatchSize,
+			String theSourceVersionForProvenance,
+			String theTargetVersionForProvenance,
+			@Nullable List<ProvenanceAgentJson> theProvenanceAgents) {
+
 		mySourceId = new FhirIdJson(theReplaceReferencesRequest.sourceId);
 		myTargetId = new FhirIdJson(theReplaceReferencesRequest.targetId);
 		// Note theReplaceReferencesRequest.resourceLimit is only used for the synchronous case. It is ignored in this
 		// async case.
 		myBatchSize = theBatchSize;
 		myPartitionId = theReplaceReferencesRequest.partitionId;
+		myCreateProvenance = theReplaceReferencesRequest.createProvenance;
+		mySourceVersionForProvenance = theSourceVersionForProvenance;
+		myTargetVersionForProvenance = theTargetVersionForProvenance;
+		myProvenanceAgents = theProvenanceAgents;
 	}
 
 	public FhirIdJson getSourceId() {
@@ -90,7 +130,45 @@ public class ReplaceReferencesJobParameters extends BatchJobParametersWithTaskId
 		myPartitionId = thePartitionId;
 	}
 
-	public ReplaceReferencesRequest asReplaceReferencesRequest() {
-		return new ReplaceReferencesRequest(mySourceId.asIdDt(), myTargetId.asIdDt(), myBatchSize, myPartitionId);
+	public ReplaceReferencesRequest asReplaceReferencesRequest(FhirContext theFhirContext) {
+		return new ReplaceReferencesRequest(
+				mySourceId.asIdDt(),
+				myTargetId.asIdDt(),
+				myBatchSize,
+				myPartitionId,
+				myCreateProvenance,
+				ProvenanceAgentJson.toIProvenanceAgents(myProvenanceAgents, theFhirContext));
+	}
+
+	public boolean getCreateProvenance() {
+		return myCreateProvenance;
+	}
+
+	public void setCreateProvenance(boolean theCreateProvenance) {
+		this.myCreateProvenance = theCreateProvenance;
+	}
+
+	public String getSourceVersionForProvenance() {
+		return mySourceVersionForProvenance;
+	}
+
+	public void setSourceVersionForProvenance(String theSourceVersionForProvenance) {
+		this.mySourceVersionForProvenance = theSourceVersionForProvenance;
+	}
+
+	public String getTargetVersionForProvenance() {
+		return myTargetVersionForProvenance;
+	}
+
+	public void setTargetVersionForProvenance(String theTargetVersionForProvenance) {
+		this.myTargetVersionForProvenance = theTargetVersionForProvenance;
+	}
+
+	public List<ProvenanceAgentJson> getProvenanceAgents() {
+		return myProvenanceAgents;
+	}
+
+	public void setProvenanceAgents(List<ProvenanceAgentJson> theAgents) {
+		this.myProvenanceAgents = theAgents;
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/replacereferences/ProvenanceAgentJsonTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/replacereferences/ProvenanceAgentJsonTest.java
@@ -1,0 +1,134 @@
+package ca.uhn.fhir.batch2.jobs.replacereferences;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.model.api.ProvenanceAgent;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProvenanceAgentJsonTest {
+
+	private final FhirContext fhirContext = FhirContext.forR4();
+
+	@Test
+	void testFromAndToIProvenanceAgent_RoundTrip() {
+		ProvenanceAgent agent = new ProvenanceAgent();
+		IBaseReference who = new Reference();
+		who.setReference("Practitioner/123");
+		agent.setWho(who);
+
+		IBaseReference onBehalfOf = new Reference();
+		onBehalfOf.setReference("Organization/456");
+		agent.setOnBehalfOf(onBehalfOf);
+
+		ProvenanceAgentJson json = ProvenanceAgentJson.from(agent, fhirContext);
+		assertThat(json).isNotNull();
+		assertThat(json.getWho()).isNotNull();
+		assertThat(json.getOnBehalfOf()).isNotNull();
+
+		IProvenanceAgent result = ProvenanceAgentJson.toIProvenanceAgent(json, fhirContext);
+		assertThat(result).isNotNull();
+		assertThat(result.getWho().getReferenceElement().getValueAsString()).isEqualTo("Practitioner/123");
+		assertThat(result.getOnBehalfOf().getReferenceElement().getValueAsString()).isEqualTo("Organization/456");
+	}
+
+	@Test
+	void testToIProvenanceAgent_NullInput() {
+		assertThat(ProvenanceAgentJson.toIProvenanceAgent(null, fhirContext)).isNull();
+		assertThat(ProvenanceAgentJson.toIProvenanceAgents(null, fhirContext)).isNull();
+	}
+
+	@Test
+	void testToIProvenanceAgents_NullInput() {
+		assertThat(ProvenanceAgentJson.toIProvenanceAgents(null, fhirContext)).isNull();
+	}
+
+	@Test
+	void testFrom_NullInput() {
+		assertThat(ProvenanceAgentJson.from((IProvenanceAgent) null, fhirContext)).isNull();
+	}
+
+	@Test
+	void testFromList_NullInput() {
+		assertThat(ProvenanceAgentJson.from((List<IProvenanceAgent>) null, fhirContext)).isNull();
+	}
+
+	@Test
+	void testFromAndToIProvenanceAgent_RoundTrip_PartialFields_NullOnBehalfOf() {
+		ProvenanceAgent agent = new ProvenanceAgent();
+		IBaseReference who = new Reference();
+		who.setReference("Patient/789");
+		agent.setWho(who);
+
+		ProvenanceAgentJson json = ProvenanceAgentJson.from(agent, fhirContext);
+		assertThat(json.getWho()).isNotNull();
+		assertThat(json.getOnBehalfOf()).isNull();
+
+		IProvenanceAgent result = ProvenanceAgentJson.toIProvenanceAgent(json, fhirContext);
+		assertThat(result.getWho().getReferenceElement().getValueAsString()).isEqualTo("Patient/789");
+		assertThat(result.getOnBehalfOf()).isNull();
+	}
+
+	@Test
+	void testFromAndToIProvenanceAgent_RoundTrip_PartialFields_NullWho() {
+		ProvenanceAgent agent = new ProvenanceAgent();
+		IBaseReference onBehalfOf = new Reference();
+		onBehalfOf.setReference("Organization/456");
+		agent.setOnBehalfOf(onBehalfOf);
+
+		ProvenanceAgentJson json = ProvenanceAgentJson.from(agent, fhirContext);
+		assertThat(json.getWho()).isNull();
+		assertThat(json.getOnBehalfOf()).isNotNull();
+
+		IProvenanceAgent result = ProvenanceAgentJson.toIProvenanceAgent(json, fhirContext);
+		assertThat(result.getWho()).isNull();
+		assertThat(result.getOnBehalfOf().getReferenceElement().getValueAsString()).isEqualTo("Organization/456");
+	}
+
+	@Test
+	void testFromAndToIProvenanceAgent_RoundTrip_PartialFields_IdentifierInWhoReference() {
+		ProvenanceAgent agent = new ProvenanceAgent();
+		Reference whoReference = new Reference();
+		whoReference.getIdentifier().setSystem("http://example.org").setValue("who-identifier");
+		agent.setWho(whoReference);
+
+		ProvenanceAgentJson json = ProvenanceAgentJson.from(agent, fhirContext);
+		assertThat(json.getWho()).isNotNull();
+		assertThat(json.getOnBehalfOf()).isNull();
+
+		IProvenanceAgent result = ProvenanceAgentJson.toIProvenanceAgent(json, fhirContext);
+		assertThat(result.getOnBehalfOf()).isNull();
+		assertThat(result.getWho()).isNotNull();
+		Reference who = (Reference) result.getWho();
+		assertThat(who.hasIdentifier()).isTrue();
+		assertThat(who.getIdentifier().getSystem()).isEqualTo("http://example.org");
+		assertThat(who.getIdentifier().getValue()).isEqualTo("who-identifier");
+		assertThat(who.hasReference()).isFalse();
+	}
+
+	@Test
+	void testFromAndToIProvenanceAgent_RoundTrip_PartialFields_IdentifierInOnBehalfOfReference() {
+		ProvenanceAgent agent = new ProvenanceAgent();
+		Reference onBehalfOfReference = new Reference();
+		onBehalfOfReference.getIdentifier().setSystem("http://example.org").setValue("onBehalfOf-identifier");
+		agent.setOnBehalfOf(onBehalfOfReference);
+
+		ProvenanceAgentJson json = ProvenanceAgentJson.from(agent, fhirContext);
+		assertThat(json.getWho()).isNull();
+		assertThat(json.getOnBehalfOf()).isNotNull();
+
+		IProvenanceAgent result = ProvenanceAgentJson.toIProvenanceAgent(json, fhirContext);
+		assertThat(result.getWho()).isNull();
+		assertThat(result.getOnBehalfOf()).isNotNull();
+		Reference onBehalfOf = (Reference) result.getOnBehalfOf();
+		assertThat(onBehalfOf.hasIdentifier()).isTrue();
+		assertThat(onBehalfOf.getIdentifier().getSystem()).isEqualTo("http://example.org");
+		assertThat(onBehalfOf.getIdentifier().getValue()).isEqualTo("onBehalfOf-identifier");
+		assertThat(onBehalfOf.hasReference()).isFalse();
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/merge/MergeProvenanceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/merge/MergeProvenanceSvc.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.merge;
+
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc;
+import org.hl7.fhir.r4.model.CodeableConcept;
+
+/**
+ *  Handles Provenance resources for the $merge operation.
+ */
+public class MergeProvenanceSvc extends ReplaceReferencesProvenanceSvc {
+
+	private static final String ACTIVITY_CODE_MERGE = "merge";
+
+	public MergeProvenanceSvc(DaoRegistry theDaoRegistry) {
+		super(theDaoRegistry);
+	}
+
+	@Override
+	protected CodeableConcept getActivityCodeableConcept() {
+		CodeableConcept retVal = new CodeableConcept();
+		retVal.addCoding().setSystem(ACTIVITY_CODE_SYSTEM).setCode(ACTIVITY_CODE_MERGE);
+		return retVal;
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
@@ -1,0 +1,174 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.replacereferences;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.util.FhirTerser;
+import jakarta.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.Provenance;
+import org.hl7.fhir.r4.model.Reference;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This service is used to create a Provenance resource for the $replace-references operation
+ * and also used as a base class for {@link ca.uhn.fhir.merge.MergeProvenanceSvc} used in $merge operations.
+ * The two operations use different activity codes.
+ */
+public class ReplaceReferencesProvenanceSvc {
+
+	private static final String ACT_REASON_CODE_SYSTEM = "http://terminology.hl7.org/CodeSystem/v3-ActReason";
+	private static final String ACT_REASON_PATIENT_ADMINISTRATION_CODE = "PATADMIN";
+	protected static final String ACTIVITY_CODE_SYSTEM = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle";
+	private static final String ACTIVITY_CODE_LINK = "link";
+	private final IFhirResourceDao<IBaseResource> myProvenanceDao;
+	private final FhirContext myFhirContext;
+
+	public ReplaceReferencesProvenanceSvc(DaoRegistry theDaoRegistry) {
+		myProvenanceDao = theDaoRegistry.getResourceDao("Provenance");
+		myFhirContext = theDaoRegistry.getFhirContext();
+	}
+
+	@Nullable
+	protected CodeableConcept getActivityCodeableConcept() {
+		CodeableConcept retVal = new CodeableConcept();
+		retVal.addCoding().setSystem(ACTIVITY_CODE_SYSTEM).setCode(ACTIVITY_CODE_LINK);
+		return retVal;
+	}
+
+	protected Provenance createProvenanceObject(
+			Reference theTargetReference,
+			@Nullable Reference theSourceReference,
+			List<Reference> theUpdatedReferencingResources,
+			Date theStartTime,
+			List<IProvenanceAgent> theProvenanceAgents) {
+		Provenance provenance = new Provenance();
+
+		Date now = new Date();
+		provenance.setOccurred(new Period()
+				.setStart(theStartTime, TemporalPrecisionEnum.MILLI)
+				.setEnd(now, TemporalPrecisionEnum.MILLI));
+		provenance.setRecorded(now);
+
+		addAgents(theProvenanceAgents, provenance);
+
+		CodeableConcept activityCodeableConcept = getActivityCodeableConcept();
+		if (activityCodeableConcept != null) {
+			provenance.setActivity(activityCodeableConcept);
+		}
+		CodeableConcept activityReasonCodeableConcept = new CodeableConcept();
+		activityReasonCodeableConcept
+				.addCoding()
+				.setSystem(ACT_REASON_CODE_SYSTEM)
+				.setCode(ACT_REASON_PATIENT_ADMINISTRATION_CODE);
+
+		provenance.addReason(activityReasonCodeableConcept);
+
+		provenance.addTarget(theTargetReference);
+		if (theSourceReference != null) {
+			provenance.addTarget(theSourceReference);
+		}
+
+		theUpdatedReferencingResources.forEach(provenance::addTarget);
+		return provenance;
+	}
+
+	/**
+	 * Creates a Provenance resource for the $replace-references and $merge operations.
+	 *
+	 * @param theTargetId           the versioned id of the target resource of the operation.
+	 * @param theSourceId           the versioned id of the source resource of the operation. Can be null if the operation is $merge and the source resource is deleted.
+	 * @param thePatchResultBundles the list of patch result bundles that contain the updated resources.
+	 * @param theStartTime          the start time of the operation.
+	 * @param theRequestDetails     the request details
+	 * @param theProvenanceAgents   the list of agents to be included in the Provenance resource.
+	 */
+	public void createProvenance(
+			IIdType theTargetId,
+			@Nullable IIdType theSourceId,
+			List<Bundle> thePatchResultBundles,
+			Date theStartTime,
+			RequestDetails theRequestDetails,
+			List<IProvenanceAgent> theProvenanceAgents) {
+		Reference targetReference = new Reference(theTargetId);
+		Reference sourceReference = null;
+		if (theSourceId != null) {
+			sourceReference = new Reference(theSourceId);
+		}
+		List<Reference> references = extractUpdatedResourceReferences(thePatchResultBundles);
+		Provenance provenance =
+				createProvenanceObject(targetReference, sourceReference, references, theStartTime, theProvenanceAgents);
+		myProvenanceDao.create(provenance, theRequestDetails);
+	}
+
+	protected List<Reference> extractUpdatedResourceReferences(List<Bundle> thePatchBundles) {
+		List<Reference> patchedResourceReferences = new ArrayList<>();
+		thePatchBundles.forEach(outputBundle -> {
+			outputBundle.getEntry().forEach(entry -> {
+				if (entry.getResponse() != null && entry.getResponse().hasLocation()) {
+					Reference reference = new Reference(entry.getResponse().getLocation());
+					patchedResourceReferences.add(reference);
+				}
+			});
+		});
+		return patchedResourceReferences;
+	}
+
+	private Provenance.ProvenanceAgentComponent createR4ProvenanceAgent(IProvenanceAgent theProvenanceAgent) {
+		Provenance.ProvenanceAgentComponent agent = new Provenance.ProvenanceAgentComponent();
+		Reference whoRef = convertToR4Reference(theProvenanceAgent.getWho());
+		agent.setWho(whoRef);
+		Reference onBehalfOfRef = convertToR4Reference(theProvenanceAgent.getOnBehalfOf());
+		agent.setOnBehalfOf(onBehalfOfRef);
+		return agent;
+	}
+
+	private void addAgents(List<IProvenanceAgent> theProvenanceAgents, Provenance theProvenance) {
+		if (theProvenanceAgents != null) {
+			for (IProvenanceAgent agent : theProvenanceAgents) {
+				Provenance.ProvenanceAgentComponent r4Agent = createR4ProvenanceAgent(agent);
+				theProvenance.addAgent(r4Agent);
+			}
+		}
+	}
+
+	private Reference convertToR4Reference(IBaseReference sourceRef) {
+		if (sourceRef == null) {
+			return null;
+		}
+		FhirTerser terser = myFhirContext.newTerser();
+		Reference targetRef = new Reference();
+		terser.cloneInto(sourceRef, targetRef, false);
+		return targetRef;
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesRequest.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesRequest.java
@@ -21,9 +21,12 @@ package ca.uhn.fhir.replacereferences;
 
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IIdType;
+
+import java.util.List;
+import javax.annotation.Nonnull;
 
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_SOURCE_REFERENCE_ID;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_TARGET_REFERENCE_ID;
@@ -46,15 +49,33 @@ public class ReplaceReferencesRequest {
 
 	public final RequestPartitionId partitionId;
 
+	/**
+	 * If true, a Provenance resource will be created after the operation.
+	 * This is not exposed as a parameter a FHIR client set when calling the $replace-references operation currently.
+	 * This is rather used internally to not create a Provenance resource when the replace-references operation called
+	 * as part of another operation,
+	 * like $merge, because a provenance resource needs to be created after the calling operation is completed.
+	 */
+	public final boolean createProvenance;
+
+	/**
+	 * The list of agents to be used in the Provenance resource.
+	 */
+	public final List<IProvenanceAgent> provenanceAgents;
+
 	public ReplaceReferencesRequest(
 			@Nonnull IIdType theSourceId,
 			@Nonnull IIdType theTargetId,
 			int theResourceLimit,
-			RequestPartitionId thePartitionId) {
+			RequestPartitionId thePartitionId,
+			boolean theCreateProvenance,
+			List<IProvenanceAgent> theProvenanceAgents) {
 		sourceId = theSourceId.toUnqualifiedVersionless();
 		targetId = theTargetId.toUnqualifiedVersionless();
 		resourceLimit = theResourceLimit;
 		partitionId = thePartitionId;
+		createProvenance = theCreateProvenance;
+		provenanceAgents = theProvenanceAgents;
 	}
 
 	public void validateOrThrowInvalidParameterException() {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesRequest.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesRequest.java
@@ -50,11 +50,12 @@ public class ReplaceReferencesRequest {
 	public final RequestPartitionId partitionId;
 
 	/**
-	 * If true, a Provenance resource will be created after the operation.
-	 * This is not exposed as a parameter a FHIR client set when calling the $replace-references operation currently.
-	 * This is rather used internally to not create a Provenance resource when the replace-references operation called
-	 * as part of another operation,
-	 * like $merge, because a provenance resource needs to be created after the calling operation is completed.
+	 * Indicates whether a Provenance resource should be created after the operation.
+	 * This flag is not exposed to FHIR clients invoking the $hapi.fhir.replace-references
+	 * operation; it is used internally. It is used to avoid creating a
+	 * Provenance when the $replace-references is executed as part of another
+	 * operation (such as $merge), and the Provenance needs to be created after
+	 * the outer operation completes.
 	 */
 	public final boolean createProvenance;
 


### PR DESCRIPTION
This PR
 - creates a provenance resource for the `$merge` and `$hapi.fhir.replace-references` operations. To implement this change, a Pointcut is introduced to allow implementers to provide the data to populate the Provence.agent field. 
 - fixes `$hapi.fhir.replace-references` to return 404 ResourceNotFound if either the source resource or the target resource references provided doesn't exist.
 - some refactoring of the existing related ITs to move certain validation steps of tests into new functions for readibility and code reuse. 

## Provenance Resource for $merge operation  

The Provenance resource for the merge operation follows the example Provenance format on the spec: https://build.fhir.org/patient-operation-merge.html

It contains in the `Provenance.target` collection the references to the 1. target resource, 2. the source resource (if the source resource wasn't deleted as part of the operation), and all the updated resources as part of the merge operation. 
`Provenance.occured` contains the start and completion times of the operation and `Provenance.recorded` just the completion time. 

`Provenance.activity` is set to `http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle|merge` and `Provenance.reason` is set to `http://terminology.hl7.org/CodeSystem/v3-ActReason|PATADMIN`following the example on the spec.

To populate `Provenance.agent` field a new Pointcut named `PROVENANCE_AGENTs` is introduced. An interceptor for this pointcut could be implemented to return a list of agent data to populate the `Provenance.agent` field. If there is no registered interceptor implementing the `PROVENANCE_AGENTS` pointcut, the agent field is not populated. If there is an interceptor then it is expected that at least one agent is returned by the interceptor.

## Provenance Resource for the $hapi.fhir.replace-references 

The Provenance resource created for $hapi.fhir.replace-references is similar to the $merge one. The only difference is that the code used for `Provenance.activity` is `link` instead of `merge`. 

closes: #7037 
closes: #7038 