### PR TITLE
Refactor RuleBuilder to allow for extension of Rules

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AppliesTypeEnum.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AppliesTypeEnum.java
@@ -19,7 +19,7 @@
  */
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
-enum AppliesTypeEnum {
+public enum AppliesTypeEnum {
 	ALL_RESOURCES,
 	TYPES,
 	INSTANCES

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/BaseRule.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/BaseRule.java
@@ -33,12 +33,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-abstract class BaseRule implements IAuthRule {
-	private String myName;
+public abstract class BaseRule implements IAuthRule {
+	private final String myName;
 	private PolicyEnum myMode;
 	private List<IAuthRuleTester> myTesters;
 
-	BaseRule(String theRuleName) {
+	protected BaseRule(String theRuleName) {
 		myName = theRuleName;
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/ClassifierTypeEnum.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/ClassifierTypeEnum.java
@@ -19,7 +19,7 @@
  */
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
-enum ClassifierTypeEnum {
+public enum ClassifierTypeEnum {
 	IN_COMPARTMENT,
 	ANY_ID
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/OperationRule.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/OperationRule.java
@@ -33,7 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-class OperationRule extends BaseRule implements IAuthRule {
+public class OperationRule extends BaseRule implements IAuthRule {
 	private String myOperationName;
 	private boolean myAppliesToServer;
 	private HashSet<Class<? extends IBaseResource>> myAppliesToTypes;
@@ -45,7 +45,7 @@ class OperationRule extends BaseRule implements IAuthRule {
 	private boolean myAllowAllResponses;
 	private boolean myAllowAllResourcesAccess;
 
-	OperationRule(String theRuleName) {
+	protected OperationRule(String theRuleName) {
 		super(theRuleName);
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
@@ -63,7 +63,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hl7.fhir.instance.model.api.IAnyResource.SP_RES_ID;
 
 @SuppressWarnings("EnumSwitchStatementWhichMissesCases")
-class RuleImplOp extends BaseRule /* implements IAuthRule */ {
+public class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 	private static final Logger ourLog = LoggerFactory.getLogger(RuleImplOp.class);
 	private static final String PARAMETERS = "Parameters";
 	private static final String BUNDLE = "Bundle";
@@ -83,7 +83,7 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 	/**
 	 * Constructor
 	 */
-	RuleImplOp(String theRuleName) {
+	protected RuleImplOp(String theRuleName) {
 		super(theRuleName);
 	}
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleOpEnum.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleOpEnum.java
@@ -19,7 +19,7 @@
  */
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
-enum RuleOpEnum {
+public enum RuleOpEnum {
 	READ,
 	WRITE,
 	ALL,

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/TransactionAppliesToEnum.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/TransactionAppliesToEnum.java
@@ -19,6 +19,6 @@
  */
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
-enum TransactionAppliesToEnum {
+public enum TransactionAppliesToEnum {
 	ANY_OPERATION
 }

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBuilderExtensionTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleBuilderExtensionTest.java
@@ -1,0 +1,107 @@
+package ca.uhn.fhir.rest.server.interceptor.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class RuleBuilderExtensionTest
+{
+    @Test
+    public void testCustomReadRule()
+    {
+        RuleBuilder ruleBuilder = new RuleBuilder()
+        {
+            @Override
+            public IAuthRuleBuilderRule allow(String theRuleName)
+            {
+                return new RuleBuilderRule(PolicyEnum.ALLOW, theRuleName)
+                {
+                    @Override
+                    protected RuleBuilderRuleOp createReadRuleBuilder()
+                    {
+                        return new RuleBuilderRuleOp(RuleOpEnum.READ)
+                        {
+                            @Override
+                            public IAuthRuleBuilderRuleOpClassifier resourcesOfType(String theType)
+                            {
+                                return new RuleBuilderRuleOpClassifier(AppliesTypeEnum.TYPES, Collections.singleton(theType))
+                                {
+                                    @Override
+                                    protected IAuthRuleBuilderRuleOpClassifierFinished finished()
+                                    {
+                                        return finished(new TestRuleImpl(myRuleName));
+                                    }
+                                };
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        List<IAuthRule> rules = ruleBuilder.allow().read().resourcesOfType("Patient").withAnyId().build();
+        assertEquals(1, rules.size());
+        IAuthRule rule = rules.get(0);
+        assertInstanceOf(TestRuleImpl.class, rule);
+    }
+
+    @Test
+    public void testCustomBulkExportRule()
+    {
+        List<IAuthRule> rules = new CustomRuleBuilder().allow("Test Rule").bulkExport().groupExportOnAnyGroup().build();
+        assertEquals(1, rules.size());
+        IAuthRule rule = rules.get(0);
+        assertInstanceOf(TestRuleImpl.class, rule);
+    }
+
+    private static class CustomRuleBuilder extends RuleBuilder
+    {
+        @Override
+        public CustomRuleBuilderRule allow(String theRuleName)
+        {
+            return new CustomRuleBuilderRule(PolicyEnum.ALLOW, theRuleName);
+        }
+
+        private class CustomRuleBuilderRule extends RuleBuilderRule
+        {
+            protected CustomRuleBuilderRule(PolicyEnum theRuleMode, String theRuleName)
+            {
+                super(theRuleMode, theRuleName);
+            }
+
+            @Override
+            public CustomRuleBuilderBulkExport bulkExport()
+            {
+                return (CustomRuleBuilderBulkExport) super.bulkExport();
+            }
+
+            @Override
+            protected CustomRuleBuilderBulkExport createRuleBuilderBulkExport()
+            {
+                return new CustomRuleBuilderBulkExport();
+            }
+
+            private class CustomRuleBuilderBulkExport extends RuleBuilderBulkExport
+            {
+                public IAuthRuleFinished groupExportOnAnyGroup()
+                {
+                    TestRuleImpl rule = new TestRuleImpl(myRuleName);
+                    addRule(rule);
+                    return new RuleBuilderFinished(rule);
+                }
+            }
+        }
+    }
+
+    static class TestRuleImpl extends RuleImplOp
+    {
+        protected TestRuleImpl(String theRuleName)
+        {
+            super(theRuleName);
+        }
+    }
+}


### PR DESCRIPTION
I was trying to add a custom rule to our project, where we could allow exporting of all Groups instead of individual Groups, and found it difficult to implement. This was because most of the classes were in package or private scope, so I would need to re-implement (copy) existing HAPI classes into my project. By making  the classes protected, I'm able to easily create a custom rule. There may be more that could be refactored, but this got me to where I needed the code.