### PR TITLE
Add cds hooks fhir server to the BOM

### DIFF
--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -259,6 +259,11 @@
 				<artifactId>hapi-fhir-validation-resources-r5</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
+				<artifactId>hapi-fhir-server-cds-hooks</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 </project>


### PR DESCRIPTION
This pins the version of cds hooks in the  hapi-fhir-bom. 