### PR TITLE
fix sonatype repo id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
 	<repositories>
 		<repository>
-			<id>oss-snapshot</id>
+			<id>oss-snapshots</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 			<snapshots>
 				<enabled>true</enabled>


### PR DESCRIPTION
Weird we've never caught this, but this was causing maven to attempt to hit 2 remotes for every snapshot, since 99% of the poms use `oss-snapshots` and not `oss-snapshot`