### PR TITLE
Add new annotations to support embedded parameters, ranged values, and source type for conversion from @OperationParams.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/EmbeddableOperationParams.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/EmbeddableOperationParams.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.rest.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates a class will contain {@link OperationParam} parameters and similar annotations that will be processed
+ * in place of separate method parameters so annotated in an operation provider.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.TYPE})
+public @interface EmbeddableOperationParams {}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/EmbeddedOperationParams.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/EmbeddedOperationParams.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.rest.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a method parameter is for a class annotated with {@link EmbeddableOperationParams} which will in turn
+ * contain a constructor whose parameters will be annotated with {@link OperationParam} and similar annotations.
+ * a
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.PARAMETER})
+public @interface EmbeddedOperationParams {}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/OperationParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/OperationParam.java
@@ -74,6 +74,20 @@ public @interface OperationParam {
 	Class<? extends IBase> type() default IBase.class;
 
 	/**
+	 * The source type of the parameters if we're expecting to do a type conversion, such as String to ZonedDateTime.
+	 * Void indicates that we don't want to do a type conversion.
+	 *
+	 * @return the source type of the parameter
+	 */
+	Class<?> sourceType() default Void.class;
+
+	/**
+	 * @return The range type associated with any type conversion.  For instance, if we expect a start and end date.
+	 * NOT_APPLICABLE is the default and indicates range conversion is not applicable.
+	 */
+	OperationParameterRangeType rangeType() default OperationParameterRangeType.NOT_APPLICABLE;
+
+	/**
 	 * Optionally specifies the type of the parameter as a string, such as <code>Coding</code> or
 	 * <code>base64Binary</code>. This can be useful if you want to use a generic interface type
 	 * on the actual method,such as {@link org.hl7.fhir.instance.model.api.IPrimitiveType} or

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/OperationParameterRangeType.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/OperationParameterRangeType.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.rest.annotation;
+
+/**
+ * Used to indicate whether an {@link OperationParam} should be considered as part of a range of values, and if
+ * so whether it's the start or end of the range.
+ * <p/>
+ * Currently, hapi-fhir does not support number and quantity ranges from this annotation.
+ */
+public enum OperationParameterRangeType {
+	START,
+	END,
+	NOT_APPLICABLE
+}


### PR DESCRIPTION
- Add EmbeddableOperationParams as a type-level annotation to mark a class as an embedded parameters class that will be passed to an Operations Provider API in place of individual IdParam and OperationParam annotated method parameters
- Add EmbeddedOperationPrams as a method parameter annotation to indicate that an Operation Provider method parameter will include a type that is annotated as above with EmbeddableOperationParams
- Enhance OperationParam with the concept of sourceType (if hapi-fhir will convert a parameter of one type into a different type in the EmbeddableOperationParams class, Void.class is the default, meaning source type is not applicable) and rangeType (an enum indicating if the OperationParam is to be converted into the start of a range, end, if ranged functionality is not applicable, which is the default).
- OperationParameterRangeType:  as mentioned above, this is the type that will be passed into the OperationParam rangeType, and for now, only date ranges are supported, not numbers or quantities.
- All of these annotations are meant to go into the February release to be made available immediately as a first step to developing the embedded parameters feature