### PR TITLE
fix replace-references operation for high cardinality elements 

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaSystemProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaSystemProvider.java
@@ -182,7 +182,7 @@ public final class JpaSystemProvider<T, MT> extends BaseJpaSystemProvider<T, MT>
 		startRequest(theServletRequest);
 
 		try {
-			validateReplaceReferencesParams(theSourceId.getValue(), theTargetId.getValue());
+			validateReplaceReferencesParams(theSourceId, theTargetId);
 
 			int resourceLimit = MergeResourceHelper.setResourceLimitFromParameter(myStorageSettings, theResourceLimit);
 
@@ -205,13 +205,14 @@ public final class JpaSystemProvider<T, MT> extends BaseJpaSystemProvider<T, MT>
 		}
 	}
 
-	private static void validateReplaceReferencesParams(String theSourceId, String theTargetId) {
-		if (isBlank(theSourceId)) {
+	private static void validateReplaceReferencesParams(
+			IPrimitiveType<String> theSourceId, IPrimitiveType<String> theTargetId) {
+		if (theSourceId == null || isBlank(theSourceId.getValue())) {
 			throw new InvalidRequestException(Msg.code(2583) + "Parameter '"
 					+ OPERATION_REPLACE_REFERENCES_PARAM_SOURCE_REFERENCE_ID + "' is blank");
 		}
 
-		if (isBlank(theTargetId)) {
+		if (theTargetId == null || isBlank(theTargetId.getValue())) {
 			throw new InvalidRequestException(Msg.code(2584) + "Parameter '"
 					+ OPERATION_REPLACE_REFERENCES_PARAM_TARGET_REFERENCE_ID + "' is blank");
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -4,11 +4,15 @@ import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import jakarta.servlet.http.HttpServletResponse;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Task;
@@ -16,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
@@ -29,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
@@ -159,7 +165,84 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		myTestHelper.assertAllReferencesUpdated();
 	}
 
-	// TODO ED we should add some tests for the invalid request error cases (and assert 4xx status code)
+	@ParameterizedTest
+	@ValueSource(strings = {""})
+	@NullSource
+	void testReplaceReferences_MissingSourceId_ThrowsInvalidRequestException(String theSourceId) {
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myTestHelper.callReplaceReferencesWithResourceLimit(myClient, theSourceId, "target-id", false, null);
+		});
+		assertThat(exception.getMessage()).contains("HAPI-2583: Parameter 'source-reference-id' is blank");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {""})
+	@NullSource
+	void testReplaceReferences_MissingTargetId_ThrowsInvalidRequestException(String theTargetId) {
+		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+			myTestHelper.callReplaceReferencesWithResourceLimit(myClient, "source-id", theTargetId, false, null);
+		});
+		assertThat(exception.getMessage()).contains("HAPI-2584: Parameter 'target-reference-id' is blank");
+	}
+
+
+	@Test
+	void testReplaceReferences_WhenReplacingAHighCardinalityReferenceElement_OnlyReplacesMatchingReferences() {
+		//This test uses an Observation resource with multiple Practitioner references in the 'performer' element.
+		// Create Practitioners
+		IIdType practitionerId1 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualifiedVersionless();
+		IIdType practitionerId2 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualifiedVersionless();
+		IIdType practitionerId3 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualifiedVersionless();
+
+		// Create observation with references in the performer field
+		IIdType observationId = createObservationWithPerformers(practitionerId1, practitionerId2).toUnqualifiedVersionless();
+
+		// Call $replace-references operation to replace practitionerId1 with practitionerId3
+		Parameters outParams = myTestHelper.callReplaceReferencesWithResourceLimit(myClient,
+			practitionerId1.toString(),
+			practitionerId3.toString(),
+			false,
+			null);
+
+		// Assert operation outcome
+		Bundle patchResultBundle = (Bundle) outParams.getParameter(OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME).getResource();
+
+		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
+			1, List.of(
+				"Observation"));
+
+		// Fetch and validate updated observation
+		Observation updatedObservation = myClient
+			.read()
+			.resource(Observation.class)
+			.withId(observationId)
+			.execute();
+
+		// Extract the performer references from the updated Observation
+		List<String> actualPerformerIds = updatedObservation.getPerformer().stream()
+			.map(ref -> ref.getReferenceElement().toString())
+			.toList();
+
+		// Assert that the performer references match the expected values
+		assertThat(actualPerformerIds).containsExactly(practitionerId3.toString(), practitionerId2.toString());
+	}
+
+	private IIdType createObservationWithPerformers(IIdType... performerIds) {
+		// Create a new Observation resource
+		Observation observation = new Observation();
+
+		// Add references to performers
+		for (IIdType performerId : performerIds) {
+			observation.addPerformer(new Reference(performerId.toUnqualifiedVersionless()));
+		}
+
+		// Store the observation resource via the FHIR client
+		return myClient.create().resource(observation).execute().getId();
+
+	}
+
+
+
 
 	@Override
 	protected boolean verboseClientLogging() {

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesTestHelper.java
@@ -234,6 +234,20 @@ public class ReplaceReferencesTestHelper {
 
 	public Parameters callReplaceReferencesWithResourceLimit(
 			IGenericClient theFhirClient, boolean theIsAsync, Integer theResourceLimit) {
+		return callReplaceReferencesWithResourceLimit(
+				theFhirClient,
+				mySourcePatientId.getValue(),
+				myTargetPatientId.getValue(),
+				theIsAsync,
+				theResourceLimit);
+	}
+
+	public Parameters callReplaceReferencesWithResourceLimit(
+			IGenericClient theFhirClient,
+			String theSourceId,
+			String theTargetId,
+			boolean theIsAsync,
+			Integer theResourceLimit) {
 		IOperationUntypedWithInputAndPartialOutput<Parameters> request = theFhirClient
 				.operation()
 				.onServer()
@@ -241,10 +255,10 @@ public class ReplaceReferencesTestHelper {
 				.withParameter(
 						Parameters.class,
 						ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_SOURCE_REFERENCE_ID,
-						new StringType(mySourcePatientId.getValue()))
+						new StringType(theSourceId))
 				.andParameter(
 						ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_TARGET_REFERENCE_ID,
-						new StringType(myTargetPatientId.getValue()));
+						new StringType(theTargetId));
 		if (theResourceLimit != null) {
 			request.andParameter(
 					ProviderConstants.OPERATION_REPLACE_REFERENCES_RESOURCE_LIMIT, new IntegerType(theResourceLimit));


### PR DESCRIPTION
closes #6672 

- Added a check in replace-references patch builder for the cardinality of the element that contains the reference. If the element is a high cardinality one then a specific filter is appended to the FHIR path for the replace operation. This filter prevents overwriting all the references in the element and just replaces the specific element containing the reference to be replaced. 
- Also fixed a bug where the replace-references endpoint was failing with a 500 Internal error exception (nstead of 400 InvalidRequest ) if one of the required parameters is missing.
- Added tests. 