### PR TITLE
made $hapi.fhir.replace-references not replace versioned references

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6689-replace-references-operation-skip-versioned-refs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6689-replace-references-operation-skip-versioned-refs.yaml
@@ -1,0 +1,4 @@
+---
+type: change
+issue: 6689
+title: "$hapi.fhir.replace-references operations has been changed to not replace versioned references"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6689-replace-references-operation-skip-versioned-refs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6689-replace-references-operation-skip-versioned-refs.yaml
@@ -1,4 +1,4 @@
 ---
 type: change
 issue: 6689
-title: "$hapi.fhir.replace-references operations has been changed to not replace versioned references"
+title: "$hapi.fhir.replace-references operation has been changed to not replace versioned references"

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -12,7 +12,6 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Reference;
@@ -26,6 +25,7 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
+import java.util.Set;
 
 import static ca.uhn.fhir.jpa.provider.ReplaceReferencesSvcImpl.RESOURCE_TYPES_SYSTEM;
 import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper.EXPECTED_SMALL_BATCHES;
@@ -233,35 +233,43 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	void testReplaceReferences_ShouldNotReplaceVersionedReferences() {
 		// this configuration makes preserve versioned references in the Provenance.target
 		// so that we can test that the versioned reference was not replaced
+		// but keep a copy of the original configuration to restore it after the test
+		Set<String> originalNotStrippedPaths =
+			myFhirContext.getParserOptions().getDontStripVersionsFromReferencesAtPaths();
 		myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths("Provenance.target");
+		try {
 
-		IIdType practitionerId1 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
-		IIdType practitionerId2 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
+			IIdType practitionerId1 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
+			IIdType practitionerId2 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
 
-		Provenance provenance = new Provenance();
-		provenance.addTarget(new Reference(practitionerId1));
-		IIdType provenanceId = myClient.create().resource(provenance).execute().getId();
-		// Call $replace-references operation to replace practitionerId1 with practitionerId3
-		myTestHelper.callReplaceReferencesWithResourceLimit(myClient,
-			practitionerId1.toVersionless().toString(),
-			practitionerId2.toVersionless().toString(),
-			false,
-			null);
+			Provenance provenance = new Provenance();
+			provenance.addTarget(new Reference(practitionerId1));
+			IIdType provenanceId = myClient.create().resource(provenance).execute().getId();
+			// Call $replace-references operation to replace practitionerId1 with practitionerId3
+			myTestHelper.callReplaceReferencesWithResourceLimit(myClient,
+				practitionerId1.toVersionless().toString(),
+				practitionerId2.toVersionless().toString(),
+				false,
+				null);
 
-		// Fetch and validate the provenance
-		Provenance provenanceAfterOperation = myClient
-			.read()
-			.resource(Provenance.class)
-			.withId(provenanceId.toUnqualifiedVersionless())
-			.execute();
+			// Fetch and validate the provenance
+			Provenance provenanceAfterOperation = myClient
+				.read()
+				.resource(Provenance.class)
+				.withId(provenanceId.toUnqualifiedVersionless())
+				.execute();
 
-		// Extract the target references from the Provenance
-		List<String> actualTargetIds = provenanceAfterOperation.getTarget().stream()
-			.map(ref -> ref.getReferenceElement().toString())
-			.toList();
+			// Extract the target references from the Provenance
+			List<String> actualTargetIds = provenanceAfterOperation.getTarget().stream()
+				.map(ref -> ref.getReferenceElement().toString())
+				.toList();
 
-		// Assert that the versioned reference in the Provenance  was not replaced
-		assertThat(actualTargetIds).containsExactly(practitionerId1.toString());
+			// Assert that the versioned reference in the Provenance  was not replaced
+			assertThat(actualTargetIds).containsExactly(practitionerId1.toString());
+
+		} finally {
+			myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths(originalNotStrippedPaths);
+		}
 	}
 
 	private IIdType createObservationWithPerformers(IIdType... performerIds) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -12,7 +12,9 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Task;
@@ -225,6 +227,41 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 
 		// Assert that the performer references match the expected values
 		assertThat(actualPerformerIds).containsExactly(practitionerId3.toString(), practitionerId2.toString());
+	}
+
+	@Test
+	void testReplaceReferences_ShouldNotReplaceVersionedReferences() {
+		// this configuration makes preserve versioned references in the Provenance.target
+		// so that we can test that the versioned reference was not replaced
+		myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths("Provenance.target");
+
+		IIdType practitionerId1 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
+		IIdType practitionerId2 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
+
+		Provenance provenance = new Provenance();
+		provenance.addTarget(new Reference(practitionerId1));
+		IIdType provenanceId = myClient.create().resource(provenance).execute().getId();
+		// Call $replace-references operation to replace practitionerId1 with practitionerId3
+		myTestHelper.callReplaceReferencesWithResourceLimit(myClient,
+			practitionerId1.toVersionless().toString(),
+			practitionerId2.toVersionless().toString(),
+			false,
+			null);
+
+		// Fetch and validate the provenance
+		Provenance provenanceAfterOperation = myClient
+			.read()
+			.resource(Provenance.class)
+			.withId(provenanceId.toUnqualifiedVersionless())
+			.execute();
+
+		// Extract the target references from the Provenance
+		List<String> actualTargetIds = provenanceAfterOperation.getTarget().stream()
+			.map(ref -> ref.getReferenceElement().toString())
+			.toList();
+
+		// Assert that the versioned reference in the Provenance  was not replaced
+		assertThat(actualTargetIds).containsExactly(practitionerId1.toString());
 	}
 
 	private IIdType createObservationWithPerformers(IIdType... performerIds) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesPatchBundleSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesPatchBundleSvc.java
@@ -81,7 +81,6 @@ public class ReplaceReferencesPatchBundleSvc {
 			List<IdDt> theResourceIds,
 			RequestDetails theRequestDetails) {
 		BundleBuilder bundleBuilder = new BundleBuilder(myFhirContext);
-
 		theResourceIds.forEach(referencingResourceId -> {
 			IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(referencingResourceId.getResourceType());
 			IBaseResource resource = dao.read(referencingResourceId, theRequestDetails);
@@ -110,7 +109,7 @@ public class ReplaceReferencesPatchBundleSvc {
 	private static boolean matches(ResourceReferenceInfo refInfo, IIdType theSourceId) {
 		return refInfo.getResourceReference()
 				.getReferenceElement()
-				.toUnqualifiedVersionless()
+				.toUnqualified()
 				.getValueAsString()
 				.equals(theSourceId.getValueAsString());
 	}


### PR DESCRIPTION
closes: #6689  

The versioned references are usually kept for historical record keeping purposes such as in Provenance.target .  For that reason, it is important to keep them as they are. This MR adds a changes so that versioned references are not replaced by the $hapi.fhir.replace-references operation. 