### PR TITLE
Fixing Failure when creating a cross-partition subscription if the default partition id is not null

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
@@ -243,7 +243,7 @@ public class RequestPartitionId implements IModelJson {
 				&& Objects.equals(getPartitionIds().get(0), theDefaultPartitionId);
 	}
 
-	public boolean hasPartitionId(@Nullable Integer thePartitionId) {
+	public boolean hasPartitionId(Integer thePartitionId) {
 		Validate.notNull(myPartitionIds, "Partition IDs not set");
 		return myPartitionIds.contains(thePartitionId);
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
@@ -222,15 +222,28 @@ public class RequestPartitionId implements IModelJson {
 	 * Returns true if this request partition contains only one partition ID and it is the DEFAULT partition ID (null)
 	 */
 	public boolean isDefaultPartition() {
+		return isDefaultPartition(null);
+	}
+
+	/**
+	 * Test whether this request partition is for a given default partition ID.
+	 *
+	 * @param theDefaultPartitionId is the ID that was given to the default partition.  The default partition ID can be
+	 *                              NULL as per default or specifically assigned another value.
+	 *                              See PartitionSettings#setDefaultPartitionId.
+	 * @return <code>true</code> if the request partition contains only one partition ID and the partition ID is
+	 *         <code>theDefaultPartitionId</code>.
+	 */
+	public boolean isDefaultPartition(@Nullable Integer theDefaultPartitionId) {
 		if (isAllPartitions()) {
 			return false;
 		}
 		return hasPartitionIds()
 				&& getPartitionIds().size() == 1
-				&& getPartitionIds().get(0) == null;
+				&& Objects.equals(getPartitionIds().get(0), theDefaultPartitionId);
 	}
 
-	public boolean hasPartitionId(Integer thePartitionId) {
+	public boolean hasPartitionId(@Nullable Integer thePartitionId) {
 		Validate.notNull(myPartitionIds, "Partition IDs not set");
 		return myPartitionIds.contains(thePartitionId);
 	}
@@ -244,7 +257,11 @@ public class RequestPartitionId implements IModelJson {
 	}
 
 	public boolean hasDefaultPartitionId() {
-		return getPartitionIds().contains(null);
+		return hasDefaultPartitionId(null);
+	}
+
+	public boolean hasDefaultPartitionId(@Nullable Integer theDefaultPartitionId) {
+		return getPartitionIds().contains(theDefaultPartitionId);
 	}
 
 	public List<Integer> getPartitionIdsWithoutDefault() {
@@ -358,14 +375,6 @@ public class RequestPartitionId implements IModelJson {
 	public static RequestPartitionId forPartitionIdsAndNames(
 			List<String> thePartitionNames, List<Integer> thePartitionIds, LocalDate thePartitionDate) {
 		return new RequestPartitionId(thePartitionNames, thePartitionIds, thePartitionDate);
-	}
-
-	public static boolean isDefaultPartition(@Nullable RequestPartitionId thePartitionId) {
-		if (thePartitionId == null) {
-			return false;
-		}
-
-		return thePartitionId.isDefaultPartition();
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/model/RequestPartitionId.java
@@ -220,13 +220,22 @@ public class RequestPartitionId implements IModelJson {
 
 	/**
 	 * Returns true if this request partition contains only one partition ID and it is the DEFAULT partition ID (null)
+	 *
+	 * @deprecated use {@link #isDefaultPartition(Integer)} or {@link IRequestPartitionHelperSvc.isDefaultPartition}
+	 * instead
+	 * .
 	 */
+	@Deprecated(since = "2025.02.R01")
 	public boolean isDefaultPartition() {
 		return isDefaultPartition(null);
 	}
 
 	/**
 	 * Test whether this request partition is for a given default partition ID.
+	 *
+	 * This method can be directly invoked on a requestPartition object providing that <code>theDefaultPartitionId</code>
+	 * is known or through {@link IRequestPartitionHelperSvc.isDefaultPartition} where the implementer of the interface
+	 * will provide the default partition id (see {@link IRequestPartitionHelperSvc.getDefaultPartition}).
 	 *
 	 * @param theDefaultPartitionId is the ID that was given to the default partition.  The default partition ID can be
 	 *                              NULL as per default or specifically assigned another value.
@@ -256,10 +265,32 @@ public class RequestPartitionId implements IModelJson {
 		return myPartitionNames != null;
 	}
 
+	/**
+	 * Verifies that one of the requested partition is the default partition which is assumed to have a default value of
+	 * null.
+	 *
+	 * @return true if one of the requested partition is the default partition(null).
+	 *
+	 * @deprecated use {@link #hasDefaultPartitionId(Integer)} or {@link IRequestPartitionHelperSvc.hasDefaultPartitionId}
+	 * instead
+	 */
+	@Deprecated(since = "2025.02.R01")
 	public boolean hasDefaultPartitionId() {
 		return hasDefaultPartitionId(null);
 	}
 
+	/**
+	 * Test whether this request partition has the default partition as one of its targeted partitions.
+	 *
+	 * This method can be directly invoked on a requestPartition object providing that <code>theDefaultPartitionId</code>
+	 * is known or through {@link IRequestPartitionHelperSvc.hasDefaultPartitionId} where the implementer of the interface
+	 * will provide the default partition id (see {@link IRequestPartitionHelperSvc.getDefaultPartition}).
+	 *
+	 * @param theDefaultPartitionId is the ID that was given to the default partition.  The default partition ID can be
+	 *                              NULL as per default or specifically assigned another value.
+	 *                              See PartitionSettings#setDefaultPartitionId.
+	 * @return <code>true</code> if the request partition has the default partition as one of the targeted partition.
+	 */
 	public boolean hasDefaultPartitionId(@Nullable Integer theDefaultPartitionId) {
 		return getPartitionIds().contains(theDefaultPartitionId);
 	}

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/model/RequestPartitionIdTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/model/RequestPartitionIdTest.java
@@ -17,6 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RequestPartitionIdTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(RequestPartitionIdTest.class);
 
+	private static final Integer ourDefaultPartitionId = 0;
+	
 	@Test
 	public void testHashCode() {
 		assertEquals(31860737, RequestPartitionId.allPartitions().hashCode());
@@ -39,6 +41,29 @@ public class RequestPartitionIdTest {
 		assertFalse(RequestPartitionId.forPartitionIdsAndNames(Lists.newArrayList("Name1", "Name2"), null, null).isDefaultPartition());
 		assertFalse(RequestPartitionId.forPartitionIdsAndNames(null, Lists.newArrayList(1, 2), null).isAllPartitions());
 		assertFalse(RequestPartitionId.forPartitionIdsAndNames(null, Lists.newArrayList(1, 2), null).isDefaultPartition());
+	}
+
+	@Test
+	public void testIsDefaultPartition_withDefaultPartitionAsParameter() {
+
+		assertThat(RequestPartitionId.defaultPartition().isDefaultPartition(null)).isTrue();
+		assertThat(RequestPartitionId.fromPartitionIds(ourDefaultPartitionId).isDefaultPartition(ourDefaultPartitionId)).isTrue();
+
+		assertThat(RequestPartitionId.defaultPartition().isDefaultPartition(ourDefaultPartitionId)).isFalse();
+		assertThat(RequestPartitionId.allPartitions().isDefaultPartition(ourDefaultPartitionId)).isFalse();
+		assertThat(RequestPartitionId.fromPartitionIds(ourDefaultPartitionId, 2).isDefaultPartition(ourDefaultPartitionId)).isFalse();
+	}
+
+	@Test
+	public void testHasDefaultPartition_withDefaultPartitionAsParameter() {
+
+		assertThat(RequestPartitionId.defaultPartition().hasDefaultPartitionId(null)).isTrue();
+		assertThat(RequestPartitionId.fromPartitionIds(ourDefaultPartitionId).hasDefaultPartitionId(ourDefaultPartitionId)).isTrue();
+		assertThat(RequestPartitionId.fromPartitionIds(ourDefaultPartitionId, null).hasDefaultPartitionId(null)).isTrue();
+		assertThat(RequestPartitionId.fromPartitionIds(ourDefaultPartitionId, null).hasDefaultPartitionId(ourDefaultPartitionId)).isTrue();
+
+		assertThat(RequestPartitionId.fromPartitionIds(ourDefaultPartitionId).hasDefaultPartitionId(null)).isFalse();
+		assertThat(RequestPartitionId.defaultPartition().hasDefaultPartitionId(ourDefaultPartitionId)).isFalse();
 	}
 
 	@Test

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6686-failure-creating-cross-partition-subscription.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6686-failure-creating-cross-partition-subscription.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 6686
+title: "Previously, attempting to create a cross-partition subscription would fail when the ID of the default partition 
+was configured to a value that is different of the default value (null). This issue is fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6686-failure-creating-cross-partition-subscription.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6686-failure-creating-cross-partition-subscription.yaml
@@ -1,5 +1,6 @@
 ---
 type: fix
 issue: 6686
-title: "Previously, attempting to create a cross-partition subscription would fail when the ID of the default partition 
-was configured to a value that is different of the default value (null). This issue is fixed."
+title: "Previously, attempting to create a cross-partition subscription would fail if the default partition ID was
+assigned a value different than the default value(null). This issue is fixed."
+

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/RequestPartitionHelperSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/RequestPartitionHelperSvc.java
@@ -22,7 +22,6 @@ package ca.uhn.fhir.jpa.partition;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.entity.PartitionEntity;
-import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.apache.commons.lang3.Validate;
@@ -36,11 +35,6 @@ public class RequestPartitionHelperSvc extends BaseRequestPartitionHelperSvc {
 
 	@Autowired
 	IPartitionLookupSvc myPartitionConfigSvc;
-
-	@Autowired
-	PartitionSettings myPartitionSettings;
-
-	public RequestPartitionHelperSvc() {}
 
 	@Override
 	public RequestPartitionId validateAndNormalizePartitionIds(RequestPartitionId theRequestPartitionId) {

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/partition/IRequestPartitionHelperSvc.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/partition/IRequestPartitionHelperSvc.java
@@ -184,13 +184,35 @@ public interface IRequestPartitionHelperSvc {
 	RequestPartitionId validateAndNormalizePartitionNames(RequestPartitionId theRequestPartitionId);
 
 	/**
-	 * Test whether <code>theRequestPartitionId</code> is targeting the default partition.  Implementers should overwrite
-	 * this method to enhance the default behavior which is to invoke <code>theRequestPartitionId#isDefaultPartition</code>
+	 * This method returns the default partition ID. Implementers of this interface should overwrite this method to provide
+	 * a default partition ID that is different than the default value of null.
+	 *
+	 * @return the default partition ID
+	 */
+	@Nullable
+	default Integer getDefaultPartitionId() {
+		return null;
+	}
+
+	/**
+	 * Test whether <code>theRequestPartitionId</code> is only targeting the default partition where the ID of the default
+	 * partition is provided by {@link #getDefaultPartitionId()}.
 	 *
 	 * @param theRequestPartitionId to perform the evaluation upon.
-	 * @return true if the <code>theRequestPartitionId</code> is for the default partition.
+	 * @return true if the <code>theRequestPartitionId</code> is for the default partition only.
 	 */
 	default boolean isDefaultPartition(@Nonnull RequestPartitionId theRequestPartitionId) {
-		return theRequestPartitionId.isDefaultPartition();
+		return theRequestPartitionId.isDefaultPartition(getDefaultPartitionId());
+	}
+
+	/**
+	 * Test whether <code>theRequestPartitionId</code> has one of its targeted partitions matching the default partition
+	 * where the ID of the default partition is provided by {@link #getDefaultPartitionId()}.
+	 *
+	 * @param theRequestPartitionId to perform the evaluation upon.
+	 * @return true if the <code>theRequestPartitionId</code> is targeting the default partition.
+	 */
+	default boolean hasDefaultPartitionId(@Nonnull RequestPartitionId theRequestPartitionId) {
+		return theRequestPartitionId.hasDefaultPartitionId(getDefaultPartitionId());
 	}
 }

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/partition/IRequestPartitionHelperSvc.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/partition/IRequestPartitionHelperSvc.java
@@ -182,4 +182,15 @@ public interface IRequestPartitionHelperSvc {
 	 * @return - A {@link RequestPartitionId} with a normalized list of partition ids and partition names.
 	 */
 	RequestPartitionId validateAndNormalizePartitionNames(RequestPartitionId theRequestPartitionId);
+
+	/**
+	 * Test whether <code>theRequestPartitionId</code> is targeting the default partition.  Implementers should overwrite
+	 * this method to enhance the default behavior which is to invoke <code>theRequestPartitionId#isDefaultPartition</code>
+	 *
+	 * @param theRequestPartitionId to perform the evaluation upon.
+	 * @return true if the <code>theRequestPartitionId</code> is for the default partition.
+	 */
+	default boolean isDefaultPartition(@Nonnull RequestPartitionId theRequestPartitionId) {
+		return theRequestPartitionId.isDefaultPartition();
+	}
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -264,7 +264,7 @@ public class SubscriptionValidatingInterceptor {
 					? theRequestPartitionId
 					: determinePartition(theRequestDetails, theSubscription);
 
-			if (!toCheckPartitionId.isDefaultPartition()) {
+			if (!myRequestPartitionHelperSvc.isDefaultPartition(toCheckPartitionId)) {
 				throw new UnprocessableEntityException(
 						Msg.code(2010) + "Cross partition subscription must be created on the default partition");
 			}

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizerTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionCanonicalizerTest.java
@@ -12,6 +12,7 @@ import ca.uhn.fhir.subscription.SubscriptionConstants;
 import ca.uhn.fhir.subscription.SubscriptionTestDataHelper;
 import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nonnull;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Subscription;
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 import static ca.uhn.fhir.rest.api.Constants.CT_FHIR_JSON_NEW;
 import static ca.uhn.fhir.rest.api.Constants.RESOURCE_PARTITION_ID;
 import static ca.uhn.fhir.util.HapiExtensions.EX_SEND_DELETE_MESSAGES;
+import static java.util.Objects.isNull;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -207,15 +209,12 @@ class SubscriptionCanonicalizerTest {
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
 
-		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		} else {
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		}
+		assertCanonicalSubscriptionCrossPropertyValue(
+			canonicalSubscriptionWithoutExtension,
+			canonicalSubscriptionWithExtensionCrossPartitionTrue,
+			canonicalSubscriptionWithExtensionCrossPartitionFalse,
+			theRequestPartitionId
+		);
 	}
 
 	@ParameterizedTest
@@ -242,16 +241,12 @@ class SubscriptionCanonicalizerTest {
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
 
-		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		} else {
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		}
-
+		assertCanonicalSubscriptionCrossPropertyValue(
+			canonicalSubscriptionWithoutExtension,
+			canonicalSubscriptionWithExtensionCrossPartitionTrue,
+			canonicalSubscriptionWithExtensionCrossPartitionFalse,
+			theRequestPartitionId
+		);
 	}
 
 	@ParameterizedTest
@@ -276,15 +271,12 @@ class SubscriptionCanonicalizerTest {
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
 
-		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		} else {
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		}
+		assertCanonicalSubscriptionCrossPropertyValue(
+			canonicalSubscriptionWithoutExtension,
+			canonicalSubscriptionWithExtensionCrossPartitionTrue,
+			canonicalSubscriptionWithExtensionCrossPartitionFalse,
+			theRequestPartitionId
+		);
 	}
 
 	@ParameterizedTest
@@ -309,15 +301,12 @@ class SubscriptionCanonicalizerTest {
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionTrue = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionTrue);
 		final CanonicalSubscription canonicalSubscriptionWithExtensionCrossPartitionFalse = subscriptionCanonicalizer.canonicalize(subscriptionWithExtensionCrossPartitionFalse);
 
-		if(RequestPartitionId.isDefaultPartition(theRequestPartitionId)){
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		} else {
-			assertThat(canonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
-			assertThat(canonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
-		}
+		assertCanonicalSubscriptionCrossPropertyValue(
+			canonicalSubscriptionWithoutExtension,
+			canonicalSubscriptionWithExtensionCrossPartitionTrue,
+			canonicalSubscriptionWithExtensionCrossPartitionFalse,
+			theRequestPartitionId
+		);
 	}
 
 	private org.hl7.fhir.r4b.model.Subscription buildR4BSubscription(String thePayloadContent) {
@@ -418,5 +407,22 @@ class SubscriptionCanonicalizerTest {
 		filter.setComparator(Enumerations.SearchComparator.EQ);
 		filter.setValue(theValue);
 		return filter;
+	}
+
+	private void assertCanonicalSubscriptionCrossPropertyValue(CanonicalSubscription theCanonicalSubscriptionWithoutExtension,
+															   CanonicalSubscription theCanonicalSubscriptionWithExtensionCrossPartitionTrue,
+															   CanonicalSubscription theCanonicalSubscriptionWithExtensionCrossPartitionFalse,
+															   RequestPartitionId theRequestPartitionId) {
+
+		boolean isDefaultPartition = isNull(theRequestPartitionId) ? false : theRequestPartitionId.isDefaultPartition();
+
+		AssertionsForClassTypes.assertThat(theCanonicalSubscriptionWithoutExtension.isCrossPartitionEnabled()).isFalse();
+		AssertionsForClassTypes.assertThat(theCanonicalSubscriptionWithExtensionCrossPartitionFalse.isCrossPartitionEnabled()).isFalse();
+
+		if(isDefaultPartition){
+			AssertionsForClassTypes.assertThat(theCanonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isTrue();
+		} else {
+			AssertionsForClassTypes.assertThat(theCanonicalSubscriptionWithExtensionCrossPartitionTrue.isCrossPartitionEnabled()).isFalse();
+		}
 	}
 }

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -225,8 +225,10 @@ public class SubscriptionValidatingInterceptorTest {
 
 	@Test
 	public void testInvalidPointcut() {
+		final Subscription subscription = createSubscription();
+
 		try {
-			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(createSubscription(), null, null, Pointcut.TEST_RB);
+			mySubscriptionValidatingInterceptor.validateSubmittedSubscription(subscription, null, null, Pointcut.TEST_RB);
 			fail("");
 		} catch (UnprocessableEntityException e) {
 			assertEquals(Msg.code(2267) + "Expected Pointcut to be either STORAGE_PRESTORAGE_RESOURCE_CREATED or STORAGE_PRESTORAGE_RESOURCE_UPDATED but was: " + Pointcut.TEST_RB, e.getMessage());

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
@@ -22,6 +23,8 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
+import ca.uhn.fhir.util.ExtensionUtil;
+import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4b.model.CanonicalType;
@@ -52,6 +55,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -195,11 +199,29 @@ public class SubscriptionValidatingInterceptorTest {
 	}
 
 	@Test
+	public void testCreateSubscription_whenCreatedOnNonDefaultPartition_willFail() {
+		final Subscription subscription = createSubscription();
+		ExtensionUtil.addExtension(myFhirContext, subscription, HapiExtensions.EXTENSION_SUBSCRIPTION_CROSS_PARTITION, "boolean", Boolean.TRUE);
+
+		when(mySubscriptionSettings.isCrossPartitionSubscriptionEnabled()).thenReturn(true);
+		when(myRequestPartitionHelperSvc.isDefaultPartition(any())).thenReturn(false);
+
+		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(1);
+
+		try {
+			mySubscriptionValidatingInterceptor.resourcePreCreate(subscription, null, requestPartitionId);
+			fail();
+		} catch (UnprocessableEntityException e) {
+			assertEquals(Msg.code(2010) + "Cross partition subscription must be created on the default partition", e.getMessage());
+		}
+	}
+
+	@Test
 	public void testSubscriptionUpdate() {
 		final Subscription subscription = createSubscription();
 
-		// Assert there is no Exception thrown here.
-		mySubscriptionValidatingInterceptor.resourceUpdated(subscription, subscription, null, null);
+		assertThatThrownBy(() -> mySubscriptionValidatingInterceptor.resourceUpdated(subscription, subscription, null, null))
+			.doesNotThrowAnyException();
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -54,8 +54,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -220,8 +220,7 @@ public class SubscriptionValidatingInterceptorTest {
 	public void testSubscriptionUpdate() {
 		final Subscription subscription = createSubscription();
 
-		assertThatThrownBy(() -> mySubscriptionValidatingInterceptor.resourceUpdated(subscription, subscription, null, null))
-			.doesNotThrowAnyException();
+		assertThatNoException().isThrownBy(() -> mySubscriptionValidatingInterceptor.resourceUpdated(subscription, subscription, null, null));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
@@ -220,6 +220,7 @@ public class SubscriptionValidatingInterceptorTest {
 		when(myDaoRegistry.isResourceTypeSupported("Patient")).thenReturn(true);
 		when(mySubscriptionSettings.isCrossPartitionSubscriptionEnabled()).thenReturn(true);
 		when(myRequestPartitionHelperSvc.determineCreatePartitionForRequest(isA(RequestDetails.class), isA(Subscription.class), eq("Subscription"))).thenReturn(RequestPartitionId.defaultPartition());
+		when(myRequestPartitionHelperSvc.isDefaultPartition(any())).thenReturn(true);
 
 		Subscription subscription = new Subscription();
 		subscription.setStatus(Subscription.SubscriptionStatus.ACTIVE);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionValidatingInterceptorTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.jpa.subscription.submit.interceptor.validator.RestHookChannelValidator.IEndpointUrlValidationStrategy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -108,7 +109,7 @@ public class SubscriptionValidatingInterceptorTest {
 		subscription.getChannel().setPayload("application/fhir+json");
 		subscription.getChannel().setEndpoint("http://foo");
 
-		mySvc.resourcePreCreate(subscription, null, null);
+		assertThatNoException().isThrownBy(() -> mySvc.resourcePreCreate(subscription, null, null));
 	}
 
 	@Test
@@ -196,7 +197,7 @@ public class SubscriptionValidatingInterceptorTest {
 		subscription.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
 		subscription.getChannel().setEndpoint("http://foo");
 
-		mySvc.resourcePreCreate(subscription, null, null);
+		assertThatNoException().isThrownBy(() -> mySvc.resourcePreCreate(subscription, null, null));
 	}
 
 	@Test

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
@@ -364,8 +364,9 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 	}
 
 	@Override
-	public boolean isDefaultPartition(@Nonnull RequestPartitionId theRequestPartitionId) {
-		return theRequestPartitionId.isDefaultPartition(myPartitionSettings.getDefaultPartitionId());
+	@Nullable
+	public Integer getDefaultPartitionId() {
+		return myPartitionSettings.getDefaultPartitionId();
 	}
 
 	private boolean isResourceNonPartitionable(String theResourceType) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
@@ -189,7 +189,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 			SystemRequestDetails theRequest, boolean theNonPartitionableResource) {
 		RequestPartitionId requestPartitionId;
 		requestPartitionId = getSystemRequestPartitionId(theRequest);
-		if (theNonPartitionableResource && !requestPartitionId.isDefaultPartition()) {
+		if (theNonPartitionableResource && !isDefaultPartition(requestPartitionId)) {
 			throw new InternalErrorException(Msg.code(1315)
 					+ "System call is attempting to write a non-partitionable resource to a partition! This is a bug!");
 		}
@@ -326,7 +326,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 		// Replace null partition ID with non-null default partition ID if one is being used
 		if (myPartitionSettings.getDefaultPartitionId() != null
 				&& retVal.hasPartitionIds()
-				&& retVal.hasDefaultPartitionId()) {
+				&& hasDefaultPartitionId(retVal)) {
 			List<Integer> partitionIds = new ArrayList<>(retVal.getPartitionIds());
 			for (int i = 0; i < partitionIds.size(); i++) {
 				if (partitionIds.get(i) == null) {
@@ -380,7 +380,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 		validateSinglePartitionIdOrName(theRequestPartitionId.getPartitionNames());
 
 		// Make sure we're not using one of the conformance resources in a non-default partition
-		if (theRequestPartitionId.isDefaultPartition() || theRequestPartitionId.isAllPartitions()) {
+		if (isDefaultPartition(theRequestPartitionId) || theRequestPartitionId.isAllPartitions()) {
 			return;
 		}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
@@ -363,6 +363,11 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 		return theResourceType != null && !myNonPartitionableResourceNames.contains(theResourceType);
 	}
 
+	@Override
+	public boolean isDefaultPartition(@Nonnull RequestPartitionId theRequestPartitionId) {
+		return theRequestPartitionId.isDefaultPartition(myPartitionSettings.getDefaultPartitionId());
+	}
+
 	private boolean isResourceNonPartitionable(String theResourceType) {
 		return theResourceType != null && !isResourcePartitionable(theResourceType);
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
@@ -189,7 +189,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 			SystemRequestDetails theRequest, boolean theNonPartitionableResource) {
 		RequestPartitionId requestPartitionId;
 		requestPartitionId = getSystemRequestPartitionId(theRequest);
-		if (theNonPartitionableResource && !isDefaultPartition(requestPartitionId)) {
+		if (theNonPartitionableResource && !requestPartitionId.isDefaultPartition()) {
 			throw new InternalErrorException(Msg.code(1315)
 					+ "System call is attempting to write a non-partitionable resource to a partition! This is a bug!");
 		}


### PR DESCRIPTION
**Background:**
- The default value of the ID for the default partition is null;
- clients can provide another value for the default partition id through the partitionSettings.setDefaultPartitionId

**Root cause of the issue:**
invocation of RequestPartitionId.isDefaultParttition() only considers that the default partition id is and should be null;

**What was done:**
- added failing test;
- added api to an existing helper service to perform default partition check against the client configured defaultPartition Id (PartitionSettings);



Closes #6686 