### PR TITLE
Fix _security label filtering with :not operator in the in-memory matcher

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6692-fix-security-label-filtering-with-not-operator.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/7_8_0/6692-fix-security-label-filtering-with-not-operator.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 6692
+jira: SMILE-9736
+title: "Previously, when the in-memory matcher was used to match resources with a `_security` label filter 
+and a `:not` operator (i.e. `_security:not=http://terminology.hl7.org/CodeSystem/v3-ActCode|NODSCLCD`), 
+resources with no security labels at all were not matched. This has been fixed."

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
@@ -72,6 +72,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.searchparam.extractor.ResourceIndexedSearchParams.isMatchSearchParam;
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -438,6 +439,10 @@ public class InMemoryResourceMatcher {
 		}
 
 		if (param.getModifier() == TokenParamModifier.NOT) {
+			// :not filters for security labels / tags should always match resources with no security labels / tags
+			if (isEmpty(list)){
+				return true;
+			}
 			haveMatch = !haveMatch;
 		}
 

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcher.java
@@ -440,7 +440,7 @@ public class InMemoryResourceMatcher {
 
 		if (param.getModifier() == TokenParamModifier.NOT) {
 			// :not filters for security labels / tags should always match resources with no security labels / tags
-			if (isEmpty(list)){
+			if (isEmpty(list)) {
 				return true;
 			}
 			haveMatch = !haveMatch;

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/matcher/InMemoryResourceMatcherR5Test.java
@@ -454,7 +454,6 @@ public class InMemoryResourceMatcherR5Test {
 		ResourceIndexedSearchParams retval = ResourceIndexedSearchParams.withSets();
 		retval.myDateParams.add(extractEffectiveDateParam(theObservation));
 		retval.myTokenParams.add(extractCodeTokenParam(theObservation));
-		retval.myTokenParams.add(extractSecurityTokenParam(theObservation));
 		return retval;
 	}
 
@@ -467,11 +466,6 @@ public class InMemoryResourceMatcherR5Test {
 	protected ResourceIndexedSearchParamToken extractCodeTokenParam(Observation theObservation) {
 		Coding coding = theObservation.getCode().getCodingFirstRep();
 		return new ResourceIndexedSearchParamToken(new PartitionSettings(), "Observation", "code", coding.getSystem(), coding.getCode());
-	}
-
-	protected ResourceIndexedSearchParamToken extractSecurityTokenParam(Observation theObservation) {
-		Coding security = theObservation.getMeta().getSecurityFirstRep();
-		return new ResourceIndexedSearchParamToken(new PartitionSettings(), "Observation", "_security", security.getSystem(), security.getCode());
 	}
 
 	protected ResourceIndexedSearchParamUri extractSourceUriParam(Observation theObservation) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/AuthorizationInterceptorJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/AuthorizationInterceptorJpaR4Test.java
@@ -1,5 +1,11 @@
 package ca.uhn.fhir.jpa.provider.r4;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.delete.ThreadSafeResourceDeleterSvc;
 import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
@@ -83,12 +89,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class AuthorizationInterceptorJpaR4Test extends BaseResourceProviderR4Test {
@@ -1983,64 +1986,6 @@ public class AuthorizationInterceptorJpaR4Test extends BaseResourceProviderR4Tes
 		assertEquals(newBirthDate.getValueAsString(), savedPatient.getBirthDateElement().getValueAsString());
 	}
 
-	@Test
-	public void testNotSecurityFilter_onBundleWithDisallowedSecurityTag_isRejected(){
-		final String filter = "_security:not=http://terminology.hl7.org/CodeSystem/v3-ActCode|NODSCLCD";
-		AuthorizationInterceptor interceptor = new ReadAllOfTypeWithFilterAuthorizationInterceptor("Bundle", filter);
-		interceptor.setAuthorizationSearchParamMatcher(new AuthorizationSearchParamMatcher(mySearchParamMatcher));
-		myServer.getRestfulServer().registerInterceptor(interceptor);
-
-		Bundle bundle = createCollectionBundle("bundle-1");
-		bundle.getMeta().addSecurity(new Coding().setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode").setCode("NODSCLCD"));
-		doUpdateResource(bundle);
-
-		try {
-			myClient.read().resource(Bundle.class).withId("Bundle/bundle-1").execute();
-			fail();
-		} catch (ForbiddenOperationException e){
-			// pass
-		}
-	}
-
-	@Test
-	public void testNotSecurityFilter_onBundleWithAllowedSecurityTag_isAllowed(){
-		final String filter = "_security:not=http://terminology.hl7.org/CodeSystem/v3-ActCode|NODSCLCD";
-
-		AuthorizationInterceptor interceptor = new ReadAllOfTypeWithFilterAuthorizationInterceptor("Bundle", filter);
-		interceptor.setAuthorizationSearchParamMatcher(new AuthorizationSearchParamMatcher(mySearchParamMatcher));
-		myServer.getRestfulServer().registerInterceptor(interceptor);
-
-		Bundle bundle = createCollectionBundle("bundle-1");
-		bundle.getMeta().addSecurity(new Coding().setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode").setCode("OTHER_CODE"));
-		doUpdateResource(bundle);
-
-		Bundle foundBundle = myClient.read().resource(Bundle.class).withId("bundle-1").execute();
-		assertEquals(bundle.getIdElement().toUnqualifiedVersionless(), foundBundle.getIdElement().toUnqualifiedVersionless());
-	}
-
-	@Test
-	public void testNotSecurityFilter_onBundleWithNoSecurityTags_isAllowed(){
-		final String filter = "_security:not=http://terminology.hl7.org/CodeSystem/v3-ActCode|NODSCLCD";
-
-		AuthorizationInterceptor interceptor = new ReadAllOfTypeWithFilterAuthorizationInterceptor("Bundle", filter);
-		interceptor.setAuthorizationSearchParamMatcher(new AuthorizationSearchParamMatcher(mySearchParamMatcher));
-		myServer.getRestfulServer().registerInterceptor(interceptor);
-
-		Bundle bundle = createCollectionBundle("bundle-1");
-		assertTrue(bundle.getMeta().getSecurity().isEmpty());
-		doUpdateResource(bundle);
-
-		Bundle foundBundle = myClient.read().resource(Bundle.class).withId("bundle-1").execute();
-		assertEquals(bundle.getIdElement().toUnqualifiedVersionless(), foundBundle.getIdElement().toUnqualifiedVersionless());
-	}
-
-	private Bundle createCollectionBundle(String theId){
-		Bundle bundle = new Bundle();
-		bundle.setId(theId);
-		bundle.setType(Bundle.BundleType.COLLECTION);
-		return bundle;
-	}
-
 	private Patient createPatient(String theFirstName, String theLastName) {
 		Patient patient = new Patient();
 		patient.addName().addGiven(theFirstName).setFamily(theLastName);
@@ -2252,29 +2197,6 @@ public class AuthorizationInterceptorJpaR4Test extends BaseResourceProviderR4Tes
 			return new RuleBuilder()
 				.allow().transaction().withAnyOperation().andApplyNormalRules().andThen()
 				.allow().write().allResources().withAnyId().andThen()
-				.build();
-		}
-	}
-
-	static class ReadAllOfTypeWithFilterAuthorizationInterceptor extends AuthorizationInterceptor {
-
-		private final String myResourceType;
-		private final String myFilter;
-
-		public ReadAllOfTypeWithFilterAuthorizationInterceptor(String theResourceType, String theFilter) {
-			super(PolicyEnum.DENY);
-			myResourceType = theResourceType;
-			myFilter = theFilter;
-		}
-
-		@Override
-		public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
-			return new RuleBuilder()
-				.allow()
-				.read()
-				.resourcesOfType(myResourceType)
-				.withFilter(myFilter)
-				.andThen()
 				.build();
 		}
 	}


### PR DESCRIPTION
Previously, when the in-memory matcher was used to match resources with a `_security` label filter 
and a `:not` operator (i.e. `_security:not=http://terminology.hl7.org/CodeSystem/v3-ActCode|NODSCLCD`), resources with no security labels at all were not matched. This has been fixed.