### PR TITLE
Account for case differences in DBPM contributor

### DIFF
--- a/hapi-fhir-jpa-hibernate-services/pom.xml
+++ b/hapi-fhir-jpa-hibernate-services/pom.xml
@@ -3,9 +3,9 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<artifactId>hapi-fhir</artifactId>
+		<artifactId>hapi-deployable-pom</artifactId>
 		<version>7.7.18-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
+		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>hapi-fhir-jpa-hibernate-services</artifactId>

--- a/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/DatabasePartitionModeIdFilteringMappingContributor.java
+++ b/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/DatabasePartitionModeIdFilteringMappingContributor.java
@@ -272,15 +272,16 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 			if (remove != null) {
 				iter.remove();
 				idRemovedColumns.addAll(property.getColumns());
-				idRemovedColumnNames.addAll(
-						property.getColumns().stream().map(Column::getName).collect(Collectors.toSet()));
+				idRemovedColumnNames.addAll(property.getColumns().stream()
+						.map(c -> c.getName().toUpperCase(Locale.ROOT))
+						.collect(Collectors.toSet()));
 				property.getColumns().stream()
 						.map(theColumn -> new TableAndColumnName(table.getName(), theColumn.getName()))
 						.forEach(myQualifiedIdRemovedColumnNames::add);
 				idRemovedProperties.add(property.getName());
 
 				for (Column next : entityPersistentClass.getTable().getColumns()) {
-					if (idRemovedColumnNames.contains(next.getName())) {
+					if (idRemovedColumnNames.contains(next.getName().toUpperCase(Locale.ROOT))) {
 						next.setNullable(true);
 					}
 				}
@@ -384,7 +385,7 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 					theClassLoaderService, theMetadata, theTable, theEntityTypeName, manyToOne);
 			removeColumns(
 					theForeignKey.getColumns(),
-					t1 -> columnNamesToRemoveFromFks.contains(t1.getName().toUpperCase(Locale.US)));
+					t1 -> columnNamesToRemoveFromFks.contains(t1.getName().toUpperCase(Locale.ROOT)));
 		} else {
 
 			theForeignKey
@@ -413,7 +414,7 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 
 		removeColumns(
 				manyToOne.getColumns(),
-				t1 -> columnNamesToRemoveFromFks.contains(t1.getName().toUpperCase(Locale.US)));
+				t1 -> columnNamesToRemoveFromFks.contains(t1.getName().toUpperCase(Locale.ROOT)));
 
 		columnNamesToRemoveFromFks.forEach(
 				t -> myQualifiedIdRemovedColumnNames.add(new TableAndColumnName(theTable.getName(), t)));
@@ -462,7 +463,7 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 				}
 				if (myQualifiedIdRemovedColumnNames.contains(
 						new TableAndColumnName(theTargetTableName, targetColumnName))) {
-					columnNamesToRemoveFromFks.add(sourceColumnName.toUpperCase(Locale.US));
+					columnNamesToRemoveFromFks.add(sourceColumnName.toUpperCase(Locale.ROOT));
 				}
 			}
 		}
@@ -482,13 +483,15 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 				for (PartitionedIndex partitionedIndex : partitionedIndexes.value()) {
 					String indexName = partitionedIndex.name();
 					Set<String> columnNames = Set.of(partitionedIndex.columns());
+					assert columnNames.stream().allMatch(t -> t.equals(t.toUpperCase(Locale.ROOT)));
+
 					Index index = table.getIndex(indexName);
 					if (index != null) {
 
 						List<Selectable> selectables = getFieldValue(index, "selectables");
 						for (Iterator<Selectable> iter = selectables.iterator(); iter.hasNext(); ) {
 							Column next = (Column) iter.next();
-							if (!columnNames.contains(next.getName())) {
+							if (!columnNames.contains(next.getName().toUpperCase(Locale.ROOT))) {
 								iter.remove();
 							}
 						}
@@ -591,8 +594,8 @@ public class DatabasePartitionModeIdFilteringMappingContributor
 		private final int myHashCode;
 
 		private TableAndColumnName(String theTableName, String theColumnName) {
-			myTableName = theTableName.toUpperCase(Locale.US);
-			myColumnName = theColumnName.toUpperCase(Locale.US);
+			myTableName = theTableName.toUpperCase(Locale.ROOT);
+			myColumnName = theColumnName.toUpperCase(Locale.ROOT);
 			myHashCode = Objects.hash(myTableName, myColumnName);
 		}
 

--- a/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/HapiHibernateDialectSettingsService.java
+++ b/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/HapiHibernateDialectSettingsService.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Hibernate Services
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.hapi.fhir.sql.hibernatesvc;
 
 import org.hibernate.service.Service;

--- a/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/PartitionedIdProperty.java
+++ b/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/PartitionedIdProperty.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Hibernate Services
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.hapi.fhir.sql.hibernatesvc;
 
 import java.lang.annotation.Retention;

--- a/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/PartitionedIndex.java
+++ b/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/PartitionedIndex.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Hibernate Services
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.hapi.fhir.sql.hibernatesvc;
 
 import java.lang.annotation.Retention;

--- a/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/PartitionedIndexes.java
+++ b/hapi-fhir-jpa-hibernate-services/src/main/java/ca/uhn/hapi/fhir/sql/hibernatesvc/PartitionedIndexes.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Hibernate Services
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.hapi.fhir.sql.hibernatesvc;
 
 import java.lang.annotation.ElementType;

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<version>7.7.18-SNAPSHOT</version>
-
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptMapGroup.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptMapGroup.java
@@ -37,6 +37,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -65,19 +66,22 @@ public class TermConceptMapGroup extends BasePartitionable implements Serializab
 			value = {
 				@JoinColumn(
 						name = "CONCEPT_MAP_PID",
-						insertable = true,
+						insertable = false,
 						updatable = false,
 						nullable = false,
 						referencedColumnName = "PID"),
 				@JoinColumn(
 						name = "PARTITION_ID",
 						referencedColumnName = "PARTITION_ID",
-						insertable = true,
+						insertable = false,
 						updatable = false,
 						nullable = false)
 			},
 			foreignKey = @ForeignKey(name = "FK_TCMGROUP_CONCEPTMAP"))
 	private TermConceptMap myConceptMap;
+
+	@Column(name = "CONCEPT_MAP_PID", nullable = false)
+	private Long myConceptMapPid;
 
 	@Column(name = "SOURCE_URL", nullable = false, length = TermCodeSystem.MAX_URL_LENGTH)
 	private String mySource;
@@ -109,6 +113,8 @@ public class TermConceptMapGroup extends BasePartitionable implements Serializab
 
 	public TermConceptMapGroup setConceptMap(TermConceptMap theTermConceptMap) {
 		myConceptMap = theTermConceptMap;
+		myConceptMapPid = theTermConceptMap.getId();
+		Validate.notNull(myConceptMapPid, "Concept map pid must not be null");
 		setPartitionId(theTermConceptMap.getPartitionId());
 		return this;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptMapGroupElement.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptMapGroupElement.java
@@ -37,6 +37,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -71,19 +72,22 @@ public class TermConceptMapGroupElement extends BasePartitionable implements Ser
 			value = {
 				@JoinColumn(
 						name = "CONCEPT_MAP_GROUP_PID",
-						insertable = true,
+						insertable = false,
 						updatable = false,
 						nullable = false,
 						referencedColumnName = "PID"),
 				@JoinColumn(
 						name = "PARTITION_ID",
 						referencedColumnName = "PARTITION_ID",
-						insertable = true,
+						insertable = false,
 						updatable = false,
 						nullable = false)
 			},
 			foreignKey = @ForeignKey(name = "FK_TCMGELEMENT_GROUP"))
 	private TermConceptMapGroup myConceptMapGroup;
+
+	@Column(name = "CONCEPT_MAP_GROUP_PID", nullable = false)
+	private Long myConceptMapGroupPid;
 
 	@Column(name = "SOURCE_CODE", nullable = false, length = TermConcept.MAX_CODE_LENGTH)
 	private String myCode;
@@ -126,6 +130,8 @@ public class TermConceptMapGroupElement extends BasePartitionable implements Ser
 
 	public TermConceptMapGroupElement setConceptMapGroup(TermConceptMapGroup theTermConceptMapGroup) {
 		myConceptMapGroup = theTermConceptMapGroup;
+		myConceptMapGroupPid = theTermConceptMapGroup.getId();
+		Validate.notNull(myConceptMapGroupPid, "ConceptMapGroupPid must not be null");
 		setPartitionId(theTermConceptMapGroup.getPartitionId());
 		return this;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptMapGroupElementTarget.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptMapGroupElementTarget.java
@@ -38,6 +38,7 @@ import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -74,19 +75,22 @@ public class TermConceptMapGroupElementTarget extends BasePartitionable implemen
 			value = {
 				@JoinColumn(
 						name = "CONCEPT_MAP_GRP_ELM_PID",
-						insertable = true,
+						insertable = false,
 						updatable = false,
 						nullable = false,
 						referencedColumnName = "PID"),
 				@JoinColumn(
 						name = "PARTITION_ID",
 						referencedColumnName = "PARTITION_ID",
-						insertable = true,
+						insertable = false,
 						updatable = false,
 						nullable = false)
 			},
 			foreignKey = @ForeignKey(name = "FK_TCMGETARGET_ELEMENT"))
 	private TermConceptMapGroupElement myConceptMapGroupElement;
+
+	@Column(name = "CONCEPT_MAP_GRP_ELM_PID", nullable = false)
+	private Long myConceptMapGroupElementPid;
 
 	@Column(name = "TARGET_CODE", nullable = true, length = TermConcept.MAX_CODE_LENGTH)
 	private String myCode;
@@ -131,6 +135,8 @@ public class TermConceptMapGroupElementTarget extends BasePartitionable implemen
 
 	public void setConceptMapGroupElement(TermConceptMapGroupElement theTermConceptMapGroupElement) {
 		myConceptMapGroupElement = theTermConceptMapGroupElement;
+		myConceptMapGroupElementPid = theTermConceptMapGroupElement.getId();
+		Validate.notNull(myConceptMapGroupElementPid, "ConceptMapGroupElement must not be null");
 		setPartitionId(theTermConceptMapGroupElement.getPartitionId());
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitioningSqlR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitioningSqlR4Test.java
@@ -60,6 +60,7 @@ import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.ConceptMap;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.IdType;

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/TestDefinitions.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/TestDefinitions.java
@@ -57,9 +57,12 @@ import jakarta.annotation.Nonnull;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.statement.update.UpdateSet;
 import org.assertj.core.api.Assertions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r5.model.ConceptMap;
 import org.hl7.fhir.r5.model.Bundle;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.DateTimeType;
@@ -102,6 +105,7 @@ import static ca.uhn.fhir.rest.api.Constants.PARAM_TAG;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hl7.fhir.instance.model.api.IAnyResource.SP_RES_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -133,9 +137,11 @@ abstract class TestDefinitions implements ITestDataBuilder {
 	@Autowired
 	private IFhirResourceDaoPatient<Patient> myPatientDao;
 	@Autowired
-	private IFhirResourceDaoObservation<Observation> myObservationDao;
-	@Autowired
 	private IFhirResourceDao<CodeSystem> myCodeSystemDao;
+	@Autowired
+	private IFhirResourceDao<ConceptMap> myConceptMapDao;
+	@Autowired
+	private IFhirResourceDaoObservation<Observation> myObservationDao;
 	@Autowired
 	private IFhirResourceDao<ValueSet> myValueSetDao;
 	@Autowired
@@ -288,6 +294,96 @@ abstract class TestDefinitions implements ITestDataBuilder {
 		assertEquals(0, myCaptureQueriesListener.countUpdateQueries());
 		assertEquals(0, myCaptureQueriesListener.countDeleteQueries());
 	}
+
+
+	@Test
+	public void testCreate_ConceptMap() throws JSQLParserException {
+		ConceptMap cm = new ConceptMap();
+		cm.setId("cm");
+		cm.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		cm.setUrl("http://example.com/cm");
+		ConceptMap.ConceptMapGroupComponent group = cm.addGroup();
+		group.setSource("http://source");
+		group.setTarget("http://target");
+		ConceptMap.SourceElementComponent code0 = group.addElement().setCode("code0").setDisplay("display0");
+		code0.addTarget().setCode("target0").setDisplay("target0display0");
+
+		// Test
+		myCaptureQueriesListener.clear();
+		myConceptMapDao.update(cm, new SystemRequestDetails());
+
+		// Verify
+		myCaptureQueriesListener.logInsertQueries();
+
+		String expectedPartitionId = "NULL";
+		if (myPartitionSettings.isPartitioningEnabled()) {
+			if (myPartitionSettings.getDefaultPartitionId() != null) {
+				expectedPartitionId = "'" + myPartitionSettings.getDefaultPartitionId() + "'";
+			}
+		}
+
+		List<SqlQuery> insertConceptMaps = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CONCEPT_MAP "));
+		assertEquals(1, insertConceptMaps.size());
+		assertEquals(expectedPartitionId, parseInsertStatementParams(insertConceptMaps.get(0).getSql(true, false)).get("PARTITION_ID"));
+
+		List<SqlQuery> insertConceptMapGroups = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CONCEPT_MAP_GROUP "));
+		assertEquals(1, insertConceptMapGroups.size());
+		assertEquals(expectedPartitionId, parseInsertStatementParams(insertConceptMapGroups.get(0).getSql(true, false)).get("PARTITION_ID"));
+
+		List<SqlQuery> insertConceptMapGroupElements = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CONCEPT_MAP_GRP_ELEMENT "));
+		assertEquals(1, insertConceptMapGroupElements.size());
+		assertEquals(expectedPartitionId, parseInsertStatementParams(insertConceptMapGroupElements.get(0).getSql(true, false)).get("PARTITION_ID"));
+
+		List<SqlQuery> insertConceptMapGroupElementTargets = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CONCEPT_MAP_GRP_ELM_TGT "));
+		assertEquals(1, insertConceptMapGroupElementTargets.size());
+		assertEquals(expectedPartitionId, parseInsertStatementParams(insertConceptMapGroupElementTargets.get(0).getSql(true, false)).get("PARTITION_ID"));
+	}
+
+	@Test
+	public void testCreate_CodeSystem() throws JSQLParserException {
+		CodeSystem cs = new CodeSystem();
+		cs.setId("cs");
+		cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		cs.setUrl("http://example.com/cs");
+		cs.addConcept().setCode("code0").setDisplay("display0");
+
+		// Test
+		myCaptureQueriesListener.clear();
+		myCodeSystemDao.update(cs, new SystemRequestDetails());
+
+		// Verify
+		myCaptureQueriesListener.logInsertQueries();
+
+		String expectedPartitionId = "NULL";
+		if (myPartitionSettings.isPartitioningEnabled()) {
+			if (myPartitionSettings.getDefaultPartitionId() != null) {
+				expectedPartitionId = "'" + myPartitionSettings.getDefaultPartitionId() + "'";
+			}
+		}
+
+		List<SqlQuery> insertTrmCodeSystem = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CODESYSTEM "));
+		assertEquals(1, insertTrmCodeSystem.size());
+		assertEquals(expectedPartitionId, parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("PARTITION_ID"));
+		assertEquals("NULL", parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("CURRENT_VERSION_PID"));
+		assertEquals("NULL", parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("CURRENT_VERSION_PARTITION_ID"));
+		String termCodeSystemPid = parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("PID");
+
+		List<SqlQuery> insertTrmConcept = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CONCEPT "));
+		assertEquals(1, insertTrmConcept.size());
+		assertEquals(expectedPartitionId, parseInsertStatementParams(insertTrmConcept.get(0).getSql(true, false)).get("PARTITION_ID"));
+
+		myCaptureQueriesListener.logUpdateQueries();
+		List<SqlQuery> updateCodeSystems = myCaptureQueriesListener.getUpdateQueries(t -> t.getSql(true, false).startsWith("update TRM_CODESYSTEM "));
+		assertEquals(1, updateCodeSystems.size());
+		assertEquals(termCodeSystemPid, parseUpdateStatementParams(updateCodeSystems.get(0).getSql(true, false)).get("CURRENT_VERSION_PID"));
+		assertEquals(expectedPartitionId, parseUpdateStatementParams(updateCodeSystems.get(0).getSql(true, false)).get("CURRENT_VERSION_PARTITION_ID"));
+
+		List<SqlQuery> updateCodeSystemVersions = myCaptureQueriesListener.getUpdateQueries(t -> t.getSql(true, false).startsWith("update TRM_CODESYSTEM_VER "));
+		assertEquals(1, updateCodeSystemVersions.size());
+		assertEquals(termCodeSystemPid, parseUpdateStatementParams(updateCodeSystemVersions.get(0).getSql(true, false)).get("CODESYSTEM_PID"));
+
+	}
+
 
 	@ParameterizedTest
 	@EnumSource(PartitionSettings.CrossPartitionReferenceMode.class)
@@ -1778,7 +1874,25 @@ abstract class TestDefinitions implements ITestDataBuilder {
 		for (int i = 0; i < parsedStatement.getColumns().size(); i++) {
 			String columnName = parsedStatement.getColumns().get(i).getColumnName();
 			String columnValue = parsedStatement.getValues().getExpressions().get(i).toString();
+			assertFalse(retVal.containsKey(columnName), ()->"Duplicate column in insert statement: " + columnName);
 			retVal.put(columnName, columnValue);
+		}
+
+		return retVal;
+	}
+
+	private static Map<String, String> parseUpdateStatementParams(String theUpdateSql) throws JSQLParserException {
+		Update parsedStatement = (Update) CCJSqlParserUtil.parse(theUpdateSql);
+
+		Map<String, String> retVal = new HashMap<>();
+
+		for (UpdateSet updateSet : parsedStatement.getUpdateSets()) {
+			for (int i = 0; i < updateSet.getColumns().size(); i++) {
+				String columnName = updateSet.getColumns().get(i).getColumnName();
+				String columnValue = updateSet.getValues().getExpressions().get(i).toString();
+				assertFalse(retVal.containsKey(columnName), ()->"Duplicate column in insert statement: " + columnName);
+				retVal.put(columnName, columnValue);
+			}
 		}
 
 		return retVal;

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/TestDefinitions.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/TestDefinitions.java
@@ -366,7 +366,6 @@ abstract class TestDefinitions implements ITestDataBuilder {
 		assertEquals(expectedPartitionId, parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("PARTITION_ID"));
 		assertEquals("NULL", parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("CURRENT_VERSION_PID"));
 		assertEquals("NULL", parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("CURRENT_VERSION_PARTITION_ID"));
-		String termCodeSystemPid = parseInsertStatementParams(insertTrmCodeSystem.get(0).getSql(true, false)).get("PID");
 
 		List<SqlQuery> insertTrmConcept = myCaptureQueriesListener.getInsertQueries(t -> t.getSql(true, false).startsWith("insert into TRM_CONCEPT "));
 		assertEquals(1, insertTrmConcept.size());
@@ -375,13 +374,10 @@ abstract class TestDefinitions implements ITestDataBuilder {
 		myCaptureQueriesListener.logUpdateQueries();
 		List<SqlQuery> updateCodeSystems = myCaptureQueriesListener.getUpdateQueries(t -> t.getSql(true, false).startsWith("update TRM_CODESYSTEM "));
 		assertEquals(1, updateCodeSystems.size());
-		assertEquals(termCodeSystemPid, parseUpdateStatementParams(updateCodeSystems.get(0).getSql(true, false)).get("CURRENT_VERSION_PID"));
 		assertEquals(expectedPartitionId, parseUpdateStatementParams(updateCodeSystems.get(0).getSql(true, false)).get("CURRENT_VERSION_PARTITION_ID"));
 
 		List<SqlQuery> updateCodeSystemVersions = myCaptureQueriesListener.getUpdateQueries(t -> t.getSql(true, false).startsWith("update TRM_CODESYSTEM_VER "));
 		assertEquals(1, updateCodeSystemVersions.size());
-		assertEquals(termCodeSystemPid, parseUpdateStatementParams(updateCodeSystemVersions.get(0).getSql(true, false)).get("CODESYSTEM_PID"));
-
 	}
 
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/util/CircularQueueCaptureQueriesListener.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/util/CircularQueueCaptureQueriesListener.java
@@ -224,6 +224,13 @@ public class CircularQueueCaptureQueriesListener extends BaseCaptureQueriesListe
 	/**
 	 * Returns all UPDATE queries executed on the current thread - Index 0 is oldest
 	 */
+	public List<SqlQuery> getUpdateQueries(Predicate<SqlQuery> theFilter) {
+		return getQueriesStartingWith("update").stream().filter(theFilter).collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns all UPDATE queries executed on the current thread - Index 0 is oldest
+	 */
 	public List<SqlQuery> getDeleteQueries() {
 		return getQueriesStartingWith("delete");
 	}


### PR DESCRIPTION
This change fixes 2 regressions caused by Database Partitioning Mode:

* The mapping contributor was accidentally case sensitive when comparing table and column names, which meant that it could miss columns when running in an environment using lower-case identifiers (this is the case in the JPA Starter project)
* Several partitioned foreign keys in the terminology tables were not set as `insertable=false` which caused them to fail when used in non-DBPM mode.