### PR TITLE
Upgrade uses of Jena to 5.3.0

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -62,7 +62,7 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- <dependency> <groupId>xerces</groupId> <artifactId>xercesImpl</artifactId> 
+		<!-- <dependency> <groupId>xerces</groupId> <artifactId>xercesImpl</artifactId>
 			<version>2.11.0</version> <optional>true</optional> </dependency> -->
 
 		<!-- General -->
@@ -70,7 +70,10 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+		</dependency>
 		<!-- JENA Dependencies - Used for Turtle encoding -->
 		<dependency>
 			<groupId>org.apache.jena</groupId>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/RDFParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/RDFParser.java
@@ -166,7 +166,7 @@ public class RDFParser extends BaseParser {
 		try {
 			RDFUtil.writeRDFModel(writer, rdfModel, lang);
 		} catch (Exception e) {
-			throw new DataFormatException("Error writing RDF model to writer", e);
+			throw new DataFormatException(Msg.code(2618) + "Error writing RDF model to writer", e);
 		}
 	}
 
@@ -186,7 +186,7 @@ public class RDFParser extends BaseParser {
 		try {
 			model = RDFUtil.readRDFToModel(reader, this.lang);
 		} catch (Exception e) {
-			throw new DataFormatException("Error reading RDF model from reader", e);
+			throw new DataFormatException(Msg.code(2619) + "Error reading RDF model from reader", e);
 		}
 		return parseResource(resourceType, model);
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/rdf/RDFUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/rdf/RDFUtil.java
@@ -19,12 +19,18 @@
  */
 package ca.uhn.fhir.util.rdf;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.Reader;
+import java.io.StringReader;
 import java.io.Writer;
 
 public class RDFUtil {
@@ -34,17 +40,28 @@ public class RDFUtil {
 		return ModelFactory.createDefaultModel();
 	}
 
-	public static Model readRDFToModel(final Reader reader, final Lang lang) {
+	public static Model readRDFToModel(final Reader reader, final Lang lang) throws IOException {
+		// Jena has removed methods that use a generic Reader.
+		// reads only from InputStream, StringReader, or String
+		// Reader must be explicitly cast to StringReader
 		Model rdfModel = initializeRDFModel();
-		RDFDataMgr.read(rdfModel, reader, null, lang);
+		if (reader instanceof StringReader) {
+			RDFDataMgr.read(rdfModel, (StringReader) reader, null, lang);
+		} else if (reader instanceof InputStreamReader) {
+			String content = IOUtils.toString(reader);
+			RDFDataMgr.read(rdfModel, new StringReader(content), null, lang);
+		}
 		return rdfModel;
 	}
 
-	public static void writeRDFModel(Writer writer, Model rdfModel, Lang lang) {
-		// This writes to the provided Writer.
-		// Jena has deprecated methods that use a generic Writer
-		// writer could be explicitly casted to StringWriter in order to hit a
-		// non-deprecated overload
-		RDFDataMgr.write(writer, rdfModel, lang);
+	public static void writeRDFModel(Writer writer, Model rdfModel, Lang lang) throws IOException {
+		// Jena has removed methods that use a generic Writer.
+		// Writer must be explicitly cast to StringWriter or OutputStream
+		// in order to hit a write method.
+		OutputStream outputStream = WriterOutputStream.builder()
+				.setWriter(writer)
+				.setCharset("UTF-8")
+				.get();
+		RDFDataMgr.write(outputStream, rdfModel, lang);
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6704-upgrade-jena.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6704-upgrade-jena.yaml
@@ -1,0 +1,5 @@
+---
+type: change
+issue: 6704
+title: "The JENA library used to provide RDF/Turtle encoding and parsing services has been
+  upgraded from 4.9.0 to 5.3.0. Thanks to Dylan Krause for the contribution!"

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -13,10 +13,6 @@
 	<artifactId>hapi-fhir-structures-r4</artifactId>
 	<packaging>bundle</packaging>
 
-	<properties>
-		<shexjava_version>1.3beta</shexjava_version>
-	</properties>
-
 	<name>HAPI FHIR Structures - FHIR R4</name>
 
 	<dependencies>
@@ -25,7 +21,7 @@
 			<artifactId>okhttp</artifactId>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
@@ -59,7 +55,7 @@
 			</exclusions>
 		</dependency>
 
-		<!-- 
+		<!--
 		Optional dependencies from RI codebase
 		-->
 		<dependency>
@@ -85,7 +81,7 @@
 
 
 		<!--
-		Test dependencies on other optional parts of HAPI 
+		Test dependencies on other optional parts of HAPI
 		-->
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
@@ -124,21 +120,8 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>fr.inria.lille.shexjava</groupId>
-			<artifactId>shexjava-core</artifactId>
-			<version>${shexjava_version}</version>
-			<scope>test</scope>
-			<exclusions>
-				<!-- If this is included it confused the RDFParser -->
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-rdf-jena</artifactId>
-				</exclusion>
-				<exclusion>
-					<artifactId>xml-apis</artifactId>
-					<groupId>xml-apis</groupId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>jena-shex</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.helger.commons</groupId>

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/RDFParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/RDFParserR4Test.java
@@ -2,19 +2,25 @@ package ca.uhn.fhir.parser;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
 import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RDFParserR4Test {
 	private static final FhirContext ourCtx = FhirContext.forR4Cached();
-
-
 
 	@Test
 	public void testEncodeToString_PrimitiveDataType() {
@@ -43,8 +49,32 @@ public class RDFParserR4Test {
 			        fhir:nodeRole        fhir:treeRoot .
 			""";
 
+		Model expectedModel = ModelFactory.createDefaultModel();
+		RDFDataMgr.read(expectedModel, new StringReader(expected), null, Lang.TURTLE);
+
 		String actual = ourCtx.newRDFParser().encodeToString(p);
-		assertEquals(expected, actual);
+		Model actualModel = ModelFactory.createDefaultModel();
+		RDFDataMgr.read(actualModel, new StringReader(actual), null, Lang.TURTLE);
+
+		assertTrue(expectedModel.isIsomorphicWith(actualModel));
+
+		String unexpected = """
+			@prefix fhir: <http://hl7.org/fhir/> .
+			@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix sct:  <http://snomed.info/id#> .
+			@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+			   
+			<http://hl7.org/fhir/Patient/123>
+			        rdf:type             fhir:Patient;
+			        fhir:Patient.active  [ fhir:value  true ];
+			        fhir:Resource.id     [ fhir:value  "124" ];
+			        fhir:nodeRole        fhir:treeRoot .
+			""";
+
+		Model unexpectedModel = ModelFactory.createDefaultModel();
+		RDFDataMgr.read(unexpectedModel, new StringReader(unexpected), null, Lang.TURTLE);
+		assertFalse(actualModel.isIsomorphicWith(unexpectedModel));
 	}
 
 	@Test

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/RDFParserTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/RDFParserTest.java
@@ -22,18 +22,22 @@ package ca.uhn.fhir.parser;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.test.BaseTest;
-import fr.inria.lille.shexjava.GlobalFactory;
-import fr.inria.lille.shexjava.schema.Label;
-import fr.inria.lille.shexjava.schema.ShexSchema;
-import fr.inria.lille.shexjava.schema.parsing.GenParser;
-import fr.inria.lille.shexjava.validation.RecursiveValidation;
-import fr.inria.lille.shexjava.validation.ValidationAlgorithm;
-import org.apache.commons.rdf.api.Graph;
-import org.apache.commons.rdf.api.RDFTerm;
-import org.apache.commons.rdf.rdf4j.RDF4J;
-import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.Rio;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.Lang;
+
+import org.apache.jena.shex.Shex;
+import org.apache.jena.shex.ShexReport;
+import org.apache.jena.shex.ShexSchema;
+import org.apache.jena.shex.ShexValidator;
+import org.apache.jena.shex.ShapeMap;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Bundle;
@@ -55,9 +59,7 @@ import java.io.StringReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static ca.uhn.fhir.parser.JsonParserR4Test.createBundleWithCrossReferenceFullUrlsAndNoIds;
@@ -72,12 +74,12 @@ public class RDFParserTest extends BaseTest {
 	public static final String FHIR_SHAPE_PREFIX = "http://hl7.org/fhir/shape/";
 	private static final FhirContext ourCtx = FhirContext.forR4();
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(RDFParserTest.class);
-	private static ShexSchema fhirSchema = null;
+	private static ShexSchema fhirShexSchema = null;
 
 	@BeforeAll
 	static void parseShExSchema() throws Exception {
 		Path schemaFile = Paths.get("target", "test-classes", "rdf-validation", "fhir-r4.shex");
-		fhirSchema = GenParser.parseSchema(schemaFile, Collections.emptyList());
+		fhirShexSchema = Shex.readSchema(schemaFile.toUri().toString());
 	}
 
 	/**
@@ -169,55 +171,45 @@ public class RDFParserTest extends BaseTest {
 
 	public void validateRdf(String rdfContent, String referenceFileName, IBaseResource referenceResource) throws IOException {
 		String baseIRI = "http://a.example/shex/";
-		RDF4J factory = new RDF4J();
-		GlobalFactory.RDFFactory = factory; //set the global factory used in shexjava
-		Model data = Rio.parse(new StringReader(rdfContent), baseIRI, RDFFormat.TURTLE);
-		FixedShapeMapEntry fixedMapEntry = new FixedShapeMapEntry(factory, data, referenceResource.fhirType(), baseIRI);
-		Graph dataGraph = factory.asGraph(data); // create the graph
-		ValidationAlgorithm validation = new RecursiveValidation(fhirSchema, dataGraph);
-		validation.validate(fixedMapEntry.node, fixedMapEntry.shape);
-		boolean result = validation.getTyping().isConformant(fixedMapEntry.node, fixedMapEntry.shape);
+		Model model = ModelFactory.createDefaultModel();
+		RDFDataMgr.read(model, new StringReader(rdfContent), baseIRI, Lang.TURTLE);
+		Graph modelAsGraph = model.getGraph();
+		FixedShapeMapEntry fixedMapEntry = new FixedShapeMapEntry(model, referenceResource.fhirType());
+		ShexReport report = ShexValidator.get().validate(modelAsGraph, fhirShexSchema, fixedMapEntry.getShapeMap());
+		boolean result = report.conforms();
 		assertThat(result).as(referenceFileName + ": failed to validate " + fixedMapEntry
 			+ "\n" + referenceFileName
 			+ "\n" + rdfContent).isTrue();
 	}
 
-	// Shape Expressions functions
-	class FixedShapeMapEntry {
-		RDFTerm node;
-		Label shape;
+	static class FixedShapeMapEntry {
+		private Node focusNode = null;
+		private final Node shapeRefNode;
+		private final ShapeMap shapeMap;
 
-		FixedShapeMapEntry(RDF4J factory, Model data, String resourceType, String baseIRI) {
-			String rootSubjectIri = null;
-			// StmtIterator i = data.listStatements();
-			for (org.eclipse.rdf4j.model.Resource resourceStream : data.subjects()) {
-//				if (resourceStream instanceof SimpleIRI) {
-					Model filteredModel = data.filter(resourceStream, factory.getValueFactory().createIRI(NODE_ROLE_IRI), factory.getValueFactory().createIRI(TREE_ROOT_IRI), (org.eclipse.rdf4j.model.Resource)null);
-					if (filteredModel != null && filteredModel.subjects().size() == 1) {
-						Optional<org.eclipse.rdf4j.model.Resource> rootResource = filteredModel.subjects().stream().findFirst();
-						if (rootResource.isPresent()) {
-							rootSubjectIri = rootResource.get().stringValue();
-							break;
-						}
+		FixedShapeMapEntry(Model model, String resourceType) {
 
-					}
-//				}
+			// Identify the main subject (root node) of the RDF model;
+			for (org.apache.jena.rdf.model.Resource resource : model.listSubjects().toList()) {
+				if (model.contains(resource, model.createProperty(NODE_ROLE_IRI), model.createResource(TREE_ROOT_IRI))) {
+					focusNode = resource.asNode();
+					break;
+				}
 			}
 
-			// choose focus node and shapelabel
-			this.node = rootSubjectIri.indexOf(":") == -1
-				? factory.createBlankNode(rootSubjectIri)
-			 	: factory.createIRI(rootSubjectIri);
-			Label shapeLabel = new Label(factory.createIRI(FHIR_SHAPE_PREFIX + resourceType));
-//			this.node = focusNode;
-			this.shape = shapeLabel;
+			this.shapeRefNode = NodeFactory.createURI(FHIR_SHAPE_PREFIX + resourceType);
+
+			this.shapeMap = ShapeMap.newBuilder().add(this.focusNode, this.shapeRefNode).build();
+		}
+
+		public ShapeMap getShapeMap() {
+			return shapeMap;
 		}
 
 		public String toString() {
-			return "<" + node.toString() + ">@" + shape.toPrettyString();
+			return "<" + focusNode.toString() + ">@" + shapeRefNode.toString();
 		}
 	}
-
 
 	@Test
 	public void testEncodeBundleWithCrossReferenceFullUrlsAndNoIds() {

--- a/pom.xml
+++ b/pom.xml
@@ -974,6 +974,11 @@
 			<name>Eliott Lavy</name>
 			<organization>Harris</organization>
 		</developer>
+		<developer>
+			<id>krauzer</id>
+			<name>Dylan Krause</name>
+			<organization>Corbalt</organization>
+		</developer>
 	</developers>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -1024,7 +1024,7 @@
 		<jaxb_api_version>2.3.1</jaxb_api_version>
 		<jaxb_core_version>2.3.0.1</jaxb_core_version>
 		<jaxb_runtime_version>4.0.4</jaxb_runtime_version>
-		<jena_version>4.9.0</jena_version>
+		<jena_version>5.3.0</jena_version>
 		<jersey_version>3.0.3</jersey_version>
 		<jetty_version>12.0.15</jetty_version>
 		<jsr305_version>3.0.2</jsr305_version>
@@ -1662,6 +1662,11 @@
 			<dependency>
 				<groupId>org.apache.jena</groupId>
 				<artifactId>jena-arq</artifactId>
+				<version>${jena_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.jena</groupId>
+				<artifactId>jena-shex</artifactId>
 				<version>${jena_version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Hello, 

This PR upgrades uses of Apache Jena to 5.3.0 for RDF writing and reading. This resolves #6302. 

The main issue is that Jena removed the uses of reader and writer in their read and write methods in version 5, so I modified the utility method to check for StringReader and InputStreamReader on read, and building a OutputStream out of the passed writer. Those readers were the types I could infer that were coming in from HAPI for RDF. Jena only handles a couple types anyway. 

Below are the more specific changes I made to accommodate the use of the latest version, as well as removing some unmaintained testing dependencies for RDF. 

If there are any adjustments/changes I should make, let me know and I can try to make them. We plan to use HAPI within CMS, where I work, and we'd like to be able to contribute to the code where we can/when needed, such as resolving security issues. 

Changes: 

-fixes CVE-2024-7254 in dependencies prior to 5.2.0 
-hapi-fhir-base: include httpclient dependency which was removed from jena-arq 
-hapi-fhir-base RDFParser: init JenaSystem on initialization 
-hapi-fhir-base RDFParser: specify signature for null values on methods that are overloaded 
-hapi-fhir-base RDFUtil: Jena Riot RDFDataMgr no longer accepts reading and writing into generic reader and writer. Handle reading for StringReader and InputStreamReader. Handle writing by building an output stream from the writer. 
-hapi-fhir-structures-r4: Remove shexjava dependency - unmaintained 
-hapi-fhir-structures-r4: Use jena-shex for shex validation 
-hapi-fhir-structures-r4 RDFParserTest: use jena libraries - compatibile with jena-shex 
-hapi-fhir-structures-r4 RDFParserTest: simplify FixedShapeMapEntry by attaching nodes vs recreating them (handles blank nodes) 
-hapi-fhir-structures-r4 RDFParserR4Test: jena 5.0.0 defaults to using PREFIX, not @prefix. Read testing strings and use isomorphic comparison to check for equality. Added extra assertion to test isomorphism check.