### PR TITLE
Remove HTTPClient dependency in hapi-fhir-base

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -70,10 +70,7 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-		</dependency>
+
 		<!-- JENA Dependencies - Used for Turtle encoding -->
 		<dependency>
 			<groupId>org.apache.jena</groupId>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -31,9 +31,6 @@ import com.google.common.net.PercentEscaper;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.message.BasicNameValuePair;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import java.io.UnsupportedEncodingException;
@@ -570,39 +567,6 @@ public class UrlUtil {
 			}
 		}
 		return theString;
-	}
-
-	public static List<NameValuePair> translateMatchUrl(String theMatchUrl) {
-		List<NameValuePair> parameters;
-		String matchUrl = theMatchUrl;
-		int questionMarkIndex = matchUrl.indexOf('?');
-		if (questionMarkIndex != -1) {
-			matchUrl = matchUrl.substring(questionMarkIndex + 1);
-		}
-
-		final String[] searchList = new String[] {"|", "=>=", "=<=", "=>", "=<"};
-		final String[] replacementList = new String[] {"%7C", "=%3E%3D", "=%3C%3D", "=%3E", "=%3C"};
-		matchUrl = StringUtils.replaceEach(matchUrl, searchList, replacementList);
-		if (matchUrl.contains(" ")) {
-			throw new InvalidRequestException(Msg.code(1744) + "Failed to parse match URL[" + theMatchUrl
-					+ "] - URL is invalid (must not contain spaces)");
-		}
-
-		parameters = URLEncodedUtils.parse((matchUrl), Constants.CHARSET_UTF8, '&');
-
-		// One issue that has happened before is people putting a "+" sign into an email address in a match URL
-		// and having that turn into a " ". Since spaces are never appropriate for email addresses, let's just
-		// assume they really meant "+".
-		for (int i = 0; i < parameters.size(); i++) {
-			NameValuePair next = parameters.get(i);
-			if (next.getName().equals("email") && next.getValue().contains(" ")) {
-				BasicNameValuePair newPair =
-						new BasicNameValuePair(next.getName(), next.getValue().replace(' ', '+'));
-				parameters.set(i, newPair);
-			}
-		}
-
-		return parameters;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/MatchUrlService.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/MatchUrlService.java
@@ -37,6 +37,7 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ParameterUtil;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
+import ca.uhn.fhir.rest.server.util.ServletRequestUtil;
 import ca.uhn.fhir.util.ReflectionUtil;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.collect.ArrayListMultimap;
@@ -59,7 +60,7 @@ public class MatchUrlService {
 	public SearchParameterMap translateMatchUrl(
 			String theMatchUrl, RuntimeResourceDefinition theResourceDefinition, Flag... theFlags) {
 		SearchParameterMap paramMap = new SearchParameterMap();
-		List<NameValuePair> parameters = UrlUtil.translateMatchUrl(theMatchUrl);
+		List<NameValuePair> parameters = ServletRequestUtil.translateMatchUrl(theMatchUrl);
 
 		ArrayListMultimap<String, QualifiedParamList> nameToParamLists = ArrayListMultimap.create();
 		for (NameValuePair next : parameters) {

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -49,6 +49,11 @@
 			<artifactId>owasp-java-html-sanitizer</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+		</dependency>
+
 		<!-- 
 		Spring is added as an optional dependency just so that it
 		can be used for CORS

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/MatchUrlUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/MatchUrlUtil.java
@@ -1,0 +1,48 @@
+package ca.uhn.fhir.rest.server.util;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+
+import java.util.List;
+
+public class MatchUrlUtil {
+
+	public static List<NameValuePair> translateMatchUrl(String theMatchUrl) {
+		List<NameValuePair> parameters;
+		String matchUrl = theMatchUrl;
+		int questionMarkIndex = matchUrl.indexOf('?');
+		if (questionMarkIndex != -1) {
+			matchUrl = matchUrl.substring(questionMarkIndex + 1);
+		}
+
+		final String[] searchList = new String[] {"|", "=>=", "=<=", "=>", "=<"};
+		final String[] replacementList = new String[] {"%7C", "=%3E%3D", "=%3C%3D", "=%3E", "=%3C"};
+		matchUrl = StringUtils.replaceEach(matchUrl, searchList, replacementList);
+		if (matchUrl.contains(" ")) {
+			throw new InvalidRequestException(Msg.code(1744) + "Failed to parse match URL[" + theMatchUrl
+				+ "] - URL is invalid (must not contain spaces)");
+		}
+
+		parameters = URLEncodedUtils.parse((matchUrl), Constants.CHARSET_UTF8, '&');
+
+		// One issue that has happened before is people putting a "+" sign into an email address in a match URL
+		// and having that turn into a " ". Since spaces are never appropriate for email addresses, let's just
+		// assume they really meant "+".
+		for (int i = 0; i < parameters.size(); i++) {
+			NameValuePair next = parameters.get(i);
+			if (next.getName().equals("email") && next.getValue().contains(" ")) {
+				BasicNameValuePair newPair =
+					new BasicNameValuePair(next.getName(), next.getValue().replace(' ', '+'));
+				parameters.set(i, newPair);
+			}
+		}
+
+		return parameters;
+	}
+
+}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ServletRequestUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ServletRequestUtil.java
@@ -22,7 +22,6 @@ package ca.uhn.fhir.rest.server.util;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.rest.server.servlet.ServletSubRequestDetails;
-import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.collect.ArrayListMultimap;
 import org.apache.http.NameValuePair;
 
@@ -43,7 +42,7 @@ public class ServletRequestUtil {
 		requestDetails.setParameters(new HashMap<>());
 		if (qIndex != -1) {
 			String params = url.substring(qIndex);
-			List<NameValuePair> parameters = UrlUtil.translateMatchUrl(params);
+			List<NameValuePair> parameters = MatchUrlUtil.translateMatchUrl(params);
 			for (NameValuePair next : parameters) {
 				theParamValues.put(next.getName(), next.getValue());
 			}
@@ -68,4 +67,5 @@ public class ServletRequestUtil {
 		theRequestDetails.getServer().populateRequestDetailsFromRequestPath(requestDetails, url);
 		return requestDetails;
 	}
+
 }

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/util/MatchUrlUtilTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/util/MatchUrlUtilTest.java
@@ -1,0 +1,30 @@
+package ca.uhn.fhir.rest.server.util;
+
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MatchUrlUtilTest {
+
+	@Test
+	public void testTranslateMatchUrl_UrlWithSpaces() {
+		// %20 is an encoded space character
+		assertThat(MatchUrlUtil.translateMatchUrl("Observation?names=homer%20simpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer simpson"));
+
+		// + is also an encoded space character
+		assertThat(MatchUrlUtil.translateMatchUrl("Observation?names=homer+simpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer simpson"));
+	}
+
+	@Test
+	public void testTranslateMatchUrl_UrlWithPlusSign() {
+		// %2B is an encoded plus sign
+		assertThat(MatchUrlUtil.translateMatchUrl("Observation?names=homer%2Bsimpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer+simpson"));
+	}
+
+	@Test
+	public void testTranslateMatchUrl_UrlWithPipe() {
+		// Real space
+		assertThat(MatchUrlUtil.translateMatchUrl("Observation?names=homer|simpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer|simpson"));
+	}
+}

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import org.apache.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -113,27 +112,6 @@ public class UrlUtilTest {
 		assertEquals(" &#10; ", UrlUtil.sanitizeUrlPart(" \n "));
 		assertEquals(" &#13; ", UrlUtil.sanitizeUrlPart(" \r "));
 		assertEquals("  ", UrlUtil.sanitizeUrlPart(" \0 "));
-	}
-
-	@Test
-	public void testTranslateMatchUrl_UrlWithSpaces() {
-		// %20 is an encoded space character
-		assertThat(UrlUtil.translateMatchUrl("Observation?names=homer%20simpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer simpson"));
-
-		// + is also an encoded space character
-		assertThat(UrlUtil.translateMatchUrl("Observation?names=homer+simpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer simpson"));
-	}
-
-	@Test
-	public void testTranslateMatchUrl_UrlWithPlusSign() {
-		// %2B is an encoded plus sign
-		assertThat(UrlUtil.translateMatchUrl("Observation?names=homer%2Bsimpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer+simpson"));
-	}
-
-	@Test
-	public void testTranslateMatchUrl_UrlWithPipe() {
-		// Real space
-		assertThat(UrlUtil.translateMatchUrl("Observation?names=homer|simpson")).containsExactlyInAnyOrder(new BasicNameValuePair("names", "homer|simpson"));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
PR #6704 (upgrading Jena) revealed an unrelated issue, an unintended dependency on Apache HttpClient from hapi-fhir-base. The base module should be concerned only with parsing and other similar infrastructure and should not need HTTP client/server dependencies.

This PR moves the dependent method into the hapi-fhir-server project