### PR TITLE
Throw DataFormatException with polymorphic item without .ofType() function

### DIFF
--- a/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/parser/HfqlFhirPathParser.java
+++ b/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/parser/HfqlFhirPathParser.java
@@ -30,6 +30,7 @@ import org.apache.commons.text.WordUtils;
 
 import java.util.Map;
 
+import static ca.uhn.fhir.jpa.fql.parser.HfqlStatementParser.newExceptionUnexpectedTokenExpectDescription;
 import static java.util.Map.entry;
 
 public class HfqlFhirPathParser {
@@ -147,6 +148,9 @@ public class HfqlFhirPathParser {
 			if (childDefForNode == null) {
 				childDefForNode = currentElementDefinition.getChildByName(nextTokenString + "[x]");
 				if (childDefForNode != null) {
+					if (!lexer.hasNextToken(HfqlLexerOptions.FHIRPATH_EXPRESSION_PART)) {
+						throw newExceptionUnexpectedTokenExpectDescription(null, ".ofType() function after polymorphic item " + nextTokenString);
+					}
 					if (lexer.peekNextToken(HfqlLexerOptions.FHIRPATH_EXPRESSION_PART)
 							.getToken()
 							.equals(".")) {

--- a/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/parser/HfqlStatementParser.java
+++ b/hapi-fhir-jpaserver-hfql/src/main/java/ca/uhn/fhir/jpa/fql/parser/HfqlStatementParser.java
@@ -125,8 +125,8 @@ public class HfqlStatementParser {
 	}
 
 	@Nonnull
-	private static DataFormatException newExceptionUnexpectedTokenExpectDescription(
-			@Nullable HfqlLexerToken theToken, @Nullable String theExpectedDescription) {
+	static DataFormatException newExceptionUnexpectedTokenExpectDescription(
+		@Nullable HfqlLexerToken theToken, @Nullable String theExpectedDescription) {
 		StringBuilder b = new StringBuilder();
 		b.append("Unexpected ");
 		if (theToken != null) {


### PR DESCRIPTION
Added error message: "Unexpected end of stream (expected .ofType() function after polymorphic item <item_name>)" in case of polymorphic fields without specifying the wanted type.

Closes #6720 