### PR TITLE
With partitioning selection mode set to request tenant, creating a cross partition subscription will fail if the default partition id is not null

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_0_0/6747-request-tenant-failure-creating-cross-partition-subscription.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_0_0/6747-request-tenant-failure-creating-cross-partition-subscription.yaml
@@ -1,7 +1,6 @@
 ---
 type: fix
-issue: 6686
-title: "With partitioning selection mode set to 'PATIENT_ID', attempting to create a cross-partition subscription 
+issue: 6747
+title: "With partitioning selection mode set to 'REQUEST_TENANT', attempting to create a cross-partition subscription 
 would fail if the default partition ID was assigned a value different than the default value(null). This issue is fixed."
-
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/RequestPartitionHelperSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/RequestPartitionHelperSvc.java
@@ -144,7 +144,7 @@ public class RequestPartitionHelperSvc extends BaseRequestPartitionHelperSvc {
 				if (partition != null) {
 					ids.add(partition.getId());
 				} else {
-					ids.add(null);
+					ids.add(myPartitionSettings.getDefaultPartitionId());
 				}
 			}
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/RequestPartitionHelperSvcTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/partition/RequestPartitionHelperSvcTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static ca.uhn.fhir.jpa.model.util.JpaConstants.DEFAULT_PARTITION_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -190,7 +191,7 @@ class RequestPartitionHelperSvcTest extends BaseJpaR4Test {
 	}
 
 	@ParameterizedTest
-	@MethodSource
+	@MethodSource("withPartitionIds")
 	public void testDefaultPartition_whenDefaultPartitionIsNotNull(Integer theRequestPartitionId) {
 		final Integer defaultPartitionId = 0;
 		myPartitionSettings.setDefaultPartitionId(defaultPartitionId);
@@ -206,7 +207,20 @@ class RequestPartitionHelperSvcTest extends BaseJpaR4Test {
 		}
 	}
 
-	private static Stream<Integer> testDefaultPartition_whenDefaultPartitionIsNotNull(){
+	@ParameterizedTest
+	@MethodSource("withPartitionIds")
+	public void testValidateAndNormalizePartitionNames_willResolveDefaultPartitionNameToCorrectPartitionId(Integer theDefaultPartitionId) {
+		myPartitionSettings.setDefaultPartitionId(theDefaultPartitionId);
+
+		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionName(DEFAULT_PARTITION_NAME);
+
+		RequestPartitionId normalizedRequestPartitionId = mySvc.validateAndNormalizePartitionNames(requestPartitionId);
+
+		assertThat(normalizedRequestPartitionId.isDefaultPartition(theDefaultPartitionId)).isTrue();
+
+	}
+
+	private static Stream<Integer> withPartitionIds(){
 		return Stream.of(null, 1,2,3);
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
@@ -326,7 +326,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 		// Replace null partition ID with non-null default partition ID if one is being used
 		if (myPartitionSettings.getDefaultPartitionId() != null
 				&& retVal.hasPartitionIds()
-				&& hasDefaultPartitionId(retVal)) {
+				&& retVal.hasDefaultPartitionId(null)) {
 			List<Integer> partitionIds = new ArrayList<>(retVal.getPartitionIds());
 			for (int i = 0; i < partitionIds.size(); i++) {
 				if (partitionIds.get(i) == null) {


### PR DESCRIPTION
**Background:**

- The default value of the ID for the default partition is null;
- clients can provide another value for the default partition id through the partitionSettings.setDefaultPartitionId

**Root cause of the issue:**
Issuing POST /DEFAULT/Subscription {} would result in  the RequestPartitionHelperSvc normalising the DEFAULT partition name to the default partition id of null.


**What was done:**

- added failing test;
- resolving the defaultPartitionId to PartitionSettings.getDefaultPartitionId instead of null;
- added changelog;
- updated changlog for #6686


Closes #6747