### PR TITLE
Ignore contained resources in IPA generation reference check so they are not removed

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6754-preserve-contained-resources-in-ips.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6754-preserve-contained-resources-in-ips.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 6754
+title: "The IPS generator will no longer strip references to contained resources when
+  assembling data to create an IPS document. Thanks to Xun Ma for the contribution!"

--- a/hapi-fhir-jpaserver-ips/src/main/java/ca/uhn/fhir/jpa/ips/generator/IpsGeneratorSvcImpl.java
+++ b/hapi-fhir-jpaserver-ips/src/main/java/ca/uhn/fhir/jpa/ips/generator/IpsGeneratorSvcImpl.java
@@ -480,7 +480,7 @@ public class IpsGeneratorSvcImpl implements IIpsGeneratorSvc {
 
 		compositionBuilder.setStatus(Composition.CompositionStatus.FINAL.toCode());
 		compositionBuilder.setSubject(thePatient.getIdElement().toUnqualifiedVersionless());
-		compositionBuilder.addTypeCoding("http://loinc.org", "60591-5", "Patient Summary Document");
+		compositionBuilder.addTypeCoding("http://loinc.org", "60591-5", "Patient summary Document");
 		compositionBuilder.setDate(InstantType.now());
 		compositionBuilder.setTitle(theStrategy.createTitle(context));
 		compositionBuilder.setConfidentiality(theStrategy.createConfidentiality(context));

--- a/hapi-fhir-jpaserver-ips/src/main/java/ca/uhn/fhir/jpa/ips/generator/IpsGeneratorSvcImpl.java
+++ b/hapi-fhir-jpaserver-ips/src/main/java/ca/uhn/fhir/jpa/ips/generator/IpsGeneratorSvcImpl.java
@@ -234,7 +234,7 @@ public class IpsGeneratorSvcImpl implements IIpsGeneratorSvc {
 						.getResourceReference()
 						.getReferenceElement()
 						.getValue();
-				if (isNotBlank(existingReference)) {
+				if (isNotBlank(existingReference) && !existingReference.startsWith("#")) {
 					existingReference = new IdType(existingReference)
 							.toUnqualifiedVersionless()
 							.getValue();

--- a/pom.xml
+++ b/pom.xml
@@ -979,6 +979,11 @@
 			<name>Dylan Krause</name>
 			<organization>Corbalt</organization>
 		</developer>
+		<developer>
+			<id>xmhorsehead</id>
+			<name>Xun Ma</name>
+			<organization>CSIRO</organization>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Closes #6708 
Also fixed composition code display to exactly match LOINC, see https://loinc.org/60591-5/
Apparently FHIR validator is case sensitive...