### PR TITLE
Fixing concurrent modification problem in VersionSpecificContextWrapper 

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapper.java
@@ -235,6 +235,7 @@ public class VersionSpecificWorkerContextWrapper extends I18nBase implements IWo
 			myAllStructures = retVal;
 
 			try {
+				retVal = new ArrayList<>();
 				for (IBaseResource next : allStructureDefinitions) {
 					Resource converted = convertToCanonicalVersionAndGenerateSnapshot(next, false);
 					retVal.add((StructureDefinition) converted);

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapperTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/VersionSpecificWorkerContextWrapperTest.java
@@ -195,6 +195,16 @@ public class VersionSpecificWorkerContextWrapperTest extends BaseValidationTestW
 		assertThat(sourcePackage.getId()).isEqualTo("hl7.fhir.r999.core");
 	}
 
+	@Test
+	public void allStructureDefinitions() {
+		setupValidation();
+		StructureDefinition sd = new StructureDefinition();
+		sd.setUrl("http://foo");
+		when(myValidationSupportContext.getRootValidationSupport().fetchAllStructureDefinitions()).thenReturn(List.of(sd));
+		var list = myWorkerContextWrapper.fetchResourcesByType(org.hl7.fhir.r5.model.StructureDefinition.class);
+		assertThat(list).hasSize(1).allSatisfy(sdResult -> assertThat(sdResult.getUrl()).isEqualTo(sd.getUrl()));
+	}
+
 	private List<StructureDefinition> createPrimitiveStructureDefinitions() {
 		StructureDefinition stringType = createPrimitive("string");
 		StructureDefinition boolType = createPrimitive("boolean");


### PR DESCRIPTION
This change fixes #6661. The test case added only checks the synchronous error case. 
The concurrency issue could be tested, but not deterministically. And on my machine this
needs many iterations to trigger the problem. On my machine it takes around 5 seconds
to trigger the issue.