### PR TITLE
support pagination for CDS Hooks prefetch request

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleBuilder.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/BundleBuilder.java
@@ -420,7 +420,7 @@ public class BundleBuilder {
 		return id;
 	}
 
-	private void addFullUrl(IBase theEntry, String theFullUrl) {
+	public void addFullUrl(IBase theEntry, String theFullUrl) {
 		IPrimitiveType<?> fullUrl =
 				(IPrimitiveType<?>) myContext.getElementDefinition("uri").newInstance();
 		fullUrl.setValueAsString(theFullUrl);

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6781-support-CDS-Hooks-prefetch-pagination.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6781-support-CDS-Hooks-prefetch-pagination.yaml
@@ -1,0 +1,7 @@
+---
+type: add
+issue: 6781
+title: "CDS Hooks implementation now supports pagination when prefetching data for requests issued to the FHIR server
+ for missing prefetch keys. If a prefetch request to a FHIR server returns a paginated bundle, the prefetch service now 
+ paginates through the bundle, and collects all the data into a single bundle before passing it on to the CDS Hooks 
+ service."

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvc.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvc.java
@@ -27,10 +27,18 @@ import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.util.BundleBuilder;
+import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.UrlUtil;
+import ca.uhn.fhir.util.bundle.SearchBundleEntryParts;
 import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class CdsPrefetchFhirClientSvc {
@@ -54,10 +62,59 @@ public class CdsPrefetchFhirClientSvc {
 		if (resourceId != null) {
 			return client.read().resource(resourceType).withId(resourceId).execute();
 		} else if (matchUrl != null) {
-			return client.search().byUrl(theUrl).execute();
+			return collectResourcesFromUrlFollowingNextLinks(client, theUrl);
 		} else {
 			throw new InvalidRequestException(
 					Msg.code(2384) + "Unable to translate url " + theUrl + " into a resource or a bundle.");
+		}
+	}
+
+	/**
+	 * Collect resources from a URL that returns a bundle. If the bundle has more than one page,
+	 * this paginates and collect all resources into a single bundle
+	 */
+	private IBaseBundle collectResourcesFromUrlFollowingNextLinks(IGenericClient theClient, String theUrl) {
+		IBaseBundle bundle = theClient.search().byUrl(theUrl).execute();
+
+		boolean hasNext = BundleUtil.getLinkUrlOfType(myFhirContext, bundle, "next") != null;
+		if (!hasNext) {
+			return bundle;
+		}
+
+		// bundle has more than one page, paginate and collect all resources into a single bundle
+		BundleBuilder bundleBuilder = new BundleBuilder(myFhirContext);
+		bundleBuilder.setType(BundleUtil.getBundleType(myFhirContext, bundle));
+		addAllResourcesOfBundleToBundleBuilder(bundleBuilder, bundle);
+
+		while (hasNext) {
+			bundle = theClient.loadPage().next(bundle).execute();
+			addAllResourcesOfBundleToBundleBuilder(bundleBuilder, bundle);
+			hasNext = BundleUtil.getLinkUrlOfType(myFhirContext, bundle, "next") != null;
+		}
+
+		return bundleBuilder.getBundle();
+	}
+
+	private void addAllResourcesOfBundleToBundleBuilder(BundleBuilder theBundleBuilder, IBaseBundle theBundle) {
+		List<SearchBundleEntryParts> entries = BundleUtil.getSearchBundleEntryParts(myFhirContext, theBundle);
+
+		for (SearchBundleEntryParts currentEntry : entries) {
+			IBase newEntry = theBundleBuilder.addEntry();
+			theBundleBuilder.addFullUrl(newEntry, currentEntry.getFullUrl());
+			theBundleBuilder.addToEntry(newEntry, "resource", currentEntry.getResource());
+			boolean hasSearchMode = currentEntry.getSearchMode() != null;
+			boolean hasSearchScore = currentEntry.getSearchScore() != null;
+			if (hasSearchMode || hasSearchScore) {
+				IBaseBackboneElement search = theBundleBuilder.addSearch(newEntry);
+				if (hasSearchMode) {
+					theBundleBuilder.setSearchField(
+							search, "mode", currentEntry.getSearchMode().getCode());
+				}
+				if (hasSearchScore) {
+					theBundleBuilder.setSearchField(
+							search, "score", currentEntry.getSearchScore().toString());
+				}
+			}
 		}
 	}
 

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvcTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchFhirClientSvcTest.java
@@ -5,44 +5,64 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestAuthorizationJson;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
+import ca.uhn.fhir.util.BundleUtil;
+import ca.uhn.fhir.util.bundle.BundleEntryParts;
+import ca.uhn.fhir.util.bundle.SearchBundleEntryParts;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CdsPrefetchFhirClientSvcTest {
 
 	private IGenericClient myMockClient;
-	private FhirContext myMockFhirContext;
+	private FhirContext mySpyFhirContext;
 	private CdsPrefetchFhirClientSvc myCdsPrefetchFhirClientSvc;
 
 	@BeforeEach
 	public void beforeEach() {
 		myMockClient = Mockito.mock(IGenericClient.class, Mockito.RETURNS_DEEP_STUBS);
-		myMockFhirContext = Mockito.mock(FhirContext.class);
-		myCdsPrefetchFhirClientSvc = new CdsPrefetchFhirClientSvc(myMockFhirContext);
+		mySpyFhirContext = Mockito.spy(FhirContext.forR4());
+		doReturn(myMockClient).when(mySpyFhirContext).newRestfulGenericClient(any(String.class));
+		myCdsPrefetchFhirClientSvc = new CdsPrefetchFhirClientSvc(mySpyFhirContext);
+	}
+
+	private void setupClientForSearchBundleWithNoNextLink() {
 		Bundle results = new Bundle();
-		Mockito.when(myMockFhirContext.newRestfulGenericClient(any(String.class))).thenReturn(myMockClient);
 		Mockito.when(myMockClient.search().byUrl(any(String.class)).execute()).thenReturn(results);
+	}
+
+	private void setupClientForReadResourceById() {
+		Bundle results = new Bundle();
 		Mockito.when(
-			myMockClient.read()
-				.resource(any(String.class))
-				.withId(any(String.class))
-				.execute())
+				myMockClient.read()
+					.resource(any(String.class))
+					.withId(any(String.class))
+					.execute())
 			.thenReturn(results);
 	}
 
+
 	@Test
 	void testParseResourceWithSearchParams() throws IllegalArgumentException {
+		setupClientForSearchBundleWithNoNextLink();
 		CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
 		cdsServiceRequestJson.setFhirServer("http://localhost:8000");
 
@@ -53,15 +73,19 @@ class CdsPrefetchFhirClientSvcTest {
 
 	@Test
 	void testParseResourceWithAdditionalSearchParams() throws IllegalArgumentException {
+		setupClientForSearchBundleWithNoNextLink();
 		CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
 		cdsServiceRequestJson.setFhirServer("http://localhost:8000");
+
 		IBaseResource srq = myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "ServiceRequest?_id=1234&_include=ServiceRequest:performer&_include=ServiceRequest:requester");
 		assertNotNull(srq);
 		verify(myMockClient.search(), times(1)).byUrl("ServiceRequest?_id=1234&_include=ServiceRequest:performer&_include=ServiceRequest:requester");
+		verify(myMockClient, never()).loadPage();
 	}
 
 	@Test
-	void testParseResourceWithReferenceUrlAndAuth() throws Exception {
+	void testParseResourceWithReferenceUrlAndAuth() {
+		setupClientForReadResourceById();
 		CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
 		CdsServiceRequestAuthorizationJson cdsServiceRequestAuthorizationJson = spy(new CdsServiceRequestAuthorizationJson());
 		cdsServiceRequestAuthorizationJson.setAccessToken("test123");
@@ -76,6 +100,7 @@ class CdsPrefetchFhirClientSvcTest {
 
 	@Test
 	void testParseResourceWithReferenceUrl() {
+		setupClientForReadResourceById();
 		CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
 		cdsServiceRequestJson.setFhirServer("http://localhost:8000");
 
@@ -90,7 +115,7 @@ class CdsPrefetchFhirClientSvcTest {
 		cdsServiceRequestJson.setFhirServer("http://localhost:8000");
 
 		try {
-			IBaseResource srq = myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "1234");
+			myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "1234");
 			fail("should throw, no resource present");
 		} catch (InvalidRequestException e) {
 			assertEquals("HAPI-2384: Unable to translate url 1234 into a resource or a bundle.", e.getMessage());
@@ -108,5 +133,98 @@ class CdsPrefetchFhirClientSvcTest {
 		} catch (InvalidRequestException e) {
 			assertEquals("HAPI-2383: Failed to resolve /1234. Url does not start with a resource type.", e.getMessage());
 		}
+	}
+
+	@Test
+	void testResourceFromUrl_SearchSetBundleWithPagination() {
+		CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
+		cdsServiceRequestJson.setFhirServer("http://localhost:8000");
+
+		// Create the first bundle with a next link
+		Bundle firstBundle = new Bundle();
+		firstBundle.setType(Bundle.BundleType.SEARCHSET);
+		firstBundle.addLink().setRelation("next").setUrl("http://localhost:8000/page2");
+		firstBundle.addEntry()
+			.setFullUrl("http://localhost:8000/Patient/1_p1")
+			.setResource(new Patient().setId("Patient/1_p1"))
+			.setSearch( new Bundle.BundleEntrySearchComponent().setMode(Bundle.SearchEntryMode.MATCH).setScore(1.0));
+		firstBundle.addEntry()
+			.setFullUrl("http://localhost:8000/Patient/2_p1")
+			.setResource(new Patient().setId("Patient/2_p1"));
+
+		// Create the second bundle again with a next link
+		Bundle secondBundle = new Bundle();
+		secondBundle.addLink().setRelation("next").setUrl("http://localhost:8000/page3");
+		secondBundle.addEntry()
+			.setFullUrl("http://localhost:8000/Patient/1_p2")
+			.setResource(new Patient().setId("Patient/1_p2"))
+			.setSearch(new Bundle.BundleEntrySearchComponent().setMode(Bundle.SearchEntryMode.INCLUDE));
+
+		Bundle thirdBundle = new Bundle();
+		thirdBundle.addEntry()
+			.setFullUrl("http://localhost:8000/Patient/1_p3")
+			.setResource(new Patient().setId("Patient/1_p3"))
+			.setSearch(new Bundle.BundleEntrySearchComponent().setScore(0.5));
+
+		// Mock the client to return the bundles
+		when(myMockClient.search().byUrl(any(String.class)).execute()).thenReturn(firstBundle);
+
+		when(myMockClient.loadPage().next(firstBundle).execute()).thenReturn(secondBundle);
+
+		when(myMockClient.loadPage().next(secondBundle).execute()).thenReturn(thirdBundle);
+		IBaseBundle resultBundle = (IBaseBundle) myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "Patient?given=name");
+
+		assertEquals("searchset", BundleUtil.getBundleType(mySpyFhirContext, resultBundle));
+		// Verify the result bundle contains patients from all pages
+		List<SearchBundleEntryParts> entries = BundleUtil.getSearchBundleEntryParts(mySpyFhirContext, resultBundle);
+		assertEquals(4, entries.size());
+
+		assertEquals("Patient/1_p1", entries.get(0).getResource().getIdElement().getValue());
+		assertEquals("http://localhost:8000/Patient/1_p1", entries.get(0).getFullUrl());
+		assertEquals("match", entries.get(0).getSearchMode().getCode());
+		assertEquals("1.0", entries.get(0).getSearchScore().toString());
+		assertEquals("Patient/2_p1", entries.get(1).getResource().getIdElement().getValue());
+		assertEquals("http://localhost:8000/Patient/2_p1", entries.get(1).getFullUrl());
+		assertNull(entries.get(1).getSearchMode());
+		assertNull(entries.get(1).getSearchScore());
+		assertEquals("Patient/1_p2", entries.get(2).getResource().getIdElement().getValue());
+		assertEquals("http://localhost:8000/Patient/1_p2", entries.get(2).getFullUrl());
+		assertEquals("include", entries.get(2).getSearchMode().getCode());
+		assertNull(entries.get(2).getSearchScore());
+		assertEquals("Patient/1_p3", entries.get(3).getResource().getIdElement().getValue());
+		assertEquals("http://localhost:8000/Patient/1_p3", entries.get(3).getFullUrl());
+		assertNull(entries.get(3).getSearchMode());
+		assertEquals("0.5", entries.get(3).getSearchScore().toString());
+	}
+
+	@Test
+	void testResourceFromUrl_PaginatedBundleEntriesWithMissingResourceAndFullUrl_DoesNotThrowException() {
+		CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
+		cdsServiceRequestJson.setFhirServer("http://localhost:8000");
+
+		// Create the first bundle with a next link, missing resource
+		Bundle firstBundle = new Bundle();
+		firstBundle.setType(Bundle.BundleType.SEARCHSET);
+		firstBundle.addLink().setRelation("next").setUrl("http://localhost:8000/page2");
+		firstBundle.addEntry()
+			.setFullUrl("http://localhost:8000/Patient/1_p1");
+
+		//second entry missing FullUrl
+		Bundle secondBundle = new Bundle();
+		secondBundle.addEntry()
+			.setResource(new Patient().setId("Patient/1_p2"));
+
+		when(myMockClient.search().byUrl(any(String.class)).execute()).thenReturn(firstBundle);
+		when(myMockClient.loadPage().next(firstBundle).execute()).thenReturn(secondBundle);
+
+		IBaseBundle resultBundle = (IBaseBundle) myCdsPrefetchFhirClientSvc.resourceFromUrl(cdsServiceRequestJson, "Patient?given=name");
+
+		assertEquals("searchset", BundleUtil.getBundleType(mySpyFhirContext, resultBundle));
+		List<BundleEntryParts> entries = BundleUtil.toListOfEntries(mySpyFhirContext, resultBundle);
+		assertEquals(2, entries.size());
+		assertEquals("http://localhost:8000/Patient/1_p1", entries.get(0).getFullUrl());
+		assertNull(entries.get(0).getResource());
+		assertNull(entries.get(1).getFullUrl());
+		assertEquals("Patient/1_p2", entries.get(1).getResource().getIdElement().getValue());
 	}
 }


### PR DESCRIPTION
closes: #6781 

With this PR, CDS Hooks implementation now supports pagination when prefetching data for requests issued to the FHIR server for missing prefetch keys. If a prefetch request to a FHIR server returns a paginated bundle, the prefetch service now paginates through the bundle, and collects all the data into a single bundle before passing it on the CDS Hooks service.