### PR TITLE
Batch2 Remove Paging Iterator

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6784-remove-batch2-paginator.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6784-remove-batch2-paginator.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 6783
+title: "The batch2 job processor will no longer use paginator to queue workchunks as 'ready' due to performance bottleneck
+around saturation of available workchunk-processors or consumers"

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IWorkChunkErrorActionsTests.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IWorkChunkErrorActionsTests.java
@@ -119,7 +119,7 @@ public interface IWorkChunkErrorActionsTests extends IWorkChunkCommon, WorkChunk
 		assertEquals(WorkChunkStatusEnum.FAILED, chunk.getStatus());
 		assertEquals(4, chunk.getErrorCount());
 		assertThat(chunk.getErrorMessage()).as("Error message contains last error").contains(ERROR_MESSAGE_C);
-		assertThat(chunk.getErrorMessage()).as("Error message contains error count and complaint").contains("many errors: 4");
+		assertThat(chunk.getErrorMessage()).as("Error message contains error count and complaint").contains("many errors (4)");
 	}
 
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -284,10 +284,10 @@ public class JobInstanceProcessor {
 		long deadline = System.currentTimeMillis() + 60 * 1000;
 		boolean done = false;
 		do {
-			// PageNumber '0' is hardcoded to re-saturate 10k records to process at a time instead of fixed smaller
-			// pages
-			// once the first processed page of records is completed, the next 10k needing processing will automatically
-			// be retrieved
+			// Paginator has an issue keeping worker nodes saturated due to processing workloads a page at a time
+			// PageNumber '0' is hardcoded to re-saturate 10k records to process at a time instead
+			// Each consecutive request for results will be the next 10k records needing updating (no paging needed)
+			// Recommend this eventually moves to java stream once architecture supports the change
 			Pageable pageable = Pageable.ofSize(WORK_CHUNK_METADATA_BATCH_SIZE).withPage(0);
 			Page<WorkChunkMetadata> results = myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(
 					pageable, myInstanceId, Set.of(WorkChunkStatusEnum.READY));

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -297,8 +297,7 @@ public class JobInstanceProcessor {
 			int counter = 0;
 
 			if (!done) {
-				Iterator<WorkChunkMetadata> iter = results.iterator();
-				while (iter.hasNext()) {
+				for (WorkChunkMetadata metadata : results) {
 					/*
 					 * For each chunk id
 					 * * Move to QUEUE'd
@@ -306,7 +305,6 @@ public class JobInstanceProcessor {
 					 * * flush changes
 					 * * commit
 					 */
-					WorkChunkMetadata metadata = iter.next();
 					updateChunkAndSendToQueue(metadata);
 					counter++;
 				}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -281,7 +281,7 @@ public class JobInstanceProcessor {
 	private void enqueueReadyChunks(JobInstance theJobInstance, JobDefinition<?> theJobDefinition) {
 		// timebox to prevent unusual amount of time updating resources
 		long minuteMS = 60 * 1000;
-		long deadline = System.currentTimeMillis() + minuteMS;
+		long deadline = System.currentTimeMillis() + DateUtils.MILLIS_PER_MINUTE;
 		boolean done = false;
 		do {
 			// Paginator has an issue keeping worker nodes saturated due to processing workloads a page at a time

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -281,7 +281,8 @@ public class JobInstanceProcessor {
 	 */
 	private void enqueueReadyChunks(JobInstance theJobInstance, JobDefinition<?> theJobDefinition) {
 		// timebox to prevent unusual amount of time updating resources
-		long deadline = System.currentTimeMillis() + 60 * 1000;
+		long minuteMS = 60 * 1000;
+		long deadline = System.currentTimeMillis() + minuteMS;
 		boolean done = false;
 		do {
 			// Paginator has an issue keeping worker nodes saturated due to processing workloads a page at a time

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -279,7 +279,6 @@ public class JobInstanceProcessor {
 	 * We will move READY chunks to QUEUE'd and send them to the queue/topic (kafka)
 	 * for processing.
 	 */
-
 	private void enqueueReadyChunks(JobInstance theJobInstance, JobDefinition<?> theJobDefinition) {
 		long deadline = System.currentTimeMillis() + 60 * 1000;
 		boolean done = false;
@@ -288,10 +287,10 @@ public class JobInstanceProcessor {
 			// This allows for all nodes to remain busy instead of processing each page's worth of data at a time
 			Pageable pageable = Pageable.ofSize(WORK_CHUNK_METADATA_BATCH_SIZE).withPage(0);
 			Page<WorkChunkMetadata> results = myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(
-				pageable, myInstanceId, Set.of(WorkChunkStatusEnum.READY));
+					pageable, myInstanceId, Set.of(WorkChunkStatusEnum.READY));
 			if (results.isEmpty()) {
 				break;
-				}
+			}
 			Iterator<WorkChunkMetadata> iter = results.iterator();
 			int counter = 0;
 			while (iter.hasNext()) {
@@ -306,13 +305,13 @@ public class JobInstanceProcessor {
 				updateChunkAndSendToQueue(metadata);
 				counter++;
 			}
-		ourLog.debug(
-				"Encountered {} READY work chunks for job {} of type {}",
-				counter,
-				theJobInstance.getInstanceId(),
-				theJobDefinition.getJobDefinitionId());
-		// timebox update  of 10k records
-		} while(deadline>System.currentTimeMillis() && !done);
+			ourLog.debug(
+					"Encountered {} READY work chunks for job {} of type {}",
+					counter,
+					theJobInstance.getInstanceId(),
+					theJobDefinition.getJobDefinitionId());
+			// timebox update  of 10k records
+		} while (deadline > System.currentTimeMillis() && !done);
 	}
 
 	/**

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -319,15 +319,16 @@ public class JobInstanceProcessor {
 					theJobInstance.getInstanceId(),
 					theJobDefinition.getJobDefinitionId());
 
-			// Log warning if deadline is exceeded
+			// Log warning and exit if deadline is exceeded
 			if (System.currentTimeMillis() >= deadline) {
 				ourLog.warn(
 						"Deadline exceeded while processing job {} of type {}. Some chunks may not have been processed.",
 						theJobInstance.getInstanceId(),
 						theJobDefinition.getJobDefinitionId());
+				break;
 			}
 
-		} while (deadline > System.currentTimeMillis() && !done);
+		} while (!done);
 	}
 
 	/**

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobInstanceProcessor.java
@@ -320,7 +320,15 @@ public class JobInstanceProcessor {
 					counter,
 					theJobInstance.getInstanceId(),
 					theJobDefinition.getJobDefinitionId());
-			// timebox update of 10k records
+
+			// Log warning if deadline is exceeded
+			if (System.currentTimeMillis() >= deadline) {
+				ourLog.warn(
+						"Deadline exceeded while processing job {} of type {}. Some chunks may not have been processed.",
+						theJobInstance.getInstanceId(),
+						theJobDefinition.getJobDefinitionId());
+			}
+
 		} while (deadline > System.currentTimeMillis() && !done);
 	}
 


### PR DESCRIPTION
closes #6784 

eliminate use of PagingIterator and find an alternative approach to queue workchunks without bloating memory or under utilizing available processors