### PR TITLE
Offset Support for History Search Requests

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IHistoryTyped.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IHistoryTyped.java
@@ -50,4 +50,10 @@ public interface IHistoryTyped<T> extends IClientExecutable<IHistoryTyped<T>, T>
 	 * Request that the server return only resource versions that were created at or after the given time (inclusive)
 	 */
 	IHistoryTyped<T> since(Date theCutoff);
+
+	/**
+	 * Specifies the <code>_offset</code> parameter, which indicates to the server the offset of the history query. Use
+	 * with {@link #count(int)}.	 
+	 */
+	IHistoryTyped<T> offset(Integer theOffset);
 }

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/GenericClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/GenericClient.java
@@ -941,6 +941,7 @@ public class GenericClient extends BaseClient implements IGenericClient {
 	private class HistoryInternal extends BaseClientExecutable implements IHistory, IHistoryUntyped, IHistoryTyped {
 
 		private Integer myCount;
+		private Integer myOffset;
 		private IIdType myId;
 		private Class<? extends IBaseBundle> myReturnType;
 		private IPrimitiveType mySince;
@@ -972,6 +973,12 @@ public class GenericClient extends BaseClient implements IGenericClient {
 			return this;
 		}
 
+		@Override
+		public IHistoryTyped offset(Integer theOffset) {
+			myOffset = theOffset;
+			return this;
+		}
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public Object execute() {
@@ -989,7 +996,7 @@ public class GenericClient extends BaseClient implements IGenericClient {
 			}
 
 			HttpGetClientInvocation invocation =
-					HistoryMethodBinding.createHistoryInvocation(myContext, resourceName, id, mySince, myCount, myAt);
+					HistoryMethodBinding.createHistoryInvocation(myContext, resourceName, id, mySince, myCount, myAt,myOffset);
 
 			IClientResponseHandler handler;
 			handler = new ResourceResponseHandler(myReturnType, getPreferResponseTypes(myType));

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HistoryMethodBinding.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HistoryMethodBinding.java
@@ -119,7 +119,8 @@ public class HistoryMethodBinding extends BaseResourceReturningMethodBinding {
 			String theId,
 			IPrimitiveType<Date> theSince,
 			Integer theLimit,
-			DateRangeParam theAt) {
+			DateRangeParam theAt,
+			Integer theOffset) {
 		StringBuilder b = new StringBuilder();
 		if (theResourceName != null) {
 			b.append(theResourceName);
@@ -142,6 +143,11 @@ public class HistoryMethodBinding extends BaseResourceReturningMethodBinding {
 			b.append(haveParam ? '&' : '?');
 			haveParam = true;
 			b.append(Constants.PARAM_COUNT).append('=').append(theLimit);
+		}
+		if (theOffset != null) {
+			b.append(haveParam ? '&' : '?');
+			haveParam = true;
+			b.append(Constants.PARAM_OFFSET).append('=').append(theOffset);
 		}
 		if (theAt != null) {
 			for (DateParam next : theAt.getValuesAsQueryTokens()) {


### PR DESCRIPTION
This pull request implements offset support for history search requests, such as:
```plaintext
GET https://hapi.fhir.org/baseR4/_history?_count=20&_offset=20
```

Now, the offset can be set using similar to the following code:
```java
client.history()
  .onServer()
  .returnBundle(Bundle.class)
  .count(20)
  .offset(20);
```

This change enables `IGenericClient` to implement pagination for history search requests.

**Closes #5581**
