### PR TITLE
Handle null values gracefully in parseExtension

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -1471,6 +1471,10 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 	}
 
 	private void parseExtension(ParserState<?> theState, BaseJsonLikeArray theValues, boolean theIsModifier) {
+		if (theValues == null) {
+			return;
+		}
+
 		int allUnderscoreNames = 0;
 		int handledUnderscoreNames = 0;
 


### PR DESCRIPTION
`parseChildren` `parseAlternates` and `parseExtension` all invoke `parseExtension` after `grabJsonArray`. `grabJsonArray` may return a null value in the case of a JSON null (`object.isNull()`). Some JSON serializers tend to put `"extension": null` rather than leaving out `"extension"` in certain cases, and this makes sure our deserializer handles those inputs gracefully.