### PR TITLE
enforce fhirServer field is https for Cds Hooks version 2

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6805-cds-hooks-v2-enforce-http-for-fhirServer.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6805-cds-hooks-v2-enforce-http-for-fhirServer.yaml
@@ -1,0 +1,8 @@
+---
+type: add
+issue: 6805
+title: "CDS Hooks now requires the `fhirServer` field to use HTTPS in requests when using 
+[CDS Hooks version 2.0](https://cds-hooks.hl7.org/2.0/), as per 
+the specification. You can configure the CDS Hooks version by providing a bean that returns a CDSHooksVersion enum, 
+introduced in this update. By default, the version is set to 1.1 to maintain compatibility with existing 
+implementations."

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/CDSHooksVersion.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/CDSHooksVersion.java
@@ -1,0 +1,39 @@
+/*-
+ * #%L
+ * HAPI FHIR - CDS Hooks
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.hapi.fhir.cdshooks.api;
+
+import jakarta.annotation.Nullable;
+
+public enum CDSHooksVersion {
+	V_1_1,
+	V_2_0;
+
+	/**
+	 * Using V_1_1 as the default for not breaking existing implementations
+	 */
+	public static final CDSHooksVersion DEFAULT = V_1_1;
+
+	public static CDSHooksVersion getOrDefault(@Nullable CDSHooksVersion theVersion) {
+		if (theVersion == null) {
+			return DEFAULT;
+		}
+		return theVersion;
+	}
+}

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.hapi.fhir.cdshooks.api.CDSHooksVersion;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsConfigService;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsHooksDaoAuthorizationSvc;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceRegistry;
@@ -102,7 +103,8 @@ public class CdsHooksConfig {
 			@Qualifier(CDS_HOOKS_OBJECT_MAPPER_FACTORY) ObjectMapper theObjectMapper,
 			ICdsCrServiceFactory theCdsCrServiceFactory,
 			ICrDiscoveryServiceFactory theCrDiscoveryServiceFactory,
-			FhirContext theFhirContext) {
+			FhirContext theFhirContext,
+			@Nullable CDSHooksVersion theCDSHooksVersion) {
 		final CdsServiceRequestJsonDeserializer cdsServiceRequestJsonDeserializer =
 				new CdsServiceRequestJsonDeserializer(theFhirContext, theObjectMapper);
 		return new CdsServiceRegistryImpl(
@@ -111,7 +113,8 @@ public class CdsHooksConfig {
 				theObjectMapper,
 				theCdsCrServiceFactory,
 				theCrDiscoveryServiceFactory,
-				cdsServiceRequestJsonDeserializer);
+				cdsServiceRequestJsonDeserializer,
+				CDSHooksVersion.getOrDefault(theCDSHooksVersion));
 	}
 
 	@Bean

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImpl.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImpl.java
@@ -23,7 +23,9 @@ import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsHooksExtension;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.hapi.fhir.cdshooks.api.CDSHooksVersion;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceRegistry;
@@ -56,6 +58,7 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 	private final ObjectMapper myObjectMapper;
 	private final ICdsCrServiceFactory myCdsCrServiceFactory;
 	private final ICrDiscoveryServiceFactory myCrDiscoveryServiceFactory;
+	private final CDSHooksVersion myCdsHooksVersion;
 
 	public CdsServiceRegistryImpl(
 			CdsHooksContextBooter theCdsHooksContextBooter,
@@ -64,12 +67,31 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 			ICdsCrServiceFactory theCdsCrServiceFactory,
 			ICrDiscoveryServiceFactory theCrDiscoveryServiceFactory,
 			CdsServiceRequestJsonDeserializer theCdsServiceRequestJsonDeserializer) {
+		this(
+				theCdsHooksContextBooter,
+				theCdsPrefetchSvc,
+				theObjectMapper,
+				theCdsCrServiceFactory,
+				theCrDiscoveryServiceFactory,
+				theCdsServiceRequestJsonDeserializer,
+				CDSHooksVersion.DEFAULT);
+	}
+
+	public CdsServiceRegistryImpl(
+			CdsHooksContextBooter theCdsHooksContextBooter,
+			CdsPrefetchSvc theCdsPrefetchSvc,
+			ObjectMapper theObjectMapper,
+			ICdsCrServiceFactory theCdsCrServiceFactory,
+			ICrDiscoveryServiceFactory theCrDiscoveryServiceFactory,
+			CdsServiceRequestJsonDeserializer theCdsServiceRequestJsonDeserializer,
+			CDSHooksVersion theCDSHooksVersion) {
 		myCdsHooksContextBooter = theCdsHooksContextBooter;
 		myCdsPrefetchSvc = theCdsPrefetchSvc;
 		myObjectMapper = theObjectMapper;
 		myCdsCrServiceFactory = theCdsCrServiceFactory;
 		myCrDiscoveryServiceFactory = theCrDiscoveryServiceFactory;
 		myCdsServiceRequestJsonDeserializer = theCdsServiceRequestJsonDeserializer;
+		myCdsHooksVersion = theCDSHooksVersion;
 	}
 
 	@PostConstruct
@@ -87,6 +109,7 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 		final CdsServiceJson cdsServiceJson = getCdsServiceJson(theServiceId);
 		final CdsServiceRequestJson deserializedRequest =
 				myCdsServiceRequestJsonDeserializer.deserialize(cdsServiceJson, theCdsServiceRequestJson);
+		validateHookRequestFhirServer(deserializedRequest);
 		ICdsServiceMethod serviceMethod = (ICdsServiceMethod) getCdsServiceMethodOrThrowException(theServiceId);
 		myCdsPrefetchSvc.augmentRequest(deserializedRequest, serviceMethod);
 		Object response = serviceMethod.invoke(myObjectMapper, deserializedRequest, theServiceId);
@@ -244,5 +267,16 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 	@VisibleForTesting
 	void setServiceCache(CdsServiceCache theCdsServiceCache) {
 		myServiceCache = theCdsServiceCache;
+	}
+
+	private void validateHookRequestFhirServer(CdsServiceRequestJson theCdsServiceRequestJson) {
+		if (myCdsHooksVersion != CDSHooksVersion.V_1_1) {
+			// for a version greater than V_1_1 (which is the base version supported),
+			// the fhirServer is required to use https scheme
+			String fhirServer = theCdsServiceRequestJson.getFhirServer();
+			if (fhirServer != null && !fhirServer.startsWith("https")) {
+				throw new InvalidRequestException(Msg.code(2632) + "The scheme for the fhirServer must be https");
+			}
+		}
 	}
 }

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImplTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImplTest.java
@@ -1,6 +1,10 @@
 package ca.uhn.hapi.fhir.cdshooks.svc;
 
 import ca.uhn.fhir.context.ConfigurationException;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.hapi.fhir.cdshooks.api.CDSHooksVersion;
+import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceFeedbackJson;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceResponseJson;
@@ -10,6 +14,7 @@ import ca.uhn.hapi.fhir.cdshooks.svc.cr.discovery.ICrDiscoveryServiceFactory;
 import ca.uhn.hapi.fhir.cdshooks.svc.prefetch.CdsPrefetchSvc;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +23,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CdsServiceRegistryImplTest {
@@ -177,4 +188,68 @@ class CdsServiceRegistryImplTest {
 			myFixture.getCdsServiceJson(serviceId);
 		}).withMessage("HAPI-2536: No service with " + serviceId +  " is registered.");
 	}
+
+	@Test
+	void testCallService_doesNotEnforceFhirServerIsHttpsForCDSHooksV1() {
+		String fhirServer = "http://localhost:8000/remote_fhir";
+		String response = "{\"cards\": []}";
+		CdsServiceRegistryImpl serviceRegistryImpl = createAndSetupCdsServiceRegistryImplForCallService(CDSHooksVersion.V_1_1, fhirServer, response);
+		CdsServiceResponseJson responseJson = serviceRegistryImpl.callService(SERVICE_ID, "");
+		assertThat(responseJson).isNotNull();
+	}
+
+	@Test
+	void testCallService_noValidationIfFhirServerIsNullForCDSHooksV2() {
+		String response = "{\"cards\": []}";
+		CdsServiceRegistryImpl serviceRegistryImpl = createAndSetupCdsServiceRegistryImplForCallService(CDSHooksVersion.V_2_0, null, response);
+		CdsServiceResponseJson responseJson = serviceRegistryImpl.callService(SERVICE_ID, "");
+		assertThat(responseJson).isNotNull();
+	}
+
+	@Test
+	void testCallService_enforcesFhirServerIsHttpsForCDSHooksV2_InvalidInput() {
+		String fhirServer = "http://localhost:8000/remote_fhir";
+		CdsServiceRegistryImpl serviceRegistryImpl = createAndSetupCdsServiceRegistryImplForCallService(CDSHooksVersion.V_2_0, fhirServer, null);
+		InvalidRequestException ex = assertThrows(InvalidRequestException.class, () -> serviceRegistryImpl.callService(SERVICE_ID, ""));
+		assertThat(ex.getMessage()).isEqualTo("HAPI-2632: The scheme for the fhirServer must be https");
+	}
+
+	@Test
+	void testCallService_enforcesFhirServerIsHttpsForCDSHooksV2_ValidInput() {
+		String fhirServer = "https://localhost:8000/remote_fhir";
+		String response = "{\"cards\": []}";
+		CdsServiceRegistryImpl serviceRegistryImpl = createAndSetupCdsServiceRegistryImplForCallService(CDSHooksVersion.V_2_0, fhirServer, response);
+		CdsServiceResponseJson responseJson = serviceRegistryImpl.callService(SERVICE_ID, "");
+		assertThat(responseJson).isNotNull();
+	}
+
+	private CdsServiceRegistryImpl createAndSetupCdsServiceRegistryImplForCallService(CDSHooksVersion theCdsHooksVersion, @Nullable String theFhirServer, @Nullable String theSuccessResponse) {
+		CdsServiceRegistryImpl serviceRegistryImpl = new CdsServiceRegistryImpl(
+			myCdsHooksContextBooter,
+			myCdsPrefetchSvc,
+			myObjectMapper,
+			myCdsCrServiceFactory,
+			myCrDiscoveryServiceFactory,
+			myCdsServiceRequestJsonDeserializer,
+			theCdsHooksVersion);
+
+		final CdsServiceJson cdsService = new CdsServiceJson();
+		cdsService.setId(SERVICE_ID);
+		serviceRegistryImpl.setServiceCache(myCdsServiceCache);
+		doReturn(cdsService).when(myCdsServiceCache).getCdsServiceJson(SERVICE_ID);
+
+		CdsServiceRequestJson requestJson = new CdsServiceRequestJson();
+		requestJson.setFhirServer(theFhirServer);
+		doReturn(requestJson).when(myCdsServiceRequestJsonDeserializer).deserialize(eq(cdsService), anyString());
+
+		if (theSuccessResponse != null) {
+			ICdsServiceMethod theMethodMock= mock(ICdsServiceMethod.class);
+			when(theMethodMock.invoke(myObjectMapper, requestJson, SERVICE_ID)).thenReturn(theSuccessResponse);
+			when(myCdsServiceCache.getServiceMethod(SERVICE_ID)).thenReturn(theMethodMock);
+		}
+
+
+		return serviceRegistryImpl;
+	}
+
 }


### PR DESCRIPTION
closes: #6805 

- Added CDSHooksVersion enum to speficy the CDSHooks version that the implementation should conform to. 
- If CDSHooksVersion is set to 2.0, then the fhirServer field will be enforced to use 'https' as the scheme.
- The default CDS hooks version is set to 1.1 to not break existing implementations.