### PR TITLE
Valueset expansion overwriting codesystem concepts properties

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6808-fix-valueset-expansion-may-corrupt-referred-codesystem.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6808-fix-valueset-expansion-may-corrupt-referred-codesystem.yaml
@@ -2,6 +2,6 @@
 type: fix
 issue: 6808
 jira: SMILE-9953
-title: "Previously, expanding a valueSet may have caused modifications CodeSystem Concepts. The issue was encountered 
+title: "Previously, expanding a valueSet may have caused modifications to CodeSystem Concepts. The issue was encountered 
 when a `valueSet.compose.include.concept.display` differed from the referred `codeSystem.concept.display`. This has been 
 fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6808-fix-valueset-expansion-may-corrupt-referred-codesystem.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6808-fix-valueset-expansion-may-corrupt-referred-codesystem.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 6808
+jira: SMILE-9953
+title: "Previously, expanding a valueSet may have caused modifications CodeSystem Concepts. The issue was encountered 
+when a `valueSet.compose.include.concept.display` differed from the referred `codeSystem.concept.display`. This has been 
+fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -1202,6 +1202,12 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 							ValueSet.ConceptReferenceComponent theIncludeConcept =
 									getMatchedConceptIncludedInValueSet(theIncludeOrExclude, concept);
 							if (theIncludeConcept != null && isNotBlank(theIncludeConcept.getDisplay())) {
+								// the valueSet concept.display property was populated and may be different from the
+								// codeSystem.concept.display.  Since 'concept' is a managed object, we need to tell the
+								// entityManager to ignore any changes to it before assigning the custom display value.
+								// If we don't, the modification will propagate to persistence during the flush() operation
+								// effectively corrupting the codeSystem.
+								myEntityManager.detach(concept);
 								concept.setDisplay(theIncludeConcept.getDisplay());
 							}
 						}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -1205,7 +1205,8 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 								// the valueSet concept.display property was populated and may be different from the
 								// codeSystem.concept.display.  Since 'concept' is a managed object, we need to tell the
 								// entityManager to ignore any changes to it before assigning the custom display value.
-								// If we don't, the modification will propagate to persistence during the flush() operation
+								// If we don't, the modification will propagate to persistence during the flush()
+								// operation
 								// effectively corrupting the codeSystem.
 								myEntityManager.detach(concept);
 								concept.setDisplay(theIncludeConcept.getDisplay());

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -1206,8 +1206,7 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 								// codeSystem.concept.display.  Since 'concept' is a managed object, we need to tell the
 								// entityManager to ignore any changes to it before assigning the custom display value.
 								// If we don't, the modification will propagate to persistence during the flush()
-								// operation
-								// effectively corrupting the codeSystem.
+								// operation effectively corrupting the codeSystem.concept.
 								myEntityManager.detach(concept);
 								concept.setDisplay(theIncludeConcept.getDisplay());
 							}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -309,12 +309,12 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 			IValueSetConceptAccumulator theValueSetCodeAccumulator,
 			Set<String> theAddedCodes,
 			TermConcept theConcept,
+			String theConceptDisplayValue,
 			boolean theAdd,
 			String theValueSetIncludeVersion) {
 		String codeSystem = theConcept.getCodeSystemVersion().getCodeSystem().getCodeSystemUri();
 		String codeSystemVersion = theConcept.getCodeSystemVersion().getCodeSystemVersionId();
 		String code = theConcept.getCode();
-		String display = theConcept.getDisplay();
 		Long sourceConceptPid = theConcept.getId();
 		String directParentPids = "";
 
@@ -325,31 +325,22 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 		}
 
 		Collection<TermConceptDesignation> designations = theConcept.getDesignations();
+
 		if (StringUtils.isNotEmpty(theValueSetIncludeVersion)) {
-			return addCodeIfNotAlreadyAdded(
-					theValueSetCodeAccumulator,
-					theAddedCodes,
-					designations,
-					theAdd,
-					codeSystem + OUR_PIPE_CHARACTER + theValueSetIncludeVersion,
-					code,
-					display,
-					sourceConceptPid,
-					directParentPids,
-					codeSystemVersion);
-		} else {
-			return addCodeIfNotAlreadyAdded(
-					theValueSetCodeAccumulator,
-					theAddedCodes,
-					designations,
-					theAdd,
-					codeSystem,
-					code,
-					display,
-					sourceConceptPid,
-					directParentPids,
-					codeSystemVersion);
+			codeSystem = codeSystem + OUR_PIPE_CHARACTER + theValueSetIncludeVersion;
 		}
+
+		return addCodeIfNotAlreadyAdded(
+				theValueSetCodeAccumulator,
+				theAddedCodes,
+				designations,
+				theAdd,
+				codeSystem,
+				code,
+				theConceptDisplayValue,
+				sourceConceptPid,
+				directParentPids,
+				codeSystemVersion);
 	}
 
 	private boolean addCodeIfNotAlreadyAdded(
@@ -1198,17 +1189,12 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 					for (TermConcept concept : termConcepts) {
 						count++;
 						countForBatch++;
+						String conceptDisplayValue = concept.getDisplay();
 						if (theAdd && searchProps.hasIncludeOrExcludeCodes()) {
 							ValueSet.ConceptReferenceComponent theIncludeConcept =
 									getMatchedConceptIncludedInValueSet(theIncludeOrExclude, concept);
 							if (theIncludeConcept != null && isNotBlank(theIncludeConcept.getDisplay())) {
-								// the valueSet concept.display property was populated and may be different from the
-								// codeSystem.concept.display.  Since 'concept' is a managed object, we need to tell the
-								// entityManager to ignore any changes to it before assigning the custom display value.
-								// If we don't, the modification will propagate to persistence during the flush()
-								// operation effectively corrupting the codeSystem.concept.
-								myEntityManager.detach(concept);
-								concept.setDisplay(theIncludeConcept.getDisplay());
+								conceptDisplayValue = theIncludeConcept.getDisplay();
 							}
 						}
 						boolean added = addCodeIfNotAlreadyAdded(
@@ -1216,6 +1202,7 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 								theValueSetCodeAccumulator,
 								theAddedCodes,
 								concept,
+								conceptDisplayValue,
 								theAdd,
 								includeOrExcludeVersion);
 						if (added) {

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseValueSetHSearchExpansionR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseValueSetHSearchExpansionR4Test.java
@@ -2001,7 +2001,8 @@ public abstract class BaseValueSetHSearchExpansionR4Test extends BaseJpaTest {
 			assertThat(termConcept.getCode()).isEqualTo(code);
 			assertThat(termConcept.getDisplay()).isNull();
 
-			// given a ValueSet including the code system concept and overwriting the display value
+			// given a ValueSet including the codeSystem concept and overwriting the display value with a more suiting
+			// description.
 			ValueSet vs = new ValueSet();
 			ValueSet.ConceptSetComponent include = vs.getCompose().addInclude();
 			include.setSystem(CS_URL);

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseValueSetHSearchExpansionR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseValueSetHSearchExpansionR4Test.java
@@ -68,10 +68,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -1983,6 +1985,44 @@ public abstract class BaseValueSetHSearchExpansionR4Test extends BaseJpaTest {
 			}
 			ValueSet outcome = myTermSvc.expandValueSet(null, vs);
 			return toCodesContains(outcome.getExpansion().getContains());
+		}
+
+	}
+
+	@Nested
+	public class TestValueSetExpansion{
+		@Test
+		public void testValueSetConceptDisplay_expandsWithoutOverwritingCodeSystemConceptDisplay(){
+			String code = "ParentWithNoChildrenA";
+
+			// given a code system declaring a termConcept with 'ParentWithNoChildrenA' as code and not display
+			createCodeSystem();
+			TermConcept termConcept = readTermConcept( CS_URL, code);
+			assertThat(termConcept.getCode()).isEqualTo(code);
+			assertThat(termConcept.getDisplay()).isNull();
+
+			// given a ValueSet including the code system concept and overwriting the display value
+			ValueSet vs = new ValueSet();
+			ValueSet.ConceptSetComponent include = vs.getCompose().addInclude();
+			include.setSystem(CS_URL);
+			include.addConcept().setCode(code).setDisplay("valueSetDisplay");
+
+			// when
+			myTermSvc.expandValueSet(null, vs);
+
+			// then codeSystem concept.display was not overwritten
+			termConcept = readTermConcept( CS_URL, code);
+			assertThat(termConcept.getCode()).isEqualTo(code);
+			assertThat(termConcept.getDisplay()).isNull();
+		}
+
+		public TermConcept readTermConcept(String theUrl, String theCode) {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(getTxManager());
+
+			Optional<TermConcept> optionalTermConcept =
+				transactionTemplate.execute(x -> myTermSvc.findCode( theUrl, theCode));
+			assertThat(optionalTermConcept).isNotNull();
+			return optionalTermConcept.orElseThrow();
 		}
 
 	}


### PR DESCRIPTION
**Root cause:**
The issue is caused by the modification of managed `codeSystem.concepts` during the creation of valueSet concepts.

**What was done:**
- added failing test;
- added one liner fix with comment;
- added changelog.

closes #6808 