### PR TITLE
cds hooks operation outcome failure mode

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6836-cds-hooks-prefetch-failure-modes.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6836-cds-hooks-prefetch-failure-modes.yaml
@@ -1,0 +1,7 @@
+---
+type: add
+issue: 6836
+title: "CDS Hooks services can now specify how to handle prefetch failures using the `failureMode` property on the 
+`CDSServicePrefetch` annotation. The failure mode can be set to `FAIL` (default), `OMIT` or `OPERATION_OUTCOME. This
+applies in cases where an auto-prefetch request fails, or the CDS Client sends an OperationOutcome as a prefetch 
+resource, which is allowed by the [CDS Hooks version 2.0](https://cds-hooks.hl7.org/2.0/) specification."

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/CdsPrefetchFailureMode.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/CdsPrefetchFailureMode.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * HAPI FHIR - CDS Hooks
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.hapi.fhir.cdshooks.api;
+
+/**
+ * Enum representing different modes of handling CDS Hooks prefetch failures.
+ * This applies
+ *  - if a failure occurs when auto-prefetching a resource, or
+ *  - if a CDS Client sends an OperationOutcome as a prefetch resource. With version 2.0 of the CDS Hooks specification, CDS Clients are
+ * allowed to send an OperationOutcome as a prefetch if they encounter a failure prefetching a resource.
+ */
+public enum CdsPrefetchFailureMode {
+	/**
+	 * The CDS Hooks request will fail.
+	 */
+	FAIL,
+	/**
+	 * The prefetch resource will be omitted from the CDS Request.
+	 * i.e. {@link ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson} object will not contain the failed prefetch key.
+	 */
+	OMIT,
+	/**
+	 * The prefetch key will map to OperationOutcome resource. That is, if the CDS Client sends an OperationOutcome,that will be passed on
+	 * as is. If the auto-prefetch fails, and then an OperationOutcome will be either extracted from the FHIR server's response, or created
+	 * if one is not available in the response.
+	 */
+	OPERATION_OUTCOME
+}

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/CdsServicePrefetch.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/CdsServicePrefetch.java
@@ -45,4 +45,9 @@ public @interface CdsServicePrefetch {
 	 * The strategy used for this query, defaults to the service-wide strategy
 	 */
 	CdsResolutionStrategyEnum source() default CdsResolutionStrategyEnum.NONE;
+
+	/**
+	 * How to handle prefetch failures, applies to both auto-prefetch failures or an OperationOutcome sent by the CDSClient as a prefetch resource.
+	 */
+	CdsPrefetchFailureMode failureMode() default CdsPrefetchFailureMode.FAIL;
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/json/CdsServiceJson.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/api/json/CdsServiceJson.java
@@ -20,6 +20,7 @@
 package ca.uhn.hapi.fhir.cdshooks.api.json;
 
 import ca.uhn.fhir.rest.api.server.cdshooks.BaseCdsServiceJson;
+import ca.uhn.hapi.fhir.cdshooks.api.CdsPrefetchFailureMode;
 import ca.uhn.hapi.fhir.cdshooks.api.CdsResolutionStrategyEnum;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -55,6 +56,8 @@ public class CdsServiceJson extends BaseCdsServiceJson {
 	private Map<String, String> myPrefetch;
 
 	private Map<String, CdsResolutionStrategyEnum> mySource;
+
+	private Map<String, CdsPrefetchFailureMode> myPrefetchFailureModes;
 
 	public String getHook() {
 		return myHook;
@@ -118,5 +121,19 @@ public class CdsServiceJson extends BaseCdsServiceJson {
 			mySource = new LinkedHashMap<>();
 		}
 		return Collections.unmodifiableMap(mySource);
+	}
+
+	public void addPrefetchFailureMode(String theKey, CdsPrefetchFailureMode theFailureMode) {
+		if (myPrefetchFailureModes == null) {
+			myPrefetchFailureModes = new LinkedHashMap<>();
+		}
+		myPrefetchFailureModes.put(theKey, theFailureMode);
+	}
+
+	public CdsPrefetchFailureMode getPrefetchFailureMode(String theKey) {
+		if (myPrefetchFailureModes == null) {
+			myPrefetchFailureModes = new LinkedHashMap<>();
+		}
+		return myPrefetchFailureModes.getOrDefault(theKey, CdsPrefetchFailureMode.FAIL);
 	}
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
@@ -215,12 +215,14 @@ public class CdsHooksConfig {
 			CdsPrefetchDaoSvc theResourcePrefetchDao,
 			CdsPrefetchFhirClientSvc theResourcePrefetchFhirClient,
 			ICdsHooksDaoAuthorizationSvc theCdsHooksDaoAuthorizationSvc,
+			FhirContext theFhirContext,
 			@Nullable IInterceptorBroadcaster theInterceptorBroadcaster) {
 		return new CdsPrefetchSvc(
 				theCdsResolutionStrategySvc,
 				theResourcePrefetchDao,
 				theResourcePrefetchFhirClient,
 				theCdsHooksDaoAuthorizationSvc,
+				theFhirContext,
 				theInterceptorBroadcaster);
 	}
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsHooksContextBooter.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsHooksContextBooter.java
@@ -91,6 +91,7 @@ public class CdsHooksContextBooter {
 				for (CdsServicePrefetch prefetch : annotation.prefetch()) {
 					cdsServiceJson.addPrefetch(prefetch.value(), prefetch.query());
 					cdsServiceJson.addSource(prefetch.value(), prefetch.source());
+					cdsServiceJson.addPrefetchFailureMode(prefetch.value(), prefetch.failureMode());
 				}
 				myCdsServiceCache.registerService(
 						cdsServiceJson.getId(),

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.hapi.fhir.cdshooks.svc.prefetch;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
@@ -26,12 +27,15 @@ import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import ca.uhn.fhir.util.OperationOutcomeUtil;
+import ca.uhn.hapi.fhir.cdshooks.api.CdsPrefetchFailureMode;
 import ca.uhn.hapi.fhir.cdshooks.api.CdsResolutionStrategyEnum;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsHooksDaoAuthorizationSvc;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 import ca.uhn.hapi.fhir.cdshooks.api.json.prefetch.CdsHookPrefetchPointcutContextJson;
 import jakarta.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +51,7 @@ public class CdsPrefetchSvc {
 	private final CdsPrefetchDaoSvc myResourcePrefetchDao;
 	private final CdsPrefetchFhirClientSvc myResourcePrefetchFhirClient;
 	private final ICdsHooksDaoAuthorizationSvc myCdsHooksDaoAuthorizationSvc;
+	private final FhirContext myFhirContext;
 
 	@Nullable
 	private final IInterceptorBroadcaster myInterceptorBroadcaster;
@@ -56,17 +61,24 @@ public class CdsPrefetchSvc {
 			CdsPrefetchDaoSvc theResourcePrefetchDao,
 			CdsPrefetchFhirClientSvc theResourcePrefetchFhirClient,
 			ICdsHooksDaoAuthorizationSvc theCdsHooksDaoAuthorizationSvc,
+			FhirContext theFhirContext,
 			@Nullable IInterceptorBroadcaster theInterceptorBroadcaster) {
 		myCdsResolutionStrategySvc = theCdsResolutionStrategySvc;
 		myResourcePrefetchDao = theResourcePrefetchDao;
 		myResourcePrefetchFhirClient = theResourcePrefetchFhirClient;
 		myCdsHooksDaoAuthorizationSvc = theCdsHooksDaoAuthorizationSvc;
+		myFhirContext = theFhirContext;
 		myInterceptorBroadcaster = theInterceptorBroadcaster;
 	}
 
 	public void augmentRequest(CdsServiceRequestJson theCdsServiceRequestJson, ICdsServiceMethod theServiceMethod) {
 		CdsServiceJson serviceSpec = theServiceMethod.getCdsServiceJson();
 		Set<String> missingPrefetch = findMissingPrefetch(serviceSpec, theCdsServiceRequestJson);
+		// It is important to call handleOperationOutcomesSentByCdsClient after calculating the missing prefetches.
+		// In case the failure mode is OMIT, and if the client sends an OperationOutcome as a prefetch key, that
+		// prefetch will be cleared by handleOperationOutcomesSentByCdsClient, which may be wrongly interpreted as
+		// missing.
+		handleOperationOutcomesSentByCdsClient(serviceSpec, theCdsServiceRequestJson);
 		if (missingPrefetch.isEmpty()) {
 			return;
 		}
@@ -82,14 +94,56 @@ public class CdsPrefetchSvc {
 		}
 	}
 
+	/**
+	 * This method checks if the CDS client sent an OperationOutcome as a prefetch resource.
+	 * If that is the case, it handles the OperationOutcome according to the failure mode for that prefetch key.
+	 * If the failure mode is FAIL, it throws a PreconditionFailedException.
+	 * If the failure mode is OMIT, it removes the prefetch key from the request.
+	 * If the failure mode is OPERATION_OUTCOME, it keeps the OperationOutcome in the prefetch.
+	 * @param theServiceSpec the definition of the CDS service
+	 * @param theCdsServiceRequestJson the CDS request
+	 */
+	private void handleOperationOutcomesSentByCdsClient(
+			CdsServiceJson theServiceSpec, CdsServiceRequestJson theCdsServiceRequestJson) {
+		Set<String> prefetchKeysToRemove = new HashSet<>();
+		String serviceId = theServiceSpec.getId();
+		for (String prefetchKey : theCdsServiceRequestJson.getPrefetchKeys()) {
+			IBaseResource resource = theCdsServiceRequestJson.getPrefetch(prefetchKey);
+			CdsPrefetchFailureMode failureMode = theServiceSpec.getPrefetchFailureMode(prefetchKey);
+			if (resource instanceof IBaseOperationOutcome) {
+				if (failureMode == CdsPrefetchFailureMode.FAIL) {
+					String message = String.format(
+							"The CDS service '%s' received an OperationOutcome resource for prefetch key '%s' "
+									+ "but the service isn't configured to handle OperationOutcome",
+							serviceId, prefetchKey);
+					throw new PreconditionFailedException(Msg.code(2635) + message);
+				} else if (failureMode == CdsPrefetchFailureMode.OMIT) {
+					ourLog.info(
+							"The CDS service '{}' received an OperationOutcome for the prefetch key '{}' and the failure mode is set to 'OMIT'. "
+									+ "The prefetch key will be removed from the request.",
+							serviceId,
+							prefetchKey);
+					prefetchKeysToRemove.add(prefetchKey);
+				}
+				// else the failure mode is OPERATION_OUTCOME, so we keep the OperationOutcome in the prefetch
+			}
+		}
+
+		for (String prefetchKey : prefetchKeysToRemove) {
+			theCdsServiceRequestJson.removePrefetch(prefetchKey);
+		}
+	}
+
 	private void fetchMissingPrefetchElements(
 			CdsServiceRequestJson theCdsServiceRequestJson,
 			CdsServiceJson theServiceSpec,
 			Set<String> theMissingPrefetch,
 			Set<CdsResolutionStrategyEnum> theStrategies) {
+
 		for (String key : theMissingPrefetch) {
 			String template = theServiceSpec.getPrefetch().get(key);
 			CdsResolutionStrategyEnum source = theServiceSpec.getSource().get(key);
+			CdsPrefetchFailureMode failureMode = theServiceSpec.getPrefetchFailureMode(key);
 			if (!theStrategies.contains(source)) {
 				throw new PreconditionFailedException(
 						Msg.code(2386) + "Unable to fetch missing resource(s) with source " + source);
@@ -115,33 +169,94 @@ public class CdsPrefetchSvc {
 			String url = PrefetchTemplateUtil.substituteTemplate(
 					template, theCdsServiceRequestJson.getContext(), myResourcePrefetchDao.getFhirContext());
 			ourLog.info("missing: {}.  Fetching with {}", theMissingPrefetch, url);
-			IBaseResource resource;
 
-			CdsHookPrefetchPointcutContextJson cdsHookPrefetchContext = new CdsHookPrefetchPointcutContextJson();
-			cdsHookPrefetchContext.setTemplate(template);
-			cdsHookPrefetchContext.setQuery(url);
-			cdsHookPrefetchContext.setCdsResolutionStrategy(source);
+			CdsHookPrefetchPointcutContextJson cdsHookPrefetchPointcutContext =
+					new CdsHookPrefetchPointcutContextJson();
+			cdsHookPrefetchPointcutContext.setTemplate(template);
+			cdsHookPrefetchPointcutContext.setQuery(url);
+			cdsHookPrefetchPointcutContext.setCdsResolutionStrategy(source);
 
-			callCdsPrefetchRequestHooks(cdsHookPrefetchContext, theCdsServiceRequestJson);
+			IBaseResource resource = prefetchResource(
+					theCdsServiceRequestJson, key, url, source, failureMode, cdsHookPrefetchPointcutContext);
 
-			try {
-				if (source == CdsResolutionStrategyEnum.FHIR_CLIENT) {
-					resource = myResourcePrefetchFhirClient.resourceFromUrl(theCdsServiceRequestJson, url);
-				} else if (source == CdsResolutionStrategyEnum.DAO) {
-					resource = getResourceFromDaoWithPermissionCheck(url);
-				} else {
-					// should never happen
-					throw new IllegalStateException(Msg.code(2388) + "Unexpected strategy " + theStrategies);
-				}
-			} catch (Exception e) {
-				callCdsPrefetchFailedHooks(cdsHookPrefetchContext, theCdsServiceRequestJson, e);
-				throw e;
+			// if the prefetch failed and the failure mode is OMIT, then the resource would be null,
+			// it shouldn't be added to the request
+			if (resource != null) {
+				theCdsServiceRequestJson.addPrefetch(key, resource);
 			}
-
-			callCdsPrefetchResponseHooks(cdsHookPrefetchContext, theCdsServiceRequestJson, resource);
-
-			theCdsServiceRequestJson.addPrefetch(key, resource);
 		}
+	}
+
+	@Nullable
+	private IBaseResource prefetchResource(
+			CdsServiceRequestJson theCdsServiceRequestJson,
+			String thePrefetchKey,
+			String theUrl,
+			CdsResolutionStrategyEnum theStrategy,
+			CdsPrefetchFailureMode theFailureMode,
+			CdsHookPrefetchPointcutContextJson theCdsHookPrefetchPointcutContext) {
+
+		callCdsPrefetchRequestHooks(theCdsHookPrefetchPointcutContext, theCdsServiceRequestJson);
+		boolean prefetchCallSucceeded = false;
+		IBaseResource resource;
+		try {
+
+			if (theStrategy == CdsResolutionStrategyEnum.FHIR_CLIENT) {
+				resource = myResourcePrefetchFhirClient.resourceFromUrl(theCdsServiceRequestJson, theUrl);
+			} else if (theStrategy == CdsResolutionStrategyEnum.DAO) {
+				resource = getResourceFromDaoWithPermissionCheck(theUrl);
+			} else {
+				throw new IllegalStateException("Unexpected strategy: " + theStrategy);
+			}
+			prefetchCallSucceeded = true;
+
+		} catch (Exception e) {
+			callCdsPrefetchFailedHooks(theCdsHookPrefetchPointcutContext, theCdsServiceRequestJson, e);
+			switch (theFailureMode) {
+				case OMIT:
+					ourLog.info(
+							"The prefetch failed for the prefetch key '{}', with the exception message: '{}'. "
+									+ "The failure mode for the prefetch key is set to 'OMIT'. The prefetch key will be omitted from the request.",
+							thePrefetchKey,
+							e.getMessage());
+					resource = null;
+					break;
+				case OPERATION_OUTCOME:
+					resource = extractOrCreateOperationOutcomeFromException(e);
+					break;
+				case FAIL:
+				default:
+					throw e;
+			}
+		}
+
+		if (prefetchCallSucceeded) {
+			callCdsPrefetchResponseHooks(theCdsHookPrefetchPointcutContext, theCdsServiceRequestJson, resource);
+		}
+		return resource;
+	}
+
+	/***
+	 * If the exception is an instance of BaseServerResponseException and contains a non-null Operation Outcome,
+	 * returns the OperationOutcome contained in the exception.
+	 * It other cases, this method creates a new OperationOutcome using the exception's message and returns it.
+	 * @param e Exception
+	 * @return OperationOutcome
+	 */
+	private IBaseOperationOutcome extractOrCreateOperationOutcomeFromException(Exception e) {
+		IBaseOperationOutcome oo = null;
+		// check first if we can get an OperationOutcome from the exception
+		if (e instanceof BaseServerResponseException) {
+			BaseServerResponseException serverException = (BaseServerResponseException) e;
+			oo = serverException.getOperationOutcome();
+		}
+
+		if (oo == null) {
+			// the exception doesn't contain an OperationOutcome, create one
+			oo = OperationOutcomeUtil.newInstance(myFhirContext);
+			OperationOutcomeUtil.addIssue(myFhirContext, oo, "error", e.getMessage(), null, "exception");
+		}
+		return oo;
 	}
 
 	private IBaseResource getResourceFromDaoWithPermissionCheck(String theUrl) {

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvcTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvcTest.java
@@ -1,18 +1,44 @@
 package ca.uhn.hapi.fhir.cdshooks.svc.prefetch;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestContextJson;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.hapi.fhir.cdshooks.api.CdsPrefetchFailureMode;
+import ca.uhn.hapi.fhir.cdshooks.api.CdsResolutionStrategyEnum;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsHooksDaoAuthorizationSvc;
+import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CdsPrefetchSvcTest {
@@ -25,6 +51,12 @@ class CdsPrefetchSvcTest {
 	private CdsPrefetchFhirClientSvc myCdsPrefetchFhirClientSvc;
 	@Mock
 	private ICdsHooksDaoAuthorizationSvc myCdsHooksDaoAuthorizationSvc;
+	@Spy
+	private FhirContext myFhirContext = FhirContext.forR4();
+	@Mock
+	private ICdsServiceMethod myServiceMethodMock;
+	@Mock
+	private IInterceptorBroadcaster myInterceptorBroadcasterMock;
 	@InjectMocks
 	private CdsPrefetchSvc myCdsPrefetchSvc;
 
@@ -65,5 +97,327 @@ class CdsPrefetchSvcTest {
 		input.addPrefetch("baz", null);
 		result = myCdsPrefetchSvc.findMissingPrefetch(spec, input);
 		assertThat(result).containsExactly("bar");
+	}
+
+
+	protected static Stream<Arguments> provideArgumentsForAllPrefetchFailureModes() {
+		return Stream.of(
+			Arguments.of(CdsPrefetchFailureMode.OPERATION_OUTCOME, CdsResolutionStrategyEnum.FHIR_CLIENT),
+			Arguments.of(CdsPrefetchFailureMode.OMIT, CdsResolutionStrategyEnum.FHIR_CLIENT),
+			Arguments.of(CdsPrefetchFailureMode.FAIL, CdsResolutionStrategyEnum.FHIR_CLIENT),
+			Arguments.of(CdsPrefetchFailureMode.OPERATION_OUTCOME, CdsResolutionStrategyEnum.DAO),
+			Arguments.of(CdsPrefetchFailureMode.OMIT, CdsResolutionStrategyEnum.DAO),
+			Arguments.of(CdsPrefetchFailureMode.FAIL, CdsResolutionStrategyEnum.DAO)
+		);
+	}
+
+
+	protected static Stream<Arguments> provideArgumentsForNonFailingPrefetchFailureModes() {
+		return Stream.of(
+			Arguments.of(CdsPrefetchFailureMode.OPERATION_OUTCOME, CdsResolutionStrategyEnum.FHIR_CLIENT),
+			Arguments.of(CdsPrefetchFailureMode.OMIT, CdsResolutionStrategyEnum.FHIR_CLIENT),
+			Arguments.of(CdsPrefetchFailureMode.OPERATION_OUTCOME, CdsResolutionStrategyEnum.DAO),
+			Arguments.of(CdsPrefetchFailureMode.OMIT, CdsResolutionStrategyEnum.DAO)
+			);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForAllPrefetchFailureModes")
+	void testAugmentRequest_PrefetchingMissingKeySucceeds_Succeeds(CdsPrefetchFailureMode theFailureMode,
+																   CdsResolutionStrategyEnum theResolutionStrategy) {
+
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(theFailureMode, theResolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+
+		setupMocksPrefetchSuccess(request, spec, theResolutionStrategy, new Patient());
+
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(spec);
+		myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_REQUEST), any());
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_RESPONSE), any());
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForNonFailingPrefetchFailureModes")
+	void testAugmentRequest_WhenPrefetchFailureModeIsNonFailing_ClientSendsOperationOutcome_Succeeds(CdsPrefetchFailureMode theFailureMode,
+																					  CdsResolutionStrategyEnum theResolutionStrategy) {
+
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(theFailureMode, theResolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+		// client sends an OperationOutcome for a prefetch
+		OperationOutcome ooInPrefetch = new OperationOutcome();
+		request.addPrefetch("patient", ooInPrefetch);
+
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(spec);
+
+		myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+
+		if (theFailureMode == CdsPrefetchFailureMode.OPERATION_OUTCOME) {
+			IBaseResource prefetchedResource = request.getPrefetch("patient");
+			assertThat(prefetchedResource).isInstanceOf(IBaseOperationOutcome.class);
+			OperationOutcome prefetchedResourceAsOperationOutcome = (OperationOutcome) prefetchedResource;
+			assertThat(prefetchedResourceAsOperationOutcome).isEqualTo(ooInPrefetch);
+		}
+		else if (theFailureMode == CdsPrefetchFailureMode.OMIT) {
+			assertThat(request.getPrefetchKeys()).doesNotContain("patient");
+		}
+
+		verifyNoInteractions(myCdsPrefetchFhirClientSvc, myCdsPrefetchDaoSvc);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForNonFailingPrefetchFailureModes")
+	void testAugmentRequest_WhenPrefetchFailureModeIsNonFailing_PrefetchingMissingKeyFails_Succeeds(CdsPrefetchFailureMode theFailureMode,
+																					  CdsResolutionStrategyEnum theResolutionStrategy) {
+
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(theFailureMode, theResolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+
+		RuntimeException ex = new RuntimeException("this is the failure message");
+
+		setupMocksForFailureModeTestPrefetchFailure(request, spec, theResolutionStrategy, ex);
+
+		myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+
+		if (theFailureMode == CdsPrefetchFailureMode.OPERATION_OUTCOME) {
+			IBaseResource prefetchedResource = request.getPrefetch("patient");
+			assertThat(prefetchedResource).isInstanceOf(IBaseOperationOutcome.class);
+			OperationOutcome prefetchedResourceAsOperationOutcome = (OperationOutcome) prefetchedResource;
+			assertThat(prefetchedResourceAsOperationOutcome.getIssue()).hasSize(1);
+			OperationOutcome.OperationOutcomeIssueComponent ooIssue = prefetchedResourceAsOperationOutcome.getIssueFirstRep();
+			assertThat(ooIssue.getDiagnostics()).isEqualTo("this is the failure message");
+			assertThat(ooIssue.getCode()).isEqualTo(OperationOutcome.IssueType.EXCEPTION);
+			assertThat(ooIssue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
+		}
+		else if (theFailureMode == CdsPrefetchFailureMode.OMIT) {
+			assertThat(request.getPrefetchKeys()).doesNotContain("patient");
+		}
+
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_REQUEST), any());
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_FAILED), any());
+	}
+
+	@Test
+	void testAugmentRequest_WhenPrefetchFailureModeIsOperationOutcome_And_PrefetchingMissingKeyFailsWithAnExceptionContainingOperationOutcome_Succeeds() {
+
+		CdsResolutionStrategyEnum resolutionStrategy = CdsResolutionStrategyEnum.FHIR_CLIENT;
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(CdsPrefetchFailureMode.OPERATION_OUTCOME, resolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+
+
+		OperationOutcome operationOutcomeInException = new OperationOutcome();
+		BaseServerResponseException ex =  new ResourceNotFoundException(new IdDt(123), operationOutcomeInException);
+
+		setupMocksForFailureModeTestPrefetchFailure(request, spec, resolutionStrategy, ex);
+
+		myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+
+		IBaseResource prefetchedResource = request.getPrefetch("patient");
+		assertThat(prefetchedResource).isInstanceOf(IBaseOperationOutcome.class);
+		OperationOutcome prefetchedResourceAsOperationOutcome = (OperationOutcome) prefetchedResource;
+		assertThat(prefetchedResourceAsOperationOutcome).isEqualTo(operationOutcomeInException);
+
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_REQUEST), any());
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_FAILED), any());
+	}
+
+	protected static Stream<Arguments> provideArgumentsForAutoFetchingResolutionStrategies() {
+		return Stream.of(
+			Arguments.of(CdsResolutionStrategyEnum.FHIR_CLIENT),
+			Arguments.of(CdsResolutionStrategyEnum.DAO)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForAutoFetchingResolutionStrategies")
+	void testAugmentRequest_WhenPrefetchFailureModeIsFail_ClientSendsOperationOutcome_ThrowsException(CdsResolutionStrategyEnum theResolutionStrategy) {
+
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(CdsPrefetchFailureMode.FAIL, theResolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+		request.addPrefetch("patient", new OperationOutcome());
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(spec);
+
+
+		PreconditionFailedException exceptionThrown = assertThrows(PreconditionFailedException.class, () -> myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock));
+		assertThat(exceptionThrown.getMessage()).isEqualTo("HAPI-2635: The CDS service 'test_failure_mode_service_id' received an OperationOutcome resource for prefetch key 'patient' but the service isn't configured to handle OperationOutcome");
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForAllPrefetchFailureModes")
+	void testAugmentRequest_WhenPrefetchFailureModeIsFail_ClientSendsPatientResource_Succeeds(CdsPrefetchFailureMode theFailureMode, CdsResolutionStrategyEnum theResolutionStrategy) {
+
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(theFailureMode, theResolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+		Patient p = new Patient();
+		request.addPrefetch("patient", p);
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(spec);
+
+
+		 myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+		 assertThat(request.getPrefetch("patient")).isEqualTo(p);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForAutoFetchingResolutionStrategies")
+	void testAugmentRequest_WhenPrefetchFailureModeIsFail_PrefetchingMissingKeyFails_ThrowsException(CdsResolutionStrategyEnum theResolutionStrategy) {
+
+		CdsServiceJson spec = createServiceDefinitionForFailureModeTest(CdsPrefetchFailureMode.FAIL, theResolutionStrategy);
+		CdsServiceRequestJson request = createRequestForFailureModeTest();
+
+		RuntimeException ex = new RuntimeException("this is the failure message");
+
+		setupMocksForFailureModeTestPrefetchFailure(request, spec, theResolutionStrategy, ex);
+
+		RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock));
+		assertThat(exceptionThrown).isEqualTo(ex);
+
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_REQUEST), any());
+		verify(myInterceptorBroadcasterMock).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_FAILED), any());
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForAutoFetchingResolutionStrategies")
+	void testAugmentRequest_MultiplePrefetchKeysWithDifferentNonFailingModes_PrefetchingMissingKeysFails_Succeeds(CdsResolutionStrategyEnum theResolutionStrategy) {
+		CdsServiceJson spec = new CdsServiceJson();
+		spec.setId("test_failure_mode_service_id");
+		spec.setHook("test_failure_mode_hook");
+
+		spec.addPrefetchFailureMode("patient1", CdsPrefetchFailureMode.OMIT);
+		spec.addPrefetch("patient1", "Patient/{{context.patientId1}}");
+		spec.addSource("patient1", theResolutionStrategy);
+
+		spec.addPrefetchFailureMode("patient2", CdsPrefetchFailureMode.OPERATION_OUTCOME);
+		spec.addPrefetch("patient2", "Patient/{{context.patientId2}}");
+		spec.addSource("patient2", theResolutionStrategy);
+
+		spec.addPrefetchFailureMode("patient3", CdsPrefetchFailureMode.OMIT);
+		spec.addPrefetch("patient3", "Patient/{{context.patientId3}}");
+		spec.addSource("patient3", theResolutionStrategy);
+
+		spec.addPrefetchFailureMode("patient4", CdsPrefetchFailureMode.OPERATION_OUTCOME);
+		spec.addPrefetch("patient4", "Patient/{{context.patientId4}}");
+		spec.addSource("patient4", theResolutionStrategy);
+
+		CdsServiceRequestContextJson reqContext = new CdsServiceRequestContextJson();
+		reqContext.put("patientId1", "p1");
+		reqContext.put("patientId2", "p2");
+		reqContext.put("patientId3", "p3");
+		reqContext.put("patientId4", "p4");
+
+		CdsServiceRequestJson request = createRequestForFailureModeTest(reqContext);
+		RuntimeException ex = new RuntimeException("this is the failure message");
+		setupMocksForFailureModeTestPrefetchFailure(request, spec, theResolutionStrategy, ex);
+
+		myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+
+		assertThat(request.getPrefetchKeys()).doesNotContain("patient1", "patient3");
+		assertThat(request.getPrefetch("patient2")).isInstanceOf(IBaseOperationOutcome.class);
+		assertThat(request.getPrefetch("patient4")).isInstanceOf(IBaseOperationOutcome.class);
+
+		verify(myInterceptorBroadcasterMock, times(4)).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_REQUEST), any());
+		verify(myInterceptorBroadcasterMock, times(4)).callHooks(eq(Pointcut.CDS_HOOK_PREFETCH_FAILED), any());
+
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideArgumentsForAutoFetchingResolutionStrategies")
+	void testAugmentRequest_MultiplePrefetchKeysWithDifferentNonFailingModes_ClientSendsPrefetchResources_Succeeds(CdsResolutionStrategyEnum theResolutionStrategy) {
+		CdsServiceJson spec = new CdsServiceJson();
+		spec.setId("test_failure_mode_service_id");
+		spec.setHook("test_failure_mode_hook");
+
+		spec.addPrefetchFailureMode("patient1", CdsPrefetchFailureMode.OMIT);
+		spec.addPrefetch("patient1", "Patient/{{context.patientId1}}");
+		spec.addSource("patient1", theResolutionStrategy);
+
+		spec.addPrefetchFailureMode("patient2", CdsPrefetchFailureMode.OPERATION_OUTCOME);
+		spec.addPrefetch("patient2", "Patient/{{context.patientId2}}");
+		spec.addSource("patient2", theResolutionStrategy);
+
+		spec.addPrefetchFailureMode("patient3", CdsPrefetchFailureMode.OMIT);
+		spec.addPrefetch("patient3", "Patient/{{context.patientId3}}");
+		spec.addSource("patient3", theResolutionStrategy);
+
+		spec.addPrefetchFailureMode("patient4", CdsPrefetchFailureMode.OPERATION_OUTCOME);
+		spec.addPrefetch("patient4", "Patient/{{context.patientId4}}");
+		spec.addSource("patient4", theResolutionStrategy);
+
+		CdsServiceRequestContextJson reqContext = new CdsServiceRequestContextJson();
+		reqContext.put("patientId1", "p1");
+		reqContext.put("patientId2", "p2");
+		reqContext.put("patientId3", "p3");
+		reqContext.put("patientId4", "p4");
+
+		CdsServiceRequestJson request = createRequestForFailureModeTest(reqContext);
+		request.addPrefetch("patient1", new OperationOutcome());
+		request.addPrefetch("patient2", new OperationOutcome());
+		request.addPrefetch("patient3", new OperationOutcome());
+		request.addPrefetch("patient4", new Patient());
+
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(spec);
+		myCdsPrefetchSvc.augmentRequest(request, myServiceMethodMock);
+
+		assertThat(request.getPrefetchKeys()).doesNotContain("patient1", "patient3");
+		assertThat(request.getPrefetch("patient2")).isInstanceOf(IBaseOperationOutcome.class);
+		assertThat(request.getPrefetch("patient4")).isInstanceOf(Patient.class);
+
+	}
+
+	private CdsServiceJson createServiceDefinitionForFailureModeTest(CdsPrefetchFailureMode theFailureMode,
+																	 CdsResolutionStrategyEnum theResolutionStrategy) {
+		CdsServiceJson spec = new CdsServiceJson();
+		spec.setId("test_failure_mode_service_id");
+		spec.addPrefetchFailureMode("patient", theFailureMode);
+		spec.addPrefetch("patient", "Patient/{{context.patientId}}");
+		spec.addSource("patient", theResolutionStrategy);
+		spec.setHook("test_failure_mode_hook");
+		return spec;
+	}
+
+	private CdsServiceRequestJson createRequestForFailureModeTest() {
+		CdsServiceRequestContextJson requestContext = new CdsServiceRequestContextJson();
+		requestContext.put("patientId", "123");
+		return createRequestForFailureModeTest(requestContext);
+	}
+
+	private CdsServiceRequestJson createRequestForFailureModeTest(CdsServiceRequestContextJson theRequestContext) {
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.setHook("test_failure_mode_hook");
+		request.setFhirServer("http://example-fhir.com/fhir");
+		request.setHookInstance("test_failure_mode_hook_instance");
+		request.setContext(theRequestContext);
+		return request;
+	}
+
+	private void setupMocksForFailureModeTestPrefetchFailure(CdsServiceRequestJson theRequest,
+															 CdsServiceJson theServiceDefinition,
+															 CdsResolutionStrategyEnum theResolutionStrategy,
+															 Exception theException) {
+		when(myInterceptorBroadcasterMock.hasHooks(Pointcut.CDS_HOOK_PREFETCH_REQUEST)).thenReturn(true);
+		when(myInterceptorBroadcasterMock.hasHooks(Pointcut.CDS_HOOK_PREFETCH_FAILED)).thenReturn(true);
+		when(myCdsResolutionStrategySvc.determineResolutionStrategy(myServiceMethodMock, theRequest)).thenReturn(Set.of(theResolutionStrategy));
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(theServiceDefinition);
+		if (theResolutionStrategy == CdsResolutionStrategyEnum.FHIR_CLIENT) {
+			when(myCdsPrefetchFhirClientSvc.resourceFromUrl(eq(theRequest), any(String.class))).thenThrow(theException);
+		}
+		else if (theResolutionStrategy == CdsResolutionStrategyEnum.DAO) {
+			when(myCdsPrefetchDaoSvc.resourceFromUrl(any(String.class))).thenThrow(theException);
+		}
+	}
+
+	private void setupMocksPrefetchSuccess(CdsServiceRequestJson theRequest,
+										   CdsServiceJson theServiceDefinition,
+										   CdsResolutionStrategyEnum theResolutionStrategy,
+										   IBaseResource theResource) {
+		when(myInterceptorBroadcasterMock.hasHooks(Pointcut.CDS_HOOK_PREFETCH_REQUEST)).thenReturn(true);
+		when(myInterceptorBroadcasterMock.hasHooks(Pointcut.CDS_HOOK_PREFETCH_RESPONSE)).thenReturn(true);
+		when(myCdsResolutionStrategySvc.determineResolutionStrategy(myServiceMethodMock, theRequest)).thenReturn(Set.of(theResolutionStrategy));
+		when(myServiceMethodMock.getCdsServiceJson()).thenReturn(theServiceDefinition);
+		if (theResolutionStrategy == CdsResolutionStrategyEnum.FHIR_CLIENT) {
+			when(myCdsPrefetchFhirClientSvc.resourceFromUrl(eq(theRequest), any(String.class))).thenReturn(theResource);
+		}
+		else if (theResolutionStrategy == CdsResolutionStrategyEnum.DAO) {
+			when(myCdsPrefetchDaoSvc.resourceFromUrl(any(String.class))).thenReturn(theResource);
+		}
 	}
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/cdshooks/CdsServiceRequestJson.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/cdshooks/CdsServiceRequestJson.java
@@ -119,6 +119,13 @@ public class CdsServiceRequestJson extends BaseCdsServiceJson {
 		return myPrefetch.get(theKey);
 	}
 
+	public void removePrefetch(String theKey) {
+		if (myPrefetch == null) {
+			return;
+		}
+		myPrefetch.remove(theKey);
+	}
+
 	public void addContext(String theKey, Object theValue) {
 		getContext().put(theKey, theValue);
 	}


### PR DESCRIPTION
closes: #6836 
Added a new  optional `failureMode` property on the `CDSServicePrefetch` annotation. This allows CDS Hooks services to specify how to handle prefetch failures. 
The failure mode can be set to `FAIL` (default), `OMIT` or `OPERATION_OUTCOME. It 
applies in cases where an auto-prefetch request fails, or the CDS Client sends an OperationOutcome as a prefetch 
resource, which is allowed by the [CDS Hooks version 2.0](https://cds-hooks.hl7.org/2.0/) specification.

