### PR TITLE
fix: nested modifierExtensions are not allowed

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -2006,11 +2006,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 				// Write child extensions
 				if (!ext.getExtension().isEmpty()) {
 
-					if (myModifier) {
-						beginArray(theEventWriter, "modifierExtension");
-					} else {
-						beginArray(theEventWriter, "extension");
-					}
+					beginArray(theEventWriter, "extension");
 
 					for (Object next : ext.getExtension()) {
 						writeUndeclaredExtension(

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
@@ -1452,6 +1452,29 @@ public class JsonParserR4Test extends BaseTest {
 		assertThat(patientString).doesNotContain("fhir_comment");
 	}
 
+	@Test
+	public void testNestedModifierExtensions() {
+		// Claim: modifier extensions may have nested extensions. Even if they are
+		// automatically treated as modifier extensions themselves, their key in serialized
+		// output must be "extension" and not "modifierExtension".
+		final Extension nestedExtension = new Extension();
+		nestedExtension.setUrl("http://example.com/nested-extension");
+		nestedExtension.setValue(new StringType("value"));
+
+		final Extension extension = new Extension();
+		extension.setUrl("http://example.com/extension");
+		extension.addExtension(nestedExtension);
+
+		final Patient patient = new Patient();
+		patient.addModifierExtension(extension);
+
+		final String patientStringJSON = ourCtx.newJsonParser().encodeResourceToString(patient);
+		assertThat(patientStringJSON).containsOnlyOnce("\"modifierExtension\"");
+
+		final String patientStringXML = ourCtx.newXmlParser().encodeResourceToString(patient);
+		assertThat(patientStringXML).containsOnlyOnce("<modifierExtension");
+	}
+
 	static List<String> patientStrs() {
 		List<String> resources = new ArrayList<>();
 


### PR DESCRIPTION
This is a proposed fix to an observed bug.

We are using JSON to communicate with our FHIR server, and we received the following output:
```json
{
  "resourceType": "MedicationRequest",
  ...
  "modifierExtension": [
    {
      "url": "http://esveikata.lt/Profile/lt-med-prescription#prescriptionStatus",
      "modifierExtension": [
        {
          "url": "http://esveikata.lt/Profile/lt-med-prescription#prescriptionStatusCode",
          "valueCode": "active"
        },
        ...
```

According to FHIR spec (irrelevant of version) [link](https://www.hl7.org/fhir/R4B/extensibility.html#modifierExtension):
> Note that complex extensions are allowed to have elements in the complex extension that are marked [Is-Modifier = true](https://www.hl7.org/fhir/R4B/conformance-rules.html#isModifier), which means that these elements modify the extension value itself. Internal extensions like this marked "Is-Modifier" are still represented using the extension element, not modifierExtension because the impact of the modifier element is expected to be known by applications that understand the containing extension.

Also, the same resource when using xml is emitted as:
```xml
<MedicationRequest xmlns="http://hl7.org/fhir">
...
    <modifierExtension url="http://esveikata.lt/Profile/lt-med-prescription#prescriptionStatus">
        <extension url="http://esveikata.lt/Profile/lt-med-prescription#prescriptionStatusCode">
            <valueCode value="active"></valueCode>
        </extension>
        ...
```

The proposed fix simply removes the seemingly incorrect condition. I was unable to build and test this locally, if you could provide me with a snapshot build of this commit, I would be able to plug this into our production system and validate.




