### PR TITLE
Add IRepositoryFactory and HapiFhirRepository

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/repository/IRepository.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/repository/IRepository.java
@@ -55,7 +55,7 @@ import java.util.Map;
  * <p>
  * One particularly odd case are FHIR Bundle links. The specification describes these as opaque to
  * the end-user, so a given FHIR repository implementation must be able to resolve those directly.
- * See {@link Repository#link(Class, String)}
+ * See {@link IRepository#link(Class, String)}
  * </p>
  *
  * <p>
@@ -84,7 +84,7 @@ import java.util.Map;
  * @see <a href="https://www.hl7.org/fhir/http.html">FHIR REST API</a>
  */
 @Beta
-public interface Repository {
+public interface IRepository {
 
 	// CRUD starts here
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6872-add-hapi-fhir-repository.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6872-add-hapi-fhir-repository.yaml
@@ -1,4 +1,5 @@
 ---
 type: add
 issue: 6872
-title: "Add the IRepositoryFactory interface and HapiFhirRepository implementation from the Clinical Reasoning module to the base HAPI packages."
+title: "Add the IRepositoryFactory interface and HapiFhirRepository implementation from the Clinical Reasoning module to the base HAPI packages.
+  This will allow for broader usage without having a dependency on the Clinical Reasoning module."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6872-add-hapi-fhir-repository.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6872-add-hapi-fhir-repository.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 6872
+title: "Add the IRepositoryFactory interface and HapiFhirRepository implementation from the Clinical Reasoning module to the base HAPI packages."

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsCrConfig.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsCrConfig.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Import;
  * Adding the condition to the configs themselves causes issues with downstream projects.
  *
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Conditional(CrConfigCondition.class)
 @Import({RepositoryConfig.class, ApplyOperationConfig.class})

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
@@ -117,11 +117,13 @@ public class CdsHooksConfig {
 				CDSHooksVersion.getOrDefault(theCDSHooksVersion));
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	@Bean
 	public ICdsCrServiceRegistry cdsCrServiceRegistry() {
 		return new CdsCrServiceRegistry();
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	@Bean
 	public ICdsCrServiceFactory cdsCrServiceFactory(
 			FhirContext theFhirContext,
@@ -153,11 +155,13 @@ public class CdsHooksConfig {
 		};
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	@Bean
 	public ICdsCrDiscoveryServiceRegistry cdsCrDiscoveryServiceRegistry() {
 		return new CdsCrDiscoveryServiceRegistry();
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	@Bean
 	public ICrDiscoveryServiceFactory crDiscoveryServiceFactory(
 			FhirContext theFhirContext,
@@ -189,6 +193,7 @@ public class CdsHooksConfig {
 		};
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	@Bean
 	public CdsServiceInterceptor cdsServiceInterceptor() {
 		if (myResourceChangeListenerRegistry == null) {

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/BaseCdsCrMethod.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/BaseCdsCrMethod.java
@@ -27,6 +27,7 @@ import ca.uhn.hapi.fhir.cdshooks.api.ICdsMethod;
 import ca.uhn.hapi.fhir.cdshooks.svc.cr.ICdsCrServiceFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 abstract class BaseCdsCrMethod implements ICdsMethod {
 	private ICdsCrServiceFactory myCdsCrServiceFactory;
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsConfigServiceImpl.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsConfigServiceImpl.java
@@ -37,6 +37,15 @@ public class CdsConfigServiceImpl implements ICdsConfigService {
 	private final IRepositoryFactory myRepositoryFactory;
 	private final RestfulServer myRestfulServer;
 
+	// Constructor without deprecated arguments
+	public CdsConfigServiceImpl(
+			@Nonnull FhirContext theFhirContext,
+			@Nonnull ObjectMapper theObjectMapper,
+			@Nullable DaoRegistry theDaoRegistry,
+			@Nullable RestfulServer theRestfulServer) {
+		this(theFhirContext, theObjectMapper, new CdsCrSettings(), theDaoRegistry, null, theRestfulServer);
+	}
+
 	public CdsConfigServiceImpl(
 			@Nonnull FhirContext theFhirContext,
 			@Nonnull ObjectMapper theObjectMapper,

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsConfigServiceImpl.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsConfigServiceImpl.java
@@ -37,15 +37,20 @@ public class CdsConfigServiceImpl implements ICdsConfigService {
 	private final IRepositoryFactory myRepositoryFactory;
 	private final RestfulServer myRestfulServer;
 
-	// Constructor without deprecated arguments
 	public CdsConfigServiceImpl(
 			@Nonnull FhirContext theFhirContext,
 			@Nonnull ObjectMapper theObjectMapper,
 			@Nullable DaoRegistry theDaoRegistry,
 			@Nullable RestfulServer theRestfulServer) {
-		this(theFhirContext, theObjectMapper, new CdsCrSettings(), theDaoRegistry, null, theRestfulServer);
+		myFhirContext = theFhirContext;
+		myObjectMapper = theObjectMapper;
+		myDaoRegistry = theDaoRegistry;
+		myRestfulServer = theRestfulServer;
+		myCdsCrSettings = new CdsCrSettings();
+		myRepositoryFactory = null;
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	public CdsConfigServiceImpl(
 			@Nonnull FhirContext theFhirContext,
 			@Nonnull ObjectMapper theObjectMapper,

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsCrServiceMethod.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsCrServiceMethod.java
@@ -23,6 +23,7 @@ import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 import ca.uhn.hapi.fhir.cdshooks.svc.cr.ICdsCrServiceFactory;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrServiceMethod extends BaseCdsCrMethod implements ICdsServiceMethod {
 	private final CdsServiceJson myCdsServiceJson;
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceCache.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceCache.java
@@ -75,6 +75,7 @@ public class CdsServiceCache {
 		}
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	public void registerCrService(
 			String theServiceId,
 			ICrDiscoveryServiceFactory theDiscoveryServiceFactory,

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImpl.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImpl.java
@@ -60,6 +60,22 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 	private final ICrDiscoveryServiceFactory myCrDiscoveryServiceFactory;
 	private final CDSHooksVersion myCdsHooksVersion;
 
+	// Constructor without deprecated arguments
+	public CdsServiceRegistryImpl(
+			CdsHooksContextBooter theCdsHooksContextBooter,
+			CdsPrefetchSvc theCdsPrefetchSvc,
+			ObjectMapper theObjectMapper,
+			CdsServiceRequestJsonDeserializer theCdsServiceRequestJsonDeserializer) {
+		this(
+				theCdsHooksContextBooter,
+				theCdsPrefetchSvc,
+				theObjectMapper,
+				null,
+				null,
+				theCdsServiceRequestJsonDeserializer,
+				CDSHooksVersion.DEFAULT);
+	}
+
 	public CdsServiceRegistryImpl(
 			CdsHooksContextBooter theCdsHooksContextBooter,
 			CdsPrefetchSvc theCdsPrefetchSvc,
@@ -140,6 +156,7 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 				theServiceId, theServiceFunction, theCdsServiceJson, theAllowAutoFhirClientPrefetch, theServiceGroupId);
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	@Override
 	public boolean registerCrService(String theServiceId) {
 		try {

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImpl.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImpl.java
@@ -60,7 +60,6 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 	private final ICrDiscoveryServiceFactory myCrDiscoveryServiceFactory;
 	private final CDSHooksVersion myCdsHooksVersion;
 
-	// Constructor without deprecated arguments
 	public CdsServiceRegistryImpl(
 			CdsHooksContextBooter theCdsHooksContextBooter,
 			CdsPrefetchSvc theCdsPrefetchSvc,
@@ -70,12 +69,26 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 				theCdsHooksContextBooter,
 				theCdsPrefetchSvc,
 				theObjectMapper,
-				null,
-				null,
 				theCdsServiceRequestJsonDeserializer,
 				CDSHooksVersion.DEFAULT);
 	}
 
+	public CdsServiceRegistryImpl(
+			CdsHooksContextBooter theCdsHooksContextBooter,
+			CdsPrefetchSvc theCdsPrefetchSvc,
+			ObjectMapper theObjectMapper,
+			CdsServiceRequestJsonDeserializer theCdsServiceRequestJsonDeserializer,
+			CDSHooksVersion theCDSHooksVersion) {
+		myCdsHooksContextBooter = theCdsHooksContextBooter;
+		myCdsPrefetchSvc = theCdsPrefetchSvc;
+		myObjectMapper = theObjectMapper;
+		myCdsServiceRequestJsonDeserializer = theCdsServiceRequestJsonDeserializer;
+		myCdsHooksVersion = theCDSHooksVersion;
+		myCdsCrServiceFactory = null;
+		myCrDiscoveryServiceFactory = null;
+	}
+
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	public CdsServiceRegistryImpl(
 			CdsHooksContextBooter theCdsHooksContextBooter,
 			CdsPrefetchSvc theCdsPrefetchSvc,
@@ -93,6 +106,7 @@ public class CdsServiceRegistryImpl implements ICdsServiceRegistry {
 				CDSHooksVersion.DEFAULT);
 	}
 
+	@Deprecated(since = "8.1.4", forRemoval = true)
 	public CdsServiceRegistryImpl(
 			CdsHooksContextBooter theCdsHooksContextBooter,
 			CdsPrefetchSvc theCdsPrefetchSvc,

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrConstants.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrConstants.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.hapi.fhir.cdshooks.svc.cr;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrConstants {
 	private CdsCrConstants() {}
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceDstu3.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceDstu3.java
@@ -64,6 +64,7 @@ import static ca.uhn.hapi.fhir.cdshooks.svc.cr.CdsCrConstants.CDS_PARAMETER_USER
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.part;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrServiceDstu3 implements ICdsCrService {
 	protected final RequestDetails myRequestDetails;
 	protected final Repository myRepository;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceR4.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceR4.java
@@ -66,6 +66,7 @@ import static ca.uhn.hapi.fhir.cdshooks.svc.cr.CdsCrConstants.CDS_PARAMETER_USER
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrServiceR4 implements ICdsCrService {
 	protected final RequestDetails myRequestDetails;
 	protected final Repository myRepository;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceR5.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceR5.java
@@ -66,6 +66,7 @@ import static ca.uhn.hapi.fhir.cdshooks.svc.cr.CdsCrConstants.CDS_PARAMETER_USER
 import static org.opencds.cqf.fhir.utility.r5.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.part;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrServiceR5 implements ICdsCrService {
 	protected final RequestDetails myRequestDetails;
 	protected final Repository myRepository;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceRegistry.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrServiceRegistry.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrServiceRegistry implements ICdsCrServiceRegistry {
 	private final Map<FhirVersionEnum, Class<? extends ICdsCrService>> myCdsCrServices;
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrSettings.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrSettings.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.hapi.fhir.cdshooks.svc.cr;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrSettings {
 	private final String DEFAULT_CLIENT_ID_HEADER_NAME = "client_id";
 	private String myClientIdHeaderName;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrUtils.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsCrUtils.java
@@ -24,6 +24,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.fhir.api.Repository;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrUtils {
 	public static IBaseResource readPlanDefinitionFromRepository(
 			FhirVersionEnum theFhirVersion, Repository theRepository, IIdType theId) {

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsServiceInterceptor.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/CdsServiceInterceptor.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import static ca.uhn.hapi.fhir.cdshooks.svc.cr.CdsCrConstants.CDS_CR_MODULE_ID;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsServiceInterceptor implements IResourceChangeListener {
 	static final Logger ourLog = LoggerFactory.getLogger(CdsServiceInterceptor.class);
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/ICdsCrService.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/ICdsCrService.java
@@ -31,6 +31,7 @@ import org.opencds.cqf.fhir.api.Repository;
 
 import java.util.Collections;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICdsCrService {
 	IBaseParameters encodeParams(CdsServiceRequestJson theJson);
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/ICdsCrServiceFactory.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/ICdsCrServiceFactory.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.hapi.fhir.cdshooks.svc.cr;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICdsCrServiceFactory {
 	ICdsCrService create(String theServiceId);
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/ICdsCrServiceRegistry.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/ICdsCrServiceRegistry.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Nonnull;
 
 import java.util.Optional;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICdsCrServiceRegistry {
 	void register(@Nonnull FhirVersionEnum theFhirVersion, @Nonnull Class<? extends ICdsCrService> theCdsCrService);
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CdsCrDiscoveryServiceRegistry.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CdsCrDiscoveryServiceRegistry.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CdsCrDiscoveryServiceRegistry implements ICdsCrDiscoveryServiceRegistry {
 	private final Map<FhirVersionEnum, Class<? extends ICrDiscoveryService>> myCrDiscoveryServices;
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryElementDstu3.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryElementDstu3.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r4.model.TriggerDefinition;
 
 import java.util.stream.Collectors;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrDiscoveryElementDstu3 implements ICrDiscoveryElement {
 	protected PlanDefinition myPlanDefinition;
 	protected PrefetchUrlList myPrefetchUrlList;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryElementR4.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryElementR4.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r4.model.TriggerDefinition;
 
 import java.util.stream.Collectors;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrDiscoveryElementR4 implements ICrDiscoveryElement {
 	protected PlanDefinition myPlanDefinition;
 	protected PrefetchUrlList myPrefetchUrlList;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryElementR5.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryElementR5.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r5.model.PlanDefinition;
 
 import java.util.stream.Collectors;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrDiscoveryElementR5 implements ICrDiscoveryElement {
 	protected PlanDefinition myPlanDefinition;
 	protected PrefetchUrlList myPrefetchUrlList;

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryServiceDstu3.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryServiceDstu3.java
@@ -36,6 +36,7 @@ import org.opencds.cqf.fhir.utility.dstu3.SearchHelper;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrDiscoveryServiceDstu3 implements ICrDiscoveryService {
 
 	protected final String PATIENT_ID_CONTEXT = "{{context.patientId}}";

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryServiceR4.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryServiceR4.java
@@ -36,6 +36,7 @@ import org.opencds.cqf.fhir.utility.r4.SearchHelper;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrDiscoveryServiceR4 implements ICrDiscoveryService {
 
 	protected final String PATIENT_ID_CONTEXT = "{{context.patientId}}";

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryServiceR5.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/CrDiscoveryServiceR5.java
@@ -36,6 +36,7 @@ import org.opencds.cqf.fhir.utility.r5.SearchHelper;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrDiscoveryServiceR5 implements ICrDiscoveryService {
 
 	protected final String PATIENT_ID_CONTEXT = "{{context.patientId}}";

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICdsCrDiscoveryServiceRegistry.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICdsCrDiscoveryServiceRegistry.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Nonnull;
 
 import java.util.Optional;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICdsCrDiscoveryServiceRegistry {
 	void register(
 			@Nonnull FhirVersionEnum theFhirVersion, @Nonnull Class<? extends ICrDiscoveryService> ICrDiscoveryService);

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICrDiscoveryElement.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICrDiscoveryElement.java
@@ -21,6 +21,7 @@ package ca.uhn.hapi.fhir.cdshooks.svc.cr.discovery;
 
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICrDiscoveryElement {
 	CdsServiceJson getCdsServiceJson();
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICrDiscoveryService.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICrDiscoveryService.java
@@ -21,6 +21,7 @@ package ca.uhn.hapi.fhir.cdshooks.svc.cr.discovery;
 
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICrDiscoveryService {
 	CdsServiceJson resolveService();
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICrDiscoveryServiceFactory.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/ICrDiscoveryServiceFactory.java
@@ -19,6 +19,7 @@
  */
 package ca.uhn.hapi.fhir.cdshooks.svc.cr.discovery;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ICrDiscoveryServiceFactory {
 	ICrDiscoveryService create(String theServiceId);
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/PrefetchUrlList.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/cr/discovery/PrefetchUrlList.java
@@ -22,6 +22,7 @@ package ca.uhn.hapi.fhir.cdshooks.svc.cr.discovery;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class PrefetchUrlList extends CopyOnWriteArrayList<String> {
 
 	@Override

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImplTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/CdsServiceRegistryImplTest.java
@@ -9,8 +9,6 @@ import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceFeedbackJson;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceResponseJson;
 import ca.uhn.hapi.fhir.cdshooks.serializer.CdsServiceRequestJsonDeserializer;
-import ca.uhn.hapi.fhir.cdshooks.svc.cr.ICdsCrServiceFactory;
-import ca.uhn.hapi.fhir.cdshooks.svc.cr.discovery.ICrDiscoveryServiceFactory;
 import ca.uhn.hapi.fhir.cdshooks.svc.prefetch.CdsPrefetchSvc;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -39,10 +36,6 @@ class CdsServiceRegistryImplTest {
 	@Mock
 	private CdsPrefetchSvc myCdsPrefetchSvc;
 	@Mock
-	private ICdsCrServiceFactory myCdsCrServiceFactory;
-	@Mock
-	private ICrDiscoveryServiceFactory myCrDiscoveryServiceFactory;
-	@Mock
 	private CdsServiceCache myCdsServiceCache;
 	@Mock
 	private CdsServiceRequestJsonDeserializer myCdsServiceRequestJsonDeserializer;
@@ -51,7 +44,7 @@ class CdsServiceRegistryImplTest {
 
 	@BeforeEach()
 	void setup() {
-		myFixture = new CdsServiceRegistryImpl(myCdsHooksContextBooter, myCdsPrefetchSvc, myObjectMapper, myCdsCrServiceFactory, myCrDiscoveryServiceFactory, myCdsServiceRequestJsonDeserializer);
+		myFixture = new CdsServiceRegistryImpl(myCdsHooksContextBooter, myCdsPrefetchSvc, myObjectMapper, myCdsServiceRequestJsonDeserializer);
 	}
 
 	@Test
@@ -228,8 +221,6 @@ class CdsServiceRegistryImplTest {
 			myCdsHooksContextBooter,
 			myCdsPrefetchSvc,
 			myObjectMapper,
-			myCdsCrServiceFactory,
-			myCrDiscoveryServiceFactory,
 			myCdsServiceRequestJsonDeserializer,
 			theCdsHooksVersion);
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
@@ -9,5 +9,5 @@ import com.google.common.annotations.Beta;
 @FunctionalInterface
 @Beta
 public interface IRepositoryFactory {
-    Repository create(RequestDetails requestDetails);
+	Repository create(RequestDetails requestDetails);
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR - Server Framework
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.rest.api.server;
 
 import ca.uhn.fhir.repository.Repository;
@@ -9,5 +28,5 @@ import com.google.common.annotations.Beta;
 @FunctionalInterface
 @Beta
 public interface IRepositoryFactory {
-	Repository create(RequestDetails requestDetails);
+	Repository create(RequestDetails theRequestDetails);
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
@@ -19,14 +19,14 @@
  */
 package ca.uhn.fhir.rest.api.server;
 
-import ca.uhn.fhir.repository.Repository;
+import ca.uhn.fhir.repository.IRepository;
 import com.google.common.annotations.Beta;
 
 /**
- * Factory interface to return a {@link Repository} from a {@link RequestDetails}
+ * Factory interface to return a {@link IRepository} from a {@link RequestDetails}
  */
 @FunctionalInterface
 @Beta
 public interface IRepositoryFactory {
-	Repository create(RequestDetails theRequestDetails);
+	IRepository create(RequestDetails theRequestDetails);
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/IRepositoryFactory.java
@@ -1,0 +1,13 @@
+package ca.uhn.fhir.rest.api.server;
+
+import ca.uhn.fhir.repository.Repository;
+import com.google.common.annotations.Beta;
+
+/**
+ * Factory interface to return a {@link Repository} from a {@link RequestDetails}
+ */
+@FunctionalInterface
+@Beta
+public interface IRepositoryFactory {
+    Repository create(RequestDetails requestDetails);
+}

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/CanonicalHelper.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/CanonicalHelper.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.common;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CanonicalHelper {
 	public static <C extends IPrimitiveType<String>> C getCanonicalType(
 			FhirVersionEnum fhirVersion, String theCanonical, String theUrl, String theVersion) {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/CodeCacheResourceChangeListener.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/CodeCacheResourceChangeListener.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 /**
  * This class listens for changes to ValueSet resources and invalidates the CodeCache. The CodeCache is used in CQL evaluation to speed up terminology operations. If ValueSet changes, it's possible that the constituent codes change and therefore the cache needs to be updated.
  **/
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CodeCacheResourceChangeListener implements IResourceChangeListener {
 
 	private static final org.slf4j.Logger ourLog =

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/CqlThreadFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/CqlThreadFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ThreadFactory;
  * This class resolves issues with loading JAXB in a server environment and using CompletableFutures
  * https://stackoverflow.com/questions/49113207/completablefuture-forkjoinpool-set-class-loader
  **/
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CqlThreadFactory implements ThreadFactory {
 	@Override
 	public Thread newThread(Runnable r) {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/ElmCacheResourceChangeListener.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/ElmCacheResourceChangeListener.java
@@ -39,6 +39,7 @@ import java.util.function.Function;
 /**
  * This class listens for changes to Library resources and invalidates the CodeCache. The CodeCache is used in CQL evaluatuon to speed up the measure operations. If underlying values change in the library then cache requires updating.
  **/
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ElmCacheResourceChangeListener implements IResourceChangeListener {
 
 	private static final org.slf4j.Logger ourLog =

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IActivityDefinitionProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IActivityDefinitionProcessorFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.activitydefinition.ActivityDefinitionProcessor;
 /**
  * This interface takes a RequestDetails object and uses it to create a Repository which is passed to the constructor of the processor class being instantiated.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IActivityDefinitionProcessorFactory {
 	ActivityDefinitionProcessor create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/ILibraryProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/ILibraryProcessorFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.library.LibraryProcessor;
 /**
  * This interface takes a RequestDetails object and uses it to create a Repository which is passed to the constructor of the processor class being instantiated.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface ILibraryProcessorFactory {
 	LibraryProcessor create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IPlanDefinitionProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IPlanDefinitionProcessorFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.plandefinition.PlanDefinitionProcessor;
 /**
  * This interface takes a RequestDetails object and uses it to create a Repository which is passed to the constructor of the processor class being instantiated.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IPlanDefinitionProcessorFactory {
 	PlanDefinitionProcessor create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IQuestionnaireProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IQuestionnaireProcessorFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.questionnaire.QuestionnaireProcessor;
 /**
  * This interface takes a RequestDetails object and uses it to create a Repository which is passed to the constructor of the processor class being instantiated.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IQuestionnaireProcessorFactory {
 	QuestionnaireProcessor create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IQuestionnaireResponseProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IQuestionnaireResponseProcessorFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.questionnaireresponse.QuestionnaireResponseProces
 /**
  * This interface takes a RequestDetails object and uses it to create a Repository which is passed to the constructor of the processor class being instantiated.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IQuestionnaireResponseProcessorFactory {
 	QuestionnaireResponseProcessor create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IRepositoryFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IRepositoryFactory.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.cr.repo.HapiFhirRepository;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import com.google.common.annotations.Beta;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 @Beta
 public interface IRepositoryFactory {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IValueSetProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IValueSetProcessorFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.valueset.ValueSetProcessor;
 /**
  * This interface takes a RequestDetails object and uses it to create a Repository which is passed to the constructor of the processor class being instantiated.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IValueSetProcessorFactory {
 	ValueSetProcessor create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IdHelper.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/IdHelper.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.fhir.utility.Ids;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class IdHelper {
 	public static IIdType getIdType(FhirVersionEnum fhirVersion, String resourceType, String theId) {
 		if (StringUtils.isBlank(theId)) {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/RepositoryFactoryForRepositoryInterface.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/RepositoryFactoryForRepositoryInterface.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.api.Repository;
 /**
  * Factory interface to return a {@link Repository} from a {@link RequestDetails}
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface RepositoryFactoryForRepositoryInterface {
 	Repository create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/StringTimePeriodHandler.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/common/StringTimePeriodHandler.java
@@ -54,6 +54,7 @@ import java.util.function.Function;
  * <p/>
  * Also used for various operations to serialize/deserialize dates to/from JSON classes.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class StringTimePeriodHandler {
 	private static final Logger ourLog = LoggerFactory.getLogger(StringTimePeriodHandler.class);
 

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/CrBaseConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/CrBaseConfig.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.time.ZoneOffset;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 public class CrBaseConfig {
 

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/CrConfigCondition.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/CrConfigCondition.java
@@ -31,6 +31,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 /**
  * The purpose of this Condition is to verify that the CR dependent beans RestfulServer and EvaluationSettings exist.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CrConfigCondition implements Condition {
 	private static final Logger ourLog = LoggerFactory.getLogger(CrConfigCondition.class);
 

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/CrProcessorConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/CrProcessorConfig.java
@@ -30,6 +30,7 @@ import org.opencds.cqf.fhir.cr.valueset.ValueSetProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 public class CrProcessorConfig {
 	@Bean

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/ProviderLoader.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/ProviderLoader.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ProviderLoader {
 	private static final Logger myLogger = LoggerFactory.getLogger(ProviderLoader.class);
 	private final ApplicationContext myApplicationContext;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/ProviderSelector.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/ProviderSelector.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ProviderSelector {
 	private final FhirContext myFhirContext;
 	private final Map<FhirVersionEnum, List<Class<?>>> myProviderMap;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/RepositoryConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/RepositoryConfig.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.rest.server.RestfulServer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 public class RepositoryConfig {
 

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/RepositoryConfigCondition.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/RepositoryConfigCondition.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class RepositoryConfigCondition implements Condition {
 	private static final Logger ourLog = LoggerFactory.getLogger(RepositoryConfigCondition.class);
 

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/ApplyOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/ApplyOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class ApplyOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/CrDstu3Config.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/CrDstu3Config.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import({RepositoryConfig.class, CrBaseConfig.class})
 public class CrDstu3Config {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/DataRequirementsOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/DataRequirementsOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class DataRequirementsOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/EvaluateOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/EvaluateOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class EvaluateOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/PackageOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/dstu3/PackageOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class PackageOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/ApplyOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/ApplyOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class ApplyOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/CrR4Config.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/CrR4Config.java
@@ -61,6 +61,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import({RepositoryConfig.class, CrBaseConfig.class})
 public class CrR4Config {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/DataRequirementsOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/DataRequirementsOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class DataRequirementsOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/EvaluateOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/EvaluateOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class EvaluateOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/ExtractOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/ExtractOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class ExtractOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/PackageOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/PackageOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class PackageOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/PopulateOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/PopulateOperationConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import(CrProcessorConfig.class)
 public class PopulateOperationConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/QuestionnaireOperationConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/r4/QuestionnaireOperationConfig.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Bean;
 import java.util.Arrays;
 import java.util.Map;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnaireOperationConfig {
 	@Bean
 	ca.uhn.fhir.cr.r4.structuredefinition.StructureDefinitionQuestionnaireProvider

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCqlProperties.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCqlProperties.java
@@ -29,7 +29,7 @@ import org.opencds.cqf.fhir.cql.CqlOptions;
 /**
  * Common CQL properties shared with downstream modules.
  */
-@Deprecated(since="8.1.4", forRemoval = true)
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class TestCqlProperties {
 
 	//cql settings

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCqlProperties.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCqlProperties.java
@@ -29,6 +29,7 @@ import org.opencds.cqf.fhir.cql.CqlOptions;
 /**
  * Common CQL properties shared with downstream modules.
  */
+@Deprecated(since="8.1.4", forRemoval = true)
 public class TestCqlProperties {
 
 	//cql settings

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrConfig.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Common hapi-fhir clinical reasoning config shared with downstream modules.
  */
+@Deprecated(since="8.1.4", forRemoval = true)
 @Configuration
 @Import({SubscriptionSubmitterConfig.class, SubscriptionChannelConfig.class})
 public class TestCrConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrConfig.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrConfig.java
@@ -69,7 +69,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Common hapi-fhir clinical reasoning config shared with downstream modules.
  */
-@Deprecated(since="8.1.4", forRemoval = true)
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import({SubscriptionSubmitterConfig.class, SubscriptionChannelConfig.class})
 public class TestCrConfig {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrStorageSettingsConfigurer.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrStorageSettingsConfigurer.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.cr.config.test;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 
+@Deprecated(since="8.1.4", forRemoval = true)
 public class TestCrStorageSettingsConfigurer {
 
 	private final JpaStorageSettings myStorageSettings;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrStorageSettingsConfigurer.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/TestCrStorageSettingsConfigurer.java
@@ -21,7 +21,7 @@ package ca.uhn.fhir.cr.config.test;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 
-@Deprecated(since="8.1.4", forRemoval = true)
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class TestCrStorageSettingsConfigurer {
 
 	private final JpaStorageSettings myStorageSettings;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/r4/TestCrR4Config.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/r4/TestCrR4Config.java
@@ -52,7 +52,7 @@ import java.util.concurrent.Executors;
 /**
  * Common hapi-fhir clinical reasoning config specifically for R4 shared with downstream modules.
  */
-@Deprecated(since="8.1.4", forRemoval = true)
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Configuration
 @Import({TestCrConfig.class, CrR4Config.class})
 public class TestCrR4Config {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/r4/TestCrR4Config.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/config/test/r4/TestCrR4Config.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Executors;
 /**
  * Common hapi-fhir clinical reasoning config specifically for R4 shared with downstream modules.
  */
+@Deprecated(since="8.1.4", forRemoval = true)
 @Configuration
 @Import({TestCrConfig.class, CrR4Config.class})
 public class TestCrR4Config {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/IMeasureServiceFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/IMeasureServiceFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.dstu3;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.dstu3.Dstu3MeasureService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IMeasureServiceFactory {
 	Dstu3MeasureService create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/activitydefinition/ActivityDefinitionApplyProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/activitydefinition/ActivityDefinitionApplyProvider.java
@@ -41,6 +41,7 @@ import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Component
 public class ActivityDefinitionApplyProvider {
 	@Autowired

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/library/LibraryDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/library/LibraryDataRequirementsProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class LibraryDataRequirementsProvider {
 	@Autowired
 	ILibraryProcessorFactory myLibraryProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/library/LibraryEvaluateProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/library/LibraryEvaluateProvider.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class LibraryEvaluateProvider {
 	@Autowired
 	ILibraryProcessorFactory myLibraryProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/library/LibraryPackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/library/LibraryPackageProvider.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class LibraryPackageProvider {
 	@Autowired
 	ILibraryProcessorFactory myLibraryProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/measure/MeasureOperationsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/measure/MeasureOperationsProvider.java
@@ -36,6 +36,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Component
 public class MeasureOperationsProvider {
 	@Autowired

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/plandefinition/PlanDefinitionApplyProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/plandefinition/PlanDefinitionApplyProvider.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Component
 public class PlanDefinitionApplyProvider {
 	@Autowired

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/plandefinition/PlanDefinitionDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/plandefinition/PlanDefinitionDataRequirementsProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class PlanDefinitionDataRequirementsProvider {
 	@Autowired
 	IPlanDefinitionProcessorFactory myPlanDefinitionProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/plandefinition/PlanDefinitionPackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/plandefinition/PlanDefinitionPackageProvider.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class PlanDefinitionPackageProvider {
 	@Autowired
 	IPlanDefinitionProcessorFactory myPlanDefinitionProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/questionnaire/QuestionnaireDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/questionnaire/QuestionnaireDataRequirementsProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnaireDataRequirementsProvider {
 	@Autowired
 	IQuestionnaireProcessorFactory myQuestionnaireFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/questionnaire/QuestionnairePackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/questionnaire/QuestionnairePackageProvider.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnairePackageProvider {
 	@Autowired
 	IQuestionnaireProcessorFactory myQuestionnaireProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/valueset/ValueSetDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/valueset/ValueSetDataRequirementsProvider.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ValueSetDataRequirementsProvider {
 	@Autowired
 	IValueSetProcessorFactory myValueSetFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/valueset/ValueSetPackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/dstu3/valueset/ValueSetPackageProvider.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ValueSetPackageProvider {
 	@Autowired
 	IValueSetProcessorFactory myValueSetProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ICareGapsServiceFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ICareGapsServiceFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.r4.R4CareGapsService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface ICareGapsServiceFactory {
 	R4CareGapsService create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ICollectDataServiceFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ICollectDataServiceFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.r4.R4CollectDataService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface ICollectDataServiceFactory {
 	R4CollectDataService create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ICqlExecutionServiceFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ICqlExecutionServiceFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.cpg.r4.R4CqlExecutionService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface ICqlExecutionServiceFactory {
 	R4CqlExecutionService create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/IDataRequirementsServiceFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/IDataRequirementsServiceFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.r4.R4DataRequirementsService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IDataRequirementsServiceFactory {
 	R4DataRequirementsService create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/IMeasureServiceFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/IMeasureServiceFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.r4.R4MeasureService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface IMeasureServiceFactory {
 	R4MeasureService create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ISubmitDataProcessorFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/ISubmitDataProcessorFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.r4.R4SubmitDataService;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public interface ISubmitDataProcessorFactory {
 	R4SubmitDataService create(RequestDetails theRequestDetails);
 }

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/R4MeasureEvaluatorSingleFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/R4MeasureEvaluatorSingleFactory.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.cr.r4;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.opencds.cqf.fhir.cr.measure.r4.R4MeasureEvaluatorSingle;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface R4MeasureEvaluatorSingleFactory {
 	R4MeasureEvaluatorSingle create(RequestDetails theRequestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/R4MeasureServiceUtilsFactory.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/R4MeasureServiceUtilsFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureServiceUtils;
 /**
  * Factory to create an {@link R4MeasureServiceUtils} from a {@link RequestDetails}
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 @FunctionalInterface
 public interface R4MeasureServiceUtilsFactory {
 	R4MeasureServiceUtils create(RequestDetails requestDetails);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/activitydefinition/ActivityDefinitionApplyProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/activitydefinition/ActivityDefinitionApplyProvider.java
@@ -41,6 +41,7 @@ import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Component
 public class ActivityDefinitionApplyProvider {
 	@Autowired

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/cpg/CqlExecutionOperationProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/cpg/CqlExecutionOperationProvider.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CqlExecutionOperationProvider {
 
 	@Autowired

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/library/LibraryDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/library/LibraryDataRequirementsProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class LibraryDataRequirementsProvider {
 	@Autowired
 	ILibraryProcessorFactory myLibraryProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/library/LibraryEvaluateProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/library/LibraryEvaluateProvider.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class LibraryEvaluateProvider {
 	@Autowired
 	ILibraryProcessorFactory myLibraryProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/library/LibraryPackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/library/LibraryPackageProvider.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class LibraryPackageProvider {
 	@Autowired
 	ILibraryProcessorFactory myLibraryProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/CareGapsOperationProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/CareGapsOperationProvider.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CareGapsOperationProvider {
 	private final ICareGapsServiceFactory myR4CareGapsProcessorFactory;
 	private final StringTimePeriodHandler myStringTimePeriodHandler;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/CollectDataOperationProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/CollectDataOperationProvider.java
@@ -31,6 +31,7 @@ import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.Parameters;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class CollectDataOperationProvider {
 	private final ICollectDataServiceFactory myR4CollectDataServiceFactory;
 	private final StringTimePeriodHandler myStringTimePeriodHandler;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/DataRequirementsOperationProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/DataRequirementsOperationProvider.java
@@ -30,6 +30,7 @@ import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Measure;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class DataRequirementsOperationProvider {
 	@Autowired
 	IDataRequirementsServiceFactory myR4DataRequirementsServiceFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/MeasureOperationsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/MeasureOperationsProvider.java
@@ -36,6 +36,7 @@ import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.Parameters;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class MeasureOperationsProvider {
 
 	private final R4MeasureEvaluatorSingleFactory myR4MeasureServiceFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/SubmitDataProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/measure/SubmitDataProvider.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class SubmitDataProvider {
 	private static final Logger ourLog = LoggerFactory.getLogger(SubmitDataProvider.class);
 

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/plandefinition/PlanDefinitionApplyProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/plandefinition/PlanDefinitionApplyProvider.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 @Component
 public class PlanDefinitionApplyProvider {
 	@Autowired

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/plandefinition/PlanDefinitionDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/plandefinition/PlanDefinitionDataRequirementsProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class PlanDefinitionDataRequirementsProvider {
 	@Autowired
 	IPlanDefinitionProcessorFactory myPlanDefinitionProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/plandefinition/PlanDefinitionPackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/plandefinition/PlanDefinitionPackageProvider.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class PlanDefinitionPackageProvider {
 	@Autowired
 	IPlanDefinitionProcessorFactory myPlanDefinitionProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaire/QuestionnaireDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaire/QuestionnaireDataRequirementsProvider.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnaireDataRequirementsProvider {
 	@Autowired
 	IQuestionnaireProcessorFactory myQuestionnaireFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaire/QuestionnairePackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaire/QuestionnairePackageProvider.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 import static ca.uhn.fhir.cr.common.IdHelper.getIdType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnairePackageProvider {
 	@Autowired
 	IQuestionnaireProcessorFactory myQuestionnaireProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaire/QuestionnairePopulateProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaire/QuestionnairePopulateProvider.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnairePopulateProvider {
 	@Autowired
 	IQuestionnaireProcessorFactory myQuestionnaireProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaireresponse/QuestionnaireResponseExtractProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/questionnaireresponse/QuestionnaireResponseExtractProvider.java
@@ -38,6 +38,7 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class QuestionnaireResponseExtractProvider {
 	@Autowired
 	IQuestionnaireResponseProcessorFactory myQuestionnaireResponseProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/structuredefinition/StructureDefinitionQuestionnaireProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/structuredefinition/StructureDefinitionQuestionnaireProvider.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class StructureDefinitionQuestionnaireProvider {
 	@Autowired
 	IQuestionnaireProcessorFactory myQuestionnaireProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/valueset/ValueSetDataRequirementsProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/valueset/ValueSetDataRequirementsProvider.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ValueSetDataRequirementsProvider {
 	@Autowired
 	IValueSetProcessorFactory myValueSetFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/valueset/ValueSetPackageProvider.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/r4/valueset/ValueSetPackageProvider.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static ca.uhn.fhir.cr.common.CanonicalHelper.getCanonicalType;
 
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class ValueSetPackageProvider {
 	@Autowired
 	IValueSetProcessorFactory myValueSetProcessorFactory;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/BundleProviderUtil.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/BundleProviderUtil.java
@@ -54,6 +54,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * the results of a BundleProvider and turning it into a Bundle.  It is intended to be used only by the
  * HapiFhirRepository.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class BundleProviderUtil {
 	private static final org.slf4j.Logger ourLog =
 			org.slf4j.LoggerFactory.getLogger(BaseResourceReturningMethodBinding.class);

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/HapiFhirRepository.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/HapiFhirRepository.java
@@ -57,6 +57,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 /**
  * This class leverages DaoRegistry from Hapi-fhir to implement CRUD FHIR API operations constrained to provide only the operations necessary for the cql-evaluator modules to function.
  **/
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class HapiFhirRepository implements Repository {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(HapiFhirRepository.class);
 	private final DaoRegistry myDaoRegistry;

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/RequestDetailsCloner.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/RequestDetailsCloner.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * RequestDetails object for reentrant calls. It retains header and tenancy information while
  * scrapping everything else.
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 class RequestDetailsCloner {
 
 	static DetailsBuilder startWith(RequestDetails theDetails) {

--- a/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/SearchConverter.java
+++ b/hapi-fhir-storage-cr/src/main/java/ca/uhn/fhir/cr/repo/SearchConverter.java
@@ -38,6 +38,7 @@ import java.util.Map;
  * The IGenericClient API represents searches with OrLists, while the FhirRepository API uses nested
  * lists. This class (will eventually) convert between them
  */
+@Deprecated(since = "8.1.4", forRemoval = true)
 public class SearchConverter {
 	// hardcoded list from FHIR specs: https://www.hl7.org/fhir/search.html
 	private final List<String> searchResultParameters = Arrays.asList(

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
@@ -16,13 +16,13 @@ import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -35,9 +35,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  */
 @SuppressWarnings("java:S107")
 public class BundleProviderUtil {
-    private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BundleProviderUtil.class);
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BundleProviderUtil.class);
 
-    private BundleProviderUtil() {}
+	private BundleProviderUtil() {}
 
 	private static class OffsetLimitInfo {
 		private final Integer offset;
@@ -48,419 +48,421 @@ public class BundleProviderUtil {
 			this.limit = limit;
 		}
 
-        int addOffsetAndLimit() {
-            return offsetOrZero() + limitOrZero();
-        }
+		int addOffsetAndLimit() {
+			return offsetOrZero() + limitOrZero();
+		}
 
-        int maxOfDifference() {
-            return Math.max(offsetOrZero() - limitOrZero(), 0);
-        }
+		int maxOfDifference() {
+			return Math.max(offsetOrZero() - limitOrZero(), 0);
+		}
 
-        private int offsetOrZero() {
-            return defaultZeroIfNull(offset);
-        }
+		private int offsetOrZero() {
+			return defaultZeroIfNull(offset);
+		}
 
-        private int limitOrZero() {
-            return defaultZeroIfNull(offset);
-        }
+		private int limitOrZero() {
+			return defaultZeroIfNull(offset);
+		}
 
-        private int defaultZeroIfNull(Integer value) {
-            return defaultIfNull(value, 0);
-        }
+		private int defaultZeroIfNull(Integer value) {
+			return defaultIfNull(value, 0);
+		}
 	}
 
 	private static class InitialPagingResults {
-            int pageSize;
-            List<IBaseResource> resourceList;
-            int numToReturn;
-            String searchId;
-            Integer numTotalResults;
+		int pageSize;
+		List<IBaseResource> resourceList;
+		int numToReturn;
+		String searchId;
+		Integer numTotalResults;
 
-			InitialPagingResults(int pageSize,
-					List<IBaseResource> resourceList,
-					int numToReturn,
-					String searchId,
-					Integer numTotalResults) {
-				this.pageSize = pageSize;
-				this.resourceList = resourceList;
-				this.numToReturn = numToReturn;
-				this.searchId = searchId;
-				this.numTotalResults = numTotalResults;
-			}
+		InitialPagingResults(
+				int pageSize,
+				List<IBaseResource> resourceList,
+				int numToReturn,
+				String searchId,
+				Integer numTotalResults) {
+			this.pageSize = pageSize;
+			this.resourceList = resourceList;
+			this.numToReturn = numToReturn;
+			this.searchId = searchId;
+			this.numTotalResults = numTotalResults;
+		}
 	}
 
 	// Once this package language level allows for them these records can be used in place of the inner static classes
-//    private record OffsetLimitInfo(Integer offset, Integer limit) {
-//        int addOffsetAndLimit() {
-//            return offsetOrZero() + limitOrZero();
-//        }
-//
-//        int maxOfDifference() {
-//            return Math.max(offsetOrZero() - limitOrZero(), 0);
-//        }
-//
-//        private int offsetOrZero() {
-//            return defaultZeroIfNull(offset);
-//        }
-//
-//        private int limitOrZero() {
-//            return defaultZeroIfNull(offset);
-//        }
-//
-//        private int defaultZeroIfNull(Integer value) {
-//            return defaultIfNull(value, 0);
-//        }
-//    }
-//
-//    private record InitialPagingResults(
-//            int pageSize,
-//            List<IBaseResource> resourceList,
-//            int numToReturn,
-//            String searchId,
-//            Integer numTotalResults) {}
+	//    private record OffsetLimitInfo(Integer offset, Integer limit) {
+	//        int addOffsetAndLimit() {
+	//            return offsetOrZero() + limitOrZero();
+	//        }
+	//
+	//        int maxOfDifference() {
+	//            return Math.max(offsetOrZero() - limitOrZero(), 0);
+	//        }
+	//
+	//        private int offsetOrZero() {
+	//            return defaultZeroIfNull(offset);
+	//        }
+	//
+	//        private int limitOrZero() {
+	//            return defaultZeroIfNull(offset);
+	//        }
+	//
+	//        private int defaultZeroIfNull(Integer value) {
+	//            return defaultIfNull(value, 0);
+	//        }
+	//    }
+	//
+	//    private record InitialPagingResults(
+	//            int pageSize,
+	//            List<IBaseResource> resourceList,
+	//            int numToReturn,
+	//            String searchId,
+	//            Integer numTotalResults) {}
 
-    public static IBaseResource createBundleFromBundleProvider(
-            IRestfulServer<?> server,
-            RequestDetails request,
-            Integer limit,
-            String linkSelf,
-            Set<Include> includes,
-            IBundleProvider result,
-            int offset,
-            BundleTypeEnum bundleType,
-            String searchId) {
+	public static IBaseResource createBundleFromBundleProvider(
+			IRestfulServer<?> server,
+			RequestDetails request,
+			Integer limit,
+			String linkSelf,
+			Set<Include> includes,
+			IBundleProvider result,
+			int offset,
+			BundleTypeEnum bundleType,
+			String searchId) {
 
-        final OffsetLimitInfo offsetLimitInfo = extractOffsetPageInfo(result, request, limit);
+		final OffsetLimitInfo offsetLimitInfo = extractOffsetPageInfo(result, request, limit);
 
-        final InitialPagingResults initialPagingResults =
-                extractInitialPagingResults(server, request, result, offset, searchId, offsetLimitInfo);
+		final InitialPagingResults initialPagingResults =
+				extractInitialPagingResults(server, request, result, offset, searchId, offsetLimitInfo);
 
-        removeNullIfNeeded(initialPagingResults.resourceList);
-        validateAllResourcesHaveId(initialPagingResults.resourceList);
+		removeNullIfNeeded(initialPagingResults.resourceList);
+		validateAllResourcesHaveId(initialPagingResults.resourceList);
 
-        final BundleLinks links = buildLinks(
-                server, request, linkSelf, includes, result, offset, bundleType, offsetLimitInfo, initialPagingResults);
+		final BundleLinks links = buildLinks(
+				server, request, linkSelf, includes, result, offset, bundleType, offsetLimitInfo, initialPagingResults);
 
-        return buildBundle(server, includes, result, bundleType, links, initialPagingResults.resourceList);
-    }
+		return buildBundle(server, includes, result, bundleType, links, initialPagingResults.resourceList);
+	}
 
-    @Nonnull
-    private static BundleLinks buildLinks(
-            IRestfulServer<?> server,
-            RequestDetails request,
-            String linkSelf,
-            Set<Include> includes,
-            IBundleProvider result,
-            int offset,
-            BundleTypeEnum bundleType,
-            OffsetLimitInfo offsetLimitInfo,
-            InitialPagingResults initialPagingResults) {
+	@Nonnull
+	private static BundleLinks buildLinks(
+			IRestfulServer<?> server,
+			RequestDetails request,
+			String linkSelf,
+			Set<Include> includes,
+			IBundleProvider result,
+			int offset,
+			BundleTypeEnum bundleType,
+			OffsetLimitInfo offsetLimitInfo,
+			InitialPagingResults initialPagingResults) {
 
-        BundleLinks links = new BundleLinks(
-                request.getFhirServerBase(),
-                includes,
-                RestfulServerUtils.prettyPrintResponse(server, request),
-                bundleType);
-        links.setSelf(linkSelf);
+		BundleLinks links = new BundleLinks(
+				request.getFhirServerBase(),
+				includes,
+				RestfulServerUtils.prettyPrintResponse(server, request),
+				bundleType);
+		links.setSelf(linkSelf);
 
-        if (result.getCurrentPageOffset() != null) {
+		if (result.getCurrentPageOffset() != null) {
 
-            if (isNotBlank(result.getNextPageId())) {
-                links.setNext(RestfulServerUtils.createOffsetPagingLink(
-                        links,
-                        request.getRequestPath(),
-                        request.getTenantId(),
-                        offsetLimitInfo.addOffsetAndLimit(),
-                        offsetLimitInfo.limit,
-                        request.getParameters()));
-            }
-            if (isNotBlank(result.getPreviousPageId())) {
-                links.setNext(RestfulServerUtils.createOffsetPagingLink(
-                        links,
-                        request.getRequestPath(),
-                        request.getTenantId(),
-                        offsetLimitInfo.maxOfDifference(),
-                        offsetLimitInfo.limit,
-                        request.getParameters()));
-            }
-        }
+			if (isNotBlank(result.getNextPageId())) {
+				links.setNext(RestfulServerUtils.createOffsetPagingLink(
+						links,
+						request.getRequestPath(),
+						request.getTenantId(),
+						offsetLimitInfo.addOffsetAndLimit(),
+						offsetLimitInfo.limit,
+						request.getParameters()));
+			}
+			if (isNotBlank(result.getPreviousPageId())) {
+				links.setNext(RestfulServerUtils.createOffsetPagingLink(
+						links,
+						request.getRequestPath(),
+						request.getTenantId(),
+						offsetLimitInfo.maxOfDifference(),
+						offsetLimitInfo.limit,
+						request.getParameters()));
+			}
+		}
 
-        if (offsetLimitInfo.offset != null || (!server.canStoreSearchResults() && !isEverythingOperation(request))) {
-            handleOffsetPage(server, request, offset, offsetLimitInfo, initialPagingResults, links);
-        } else if (isNotBlank(result.getCurrentPageId())) {
-            handleCurrentPage(request, result, initialPagingResults, links);
-        } else if (initialPagingResults.searchId != null && !initialPagingResults.resourceList.isEmpty()) {
-            handleSearchId(request, offset, initialPagingResults, links);
-        }
-        return links;
-    }
+		if (offsetLimitInfo.offset != null || (!server.canStoreSearchResults() && !isEverythingOperation(request))) {
+			handleOffsetPage(server, request, offset, offsetLimitInfo, initialPagingResults, links);
+		} else if (isNotBlank(result.getCurrentPageId())) {
+			handleCurrentPage(request, result, initialPagingResults, links);
+		} else if (initialPagingResults.searchId != null && !initialPagingResults.resourceList.isEmpty()) {
+			handleSearchId(request, offset, initialPagingResults, links);
+		}
+		return links;
+	}
 
-    private static void handleSearchId(
-            RequestDetails request, int offset, InitialPagingResults initialPagingResults, BundleLinks links) {
-        if (initialPagingResults.numTotalResults == null
-                || offset + initialPagingResults.numToReturn < initialPagingResults.numTotalResults) {
-            links.setNext((RestfulServerUtils.createPagingLink(
-                    links,
-                    request,
-                    initialPagingResults.searchId,
-                    offset + initialPagingResults.numToReturn,
-                    initialPagingResults.numToReturn,
-                    request.getParameters())));
-        }
-        if (offset > 0) {
-            int start = Math.max(0, offset - initialPagingResults.pageSize);
-            links.setPrev(RestfulServerUtils.createPagingLink(
-                    links,
-                    request,
-                    initialPagingResults.searchId,
-                    start,
-                    initialPagingResults.pageSize,
-                    request.getParameters()));
-        }
-    }
+	private static void handleSearchId(
+			RequestDetails request, int offset, InitialPagingResults initialPagingResults, BundleLinks links) {
+		if (initialPagingResults.numTotalResults == null
+				|| offset + initialPagingResults.numToReturn < initialPagingResults.numTotalResults) {
+			links.setNext((RestfulServerUtils.createPagingLink(
+					links,
+					request,
+					initialPagingResults.searchId,
+					offset + initialPagingResults.numToReturn,
+					initialPagingResults.numToReturn,
+					request.getParameters())));
+		}
+		if (offset > 0) {
+			int start = Math.max(0, offset - initialPagingResults.pageSize);
+			links.setPrev(RestfulServerUtils.createPagingLink(
+					links,
+					request,
+					initialPagingResults.searchId,
+					start,
+					initialPagingResults.pageSize,
+					request.getParameters()));
+		}
+	}
 
-    private static void handleCurrentPage(
-            RequestDetails request,
-            IBundleProvider result,
-            InitialPagingResults initialPagingResults,
-            BundleLinks links) {
-        String searchIdToUse;
-        // We're doing named pages
-        searchIdToUse = result.getUuid();
-        if (isNotBlank(result.getNextPageId())) {
-            links.setNext(RestfulServerUtils.createPagingLink(
-                    links, request, searchIdToUse, result.getNextPageId(), request.getParameters()));
-        }
-        if (isNotBlank(result.getPreviousPageId())) {
-            links.setPrev(RestfulServerUtils.createPagingLink(
-                    links,
-                    request,
-                    initialPagingResults.searchId,
-                    result.getPreviousPageId(),
-                    request.getParameters()));
-        }
-    }
+	private static void handleCurrentPage(
+			RequestDetails request,
+			IBundleProvider result,
+			InitialPagingResults initialPagingResults,
+			BundleLinks links) {
+		String searchIdToUse;
+		// We're doing named pages
+		searchIdToUse = result.getUuid();
+		if (isNotBlank(result.getNextPageId())) {
+			links.setNext(RestfulServerUtils.createPagingLink(
+					links, request, searchIdToUse, result.getNextPageId(), request.getParameters()));
+		}
+		if (isNotBlank(result.getPreviousPageId())) {
+			links.setPrev(RestfulServerUtils.createPagingLink(
+					links,
+					request,
+					initialPagingResults.searchId,
+					result.getPreviousPageId(),
+					request.getParameters()));
+		}
+	}
 
-    private static void handleOffsetPage(
-            IRestfulServer<?> server,
-            RequestDetails request,
-            int offset,
-            OffsetLimitInfo offsetLimitInfo,
-            InitialPagingResults initialPagingResults,
-            BundleLinks links) {
-        // Paging without caching
-        // We're doing offset pages
-        int requestedToReturn = initialPagingResults.numToReturn;
-        if (server.getPagingProvider() == null && offsetLimitInfo.offset != null) {
-            // There is no paging provider at all, so assume we're querying up to all the results we
-            // need every time
-            requestedToReturn += offsetLimitInfo.offset;
-        }
-        if ((initialPagingResults.numTotalResults == null || requestedToReturn < initialPagingResults.numTotalResults)
-                && !initialPagingResults.resourceList.isEmpty()) {
-            links.setNext(RestfulServerUtils.createOffsetPagingLink(
-                    links,
-                    request.getRequestPath(),
-                    request.getTenantId(),
-                    defaultIfNull(offsetLimitInfo.offset, 0) + initialPagingResults.numToReturn,
-                    initialPagingResults.numToReturn,
-                    request.getParameters()));
-        }
+	private static void handleOffsetPage(
+			IRestfulServer<?> server,
+			RequestDetails request,
+			int offset,
+			OffsetLimitInfo offsetLimitInfo,
+			InitialPagingResults initialPagingResults,
+			BundleLinks links) {
+		// Paging without caching
+		// We're doing offset pages
+		int requestedToReturn = initialPagingResults.numToReturn;
+		if (server.getPagingProvider() == null && offsetLimitInfo.offset != null) {
+			// There is no paging provider at all, so assume we're querying up to all the results we
+			// need every time
+			requestedToReturn += offsetLimitInfo.offset;
+		}
+		if ((initialPagingResults.numTotalResults == null || requestedToReturn < initialPagingResults.numTotalResults)
+				&& !initialPagingResults.resourceList.isEmpty()) {
+			links.setNext(RestfulServerUtils.createOffsetPagingLink(
+					links,
+					request.getRequestPath(),
+					request.getTenantId(),
+					defaultIfNull(offsetLimitInfo.offset, 0) + initialPagingResults.numToReturn,
+					initialPagingResults.numToReturn,
+					request.getParameters()));
+		}
 
-        if (offsetLimitInfo.offset != null && offsetLimitInfo.offset > 0) {
-            int start = Math.max(0, offset - initialPagingResults.pageSize);
-            links.setPrev(RestfulServerUtils.createOffsetPagingLink(
-                    links,
-                    request.getRequestPath(),
-                    request.getTenantId(),
-                    start,
-                    initialPagingResults.pageSize,
-                    request.getParameters()));
-        }
-    }
+		if (offsetLimitInfo.offset != null && offsetLimitInfo.offset > 0) {
+			int start = Math.max(0, offset - initialPagingResults.pageSize);
+			links.setPrev(RestfulServerUtils.createOffsetPagingLink(
+					links,
+					request.getRequestPath(),
+					request.getTenantId(),
+					start,
+					initialPagingResults.pageSize,
+					request.getParameters()));
+		}
+	}
 
-    private static OffsetLimitInfo extractOffsetPageInfo(
-            IBundleProvider result, RequestDetails request, Integer limit) {
-        Integer offsetToUse;
-        Integer limitToUse = limit;
-        if (result.getCurrentPageOffset() != null) {
-            offsetToUse = result.getCurrentPageOffset();
-            limitToUse = result.getCurrentPageSize();
-            Validate.notNull(
-                    limitToUse, "IBundleProvider returned a non-null offset, but did not return a non-null page size");
-        } else {
-            offsetToUse = RestfulServerUtils.tryToExtractNamedParameter(request, Constants.PARAM_OFFSET);
-        }
-        return new OffsetLimitInfo(offsetToUse, limitToUse);
-    }
+	private static OffsetLimitInfo extractOffsetPageInfo(
+			IBundleProvider result, RequestDetails request, Integer limit) {
+		Integer offsetToUse;
+		Integer limitToUse = limit;
+		if (result.getCurrentPageOffset() != null) {
+			offsetToUse = result.getCurrentPageOffset();
+			limitToUse = result.getCurrentPageSize();
+			Validate.notNull(
+					limitToUse, "IBundleProvider returned a non-null offset, but did not return a non-null page size");
+		} else {
+			offsetToUse = RestfulServerUtils.tryToExtractNamedParameter(request, Constants.PARAM_OFFSET);
+		}
+		return new OffsetLimitInfo(offsetToUse, limitToUse);
+	}
 
-    private static InitialPagingResults extractInitialPagingResults(
-            IRestfulServer<?> server,
-            RequestDetails request,
-            IBundleProvider result,
-            int offset,
-            String searchId,
-            OffsetLimitInfo offsetLimitInfo) {
+	private static InitialPagingResults extractInitialPagingResults(
+			IRestfulServer<?> server,
+			RequestDetails request,
+			IBundleProvider result,
+			int offset,
+			String searchId,
+			OffsetLimitInfo offsetLimitInfo) {
 
-        if (offsetLimitInfo.offset != null || !server.canStoreSearchResults()) {
-            return handleOffset(server, result, offsetLimitInfo);
-        }
+		if (offsetLimitInfo.offset != null || !server.canStoreSearchResults()) {
+			return handleOffset(server, result, offsetLimitInfo);
+		}
 
-        return handleNonOffset(server, request, result, offset, searchId, offsetLimitInfo);
-    }
+		return handleNonOffset(server, request, result, offset, searchId, offsetLimitInfo);
+	}
 
-    @Nonnull
-    private static InitialPagingResults handleNonOffset(
-            IRestfulServer<?> server,
-            RequestDetails request,
-            IBundleProvider result,
-            int offset,
-            String searchId,
-            OffsetLimitInfo offsetLimitInfo) {
+	@Nonnull
+	private static InitialPagingResults handleNonOffset(
+			IRestfulServer<?> server,
+			RequestDetails request,
+			IBundleProvider result,
+			int offset,
+			String searchId,
+			OffsetLimitInfo offsetLimitInfo) {
 
-        Integer numTotalResults = result.size();
-        List<IBaseResource> resourceList;
-        int numToReturn;
-        final int pageSize;
-        IPagingProvider pagingProvider = server.getPagingProvider();
+		Integer numTotalResults = result.size();
+		List<IBaseResource> resourceList;
+		int numToReturn;
+		final int pageSize;
+		IPagingProvider pagingProvider = server.getPagingProvider();
 
-        if (offsetLimitInfo.limit == null || offsetLimitInfo.limit.equals(0)) {
-            pageSize = pagingProvider.getDefaultPageSize();
-        } else {
-            pageSize = Math.min(pagingProvider.getMaximumPageSize(), offsetLimitInfo.limit);
-        }
-        numToReturn = pageSize;
+		if (offsetLimitInfo.limit == null || offsetLimitInfo.limit.equals(0)) {
+			pageSize = pagingProvider.getDefaultPageSize();
+		} else {
+			pageSize = Math.min(pagingProvider.getMaximumPageSize(), offsetLimitInfo.limit);
+		}
+		numToReturn = pageSize;
 
-        if (numTotalResults != null) {
-            numToReturn = Math.min(numToReturn, numTotalResults - offset);
-        }
+		if (numTotalResults != null) {
+			numToReturn = Math.min(numToReturn, numTotalResults - offset);
+		}
 
-        if (numToReturn > 0 || result.getCurrentPageId() != null) {
-            resourceList = result.getResources(offset, numToReturn + offset);
-        } else {
-            resourceList = Collections.emptyList();
-        }
-        RestfulServerUtils.validateResourceListNotNull(resourceList);
+		if (numToReturn > 0 || result.getCurrentPageId() != null) {
+			resourceList = result.getResources(offset, numToReturn + offset);
+		} else {
+			resourceList = Collections.emptyList();
+		}
+		RestfulServerUtils.validateResourceListNotNull(resourceList);
 
-        if (numTotalResults == null) {
-            numTotalResults = result.size();
-        }
+		if (numTotalResults == null) {
+			numTotalResults = result.size();
+		}
 
-        final String searchIdToUse =
-                computeSearchId(request, result, searchId, numTotalResults, numToReturn, pagingProvider);
+		final String searchIdToUse =
+				computeSearchId(request, result, searchId, numTotalResults, numToReturn, pagingProvider);
 
-        return new InitialPagingResults(pageSize, resourceList, numToReturn, searchIdToUse, numTotalResults);
-    }
+		return new InitialPagingResults(pageSize, resourceList, numToReturn, searchIdToUse, numTotalResults);
+	}
 
-    @Nullable
-    private static String computeSearchId(
-            RequestDetails request,
-            IBundleProvider result,
-            String searchId,
-            Integer numTotalResults,
-            int numToReturn,
-            IPagingProvider pagingProvider) {
-        String searchIdToUse = null;
-        if (searchId != null) {
-            searchIdToUse = searchId;
-        } else {
-            if (numTotalResults == null || numTotalResults > numToReturn) {
-                searchIdToUse = pagingProvider.storeResultList(request, result);
-                if (isBlank(searchIdToUse)) {
-                    ourLog.info(
-                            "Found {} results but paging provider did not provide an ID to use for paging",
-                            numTotalResults);
-                    searchIdToUse = null;
-                }
-            }
-        }
-        return searchIdToUse;
-    }
+	@Nullable
+	private static String computeSearchId(
+			RequestDetails request,
+			IBundleProvider result,
+			String searchId,
+			Integer numTotalResults,
+			int numToReturn,
+			IPagingProvider pagingProvider) {
+		String searchIdToUse = null;
+		if (searchId != null) {
+			searchIdToUse = searchId;
+		} else {
+			if (numTotalResults == null || numTotalResults > numToReturn) {
+				searchIdToUse = pagingProvider.storeResultList(request, result);
+				if (isBlank(searchIdToUse)) {
+					ourLog.info(
+							"Found {} results but paging provider did not provide an ID to use for paging",
+							numTotalResults);
+					searchIdToUse = null;
+				}
+			}
+		}
+		return searchIdToUse;
+	}
 
-    @Nonnull
-    private static InitialPagingResults handleOffset(
-            IRestfulServer<?> server, IBundleProvider result, OffsetLimitInfo offsetLimitInfo) {
-        String searchIdToUse = null;
-        final int pageSize;
-        int numToReturn;
-        Integer numTotalResults = result.size();
+	@Nonnull
+	private static InitialPagingResults handleOffset(
+			IRestfulServer<?> server, IBundleProvider result, OffsetLimitInfo offsetLimitInfo) {
+		String searchIdToUse = null;
+		final int pageSize;
+		int numToReturn;
+		Integer numTotalResults = result.size();
 
-        List<IBaseResource> resourceList;
-        if (offsetLimitInfo.limit != null) {
-            pageSize = offsetLimitInfo.limit;
-        } else {
-            if (server.getDefaultPageSize() != null) {
-                pageSize = server.getDefaultPageSize();
-            } else {
-                pageSize = numTotalResults != null ? numTotalResults : Integer.MAX_VALUE;
-            }
-        }
-        numToReturn = pageSize;
+		List<IBaseResource> resourceList;
+		if (offsetLimitInfo.limit != null) {
+			pageSize = offsetLimitInfo.limit;
+		} else {
+			if (server.getDefaultPageSize() != null) {
+				pageSize = server.getDefaultPageSize();
+			} else {
+				pageSize = numTotalResults != null ? numTotalResults : Integer.MAX_VALUE;
+			}
+		}
+		numToReturn = pageSize;
 
-        if (offsetLimitInfo.offset != null || result.getCurrentPageOffset() != null) {
-            // When offset query is done result already contains correct amount (+ ir includes
-            // etc.) so return everything
-            resourceList = result.getResources(0, Integer.MAX_VALUE);
-        } else if (numToReturn > 0) {
-            resourceList = result.getResources(0, numToReturn);
-        } else {
-            resourceList = Collections.emptyList();
-        }
-        RestfulServerUtils.validateResourceListNotNull(resourceList);
+		if (offsetLimitInfo.offset != null || result.getCurrentPageOffset() != null) {
+			// When offset query is done result already contains correct amount (+ ir includes
+			// etc.) so return everything
+			resourceList = result.getResources(0, Integer.MAX_VALUE);
+		} else if (numToReturn > 0) {
+			resourceList = result.getResources(0, numToReturn);
+		} else {
+			resourceList = Collections.emptyList();
+		}
+		RestfulServerUtils.validateResourceListNotNull(resourceList);
 
-        return new InitialPagingResults(pageSize, resourceList, numToReturn, searchIdToUse, numTotalResults);
-    }
+		return new InitialPagingResults(pageSize, resourceList, numToReturn, searchIdToUse, numTotalResults);
+	}
 
-    private static IBaseResource buildBundle(
-            IRestfulServer<?> server,
-            Set<Include> includes,
-            IBundleProvider result,
-            BundleTypeEnum bundleType,
-            BundleLinks links,
-            List<IBaseResource> resourceList) {
-        IVersionSpecificBundleFactory bundleFactory = server.getFhirContext().newBundleFactory();
+	private static IBaseResource buildBundle(
+			IRestfulServer<?> server,
+			Set<Include> includes,
+			IBundleProvider result,
+			BundleTypeEnum bundleType,
+			BundleLinks links,
+			List<IBaseResource> resourceList) {
+		IVersionSpecificBundleFactory bundleFactory = server.getFhirContext().newBundleFactory();
 
-        bundleFactory.addRootPropertiesToBundle(result.getUuid(), links, result.size(), result.getPublished());
-        bundleFactory.addResourcesToBundle(
-                new ArrayList<>(resourceList), bundleType, links.serverBase, server.getBundleInclusionRule(), includes);
+		bundleFactory.addRootPropertiesToBundle(result.getUuid(), links, result.size(), result.getPublished());
+		bundleFactory.addResourcesToBundle(
+				new ArrayList<>(resourceList), bundleType, links.serverBase, server.getBundleInclusionRule(), includes);
 
-        return bundleFactory.getResourceBundle();
-    }
+		return bundleFactory.getResourceBundle();
+	}
 
-    private static void removeNullIfNeeded(List<IBaseResource> resourceList) {
-        /*
-         * Remove any null entries in the list - This generally shouldn't happen but can if data has
-         * been manually purged from the JPA database
-         */
-        boolean hasNull = false;
-        for (IBaseResource next : resourceList) {
-            if (next == null) {
-                hasNull = true;
-                break;
-            }
-        }
-        if (hasNull) {
-            resourceList.removeIf(Objects::isNull);
-        }
-    }
+	private static void removeNullIfNeeded(List<IBaseResource> resourceList) {
+		/*
+		 * Remove any null entries in the list - This generally shouldn't happen but can if data has
+		 * been manually purged from the JPA database
+		 */
+		boolean hasNull = false;
+		for (IBaseResource next : resourceList) {
+			if (next == null) {
+				hasNull = true;
+				break;
+			}
+		}
+		if (hasNull) {
+			resourceList.removeIf(Objects::isNull);
+		}
+	}
 
-    private static void validateAllResourcesHaveId(List<IBaseResource> resourceList) {
-        /*
-         * Make sure all returned resources have an ID (if not, this is a bug in the user server code)
-         */
-        for (IBaseResource next : resourceList) {
-            if ((next.getIdElement() == null || next.getIdElement().isEmpty())
-                    && !(next instanceof IBaseOperationOutcome)) {
-                throw new InternalErrorException(String.format(
-                        "Server method returned resource of type[%s] with no ID specified (IResource#setId(IdDt) must be called)", next.getIdElement()));
-            }
-        }
-    }
+	private static void validateAllResourcesHaveId(List<IBaseResource> resourceList) {
+		/*
+		 * Make sure all returned resources have an ID (if not, this is a bug in the user server code)
+		 */
+		for (IBaseResource next : resourceList) {
+			if ((next.getIdElement() == null || next.getIdElement().isEmpty())
+					&& !(next instanceof IBaseOperationOutcome)) {
+				throw new InternalErrorException(String.format(
+						"Server method returned resource of type[%s] with no ID specified (IResource#setId(IdDt) must be called)",
+						next.getIdElement()));
+			}
+		}
+	}
 
-    private static boolean isEverythingOperation(RequestDetails request) {
-        return (request.getRestOperationType() == RestOperationTypeEnum.EXTENDED_OPERATION_TYPE
-                        || request.getRestOperationType() == RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE)
-                && request.getOperation() != null
-                && request.getOperation().equals("$everything");
-    }
+	private static boolean isEverythingOperation(RequestDetails request) {
+		return (request.getRestOperationType() == RestOperationTypeEnum.EXTENDED_OPERATION_TYPE
+						|| request.getRestOperationType() == RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE)
+				&& request.getOperation() != null
+				&& request.getOperation().equals("$everything");
+	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
@@ -40,15 +40,7 @@ public class BundleProviderUtil {
 
 	private BundleProviderUtil() {}
 
-	private static class OffsetLimitInfo {
-		private final Integer offset;
-		private final Integer limit;
-
-		OffsetLimitInfo(Integer offset, Integer limit) {
-			this.offset = offset;
-			this.limit = limit;
-		}
-
+	private record OffsetLimitInfo(Integer offset, Integer limit) {
 		int addOffsetAndLimit() {
 			return offsetOrZero() + limitOrZero();
 		}
@@ -70,56 +62,12 @@ public class BundleProviderUtil {
 		}
 	}
 
-	private static class InitialPagingResults {
-		int pageSize;
-		List<IBaseResource> resourceList;
-		int numToReturn;
-		String searchId;
-		Integer numTotalResults;
-
-		InitialPagingResults(
-				int pageSize,
-				List<IBaseResource> resourceList,
-				int numToReturn,
-				String searchId,
-				Integer numTotalResults) {
-			this.pageSize = pageSize;
-			this.resourceList = resourceList;
-			this.numToReturn = numToReturn;
-			this.searchId = searchId;
-			this.numTotalResults = numTotalResults;
-		}
-	}
-
-	// Once this package language level allows for them these records can be used in place of the inner static classes
-	//    private record OffsetLimitInfo(Integer offset, Integer limit) {
-	//        int addOffsetAndLimit() {
-	//            return offsetOrZero() + limitOrZero();
-	//        }
-	//
-	//        int maxOfDifference() {
-	//            return Math.max(offsetOrZero() - limitOrZero(), 0);
-	//        }
-	//
-	//        private int offsetOrZero() {
-	//            return defaultZeroIfNull(offset);
-	//        }
-	//
-	//        private int limitOrZero() {
-	//            return defaultZeroIfNull(offset);
-	//        }
-	//
-	//        private int defaultZeroIfNull(Integer value) {
-	//            return defaultIfNull(value, 0);
-	//        }
-	//    }
-	//
-	//    private record InitialPagingResults(
-	//            int pageSize,
-	//            List<IBaseResource> resourceList,
-	//            int numToReturn,
-	//            String searchId,
-	//            Integer numTotalResults) {}
+	private record InitialPagingResults(
+			int pageSize,
+			List<IBaseResource> resourceList,
+			int numToReturn,
+			String searchId,
+			Integer numTotalResults) {}
 
 	public static IBaseResource createBundleFromBundleProvider(
 			IRestfulServer<?> server,

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
@@ -1,0 +1,466 @@
+package ca.uhn.fhir.jpa.repository;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
+import ca.uhn.fhir.rest.api.BundleLinks;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.IVersionSpecificBundleFactory;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.IRestfulServer;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.IPagingProvider;
+import ca.uhn.fhir.rest.server.RestfulServerUtils;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.apache.commons.lang3.Validate;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * This class pulls existing methods from the BaseResourceReturningMethodBinding class used for taking
+ * the results of a BundleProvider and turning it into a Bundle.  It is intended to be used only by the
+ * HapiFhirRepository.
+ */
+@SuppressWarnings("java:S107")
+public class BundleProviderUtil {
+    private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BundleProviderUtil.class);
+
+    private BundleProviderUtil() {}
+
+	private static class OffsetLimitInfo {
+		private final Integer offset;
+		private final Integer limit;
+
+		OffsetLimitInfo(Integer offset, Integer limit) {
+			this.offset = offset;
+			this.limit = limit;
+		}
+
+        int addOffsetAndLimit() {
+            return offsetOrZero() + limitOrZero();
+        }
+
+        int maxOfDifference() {
+            return Math.max(offsetOrZero() - limitOrZero(), 0);
+        }
+
+        private int offsetOrZero() {
+            return defaultZeroIfNull(offset);
+        }
+
+        private int limitOrZero() {
+            return defaultZeroIfNull(offset);
+        }
+
+        private int defaultZeroIfNull(Integer value) {
+            return defaultIfNull(value, 0);
+        }
+	}
+
+	private static class InitialPagingResults {
+            int pageSize;
+            List<IBaseResource> resourceList;
+            int numToReturn;
+            String searchId;
+            Integer numTotalResults;
+
+			InitialPagingResults(int pageSize,
+					List<IBaseResource> resourceList,
+					int numToReturn,
+					String searchId,
+					Integer numTotalResults) {
+				this.pageSize = pageSize;
+				this.resourceList = resourceList;
+				this.numToReturn = numToReturn;
+				this.searchId = searchId;
+				this.numTotalResults = numTotalResults;
+			}
+	}
+
+	// Once this package language level allows for them these records can be used in place of the inner static classes
+//    private record OffsetLimitInfo(Integer offset, Integer limit) {
+//        int addOffsetAndLimit() {
+//            return offsetOrZero() + limitOrZero();
+//        }
+//
+//        int maxOfDifference() {
+//            return Math.max(offsetOrZero() - limitOrZero(), 0);
+//        }
+//
+//        private int offsetOrZero() {
+//            return defaultZeroIfNull(offset);
+//        }
+//
+//        private int limitOrZero() {
+//            return defaultZeroIfNull(offset);
+//        }
+//
+//        private int defaultZeroIfNull(Integer value) {
+//            return defaultIfNull(value, 0);
+//        }
+//    }
+//
+//    private record InitialPagingResults(
+//            int pageSize,
+//            List<IBaseResource> resourceList,
+//            int numToReturn,
+//            String searchId,
+//            Integer numTotalResults) {}
+
+    public static IBaseResource createBundleFromBundleProvider(
+            IRestfulServer<?> server,
+            RequestDetails request,
+            Integer limit,
+            String linkSelf,
+            Set<Include> includes,
+            IBundleProvider result,
+            int offset,
+            BundleTypeEnum bundleType,
+            String searchId) {
+
+        final OffsetLimitInfo offsetLimitInfo = extractOffsetPageInfo(result, request, limit);
+
+        final InitialPagingResults initialPagingResults =
+                extractInitialPagingResults(server, request, result, offset, searchId, offsetLimitInfo);
+
+        removeNullIfNeeded(initialPagingResults.resourceList);
+        validateAllResourcesHaveId(initialPagingResults.resourceList);
+
+        final BundleLinks links = buildLinks(
+                server, request, linkSelf, includes, result, offset, bundleType, offsetLimitInfo, initialPagingResults);
+
+        return buildBundle(server, includes, result, bundleType, links, initialPagingResults.resourceList);
+    }
+
+    @Nonnull
+    private static BundleLinks buildLinks(
+            IRestfulServer<?> server,
+            RequestDetails request,
+            String linkSelf,
+            Set<Include> includes,
+            IBundleProvider result,
+            int offset,
+            BundleTypeEnum bundleType,
+            OffsetLimitInfo offsetLimitInfo,
+            InitialPagingResults initialPagingResults) {
+
+        BundleLinks links = new BundleLinks(
+                request.getFhirServerBase(),
+                includes,
+                RestfulServerUtils.prettyPrintResponse(server, request),
+                bundleType);
+        links.setSelf(linkSelf);
+
+        if (result.getCurrentPageOffset() != null) {
+
+            if (isNotBlank(result.getNextPageId())) {
+                links.setNext(RestfulServerUtils.createOffsetPagingLink(
+                        links,
+                        request.getRequestPath(),
+                        request.getTenantId(),
+                        offsetLimitInfo.addOffsetAndLimit(),
+                        offsetLimitInfo.limit,
+                        request.getParameters()));
+            }
+            if (isNotBlank(result.getPreviousPageId())) {
+                links.setNext(RestfulServerUtils.createOffsetPagingLink(
+                        links,
+                        request.getRequestPath(),
+                        request.getTenantId(),
+                        offsetLimitInfo.maxOfDifference(),
+                        offsetLimitInfo.limit,
+                        request.getParameters()));
+            }
+        }
+
+        if (offsetLimitInfo.offset != null || (!server.canStoreSearchResults() && !isEverythingOperation(request))) {
+            handleOffsetPage(server, request, offset, offsetLimitInfo, initialPagingResults, links);
+        } else if (isNotBlank(result.getCurrentPageId())) {
+            handleCurrentPage(request, result, initialPagingResults, links);
+        } else if (initialPagingResults.searchId != null && !initialPagingResults.resourceList.isEmpty()) {
+            handleSearchId(request, offset, initialPagingResults, links);
+        }
+        return links;
+    }
+
+    private static void handleSearchId(
+            RequestDetails request, int offset, InitialPagingResults initialPagingResults, BundleLinks links) {
+        if (initialPagingResults.numTotalResults == null
+                || offset + initialPagingResults.numToReturn < initialPagingResults.numTotalResults) {
+            links.setNext((RestfulServerUtils.createPagingLink(
+                    links,
+                    request,
+                    initialPagingResults.searchId,
+                    offset + initialPagingResults.numToReturn,
+                    initialPagingResults.numToReturn,
+                    request.getParameters())));
+        }
+        if (offset > 0) {
+            int start = Math.max(0, offset - initialPagingResults.pageSize);
+            links.setPrev(RestfulServerUtils.createPagingLink(
+                    links,
+                    request,
+                    initialPagingResults.searchId,
+                    start,
+                    initialPagingResults.pageSize,
+                    request.getParameters()));
+        }
+    }
+
+    private static void handleCurrentPage(
+            RequestDetails request,
+            IBundleProvider result,
+            InitialPagingResults initialPagingResults,
+            BundleLinks links) {
+        String searchIdToUse;
+        // We're doing named pages
+        searchIdToUse = result.getUuid();
+        if (isNotBlank(result.getNextPageId())) {
+            links.setNext(RestfulServerUtils.createPagingLink(
+                    links, request, searchIdToUse, result.getNextPageId(), request.getParameters()));
+        }
+        if (isNotBlank(result.getPreviousPageId())) {
+            links.setPrev(RestfulServerUtils.createPagingLink(
+                    links,
+                    request,
+                    initialPagingResults.searchId,
+                    result.getPreviousPageId(),
+                    request.getParameters()));
+        }
+    }
+
+    private static void handleOffsetPage(
+            IRestfulServer<?> server,
+            RequestDetails request,
+            int offset,
+            OffsetLimitInfo offsetLimitInfo,
+            InitialPagingResults initialPagingResults,
+            BundleLinks links) {
+        // Paging without caching
+        // We're doing offset pages
+        int requestedToReturn = initialPagingResults.numToReturn;
+        if (server.getPagingProvider() == null && offsetLimitInfo.offset != null) {
+            // There is no paging provider at all, so assume we're querying up to all the results we
+            // need every time
+            requestedToReturn += offsetLimitInfo.offset;
+        }
+        if ((initialPagingResults.numTotalResults == null || requestedToReturn < initialPagingResults.numTotalResults)
+                && !initialPagingResults.resourceList.isEmpty()) {
+            links.setNext(RestfulServerUtils.createOffsetPagingLink(
+                    links,
+                    request.getRequestPath(),
+                    request.getTenantId(),
+                    defaultIfNull(offsetLimitInfo.offset, 0) + initialPagingResults.numToReturn,
+                    initialPagingResults.numToReturn,
+                    request.getParameters()));
+        }
+
+        if (offsetLimitInfo.offset != null && offsetLimitInfo.offset > 0) {
+            int start = Math.max(0, offset - initialPagingResults.pageSize);
+            links.setPrev(RestfulServerUtils.createOffsetPagingLink(
+                    links,
+                    request.getRequestPath(),
+                    request.getTenantId(),
+                    start,
+                    initialPagingResults.pageSize,
+                    request.getParameters()));
+        }
+    }
+
+    private static OffsetLimitInfo extractOffsetPageInfo(
+            IBundleProvider result, RequestDetails request, Integer limit) {
+        Integer offsetToUse;
+        Integer limitToUse = limit;
+        if (result.getCurrentPageOffset() != null) {
+            offsetToUse = result.getCurrentPageOffset();
+            limitToUse = result.getCurrentPageSize();
+            Validate.notNull(
+                    limitToUse, "IBundleProvider returned a non-null offset, but did not return a non-null page size");
+        } else {
+            offsetToUse = RestfulServerUtils.tryToExtractNamedParameter(request, Constants.PARAM_OFFSET);
+        }
+        return new OffsetLimitInfo(offsetToUse, limitToUse);
+    }
+
+    private static InitialPagingResults extractInitialPagingResults(
+            IRestfulServer<?> server,
+            RequestDetails request,
+            IBundleProvider result,
+            int offset,
+            String searchId,
+            OffsetLimitInfo offsetLimitInfo) {
+
+        if (offsetLimitInfo.offset != null || !server.canStoreSearchResults()) {
+            return handleOffset(server, result, offsetLimitInfo);
+        }
+
+        return handleNonOffset(server, request, result, offset, searchId, offsetLimitInfo);
+    }
+
+    @Nonnull
+    private static InitialPagingResults handleNonOffset(
+            IRestfulServer<?> server,
+            RequestDetails request,
+            IBundleProvider result,
+            int offset,
+            String searchId,
+            OffsetLimitInfo offsetLimitInfo) {
+
+        Integer numTotalResults = result.size();
+        List<IBaseResource> resourceList;
+        int numToReturn;
+        final int pageSize;
+        IPagingProvider pagingProvider = server.getPagingProvider();
+
+        if (offsetLimitInfo.limit == null || offsetLimitInfo.limit.equals(0)) {
+            pageSize = pagingProvider.getDefaultPageSize();
+        } else {
+            pageSize = Math.min(pagingProvider.getMaximumPageSize(), offsetLimitInfo.limit);
+        }
+        numToReturn = pageSize;
+
+        if (numTotalResults != null) {
+            numToReturn = Math.min(numToReturn, numTotalResults - offset);
+        }
+
+        if (numToReturn > 0 || result.getCurrentPageId() != null) {
+            resourceList = result.getResources(offset, numToReturn + offset);
+        } else {
+            resourceList = Collections.emptyList();
+        }
+        RestfulServerUtils.validateResourceListNotNull(resourceList);
+
+        if (numTotalResults == null) {
+            numTotalResults = result.size();
+        }
+
+        final String searchIdToUse =
+                computeSearchId(request, result, searchId, numTotalResults, numToReturn, pagingProvider);
+
+        return new InitialPagingResults(pageSize, resourceList, numToReturn, searchIdToUse, numTotalResults);
+    }
+
+    @Nullable
+    private static String computeSearchId(
+            RequestDetails request,
+            IBundleProvider result,
+            String searchId,
+            Integer numTotalResults,
+            int numToReturn,
+            IPagingProvider pagingProvider) {
+        String searchIdToUse = null;
+        if (searchId != null) {
+            searchIdToUse = searchId;
+        } else {
+            if (numTotalResults == null || numTotalResults > numToReturn) {
+                searchIdToUse = pagingProvider.storeResultList(request, result);
+                if (isBlank(searchIdToUse)) {
+                    ourLog.info(
+                            "Found {} results but paging provider did not provide an ID to use for paging",
+                            numTotalResults);
+                    searchIdToUse = null;
+                }
+            }
+        }
+        return searchIdToUse;
+    }
+
+    @Nonnull
+    private static InitialPagingResults handleOffset(
+            IRestfulServer<?> server, IBundleProvider result, OffsetLimitInfo offsetLimitInfo) {
+        String searchIdToUse = null;
+        final int pageSize;
+        int numToReturn;
+        Integer numTotalResults = result.size();
+
+        List<IBaseResource> resourceList;
+        if (offsetLimitInfo.limit != null) {
+            pageSize = offsetLimitInfo.limit;
+        } else {
+            if (server.getDefaultPageSize() != null) {
+                pageSize = server.getDefaultPageSize();
+            } else {
+                pageSize = numTotalResults != null ? numTotalResults : Integer.MAX_VALUE;
+            }
+        }
+        numToReturn = pageSize;
+
+        if (offsetLimitInfo.offset != null || result.getCurrentPageOffset() != null) {
+            // When offset query is done result already contains correct amount (+ ir includes
+            // etc.) so return everything
+            resourceList = result.getResources(0, Integer.MAX_VALUE);
+        } else if (numToReturn > 0) {
+            resourceList = result.getResources(0, numToReturn);
+        } else {
+            resourceList = Collections.emptyList();
+        }
+        RestfulServerUtils.validateResourceListNotNull(resourceList);
+
+        return new InitialPagingResults(pageSize, resourceList, numToReturn, searchIdToUse, numTotalResults);
+    }
+
+    private static IBaseResource buildBundle(
+            IRestfulServer<?> server,
+            Set<Include> includes,
+            IBundleProvider result,
+            BundleTypeEnum bundleType,
+            BundleLinks links,
+            List<IBaseResource> resourceList) {
+        IVersionSpecificBundleFactory bundleFactory = server.getFhirContext().newBundleFactory();
+
+        bundleFactory.addRootPropertiesToBundle(result.getUuid(), links, result.size(), result.getPublished());
+        bundleFactory.addResourcesToBundle(
+                new ArrayList<>(resourceList), bundleType, links.serverBase, server.getBundleInclusionRule(), includes);
+
+        return bundleFactory.getResourceBundle();
+    }
+
+    private static void removeNullIfNeeded(List<IBaseResource> resourceList) {
+        /*
+         * Remove any null entries in the list - This generally shouldn't happen but can if data has
+         * been manually purged from the JPA database
+         */
+        boolean hasNull = false;
+        for (IBaseResource next : resourceList) {
+            if (next == null) {
+                hasNull = true;
+                break;
+            }
+        }
+        if (hasNull) {
+            resourceList.removeIf(Objects::isNull);
+        }
+    }
+
+    private static void validateAllResourcesHaveId(List<IBaseResource> resourceList) {
+        /*
+         * Make sure all returned resources have an ID (if not, this is a bug in the user server code)
+         */
+        for (IBaseResource next : resourceList) {
+            if ((next.getIdElement() == null || next.getIdElement().isEmpty())
+                    && !(next instanceof IBaseOperationOutcome)) {
+                throw new InternalErrorException(String.format(
+                        "Server method returned resource of type[%s] with no ID specified (IResource#setId(IdDt) must be called)", next.getIdElement()));
+            }
+        }
+    }
+
+    private static boolean isEverythingOperation(RequestDetails request) {
+        return (request.getRestOperationType() == RestOperationTypeEnum.EXTENDED_OPERATION_TYPE
+                        || request.getRestOperationType() == RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE)
+                && request.getOperation() != null
+                && request.getOperation().equals("$everything");
+    }
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.repository;
 
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.api.BundleLinks;
@@ -452,7 +453,7 @@ public class BundleProviderUtil {
 		for (IBaseResource next : resourceList) {
 			if ((next.getIdElement() == null || next.getIdElement().isEmpty())
 					&& !(next instanceof IBaseOperationOutcome)) {
-				throw new InternalErrorException(String.format(
+				throw new InternalErrorException(Msg.code(2637) + String.format(
 						"Server method returned resource of type[%s] with no ID specified (IResource#setId(IdDt) must be called)",
 						next.getIdElement()));
 			}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/BundleProviderUtil.java
@@ -453,9 +453,10 @@ public class BundleProviderUtil {
 		for (IBaseResource next : resourceList) {
 			if ((next.getIdElement() == null || next.getIdElement().isEmpty())
 					&& !(next instanceof IBaseOperationOutcome)) {
-				throw new InternalErrorException(Msg.code(2637) + String.format(
-						"Server method returned resource of type[%s] with no ID specified (IResource#setId(IdDt) must be called)",
-						next.getIdElement()));
+				throw new InternalErrorException(Msg.code(2637)
+						+ String.format(
+								"Server method returned resource of type[%s] with no ID specified (IResource#setId(IdDt) must be called)",
+								next.getIdElement()));
 			}
 		}
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
@@ -40,334 +40,334 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  **/
 @SuppressWarnings("squid:S1135")
 public class HapiFhirRepository implements Repository {
-    private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(HapiFhirRepository.class);
-    private final DaoRegistry daoRegistry;
-    private final RequestDetails requestDetails;
-    private final RestfulServer restfulServer;
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(HapiFhirRepository.class);
+	private final DaoRegistry daoRegistry;
+	private final RequestDetails requestDetails;
+	private final RestfulServer restfulServer;
 
-    public HapiFhirRepository(DaoRegistry daoRegistry, RequestDetails requestDetails, RestfulServer restfulServer) {
-        this.daoRegistry = daoRegistry;
-        this.requestDetails = requestDetails;
-        this.restfulServer = restfulServer;
-    }
+	public HapiFhirRepository(DaoRegistry daoRegistry, RequestDetails requestDetails, RestfulServer restfulServer) {
+		this.daoRegistry = daoRegistry;
+		this.requestDetails = requestDetails;
+		this.restfulServer = restfulServer;
+	}
 
-    @Override
-    public <T extends IBaseResource, I extends IIdType> T read(
-            Class<T> resourceType, I id, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.READ)
-                .addHeaders(headers)
-                .create();
-        return daoRegistry.getResourceDao(resourceType).read(id, details);
-    }
+	@Override
+	public <T extends IBaseResource, I extends IIdType> T read(
+			Class<T> resourceType, I id, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.READ)
+				.addHeaders(headers)
+				.create();
+		return daoRegistry.getResourceDao(resourceType).read(id, details);
+	}
 
-    @Override
-    public <T extends IBaseResource> MethodOutcome create(T resource, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.CREATE)
-                .addHeaders(headers)
-                .create();
-        return daoRegistry.getResourceDao(resource).create(resource, details);
-    }
+	@Override
+	public <T extends IBaseResource> MethodOutcome create(T resource, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.CREATE)
+				.addHeaders(headers)
+				.create();
+		return daoRegistry.getResourceDao(resource).create(resource, details);
+	}
 
-    @Override
-    public <I extends IIdType, P extends IBaseParameters> MethodOutcome patch(
-            I id, P patchParameters, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.PATCH)
-                .addHeaders(headers)
-                .create();
-        // TODO update FHIR patchType once FHIRPATCH bug has been fixed
-        return daoRegistry.getResourceDao(id.getResourceType()).patch(id, null, null, null, patchParameters, details);
-    }
+	@Override
+	public <I extends IIdType, P extends IBaseParameters> MethodOutcome patch(
+			I id, P patchParameters, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.PATCH)
+				.addHeaders(headers)
+				.create();
+		// TODO update FHIR patchType once FHIRPATCH bug has been fixed
+		return daoRegistry.getResourceDao(id.getResourceType()).patch(id, null, null, null, patchParameters, details);
+	}
 
-    @Override
-    public <T extends IBaseResource> MethodOutcome update(T resource, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.UPDATE)
-                .addHeaders(headers)
-                .create();
+	@Override
+	public <T extends IBaseResource> MethodOutcome update(T resource, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.UPDATE)
+				.addHeaders(headers)
+				.create();
 
-        return daoRegistry.getResourceDao(resource).update(resource, details);
-    }
+		return daoRegistry.getResourceDao(resource).update(resource, details);
+	}
 
-    @Override
-    public <T extends IBaseResource, I extends IIdType> MethodOutcome delete(
-            Class<T> resourceType, I id, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.DELETE)
-                .addHeaders(headers)
-                .create();
+	@Override
+	public <T extends IBaseResource, I extends IIdType> MethodOutcome delete(
+			Class<T> resourceType, I id, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.DELETE)
+				.addHeaders(headers)
+				.create();
 
-        return daoRegistry.getResourceDao(resourceType).delete(id, details);
-    }
+		return daoRegistry.getResourceDao(resourceType).delete(id, details);
+	}
 
-    @Override
-    public <B extends IBaseBundle, T extends IBaseResource> B search(
-            Class<B> bundleType,
-            Class<T> resourceType,
-            Multimap<String, List<IQueryParameterType>> searchParameters,
-            Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.SEARCH_TYPE)
-                .addHeaders(headers)
-                .create();
-        SearchConverter converter = new SearchConverter();
-        converter.convertParameters(searchParameters, fhirContext());
-        details.setParameters(converter.resultParameters);
-        details.setResourceName(restfulServer.getFhirContext().getResourceType(resourceType));
-        var bundleProvider = daoRegistry.getResourceDao(resourceType).search(converter.searchParameterMap, details);
+	@Override
+	public <B extends IBaseBundle, T extends IBaseResource> B search(
+			Class<B> bundleType,
+			Class<T> resourceType,
+			Multimap<String, List<IQueryParameterType>> searchParameters,
+			Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.SEARCH_TYPE)
+				.addHeaders(headers)
+				.create();
+		SearchConverter converter = new SearchConverter();
+		converter.convertParameters(searchParameters, fhirContext());
+		details.setParameters(converter.resultParameters);
+		details.setResourceName(restfulServer.getFhirContext().getResourceType(resourceType));
+		var bundleProvider = daoRegistry.getResourceDao(resourceType).search(converter.searchParameterMap, details);
 
-        if (bundleProvider == null) {
-            return null;
-        }
+		if (bundleProvider == null) {
+			return null;
+		}
 
-        return createBundle(details, bundleProvider, null);
-    }
+		return createBundle(details, bundleProvider, null);
+	}
 
-    private <B extends IBaseBundle> B createBundle(
-            RequestDetails requestDetails, IBundleProvider bundleProvider, String pagingAction) {
-        var count = RestfulServerUtils.extractCountParameter(requestDetails);
-        var linkSelf = RestfulServerUtils.createLinkSelf(requestDetails.getFhirServerBase(), requestDetails);
+	private <B extends IBaseBundle> B createBundle(
+			RequestDetails requestDetails, IBundleProvider bundleProvider, String pagingAction) {
+		var count = RestfulServerUtils.extractCountParameter(requestDetails);
+		var linkSelf = RestfulServerUtils.createLinkSelf(requestDetails.getFhirServerBase(), requestDetails);
 
-        Set<Include> includes = new HashSet<>();
-        var reqIncludes = requestDetails.getParameters().get(Constants.PARAM_INCLUDE);
-        if (reqIncludes != null) {
-            for (String nextInclude : reqIncludes) {
-                includes.add(new Include(nextInclude));
-            }
-        }
+		Set<Include> includes = new HashSet<>();
+		var reqIncludes = requestDetails.getParameters().get(Constants.PARAM_INCLUDE);
+		if (reqIncludes != null) {
+			for (String nextInclude : reqIncludes) {
+				includes.add(new Include(nextInclude));
+			}
+		}
 
-        var offset = RestfulServerUtils.tryToExtractNamedParameter(requestDetails, Constants.PARAM_PAGINGOFFSET);
-        if (offset == null || offset < 0) {
-            offset = 0;
-        }
-        var start = offset;
-        if (bundleProvider.size() != null) {
-            start = Math.max(0, Math.min(offset, bundleProvider.size()));
-        }
+		var offset = RestfulServerUtils.tryToExtractNamedParameter(requestDetails, Constants.PARAM_PAGINGOFFSET);
+		if (offset == null || offset < 0) {
+			offset = 0;
+		}
+		var start = offset;
+		if (bundleProvider.size() != null) {
+			start = Math.max(0, Math.min(offset, bundleProvider.size()));
+		}
 
-        BundleTypeEnum bundleType = null;
-        var bundleTypeValues = requestDetails.getParameters().get(Constants.PARAM_BUNDLETYPE);
-        if (bundleTypeValues != null) {
-            bundleType = BundleTypeEnum.VALUESET_BINDER.fromCodeString(bundleTypeValues[0]);
-        } else {
-            bundleType = BundleTypeEnum.SEARCHSET;
-        }
+		BundleTypeEnum bundleType = null;
+		var bundleTypeValues = requestDetails.getParameters().get(Constants.PARAM_BUNDLETYPE);
+		if (bundleTypeValues != null) {
+			bundleType = BundleTypeEnum.VALUESET_BINDER.fromCodeString(bundleTypeValues[0]);
+		} else {
+			bundleType = BundleTypeEnum.SEARCHSET;
+		}
 
-        return unsafeCast(BundleProviderUtil.createBundleFromBundleProvider(
-                restfulServer,
-                requestDetails,
-                count,
-                linkSelf,
-                includes,
-                bundleProvider,
-                start,
-                bundleType,
-                pagingAction));
-    }
+		return unsafeCast(BundleProviderUtil.createBundleFromBundleProvider(
+				restfulServer,
+				requestDetails,
+				count,
+				linkSelf,
+				includes,
+				bundleProvider,
+				start,
+				bundleType,
+				pagingAction));
+	}
 
-    // TODO: The main use case for this is paging through Bundles, but I suppose that technically
-    // we ought to handle any old link. Maybe this is also an escape hatch for "custom non-FHIR
-    // repository action"?
-    @Override
-    public <B extends IBaseBundle> B link(Class<B> bundleType, String url, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.GET_PAGE)
-                .addHeaders(headers)
-                .create();
-        var urlParts = UrlUtil.parseUrl(url);
-        details.setCompleteUrl(url);
-        details.setParameters(UrlUtil.parseQueryStrings(urlParts.getParams()));
+	// TODO: The main use case for this is paging through Bundles, but I suppose that technically
+	// we ought to handle any old link. Maybe this is also an escape hatch for "custom non-FHIR
+	// repository action"?
+	@Override
+	public <B extends IBaseBundle> B link(Class<B> bundleType, String url, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.GET_PAGE)
+				.addHeaders(headers)
+				.create();
+		var urlParts = UrlUtil.parseUrl(url);
+		details.setCompleteUrl(url);
+		details.setParameters(UrlUtil.parseQueryStrings(urlParts.getParams()));
 
-        var pagingProvider = restfulServer.getPagingProvider();
-        if (pagingProvider == null) {
-            throw new InvalidRequestException("This server does not support paging");
-        }
+		var pagingProvider = restfulServer.getPagingProvider();
+		if (pagingProvider == null) {
+			throw new InvalidRequestException("This server does not support paging");
+		}
 
-        var pagingAction = details.getParameters().get(Constants.PARAM_PAGINGACTION)[0];
+		var pagingAction = details.getParameters().get(Constants.PARAM_PAGINGACTION)[0];
 
-        IBundleProvider bundleProvider;
+		IBundleProvider bundleProvider;
 
-        String pageId = null;
-        String[] pageIdParams = details.getParameters().get(Constants.PARAM_PAGEID);
-        if (pageIdParams != null && pageIdParams.length > 0 && isNotBlank(pageIdParams[0])) {
-            pageId = pageIdParams[0];
-        }
+		String pageId = null;
+		String[] pageIdParams = details.getParameters().get(Constants.PARAM_PAGEID);
+		if (pageIdParams != null && pageIdParams.length > 0 && isNotBlank(pageIdParams[0])) {
+			pageId = pageIdParams[0];
+		}
 
-        if (pageId != null) {
-            // This is a page request by Search ID and Page ID
-            bundleProvider = pagingProvider.retrieveResultList(details, pagingAction, pageId);
-            validateHaveBundleProvider(pagingAction, bundleProvider);
-        } else {
-            // This is a page request by Search ID and Offset
-            bundleProvider = pagingProvider.retrieveResultList(details, pagingAction);
-            validateHaveBundleProvider(pagingAction, bundleProvider);
-        }
+		if (pageId != null) {
+			// This is a page request by Search ID and Page ID
+			bundleProvider = pagingProvider.retrieveResultList(details, pagingAction, pageId);
+			validateHaveBundleProvider(pagingAction, bundleProvider);
+		} else {
+			// This is a page request by Search ID and Offset
+			bundleProvider = pagingProvider.retrieveResultList(details, pagingAction);
+			validateHaveBundleProvider(pagingAction, bundleProvider);
+		}
 
-        return createBundle(details, bundleProvider, pagingAction);
-    }
+		return createBundle(details, bundleProvider, pagingAction);
+	}
 
-    private void validateHaveBundleProvider(String pagingAction, IBundleProvider bundleProvider) {
-        // Return an HTTP 410 if the search is not known
-        if (bundleProvider == null) {
-            ourLog.info("Client requested unknown paging ID[{}]", pagingAction);
-            String msg =
-                    fhirContext().getLocalizer().getMessage(PageMethodBinding.class, "unknownSearchId", pagingAction);
-            throw new ResourceGoneException(msg);
-        }
-    }
+	private void validateHaveBundleProvider(String pagingAction, IBundleProvider bundleProvider) {
+		// Return an HTTP 410 if the search is not known
+		if (bundleProvider == null) {
+			ourLog.info("Client requested unknown paging ID[{}]", pagingAction);
+			String msg =
+					fhirContext().getLocalizer().getMessage(PageMethodBinding.class, "unknownSearchId", pagingAction);
+			throw new ResourceGoneException(msg);
+		}
+	}
 
-    @Override
-    public <C extends IBaseConformance> C capabilities(Class<C> capabilityStatementType, Map<String, String> headers) {
-        var method = restfulServer.getServerConformanceMethod();
-        if (method == null) {
-            return null;
-        }
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.METADATA)
-                .addHeaders(headers)
-                .create();
-        return unsafeCast(method.provideCapabilityStatement(restfulServer, details));
-    }
+	@Override
+	public <C extends IBaseConformance> C capabilities(Class<C> capabilityStatementType, Map<String, String> headers) {
+		var method = restfulServer.getServerConformanceMethod();
+		if (method == null) {
+			return null;
+		}
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.METADATA)
+				.addHeaders(headers)
+				.create();
+		return unsafeCast(method.provideCapabilityStatement(restfulServer, details));
+	}
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public <B extends IBaseBundle> B transaction(B bundle, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.TRANSACTION)
-                .addHeaders(headers)
-                .create();
-        return unsafeCast(daoRegistry.getSystemDao().transaction(details, bundle));
-    }
+	@Override
+	@SuppressWarnings("unchecked")
+	public <B extends IBaseBundle> B transaction(B bundle, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.TRANSACTION)
+				.addHeaders(headers)
+				.create();
+		return unsafeCast(daoRegistry.getSystemDao().transaction(details, bundle));
+	}
 
-    @Override
-    public <R extends IBaseResource, P extends IBaseParameters> R invoke(
-            String name, P parameters, Class<R> returnType, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
-                .addHeaders(headers)
-                .setOperation(name)
-                .setParameters(parameters)
-                .create();
+	@Override
+	public <R extends IBaseResource, P extends IBaseParameters> R invoke(
+			String name, P parameters, Class<R> returnType, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+				.addHeaders(headers)
+				.setOperation(name)
+				.setParameters(parameters)
+				.create();
 
-        return invoke(details);
-    }
+		return invoke(details);
+	}
 
-    @Override
-    public <P extends IBaseParameters> MethodOutcome invoke(String name, P parameters, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
-                .addHeaders(headers)
-                .setOperation(name)
-                .setParameters(parameters)
-                .create();
+	@Override
+	public <P extends IBaseParameters> MethodOutcome invoke(String name, P parameters, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+				.addHeaders(headers)
+				.setOperation(name)
+				.setParameters(parameters)
+				.create();
 
-        return invoke(details);
-    }
+		return invoke(details);
+	}
 
-    @Override
-    public <R extends IBaseResource, P extends IBaseParameters, T extends IBaseResource> R invoke(
-            Class<T> resourceType, String name, P parameters, Class<R> returnType, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
-                .addHeaders(headers)
-                .setOperation(name)
-                .setResourceType(resourceType.getSimpleName())
-                .setParameters(parameters)
-                .create();
+	@Override
+	public <R extends IBaseResource, P extends IBaseParameters, T extends IBaseResource> R invoke(
+			Class<T> resourceType, String name, P parameters, Class<R> returnType, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+				.addHeaders(headers)
+				.setOperation(name)
+				.setResourceType(resourceType.getSimpleName())
+				.setParameters(parameters)
+				.create();
 
-        return invoke(details);
-    }
+		return invoke(details);
+	}
 
-    @Override
-    public <P extends IBaseParameters, T extends IBaseResource> MethodOutcome invoke(
-            Class<T> resourceType, String name, P parameters, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
-                .addHeaders(headers)
-                .setOperation(name)
-                .setResourceType(resourceType.getSimpleName())
-                .setParameters(parameters)
-                .create();
+	@Override
+	public <P extends IBaseParameters, T extends IBaseResource> MethodOutcome invoke(
+			Class<T> resourceType, String name, P parameters, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+				.addHeaders(headers)
+				.setOperation(name)
+				.setResourceType(resourceType.getSimpleName())
+				.setParameters(parameters)
+				.create();
 
-        return invoke(details);
-    }
+		return invoke(details);
+	}
 
-    @Override
-    public <R extends IBaseResource, P extends IBaseParameters, I extends IIdType> R invoke(
-            I id, String name, P parameters, Class<R> returnType, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
-                .addHeaders(headers)
-                .setOperation(name)
-                .setResourceType(id.getResourceType())
-                .setId(id)
-                .setParameters(parameters)
-                .create();
+	@Override
+	public <R extends IBaseResource, P extends IBaseParameters, I extends IIdType> R invoke(
+			I id, String name, P parameters, Class<R> returnType, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+				.addHeaders(headers)
+				.setOperation(name)
+				.setResourceType(id.getResourceType())
+				.setId(id)
+				.setParameters(parameters)
+				.create();
 
-        return invoke(details);
-    }
+		return invoke(details);
+	}
 
-    @Override
-    public <P extends IBaseParameters, I extends IIdType> MethodOutcome invoke(
-            I id, String name, P parameters, Map<String, String> headers) {
-        var details = startWith(requestDetails)
-                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
-                .addHeaders(headers)
-                .setOperation(name)
-                .setResourceType(id.getResourceType())
-                .setId(id)
-                .setParameters(parameters)
-                .create();
+	@Override
+	public <P extends IBaseParameters, I extends IIdType> MethodOutcome invoke(
+			I id, String name, P parameters, Map<String, String> headers) {
+		var details = startWith(requestDetails)
+				.setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+				.addHeaders(headers)
+				.setOperation(name)
+				.setResourceType(id.getResourceType())
+				.setId(id)
+				.setParameters(parameters)
+				.create();
 
-        return invoke(details);
-    }
+		return invoke(details);
+	}
 
-    private void notImplemented() {
-        throw new NotImplementedOperationException("history not yet implemented");
-    }
+	private void notImplemented() {
+		throw new NotImplementedOperationException("history not yet implemented");
+	}
 
-    @Override
-    public <B extends IBaseBundle, P extends IBaseParameters> B history(
-            P parameters, Class<B> bundleType, Map<String, String> headers) {
-        notImplemented();
+	@Override
+	public <B extends IBaseBundle, P extends IBaseParameters> B history(
+			P parameters, Class<B> bundleType, Map<String, String> headers) {
+		notImplemented();
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public <B extends IBaseBundle, P extends IBaseParameters, T extends IBaseResource> B history(
-            Class<T> resourceType, P parameters, Class<B> bundleType, Map<String, String> headers) {
-        notImplemented();
+	@Override
+	public <B extends IBaseBundle, P extends IBaseParameters, T extends IBaseResource> B history(
+			Class<T> resourceType, P parameters, Class<B> bundleType, Map<String, String> headers) {
+		notImplemented();
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public <B extends IBaseBundle, P extends IBaseParameters, I extends IIdType> B history(
-            I id, P parameters, Class<B> bundleType, Map<String, String> headers) {
-        notImplemented();
+	@Override
+	public <B extends IBaseBundle, P extends IBaseParameters, I extends IIdType> B history(
+			I id, P parameters, Class<B> bundleType, Map<String, String> headers) {
+		notImplemented();
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public FhirContext fhirContext() {
-        return restfulServer.getFhirContext();
-    }
+	@Override
+	public FhirContext fhirContext() {
+		return restfulServer.getFhirContext();
+	}
 
-    protected <R> R invoke(RequestDetails details) {
-        try {
-            return unsafeCast(
-                    restfulServer.determineResourceMethod(details, null).invokeServer(restfulServer, details));
-        } catch (IOException exception) {
-            throw new InternalErrorException(exception);
-        }
-    }
+	protected <R> R invoke(RequestDetails details) {
+		try {
+			return unsafeCast(
+					restfulServer.determineResourceMethod(details, null).invokeServer(restfulServer, details));
+		} catch (IOException exception) {
+			throw new InternalErrorException(exception);
+		}
+	}
 
-    @SuppressWarnings("unchecked")
-    private static <T> T unsafeCast(Object object) {
-        return (T) object;
-    }
+	@SuppressWarnings("unchecked")
+	private static <T> T unsafeCast(Object object) {
+		return (T) object;
+	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
@@ -25,7 +25,7 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
-import ca.uhn.fhir.repository.Repository;
+import ca.uhn.fhir.repository.IRepository;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
@@ -61,7 +61,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * This class leverages DaoRegistry from Hapi-fhir to implement CRUD FHIR API operations constrained to provide only the operations necessary for the cql-evaluator modules to function.
  **/
 @SuppressWarnings("squid:S1135")
-public class HapiFhirRepository implements Repository {
+public class HapiFhirRepository implements IRepository {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(HapiFhirRepository.class);
 	private final DaoRegistry myDaoRegistry;
 	private final RequestDetails myRequestDetails;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
@@ -1,0 +1,373 @@
+package ca.uhn.fhir.jpa.repository;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
+import ca.uhn.fhir.repository.Repository;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.RestfulServerUtils;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.NotImplementedOperationException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
+import ca.uhn.fhir.rest.server.method.PageMethodBinding;
+import ca.uhn.fhir.util.UrlUtil;
+import com.google.common.collect.Multimap;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseConformance;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static ca.uhn.fhir.jpa.repository.RequestDetailsCloner.startWith;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * This class leverages DaoRegistry from Hapi-fhir to implement CRUD FHIR API operations constrained to provide only the operations necessary for the cql-evaluator modules to function.
+ **/
+@SuppressWarnings("squid:S1135")
+public class HapiFhirRepository implements Repository {
+    private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(HapiFhirRepository.class);
+    private final DaoRegistry daoRegistry;
+    private final RequestDetails requestDetails;
+    private final RestfulServer restfulServer;
+
+    public HapiFhirRepository(DaoRegistry daoRegistry, RequestDetails requestDetails, RestfulServer restfulServer) {
+        this.daoRegistry = daoRegistry;
+        this.requestDetails = requestDetails;
+        this.restfulServer = restfulServer;
+    }
+
+    @Override
+    public <T extends IBaseResource, I extends IIdType> T read(
+            Class<T> resourceType, I id, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.READ)
+                .addHeaders(headers)
+                .create();
+        return daoRegistry.getResourceDao(resourceType).read(id, details);
+    }
+
+    @Override
+    public <T extends IBaseResource> MethodOutcome create(T resource, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.CREATE)
+                .addHeaders(headers)
+                .create();
+        return daoRegistry.getResourceDao(resource).create(resource, details);
+    }
+
+    @Override
+    public <I extends IIdType, P extends IBaseParameters> MethodOutcome patch(
+            I id, P patchParameters, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.PATCH)
+                .addHeaders(headers)
+                .create();
+        // TODO update FHIR patchType once FHIRPATCH bug has been fixed
+        return daoRegistry.getResourceDao(id.getResourceType()).patch(id, null, null, null, patchParameters, details);
+    }
+
+    @Override
+    public <T extends IBaseResource> MethodOutcome update(T resource, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.UPDATE)
+                .addHeaders(headers)
+                .create();
+
+        return daoRegistry.getResourceDao(resource).update(resource, details);
+    }
+
+    @Override
+    public <T extends IBaseResource, I extends IIdType> MethodOutcome delete(
+            Class<T> resourceType, I id, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.DELETE)
+                .addHeaders(headers)
+                .create();
+
+        return daoRegistry.getResourceDao(resourceType).delete(id, details);
+    }
+
+    @Override
+    public <B extends IBaseBundle, T extends IBaseResource> B search(
+            Class<B> bundleType,
+            Class<T> resourceType,
+            Multimap<String, List<IQueryParameterType>> searchParameters,
+            Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.SEARCH_TYPE)
+                .addHeaders(headers)
+                .create();
+        SearchConverter converter = new SearchConverter();
+        converter.convertParameters(searchParameters, fhirContext());
+        details.setParameters(converter.resultParameters);
+        details.setResourceName(restfulServer.getFhirContext().getResourceType(resourceType));
+        var bundleProvider = daoRegistry.getResourceDao(resourceType).search(converter.searchParameterMap, details);
+
+        if (bundleProvider == null) {
+            return null;
+        }
+
+        return createBundle(details, bundleProvider, null);
+    }
+
+    private <B extends IBaseBundle> B createBundle(
+            RequestDetails requestDetails, IBundleProvider bundleProvider, String pagingAction) {
+        var count = RestfulServerUtils.extractCountParameter(requestDetails);
+        var linkSelf = RestfulServerUtils.createLinkSelf(requestDetails.getFhirServerBase(), requestDetails);
+
+        Set<Include> includes = new HashSet<>();
+        var reqIncludes = requestDetails.getParameters().get(Constants.PARAM_INCLUDE);
+        if (reqIncludes != null) {
+            for (String nextInclude : reqIncludes) {
+                includes.add(new Include(nextInclude));
+            }
+        }
+
+        var offset = RestfulServerUtils.tryToExtractNamedParameter(requestDetails, Constants.PARAM_PAGINGOFFSET);
+        if (offset == null || offset < 0) {
+            offset = 0;
+        }
+        var start = offset;
+        if (bundleProvider.size() != null) {
+            start = Math.max(0, Math.min(offset, bundleProvider.size()));
+        }
+
+        BundleTypeEnum bundleType = null;
+        var bundleTypeValues = requestDetails.getParameters().get(Constants.PARAM_BUNDLETYPE);
+        if (bundleTypeValues != null) {
+            bundleType = BundleTypeEnum.VALUESET_BINDER.fromCodeString(bundleTypeValues[0]);
+        } else {
+            bundleType = BundleTypeEnum.SEARCHSET;
+        }
+
+        return unsafeCast(BundleProviderUtil.createBundleFromBundleProvider(
+                restfulServer,
+                requestDetails,
+                count,
+                linkSelf,
+                includes,
+                bundleProvider,
+                start,
+                bundleType,
+                pagingAction));
+    }
+
+    // TODO: The main use case for this is paging through Bundles, but I suppose that technically
+    // we ought to handle any old link. Maybe this is also an escape hatch for "custom non-FHIR
+    // repository action"?
+    @Override
+    public <B extends IBaseBundle> B link(Class<B> bundleType, String url, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.GET_PAGE)
+                .addHeaders(headers)
+                .create();
+        var urlParts = UrlUtil.parseUrl(url);
+        details.setCompleteUrl(url);
+        details.setParameters(UrlUtil.parseQueryStrings(urlParts.getParams()));
+
+        var pagingProvider = restfulServer.getPagingProvider();
+        if (pagingProvider == null) {
+            throw new InvalidRequestException("This server does not support paging");
+        }
+
+        var pagingAction = details.getParameters().get(Constants.PARAM_PAGINGACTION)[0];
+
+        IBundleProvider bundleProvider;
+
+        String pageId = null;
+        String[] pageIdParams = details.getParameters().get(Constants.PARAM_PAGEID);
+        if (pageIdParams != null && pageIdParams.length > 0 && isNotBlank(pageIdParams[0])) {
+            pageId = pageIdParams[0];
+        }
+
+        if (pageId != null) {
+            // This is a page request by Search ID and Page ID
+            bundleProvider = pagingProvider.retrieveResultList(details, pagingAction, pageId);
+            validateHaveBundleProvider(pagingAction, bundleProvider);
+        } else {
+            // This is a page request by Search ID and Offset
+            bundleProvider = pagingProvider.retrieveResultList(details, pagingAction);
+            validateHaveBundleProvider(pagingAction, bundleProvider);
+        }
+
+        return createBundle(details, bundleProvider, pagingAction);
+    }
+
+    private void validateHaveBundleProvider(String pagingAction, IBundleProvider bundleProvider) {
+        // Return an HTTP 410 if the search is not known
+        if (bundleProvider == null) {
+            ourLog.info("Client requested unknown paging ID[{}]", pagingAction);
+            String msg =
+                    fhirContext().getLocalizer().getMessage(PageMethodBinding.class, "unknownSearchId", pagingAction);
+            throw new ResourceGoneException(msg);
+        }
+    }
+
+    @Override
+    public <C extends IBaseConformance> C capabilities(Class<C> capabilityStatementType, Map<String, String> headers) {
+        var method = restfulServer.getServerConformanceMethod();
+        if (method == null) {
+            return null;
+        }
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.METADATA)
+                .addHeaders(headers)
+                .create();
+        return unsafeCast(method.provideCapabilityStatement(restfulServer, details));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <B extends IBaseBundle> B transaction(B bundle, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.TRANSACTION)
+                .addHeaders(headers)
+                .create();
+        return unsafeCast(daoRegistry.getSystemDao().transaction(details, bundle));
+    }
+
+    @Override
+    public <R extends IBaseResource, P extends IBaseParameters> R invoke(
+            String name, P parameters, Class<R> returnType, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+                .addHeaders(headers)
+                .setOperation(name)
+                .setParameters(parameters)
+                .create();
+
+        return invoke(details);
+    }
+
+    @Override
+    public <P extends IBaseParameters> MethodOutcome invoke(String name, P parameters, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+                .addHeaders(headers)
+                .setOperation(name)
+                .setParameters(parameters)
+                .create();
+
+        return invoke(details);
+    }
+
+    @Override
+    public <R extends IBaseResource, P extends IBaseParameters, T extends IBaseResource> R invoke(
+            Class<T> resourceType, String name, P parameters, Class<R> returnType, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+                .addHeaders(headers)
+                .setOperation(name)
+                .setResourceType(resourceType.getSimpleName())
+                .setParameters(parameters)
+                .create();
+
+        return invoke(details);
+    }
+
+    @Override
+    public <P extends IBaseParameters, T extends IBaseResource> MethodOutcome invoke(
+            Class<T> resourceType, String name, P parameters, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+                .addHeaders(headers)
+                .setOperation(name)
+                .setResourceType(resourceType.getSimpleName())
+                .setParameters(parameters)
+                .create();
+
+        return invoke(details);
+    }
+
+    @Override
+    public <R extends IBaseResource, P extends IBaseParameters, I extends IIdType> R invoke(
+            I id, String name, P parameters, Class<R> returnType, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+                .addHeaders(headers)
+                .setOperation(name)
+                .setResourceType(id.getResourceType())
+                .setId(id)
+                .setParameters(parameters)
+                .create();
+
+        return invoke(details);
+    }
+
+    @Override
+    public <P extends IBaseParameters, I extends IIdType> MethodOutcome invoke(
+            I id, String name, P parameters, Map<String, String> headers) {
+        var details = startWith(requestDetails)
+                .setAction(RestOperationTypeEnum.EXTENDED_OPERATION_SERVER)
+                .addHeaders(headers)
+                .setOperation(name)
+                .setResourceType(id.getResourceType())
+                .setId(id)
+                .setParameters(parameters)
+                .create();
+
+        return invoke(details);
+    }
+
+    private void notImplemented() {
+        throw new NotImplementedOperationException("history not yet implemented");
+    }
+
+    @Override
+    public <B extends IBaseBundle, P extends IBaseParameters> B history(
+            P parameters, Class<B> bundleType, Map<String, String> headers) {
+        notImplemented();
+
+        return null;
+    }
+
+    @Override
+    public <B extends IBaseBundle, P extends IBaseParameters, T extends IBaseResource> B history(
+            Class<T> resourceType, P parameters, Class<B> bundleType, Map<String, String> headers) {
+        notImplemented();
+
+        return null;
+    }
+
+    @Override
+    public <B extends IBaseBundle, P extends IBaseParameters, I extends IIdType> B history(
+            I id, P parameters, Class<B> bundleType, Map<String, String> headers) {
+        notImplemented();
+
+        return null;
+    }
+
+    @Override
+    public FhirContext fhirContext() {
+        return restfulServer.getFhirContext();
+    }
+
+    protected <R> R invoke(RequestDetails details) {
+        try {
+            return unsafeCast(
+                    restfulServer.determineResourceMethod(details, null).invokeServer(restfulServer, details));
+        } catch (IOException exception) {
+            throw new InternalErrorException(exception);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T unsafeCast(Object object) {
+        return (T) object;
+    }
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/HapiFhirRepository.java
@@ -1,6 +1,7 @@
 package ca.uhn.fhir.jpa.repository;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.model.api.Include;
@@ -182,7 +183,7 @@ public class HapiFhirRepository implements Repository {
 
 		var pagingProvider = restfulServer.getPagingProvider();
 		if (pagingProvider == null) {
-			throw new InvalidRequestException("This server does not support paging");
+			throw new InvalidRequestException(Msg.code(2638) + "This server does not support paging");
 		}
 
 		var pagingAction = details.getParameters().get(Constants.PARAM_PAGINGACTION)[0];
@@ -214,7 +215,7 @@ public class HapiFhirRepository implements Repository {
 			ourLog.info("Client requested unknown paging ID[{}]", pagingAction);
 			String msg =
 					fhirContext().getLocalizer().getMessage(PageMethodBinding.class, "unknownSearchId", pagingAction);
-			throw new ResourceGoneException(msg);
+			throw new ResourceGoneException(Msg.code(2639) + msg);
 		}
 	}
 
@@ -325,7 +326,7 @@ public class HapiFhirRepository implements Repository {
 	}
 
 	private void notImplemented() {
-		throw new NotImplementedOperationException("history not yet implemented");
+		throw new NotImplementedOperationException(Msg.code(2640) + "history not yet implemented");
 	}
 
 	@Override
@@ -362,7 +363,7 @@ public class HapiFhirRepository implements Repository {
 			return unsafeCast(
 					restfulServer.determineResourceMethod(details, null).invokeServer(restfulServer, details));
 		} catch (IOException exception) {
-			throw new InternalErrorException(exception);
+			throw new InternalErrorException(Msg.code(2641) + exception);
 		}
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/RequestDetailsCloner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/RequestDetailsCloner.java
@@ -18,82 +18,82 @@ import java.util.Map;
  */
 class RequestDetailsCloner {
 
-    private RequestDetailsCloner() {}
+	private RequestDetailsCloner() {}
 
-    static DetailsBuilder startWith(RequestDetails details) {
-        var newDetails = new SystemRequestDetails(details);
-        newDetails.setRequestType(RequestTypeEnum.POST);
-        newDetails.setOperation(null);
-        newDetails.setResource(null);
-        newDetails.setParameters(new HashMap<>());
-        newDetails.setResourceName(null);
-        newDetails.setCompartmentName(null);
-        newDetails.setResponse(details.getResponse());
+	static DetailsBuilder startWith(RequestDetails details) {
+		var newDetails = new SystemRequestDetails(details);
+		newDetails.setRequestType(RequestTypeEnum.POST);
+		newDetails.setOperation(null);
+		newDetails.setResource(null);
+		newDetails.setParameters(new HashMap<>());
+		newDetails.setResourceName(null);
+		newDetails.setCompartmentName(null);
+		newDetails.setResponse(details.getResponse());
 
-        return new DetailsBuilder(newDetails);
-    }
+		return new DetailsBuilder(newDetails);
+	}
 
-    static class DetailsBuilder {
-        private final SystemRequestDetails details;
+	static class DetailsBuilder {
+		private final SystemRequestDetails details;
 
-        DetailsBuilder(SystemRequestDetails details) {
-            this.details = details;
-        }
+		DetailsBuilder(SystemRequestDetails details) {
+			this.details = details;
+		}
 
-        DetailsBuilder setAction(RestOperationTypeEnum restOperationType) {
-            details.setRestOperationType(restOperationType);
-            return this;
-        }
+		DetailsBuilder setAction(RestOperationTypeEnum restOperationType) {
+			details.setRestOperationType(restOperationType);
+			return this;
+		}
 
-        DetailsBuilder addHeaders(Map<String, String> headers) {
-            if (headers != null) {
-                for (var entry : headers.entrySet()) {
-                    details.addHeader(entry.getKey(), entry.getValue());
-                }
-            }
+		DetailsBuilder addHeaders(Map<String, String> headers) {
+			if (headers != null) {
+				for (var entry : headers.entrySet()) {
+					details.addHeader(entry.getKey(), entry.getValue());
+				}
+			}
 
-            return this;
-        }
+			return this;
+		}
 
-        DetailsBuilder setParameters(IBaseParameters parameters) {
-            IParser parser = details.getServer().getFhirContext().newJsonParser();
-            details.setRequestContents(parser.encodeResourceToString(parameters).getBytes());
+		DetailsBuilder setParameters(IBaseParameters parameters) {
+			IParser parser = details.getServer().getFhirContext().newJsonParser();
+			details.setRequestContents(parser.encodeResourceToString(parameters).getBytes());
 
-            return this;
-        }
+			return this;
+		}
 
-        DetailsBuilder setParameters(Map<String, String[]> parameters) {
-            details.setParameters(parameters);
+		DetailsBuilder setParameters(Map<String, String[]> parameters) {
+			details.setParameters(parameters);
 
-            return this;
-        }
+			return this;
+		}
 
-        DetailsBuilder withRestOperationType(RequestTypeEnum type) {
-            details.setRequestType(type);
+		DetailsBuilder withRestOperationType(RequestTypeEnum type) {
+			details.setRequestType(type);
 
-            return this;
-        }
+			return this;
+		}
 
-        DetailsBuilder setOperation(String operation) {
-            details.setOperation(operation);
+		DetailsBuilder setOperation(String operation) {
+			details.setOperation(operation);
 
-            return this;
-        }
+			return this;
+		}
 
-        DetailsBuilder setResourceType(String resourceName) {
-            details.setResourceName(resourceName);
+		DetailsBuilder setResourceType(String resourceName) {
+			details.setResourceName(resourceName);
 
-            return this;
-        }
+			return this;
+		}
 
-        DetailsBuilder setId(IIdType id) {
-            details.setId(id);
+		DetailsBuilder setId(IIdType id) {
+			details.setId(id);
 
-            return this;
-        }
+			return this;
+		}
 
-        SystemRequestDetails create() {
-            return details;
-        }
-    }
+		SystemRequestDetails create() {
+			return details;
+		}
+	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/RequestDetailsCloner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/RequestDetailsCloner.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.repository;
 
 import ca.uhn.fhir.parser.IParser;
@@ -20,80 +39,81 @@ class RequestDetailsCloner {
 
 	private RequestDetailsCloner() {}
 
-	static DetailsBuilder startWith(RequestDetails details) {
-		var newDetails = new SystemRequestDetails(details);
+	static DetailsBuilder startWith(RequestDetails theDetails) {
+		SystemRequestDetails newDetails = new SystemRequestDetails(theDetails);
 		newDetails.setRequestType(RequestTypeEnum.POST);
 		newDetails.setOperation(null);
 		newDetails.setResource(null);
 		newDetails.setParameters(new HashMap<>());
 		newDetails.setResourceName(null);
 		newDetails.setCompartmentName(null);
-		newDetails.setResponse(details.getResponse());
+		newDetails.setResponse(theDetails.getResponse());
 
 		return new DetailsBuilder(newDetails);
 	}
 
 	static class DetailsBuilder {
-		private final SystemRequestDetails details;
+		private final SystemRequestDetails myDetails;
 
-		DetailsBuilder(SystemRequestDetails details) {
-			this.details = details;
+		DetailsBuilder(SystemRequestDetails theDetails) {
+			myDetails = theDetails;
 		}
 
-		DetailsBuilder setAction(RestOperationTypeEnum restOperationType) {
-			details.setRestOperationType(restOperationType);
+		DetailsBuilder setAction(RestOperationTypeEnum theRestOperationType) {
+			myDetails.setRestOperationType(theRestOperationType);
 			return this;
 		}
 
-		DetailsBuilder addHeaders(Map<String, String> headers) {
-			if (headers != null) {
-				for (var entry : headers.entrySet()) {
-					details.addHeader(entry.getKey(), entry.getValue());
+		DetailsBuilder addHeaders(Map<String, String> theHeaders) {
+			if (theHeaders != null) {
+				for (Map.Entry<String, String> entry : theHeaders.entrySet()) {
+					myDetails.addHeader(entry.getKey(), entry.getValue());
 				}
 			}
 
 			return this;
 		}
 
-		DetailsBuilder setParameters(IBaseParameters parameters) {
-			IParser parser = details.getServer().getFhirContext().newJsonParser();
-			details.setRequestContents(parser.encodeResourceToString(parameters).getBytes());
+		DetailsBuilder setParameters(IBaseParameters theParameters) {
+			IParser parser = myDetails.getServer().getFhirContext().newJsonParser();
+			myDetails.setRequestContents(
+					parser.encodeResourceToString(theParameters).getBytes());
 
 			return this;
 		}
 
-		DetailsBuilder setParameters(Map<String, String[]> parameters) {
-			details.setParameters(parameters);
+		DetailsBuilder setParameters(Map<String, String[]> theParameters) {
+			myDetails.setParameters(theParameters);
 
 			return this;
 		}
 
-		DetailsBuilder withRestOperationType(RequestTypeEnum type) {
-			details.setRequestType(type);
+		DetailsBuilder withRestOperationType(RequestTypeEnum theType) {
+			myDetails.setRequestType(theType);
 
 			return this;
 		}
 
-		DetailsBuilder setOperation(String operation) {
-			details.setOperation(operation);
+		DetailsBuilder setOperation(String theOperation) {
+			myDetails.setOperation(theOperation);
 
 			return this;
 		}
 
-		DetailsBuilder setResourceType(String resourceName) {
-			details.setResourceName(resourceName);
+		DetailsBuilder setResourceType(String theResourceName) {
+			myDetails.setResourceName(theResourceName);
 
 			return this;
 		}
 
-		DetailsBuilder setId(IIdType id) {
-			details.setId(id);
+		DetailsBuilder setId(IIdType theId) {
+			myDetails.setId(theId);
 
 			return this;
 		}
 
 		SystemRequestDetails create() {
-			return details;
+			return myDetails;
 		}
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/RequestDetailsCloner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/RequestDetailsCloner.java
@@ -1,0 +1,99 @@
+package ca.uhn.fhir.jpa.repository;
+
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IIdType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class produces partial clones of RequestDetails, the intent being to reuse the context of a
+ * RequestDetails object for reentrant calls. It retains header and tenancy information while
+ * scrapping everything else.
+ */
+class RequestDetailsCloner {
+
+    private RequestDetailsCloner() {}
+
+    static DetailsBuilder startWith(RequestDetails details) {
+        var newDetails = new SystemRequestDetails(details);
+        newDetails.setRequestType(RequestTypeEnum.POST);
+        newDetails.setOperation(null);
+        newDetails.setResource(null);
+        newDetails.setParameters(new HashMap<>());
+        newDetails.setResourceName(null);
+        newDetails.setCompartmentName(null);
+        newDetails.setResponse(details.getResponse());
+
+        return new DetailsBuilder(newDetails);
+    }
+
+    static class DetailsBuilder {
+        private final SystemRequestDetails details;
+
+        DetailsBuilder(SystemRequestDetails details) {
+            this.details = details;
+        }
+
+        DetailsBuilder setAction(RestOperationTypeEnum restOperationType) {
+            details.setRestOperationType(restOperationType);
+            return this;
+        }
+
+        DetailsBuilder addHeaders(Map<String, String> headers) {
+            if (headers != null) {
+                for (var entry : headers.entrySet()) {
+                    details.addHeader(entry.getKey(), entry.getValue());
+                }
+            }
+
+            return this;
+        }
+
+        DetailsBuilder setParameters(IBaseParameters parameters) {
+            IParser parser = details.getServer().getFhirContext().newJsonParser();
+            details.setRequestContents(parser.encodeResourceToString(parameters).getBytes());
+
+            return this;
+        }
+
+        DetailsBuilder setParameters(Map<String, String[]> parameters) {
+            details.setParameters(parameters);
+
+            return this;
+        }
+
+        DetailsBuilder withRestOperationType(RequestTypeEnum type) {
+            details.setRequestType(type);
+
+            return this;
+        }
+
+        DetailsBuilder setOperation(String operation) {
+            details.setOperation(operation);
+
+            return this;
+        }
+
+        DetailsBuilder setResourceType(String resourceName) {
+            details.setResourceName(resourceName);
+
+            return this;
+        }
+
+        DetailsBuilder setId(IIdType id) {
+            details.setId(id);
+
+            return this;
+        }
+
+        SystemRequestDetails create() {
+            return details;
+        }
+    }
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/SearchConverter.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/SearchConverter.java
@@ -1,0 +1,125 @@
+package ca.uhn.fhir.jpa.repository;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.model.api.IQueryParameterAnd;
+import ca.uhn.fhir.model.api.IQueryParameterOr;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import jakarta.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The IGenericClient API represents searches with OrLists, while the FhirRepository API uses nested
+ * lists. This class (will eventually) convert between them
+ */
+public class SearchConverter {
+    // hardcoded list from FHIR specs: https://www.hl7.org/fhir/search.html
+    private final List<String> searchResultParameters = Arrays.asList(
+            "_sort",
+            "_count",
+            "_include",
+            "_revinclude",
+            "_summary",
+            "_total",
+            "_elements",
+            "_contained",
+            "_containedType");
+    public final Multimap<String, List<IQueryParameterType>> separatedSearchParameters = ArrayListMultimap.create();
+    public final Multimap<String, List<IQueryParameterType>> separatedResultParameters = ArrayListMultimap.create();
+    public final SearchParameterMap searchParameterMap = new SearchParameterMap();
+    public final Map<String, String[]> resultParameters = new HashMap<>();
+
+    public void convertParameters(Multimap<String, List<IQueryParameterType>> parameters, FhirContext fhirContext) {
+        if (parameters == null) {
+            return;
+        }
+        separateParameterTypes(parameters);
+        convertToSearchParameterMap(separatedSearchParameters);
+        convertToStringMap(separatedResultParameters, fhirContext);
+    }
+
+    public void convertToStringMap(
+            @Nonnull Multimap<String, List<IQueryParameterType>> parameters, @Nonnull FhirContext fhirContext) {
+        for (var entry : parameters.entries()) {
+            String[] values = new String[entry.getValue().size()];
+            for (int i = 0; i < entry.getValue().size(); i++) {
+                values[i] = entry.getValue().get(i).getValueAsQueryToken(fhirContext);
+            }
+            resultParameters.put(entry.getKey(), values);
+        }
+    }
+
+    public void convertToSearchParameterMap(Multimap<String, List<IQueryParameterType>> searchMap) {
+        if (searchMap == null) {
+            return;
+        }
+        for (var entry : searchMap.entries()) {
+            // if list of parameters is the value
+            if (entry.getValue().size() > 1 && !isOrList(entry.getValue()) && !isAndList(entry.getValue())) {
+                // is value a TokenParam
+                addTokenToSearchIfNeeded(entry);
+
+                // parameter type is single value list
+            } else {
+                for (IQueryParameterType value : entry.getValue()) {
+                    setParameterTypeValue(entry.getKey(), value);
+                }
+            }
+        }
+    }
+
+    private void addTokenToSearchIfNeeded(Map.Entry<String, List<IQueryParameterType>> entry) {
+        if (isTokenParam(entry.getValue().get(0))) {
+            var tokenKey = entry.getKey();
+            var tokenList = new TokenOrListParam();
+            for (IQueryParameterType rec : entry.getValue()) {
+                tokenList.add((TokenParam) rec);
+            }
+            searchParameterMap.add(tokenKey, tokenList);
+        }
+    }
+
+    public <T> void setParameterTypeValue(@Nonnull String key, @Nonnull T parameterType) {
+        if (isOrList(parameterType)) {
+            searchParameterMap.add(key, (IQueryParameterOr<?>) parameterType);
+        } else if (isAndList(parameterType)) {
+            searchParameterMap.add(key, (IQueryParameterAnd<?>) parameterType);
+        } else {
+            searchParameterMap.add(key, (IQueryParameterType) parameterType);
+        }
+    }
+
+    public void separateParameterTypes(@Nonnull Multimap<String, List<IQueryParameterType>> parameters) {
+        for (var entry : parameters.entries()) {
+            if (isSearchResultParameter(entry.getKey())) {
+                separatedResultParameters.put(entry.getKey(), entry.getValue());
+            } else {
+                separatedSearchParameters.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    public boolean isSearchResultParameter(String parameterName) {
+        return searchResultParameters.contains(parameterName);
+    }
+
+    public <T> boolean isOrList(@Nonnull T parameterType) {
+        return IQueryParameterOr.class.isAssignableFrom(parameterType.getClass());
+    }
+
+    public <T> boolean isAndList(@Nonnull T parameterType) {
+        return IQueryParameterAnd.class.isAssignableFrom(parameterType.getClass());
+    }
+
+    public <T> boolean isTokenParam(@Nonnull T parameterType) {
+        return TokenParam.class.isAssignableFrom(parameterType.getClass());
+    }
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/SearchConverter.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/repository/SearchConverter.java
@@ -21,105 +21,105 @@ import java.util.Map;
  * lists. This class (will eventually) convert between them
  */
 public class SearchConverter {
-    // hardcoded list from FHIR specs: https://www.hl7.org/fhir/search.html
-    private final List<String> searchResultParameters = Arrays.asList(
-            "_sort",
-            "_count",
-            "_include",
-            "_revinclude",
-            "_summary",
-            "_total",
-            "_elements",
-            "_contained",
-            "_containedType");
-    public final Multimap<String, List<IQueryParameterType>> separatedSearchParameters = ArrayListMultimap.create();
-    public final Multimap<String, List<IQueryParameterType>> separatedResultParameters = ArrayListMultimap.create();
-    public final SearchParameterMap searchParameterMap = new SearchParameterMap();
-    public final Map<String, String[]> resultParameters = new HashMap<>();
+	// hardcoded list from FHIR specs: https://www.hl7.org/fhir/search.html
+	private final List<String> searchResultParameters = Arrays.asList(
+			"_sort",
+			"_count",
+			"_include",
+			"_revinclude",
+			"_summary",
+			"_total",
+			"_elements",
+			"_contained",
+			"_containedType");
+	public final Multimap<String, List<IQueryParameterType>> separatedSearchParameters = ArrayListMultimap.create();
+	public final Multimap<String, List<IQueryParameterType>> separatedResultParameters = ArrayListMultimap.create();
+	public final SearchParameterMap searchParameterMap = new SearchParameterMap();
+	public final Map<String, String[]> resultParameters = new HashMap<>();
 
-    public void convertParameters(Multimap<String, List<IQueryParameterType>> parameters, FhirContext fhirContext) {
-        if (parameters == null) {
-            return;
-        }
-        separateParameterTypes(parameters);
-        convertToSearchParameterMap(separatedSearchParameters);
-        convertToStringMap(separatedResultParameters, fhirContext);
-    }
+	public void convertParameters(Multimap<String, List<IQueryParameterType>> parameters, FhirContext fhirContext) {
+		if (parameters == null) {
+			return;
+		}
+		separateParameterTypes(parameters);
+		convertToSearchParameterMap(separatedSearchParameters);
+		convertToStringMap(separatedResultParameters, fhirContext);
+	}
 
-    public void convertToStringMap(
-            @Nonnull Multimap<String, List<IQueryParameterType>> parameters, @Nonnull FhirContext fhirContext) {
-        for (var entry : parameters.entries()) {
-            String[] values = new String[entry.getValue().size()];
-            for (int i = 0; i < entry.getValue().size(); i++) {
-                values[i] = entry.getValue().get(i).getValueAsQueryToken(fhirContext);
-            }
-            resultParameters.put(entry.getKey(), values);
-        }
-    }
+	public void convertToStringMap(
+			@Nonnull Multimap<String, List<IQueryParameterType>> parameters, @Nonnull FhirContext fhirContext) {
+		for (var entry : parameters.entries()) {
+			String[] values = new String[entry.getValue().size()];
+			for (int i = 0; i < entry.getValue().size(); i++) {
+				values[i] = entry.getValue().get(i).getValueAsQueryToken(fhirContext);
+			}
+			resultParameters.put(entry.getKey(), values);
+		}
+	}
 
-    public void convertToSearchParameterMap(Multimap<String, List<IQueryParameterType>> searchMap) {
-        if (searchMap == null) {
-            return;
-        }
-        for (var entry : searchMap.entries()) {
-            // if list of parameters is the value
-            if (entry.getValue().size() > 1 && !isOrList(entry.getValue()) && !isAndList(entry.getValue())) {
-                // is value a TokenParam
-                addTokenToSearchIfNeeded(entry);
+	public void convertToSearchParameterMap(Multimap<String, List<IQueryParameterType>> searchMap) {
+		if (searchMap == null) {
+			return;
+		}
+		for (var entry : searchMap.entries()) {
+			// if list of parameters is the value
+			if (entry.getValue().size() > 1 && !isOrList(entry.getValue()) && !isAndList(entry.getValue())) {
+				// is value a TokenParam
+				addTokenToSearchIfNeeded(entry);
 
-                // parameter type is single value list
-            } else {
-                for (IQueryParameterType value : entry.getValue()) {
-                    setParameterTypeValue(entry.getKey(), value);
-                }
-            }
-        }
-    }
+				// parameter type is single value list
+			} else {
+				for (IQueryParameterType value : entry.getValue()) {
+					setParameterTypeValue(entry.getKey(), value);
+				}
+			}
+		}
+	}
 
-    private void addTokenToSearchIfNeeded(Map.Entry<String, List<IQueryParameterType>> entry) {
-        if (isTokenParam(entry.getValue().get(0))) {
-            var tokenKey = entry.getKey();
-            var tokenList = new TokenOrListParam();
-            for (IQueryParameterType rec : entry.getValue()) {
-                tokenList.add((TokenParam) rec);
-            }
-            searchParameterMap.add(tokenKey, tokenList);
-        }
-    }
+	private void addTokenToSearchIfNeeded(Map.Entry<String, List<IQueryParameterType>> entry) {
+		if (isTokenParam(entry.getValue().get(0))) {
+			var tokenKey = entry.getKey();
+			var tokenList = new TokenOrListParam();
+			for (IQueryParameterType rec : entry.getValue()) {
+				tokenList.add((TokenParam) rec);
+			}
+			searchParameterMap.add(tokenKey, tokenList);
+		}
+	}
 
-    public <T> void setParameterTypeValue(@Nonnull String key, @Nonnull T parameterType) {
-        if (isOrList(parameterType)) {
-            searchParameterMap.add(key, (IQueryParameterOr<?>) parameterType);
-        } else if (isAndList(parameterType)) {
-            searchParameterMap.add(key, (IQueryParameterAnd<?>) parameterType);
-        } else {
-            searchParameterMap.add(key, (IQueryParameterType) parameterType);
-        }
-    }
+	public <T> void setParameterTypeValue(@Nonnull String key, @Nonnull T parameterType) {
+		if (isOrList(parameterType)) {
+			searchParameterMap.add(key, (IQueryParameterOr<?>) parameterType);
+		} else if (isAndList(parameterType)) {
+			searchParameterMap.add(key, (IQueryParameterAnd<?>) parameterType);
+		} else {
+			searchParameterMap.add(key, (IQueryParameterType) parameterType);
+		}
+	}
 
-    public void separateParameterTypes(@Nonnull Multimap<String, List<IQueryParameterType>> parameters) {
-        for (var entry : parameters.entries()) {
-            if (isSearchResultParameter(entry.getKey())) {
-                separatedResultParameters.put(entry.getKey(), entry.getValue());
-            } else {
-                separatedSearchParameters.put(entry.getKey(), entry.getValue());
-            }
-        }
-    }
+	public void separateParameterTypes(@Nonnull Multimap<String, List<IQueryParameterType>> parameters) {
+		for (var entry : parameters.entries()) {
+			if (isSearchResultParameter(entry.getKey())) {
+				separatedResultParameters.put(entry.getKey(), entry.getValue());
+			} else {
+				separatedSearchParameters.put(entry.getKey(), entry.getValue());
+			}
+		}
+	}
 
-    public boolean isSearchResultParameter(String parameterName) {
-        return searchResultParameters.contains(parameterName);
-    }
+	public boolean isSearchResultParameter(String parameterName) {
+		return searchResultParameters.contains(parameterName);
+	}
 
-    public <T> boolean isOrList(@Nonnull T parameterType) {
-        return IQueryParameterOr.class.isAssignableFrom(parameterType.getClass());
-    }
+	public <T> boolean isOrList(@Nonnull T parameterType) {
+		return IQueryParameterOr.class.isAssignableFrom(parameterType.getClass());
+	}
 
-    public <T> boolean isAndList(@Nonnull T parameterType) {
-        return IQueryParameterAnd.class.isAssignableFrom(parameterType.getClass());
-    }
+	public <T> boolean isAndList(@Nonnull T parameterType) {
+		return IQueryParameterAnd.class.isAssignableFrom(parameterType.getClass());
+	}
 
-    public <T> boolean isTokenParam(@Nonnull T parameterType) {
-        return TokenParam.class.isAssignableFrom(parameterType.getClass());
-    }
+	public <T> boolean isTokenParam(@Nonnull T parameterType) {
+		return TokenParam.class.isAssignableFrom(parameterType.getClass());
+	}
 }

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/repository/BundleProviderUtilTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/repository/BundleProviderUtilTest.java
@@ -1,0 +1,133 @@
+package ca.uhn.fhir.jpa.repository;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
+import ca.uhn.fhir.rest.server.IPagingProvider;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.SimpleBundleProvider;
+import jakarta.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BundleProviderUtilTest {
+
+    private static final Resource PATIENT_1 = new Patient().setId("pat1");
+
+    private final RequestDetails requestDetails = new SystemRequestDetails();
+    private final IPagingProvider pagingProvider = new FifoMemoryPagingProvider(10);
+
+    @Test
+    void createBundleFromBundleProvider_withValidInputs_returnsBundle() {
+        IBaseResource bundle = BundleProviderUtil.createBundleFromBundleProvider(
+                getRestfulServerWithDefaultPagingProvider(),
+                requestDetails,
+                10,
+                "selfLink",
+                Set.of(),
+                getBundleProvider(PATIENT_1),
+                0,
+                BundleTypeEnum.SEARCHSET,
+                null);
+
+        assertNotNull(bundle);
+        assertFalse(bundle.isEmpty());
+    }
+
+    @Test
+    void createBundleFromBundleProvider_withEmptyResources_returnsEmptyBundle() {
+        IBaseResource bundle = BundleProviderUtil.createBundleFromBundleProvider(
+                getRestfulServerWithDefaultPagingProvider(),
+                requestDetails,
+                10,
+                "selfLink",
+                Set.of(),
+                getBundleProvider(),
+                0,
+                BundleTypeEnum.SEARCHSET,
+                null);
+
+        assertNotNull(bundle);
+        assertFalse(bundle.isEmpty());
+    }
+
+    @Test
+    void createBundleFromBundleProvider_withNullPagingProvider_returnsBundle() {
+        IBaseResource bundle = BundleProviderUtil.createBundleFromBundleProvider(
+                getRestfulServer(null),
+                requestDetails,
+                10,
+                "selfLink",
+                Set.of(),
+                getBundleProvider(),
+                0,
+                BundleTypeEnum.SEARCHSET,
+                null);
+
+        assertNotNull(bundle);
+        assertFalse(bundle.isEmpty());
+    }
+
+    @Test
+    void createBundleFromBundleProvider_withMinusOneOffset_returnsBundle() {
+        final Set<Include> includes = Set.of();
+        final RestfulServer restfulServer = getRestfulServerWithDefaultPagingProvider();
+        final IBundleProvider bundleProvider = getBundleProvider();
+
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            BundleProviderUtil.createBundleFromBundleProvider(
+                    restfulServer,
+                    requestDetails,
+                    10,
+                    "selfLink",
+                    includes,
+                    bundleProvider,
+                    -1,
+                    BundleTypeEnum.SEARCHSET,
+                    null);
+        });
+    }
+
+    @Test
+    void createBundleFromBundleProvider_withNonEmptyResources_returnsBundleWithResources() {
+        IBaseResource bundle = BundleProviderUtil.createBundleFromBundleProvider(
+                getRestfulServer(null),
+                requestDetails,
+                10,
+                "selfLink",
+                Set.of(),
+                getBundleProvider(PATIENT_1),
+                0,
+                BundleTypeEnum.SEARCHSET,
+                null);
+
+        assertNotNull(bundle);
+        assertFalse(bundle.isEmpty());
+    }
+
+    private static IBundleProvider getBundleProvider(IBaseResource... resources) {
+        return new SimpleBundleProvider(resources);
+    }
+
+    private RestfulServer getRestfulServerWithDefaultPagingProvider() {
+        return getRestfulServer(pagingProvider);
+    }
+
+    private static RestfulServer getRestfulServer(@Nullable IPagingProvider pagingProvider) {
+        final RestfulServer restfulServer = new RestfulServer(FhirContext.forR4Cached());
+
+        restfulServer.setPagingProvider(pagingProvider);
+
+        return restfulServer;
+    }
+}

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/repository/SearchConverterTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/repository/SearchConverterTest.java
@@ -88,7 +88,7 @@ class SearchConverterTest {
         String key = "theOrKey";
         UriOrListParam theValue = withUriOrListParam();
         myFixture.setParameterTypeValue(key, theValue);
-        String result = myFixture.searchParameterMap.toNormalizedQueryString(withFhirContext());
+        String result = myFixture.mySearchParameterMap.toNormalizedQueryString(withFhirContext());
         String expected = "?theOrKey=theSecondValue,theValue";
         assertEquals(expected, result);
     }
@@ -98,7 +98,7 @@ class SearchConverterTest {
         String key = "theAndKey";
         UriAndListParam theValue = withUriAndListParam();
         myFixture.setParameterTypeValue(key, theValue);
-        String result = myFixture.searchParameterMap.toNormalizedQueryString(withFhirContext());
+        String result = myFixture.mySearchParameterMap.toNormalizedQueryString(withFhirContext());
         String expected = "?theAndKey=theSecondValue,theValue&theAndKey=theSecondValueAgain,theValueAgain";
         assertEquals(expected, result);
     }
@@ -109,22 +109,22 @@ class SearchConverterTest {
         UriParam theValue = new UriParam("theValue");
         String key = "key";
         myFixture.setParameterTypeValue(key, theValue);
-        String result = myFixture.searchParameterMap.toNormalizedQueryString(withFhirContext());
+        String result = myFixture.mySearchParameterMap.toNormalizedQueryString(withFhirContext());
         assertEquals(expected, result);
     }
 
     @Test
     void separateParameterTypesShouldSeparateSearchAndResultParams() {
         myFixture.separateParameterTypes(withParamList());
-        assertThat(myFixture.separatedSearchParameters.entries()).hasSize(2);
-        assertThat(myFixture.separatedResultParameters.entries()).hasSize(3);
+        assertThat(myFixture.mySeparatedSearchParameters.entries()).hasSize(2);
+        assertThat(myFixture.mySeparatedResultParameters.entries()).hasSize(3);
     }
 
     @Test
     void convertToStringMapShouldConvert() {
         Map<String, String[]> expected = withParamListAsStrings();
         myFixture.convertToStringMap(withParamList(), withFhirContext());
-        Map<String, String[]> result = myFixture.resultParameters;
+        Map<String, String[]> result = myFixture.myResultParameters;
         assertEquals(result.keySet(), expected.keySet());
         assertThat(result.entrySet().stream().allMatch(e -> Arrays.equals(e.getValue(), expected.get(e.getKey()))))
                 .isTrue();

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/repository/SearchConverterTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/repository/SearchConverterTest.java
@@ -1,0 +1,193 @@
+package ca.uhn.fhir.jpa.repository;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.NumberAndListParam;
+import ca.uhn.fhir.rest.param.NumberOrListParam;
+import ca.uhn.fhir.rest.param.SpecialAndListParam;
+import ca.uhn.fhir.rest.param.SpecialOrListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.UriAndListParam;
+import ca.uhn.fhir.rest.param.UriOrListParam;
+import ca.uhn.fhir.rest.param.UriParam;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SearchConverterTest {
+    private SearchConverter myFixture;
+
+    @BeforeEach
+    void setupFixture() {
+        myFixture = new SearchConverter();
+    }
+
+    @Test
+    void isSearchParameterShouldReturnTrue() {
+        boolean result = myFixture.isSearchResultParameter("_elements");
+        assertTrue(result);
+    }
+
+    @Test
+    void isSearchParameterShouldReturnFalse() {
+        boolean result = myFixture.isSearchResultParameter("_id");
+        assertFalse(result);
+    }
+
+    @Test
+    void isOrListShouldReturnTrue() {
+        boolean uriOrList = myFixture.isOrList(new UriOrListParam());
+        boolean numberOrList = myFixture.isOrList(new NumberOrListParam());
+        boolean specialOrList = myFixture.isOrList(new SpecialOrListParam());
+        boolean tokenOrList = myFixture.isOrList(new TokenOrListParam());
+        assertTrue(uriOrList);
+        assertTrue(numberOrList);
+        assertTrue(specialOrList);
+        assertTrue(tokenOrList);
+    }
+
+    @Test
+    void isAndListShouldReturnTrue() {
+        boolean uriAndList = myFixture.isAndList(new UriAndListParam());
+        boolean numberAndList = myFixture.isAndList(new NumberAndListParam());
+        boolean specialAndList = myFixture.isAndList(new SpecialAndListParam());
+        boolean tokenAndList = myFixture.isAndList(new TokenAndListParam());
+        assertTrue(uriAndList);
+        assertTrue(numberAndList);
+        assertTrue(specialAndList);
+        assertTrue(tokenAndList);
+    }
+
+    @Test
+    void isOrListShouldReturnFalse() {
+        boolean uriAndList = myFixture.isOrList(new UriAndListParam());
+        assertFalse(uriAndList);
+    }
+
+    @Test
+    void isAndListShouldReturnFalse() {
+        boolean uriAndList = myFixture.isAndList(new UriOrListParam());
+        assertFalse(uriAndList);
+    }
+
+    @Test
+    void setParameterTypeValueShouldSetWithOrValue() {
+        String key = "theOrKey";
+        UriOrListParam theValue = withUriOrListParam();
+        myFixture.setParameterTypeValue(key, theValue);
+        String result = myFixture.searchParameterMap.toNormalizedQueryString(withFhirContext());
+        String expected = "?theOrKey=theSecondValue,theValue";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void setParameterTypeValueShouldSetWithAndValue() {
+        String key = "theAndKey";
+        UriAndListParam theValue = withUriAndListParam();
+        myFixture.setParameterTypeValue(key, theValue);
+        String result = myFixture.searchParameterMap.toNormalizedQueryString(withFhirContext());
+        String expected = "?theAndKey=theSecondValue,theValue&theAndKey=theSecondValueAgain,theValueAgain";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void setParameterTypeValueShouldSetWithBaseValue() {
+        String expected = "?key=theValue";
+        UriParam theValue = new UriParam("theValue");
+        String key = "key";
+        myFixture.setParameterTypeValue(key, theValue);
+        String result = myFixture.searchParameterMap.toNormalizedQueryString(withFhirContext());
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void separateParameterTypesShouldSeparateSearchAndResultParams() {
+        myFixture.separateParameterTypes(withParamList());
+        assertThat(myFixture.separatedSearchParameters.entries()).hasSize(2);
+        assertThat(myFixture.separatedResultParameters.entries()).hasSize(3);
+    }
+
+    @Test
+    void convertToStringMapShouldConvert() {
+        Map<String, String[]> expected = withParamListAsStrings();
+        myFixture.convertToStringMap(withParamList(), withFhirContext());
+        Map<String, String[]> result = myFixture.resultParameters;
+        assertEquals(result.keySet(), expected.keySet());
+        assertThat(result.entrySet().stream().allMatch(e -> Arrays.equals(e.getValue(), expected.get(e.getKey()))))
+                .isTrue();
+    }
+
+    Multimap<String, List<IQueryParameterType>> withParamList() {
+        ArrayListMultimap<String, List<IQueryParameterType>> paramList = ArrayListMultimap.create();
+        paramList.put("_id", withUriParam(1));
+        paramList.put("_elements", withUriParam(2));
+        paramList.put("_lastUpdated", withUriParam(1));
+        paramList.put("_total", withUriParam(1));
+        paramList.put("_count", withUriParam(3));
+        return paramList;
+    }
+
+    Map<String, String[]> withParamListAsStrings() {
+        Map<String, String[]> paramList = new HashMap<>();
+        paramList.put("_id", withStringParam(1));
+        paramList.put("_elements", withStringParam(2));
+        paramList.put("_lastUpdated", withStringParam(1));
+        paramList.put("_total", withStringParam(1));
+        paramList.put("_count", withStringParam(3));
+        return paramList;
+    }
+
+    List<IQueryParameterType> withUriParam(int theNumberOfParams) {
+        List<IQueryParameterType> paramList = new ArrayList<>();
+        for (int i = 0; i < theNumberOfParams; i++) {
+            paramList.add(new UriParam(Integer.toString(i)));
+        }
+        return paramList;
+    }
+
+    UriOrListParam withUriOrListParam() {
+        UriOrListParam orList = new UriOrListParam();
+        orList.add(new UriParam("theValue"));
+        orList.add(new UriParam("theSecondValue"));
+        return orList;
+    }
+
+    UriOrListParam withUriOrListParamSecond() {
+        UriOrListParam orList = new UriOrListParam();
+        orList.add(new UriParam("theValueAgain"));
+        orList.add(new UriParam("theSecondValueAgain"));
+        return orList;
+    }
+
+    UriAndListParam withUriAndListParam() {
+        UriAndListParam andList = new UriAndListParam();
+        andList.addAnd(withUriOrListParam());
+        andList.addAnd(withUriOrListParamSecond());
+        return andList;
+    }
+
+    String[] withStringParam(int theNumberOfParams) {
+        String[] paramList = new String[theNumberOfParams];
+        for (int i = 0; i < theNumberOfParams; i++) {
+            paramList[i] = Integer.toString(i);
+        }
+        return paramList;
+    }
+
+    FhirContext withFhirContext() {
+        return FhirContext.forR4Cached();
+    }
+}


### PR DESCRIPTION
Add the IRepositoryFactory interface and HapiFhirRepository implementation to base HAPI packages.  These are being moved from the Clinical Reasoning module to allow for broader usage without having a dependency on the Clinical Reasoning module.

Also deprecating all CR module classes and marking for removal in anticipation of new strategy to pull the CR module in further downstream.

Closes #6872 