### PR TITLE
Harden HAPI FHIR public server

### DIFF
--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -23,6 +23,12 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.convertors</artifactId>
 			<version>${fhir_core_version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Server -->

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -25,6 +25,8 @@
 			<version>${fhir_core_version}</version>
 			<exclusions>
 				<exclusion>
+					<!-- For some reason, the XPP dependency pulls in junit4 as a compile-scoped
+					dependency -->
 					<groupId>junit</groupId>
 					<artifactId>junit</artifactId>
 				</exclusion>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6873-add-variable-to-logginginterceptor.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6873-add-variable-to-logginginterceptor.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 6873
+title: "The server LoggingInterceptor now has a substitution variable `responseId` which
+    contains the value of the Location header for write operations"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6873-startup-resiliance.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6873-startup-resiliance.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 6873
+title: "The Subscription registry has been made more resilient to failures when
+    fetching Subscriptions on startup"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6873-subscription-rules-interceptor.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6873-subscription-rules-interceptor.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 6873
+title: "A new built-in interceptor called SubscriptionRulesInterceptor has been added, 
+    which can enforce rules on newly created subscriptions, such as mandatory criteria 
+    patterns and ensuring that target URLs are reachable."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/built_in_server_interceptors.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/built_in_server_interceptors.md
@@ -225,6 +225,14 @@ When using Subscriptions, the debug log interceptor can be used to add a number 
 * [SubscriptionDebugLogInterceptor Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/util/SubscriptionDebugLogInterceptor.java)
 
 
+# Subscription: Subscription Rules Interceptor
+
+This interceptor can be used to enforce rules on allowable subscriptions, such as mandatory criteria patteerns, or requiring a reachable target URL for REST HOOK subscriptions.
+
+* [SubscriptionRulesInterceptor JavaDoc](/apidocs/hapi-fhir-jpaserver-subscription/ca/uhn/fhir/jpa/subscription/util/SubscriptionRulesInterceptor.html)
+* [SubscriptionRulesInterceptor Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/util/SubscriptionRulesInterceptor.java)
+
+
 # Request Pre-Processing: Override Meta.source
 
 If you wish to override the value of `Resource.meta.source` using the value	supplied in an HTTP header, you can use the CaptureResourceSourceFromHeaderInterceptor to accomplish this.

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/retry/Retrier.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/retry/Retrier.java
@@ -74,7 +74,13 @@ public class Retrier<T> {
 					RetryContext context, RetryCallback<TT, E> callback, Throwable throwable) {
 				if (throwable instanceof NullPointerException
 						|| throwable instanceof UnsupportedOperationException
-						|| HapiSystemProperties.isUnitTestModeEnabled()) {
+						|| HapiSystemProperties.isUnitTestModeEnabled()
+						|| context.getRetryCount() == 1) {
+					/*
+					 * Log the stack trace only on the first retry in order to
+					 * avoid noise in the logs (except for unit test mode, and for
+					 * exceptions that indicate a bug)
+					 */
 					ourLog.error(
 							"Retry failure {}/{}: {}",
 							context.getRetryCount(),

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/util/SubscriptionRulesInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/util/SubscriptionRulesInterceptor.java
@@ -1,0 +1,161 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.subscription.util;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
+import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionCanonicalizer;
+import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscription;
+import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscriptionChannelType;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import ca.uhn.hapi.converters.canonical.SubscriptionTopicCanonicalizer;
+import jakarta.annotation.Nonnull;
+import org.apache.commons.lang3.Validate;
+import org.hl7.fhir.instance.model.api.IBaseConformance;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r5.model.SubscriptionTopic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * This interceptor enforces various rules on Subscriptions, preventing them from being
+ * registered if they don't meet the configured requirements.
+ *
+ * @since 8.2.0
+ * @see #addAllowedCriteriaPattern(String)
+ * @see #setValidateRestHookEndpointIsReachable(boolean)
+ */
+@Interceptor
+public class SubscriptionRulesInterceptor {
+
+	public static final String CRITERIA_WITH_AT_LEAST_ONE_PARAM = "^[A-Z][A-Za-z0-9]++\\?[a-z].*";
+	private static final Logger ourLog = LoggerFactory.getLogger(SubscriptionRulesInterceptor.class);
+	private final List<Pattern> myAllowedCriteriaPatterns = new ArrayList<>();
+	private final FhirContext myFhirContext;
+	private final FhirVersionEnum myVersion;
+	private final SubscriptionCanonicalizer mySubscriptionCanonicalizer;
+	private boolean myValidateRestHookEndpointIsReachable;
+
+	public SubscriptionRulesInterceptor(
+			@Nonnull FhirContext theFhirContext, @Nonnull SubscriptionSettings theSubscriptionSettings) {
+		Validate.notNull(theFhirContext, "FhirContext must not be null");
+		Validate.notNull(theSubscriptionSettings, "SubscriptionSettings must not be null");
+
+		myFhirContext = theFhirContext;
+		myVersion = myFhirContext.getVersion().getVersion();
+		mySubscriptionCanonicalizer = new SubscriptionCanonicalizer(myFhirContext, theSubscriptionSettings);
+	}
+
+	/**
+	 * Specifies a regular expression pattern which any Subscription (or SubscriptionTopic on R5+)
+	 * must match. If more than one pattern is supplied, the pattern must match at least one
+	 * pattern to be accepted, but does not need to match all of them.
+	 */
+	public void addAllowedCriteriaPattern(@Nonnull String theAllowedCriteriaPattern) {
+		Validate.notBlank(theAllowedCriteriaPattern, "Allowed criteria pattern must not be null");
+		myAllowedCriteriaPatterns.add(Pattern.compile(theAllowedCriteriaPattern));
+	}
+
+	/**
+	 * If true, Subscriptions with a type of "rest-hook" will be tested to ensure that the
+	 * endpoint is accessible. If it is not, the subscription will be blocked.
+	 */
+	public void setValidateRestHookEndpointIsReachable(boolean theValidateRestHookEndpointIsReachable) {
+		myValidateRestHookEndpointIsReachable = theValidateRestHookEndpointIsReachable;
+	}
+
+	@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
+	public void validateCreate(IBaseResource theResource) {
+		checkResource(theResource);
+	}
+
+	@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+	public void validateUpdate(IBaseResource theOldResource, IBaseResource theResource) {
+		checkResource(theResource);
+	}
+
+	private void checkResource(IBaseResource theResource) {
+		if (myVersion.isEqualOrNewerThan(FhirVersionEnum.R5)) {
+			if ("SubscriptionTopic".equals(myFhirContext.getResourceType(theResource))) {
+				ourLog.info("Validating SubscriptionTopic: {}", theResource.getIdElement());
+				validateSubscriptionTopic(theResource);
+			}
+		} else {
+			if ("Subscription".equals(myFhirContext.getResourceType(theResource))) {
+				ourLog.info("Validating Subscription: {}", theResource.getIdElement());
+				validateSubscription(theResource);
+			}
+		}
+	}
+
+	private void validateSubscriptionTopic(IBaseResource theResource) {
+		SubscriptionTopic topic = SubscriptionTopicCanonicalizer.canonicalizeTopic(myFhirContext, theResource);
+		for (SubscriptionTopic.SubscriptionTopicResourceTriggerComponent resourceTrigger : topic.getResourceTrigger()) {
+			String criteriaString = resourceTrigger.getQueryCriteria().getCurrent();
+			validateCriteriaString(criteriaString);
+		}
+	}
+
+	private void validateSubscription(IBaseResource theResource) {
+		CanonicalSubscription canonicalizedSubscription = mySubscriptionCanonicalizer.canonicalize(theResource);
+		validateCriteriaString(canonicalizedSubscription.getCriteriaString());
+		validateEndpointIsReachable(canonicalizedSubscription);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void validateEndpointIsReachable(CanonicalSubscription canonicalizedSubscription) {
+		if (myValidateRestHookEndpointIsReachable
+				&& canonicalizedSubscription.getChannelType() == CanonicalSubscriptionChannelType.RESTHOOK) {
+			String endpointUrl = canonicalizedSubscription.getEndpointUrl();
+			IGenericClient client = myFhirContext.newRestfulGenericClient(endpointUrl);
+			Class<? extends IBaseConformance> capabilityStatement = (Class<? extends IBaseConformance>)
+					myFhirContext.getResourceDefinition("CapabilityStatement").getImplementingClass();
+			try {
+				client.capabilities().ofType(capabilityStatement).execute();
+			} catch (Exception e) {
+				String message = "REST HOOK endpoint is not reachable: " + endpointUrl;
+				ourLog.warn(message);
+				throw new PreconditionFailedException(message);
+			}
+		}
+	}
+
+	private void validateCriteriaString(String theCriteriaString) {
+		if (!myAllowedCriteriaPatterns.isEmpty()) {
+			for (Pattern pattern : myAllowedCriteriaPatterns) {
+				if (pattern.matcher(theCriteriaString).matches()) {
+					return;
+				}
+			}
+			String message = "Criteria is not permitted on this server: " + theCriteriaString;
+			ourLog.warn(message);
+			throw new PreconditionFailedException(message);
+		}
+	}
+}

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionLoaderTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/match/registry/SubscriptionLoaderTest.java
@@ -11,11 +11,13 @@ import ca.uhn.fhir.jpa.subscription.match.matcher.subscriber.SubscriptionActivat
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
+import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
 import ca.uhn.test.util.LogbackTestExtension;
 import ca.uhn.test.util.LogbackTestExtensionAssert;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +33,11 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -93,6 +99,34 @@ public class SubscriptionLoaderTest {
 		subscriptionList.getAllResources().addAll(theReturnedResource);
 		return subscriptionList;
 	}
+
+	@Test
+	public void testUnfetchableResourceDoesntBlockLoading() {
+		// setup
+		Subscription subscription = new Subscription();
+		subscription.setId("Subscription/A");
+
+		// when
+		when(myDaoRegistry.getResourceDao("Subscription"))
+			.thenReturn(mySubscriptionDao);
+		when(myDaoRegistry.isResourceTypeSupported("Subscription"))
+			.thenReturn(true);
+		when(mySubscriptionDao.read(eq(new IdType("Subscription/123")), any())).thenThrow(new ResourceGoneException(new IdType("Subscription/123")));
+		when(mySubscriptionDao.read(eq(new IdType("Subscription/A")), any())).thenReturn(subscription);
+
+		// test
+		mySubscriptionLoader.handleInit(List.of(new IdType("Subscription/123"), new IdType("Subscription/A")));
+
+		// verify
+		verify(mySubscriptionDao).read(eq(new IdType("Subscription/123")), any());
+		verify(mySubscriptionDao).read(eq(new IdType("Subscription/A")), any());
+		verifyNoMoreInteractions(mySubscriptionDao);
+		verify(mySubscriptionRegistry, times(1)).unregisterAllSubscriptionsNotInCollection(any());
+		verify(mySubscriptionRegistry, times(1)).registerSubscriptionUnlessAlreadyRegistered(subscription);
+		verifyNoMoreInteractions(mySubscriptionRegistry);
+	}
+
+
 
 	@Test
 	public void refreshCache_withInactiveSubscriptionFailing_Syncs() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/SubscriptionRulesInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/SubscriptionRulesInterceptorR4Test.java
@@ -2,14 +2,22 @@ package ca.uhn.fhir.jpa.provider.r4;
 
 import ca.uhn.fhir.jpa.subscription.util.SubscriptionRulesInterceptor;
 import ca.uhn.fhir.jpa.subscription.BaseSubscriptionsR4Test;
+import ca.uhn.fhir.jpa.topic.R4SubscriptionTopicBuilder;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import ca.uhn.test.concurrency.PointcutLatch;
+import org.hl7.fhir.r4.model.Basic;
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Subscription;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static ca.uhn.fhir.interceptor.api.Pointcut.SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,11 +26,14 @@ public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test 
 
 	@ParameterizedTest
 	@ValueSource(strings = {"REQUESTED", "ACTIVE"})
-	public void testCriteriaFilter(Subscription.SubscriptionStatus theInitialStatus) {
+	public void testCriteriaFilter(Subscription.SubscriptionStatus theInitialStatus) throws InterruptedException {
 		// Setup
 		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
 		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
 		registerInterceptor(interceptor);
+
+		PointcutLatch latch = new PointcutLatch(SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED);
+		myInterceptorRegistry.registerAnonymousInterceptor(SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED, latch);
 
 		// Test
 		Subscription subsGood = new Subscription();
@@ -31,7 +42,9 @@ public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test 
 		subsGood.setCriteria("Observation?identifier=123"); // acceptable
 		subsGood.getChannel().setEndpoint("http://localhost:8888");
 		subsGood.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
+		latch.setExpectedCount(1);
 		mySubscriptionDao.update(subsGood, mySrd);
+		latch.awaitExpected();
 
 		Subscription subsBad = new Subscription();
 		subsBad.setId("BAD");
@@ -39,12 +52,10 @@ public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test 
 		subsBad.setCriteria("Observation?"); // not acceptable
 		subsBad.getChannel().setEndpoint("http://localhost:8888");
 		subsBad.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
-		PreconditionFailedException e = assertThrows(PreconditionFailedException.class, () -> mySubscriptionDao.update(subsBad, mySrd));
+		assertThatThrownBy(()-> mySubscriptionDao.update(subsBad, mySrd))
+			.hasMessage("Criteria is not permitted on this server: Observation?");
 
 		// Verify
-		await().until(() -> mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd).getStatus(), t -> t == Subscription.SubscriptionStatus.ACTIVE);
-		assertEquals("Criteria is not permitted on this server: Observation?", e.getMessage());
-
 		subsGood = mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd);
 		assertEquals(Subscription.SubscriptionStatus.ACTIVE, subsGood.getStatus());
 		assertNull(subsGood.getReason());
@@ -54,11 +65,14 @@ public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test 
 
 	@ParameterizedTest
 	@ValueSource(strings = {"REQUESTED", "ACTIVE"})
-	public void testValidateEndpoint(Subscription.SubscriptionStatus theInitialStatus) {
+	public void testValidateEndpoint(Subscription.SubscriptionStatus theInitialStatus) throws InterruptedException {
 		// Setup
 		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
 		interceptor.setValidateRestHookEndpointIsReachable(true);
 		registerInterceptor(interceptor);
+
+		PointcutLatch latch = new PointcutLatch(SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED);
+		myInterceptorRegistry.registerAnonymousInterceptor(SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED, latch);
 
 		// Test
 		Subscription subsGood = new Subscription();
@@ -67,7 +81,10 @@ public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test 
 		subsGood.setCriteria("Observation?identifier=123");
 		subsGood.getChannel().setEndpoint(ourRestfulServer.getBaseUrl()); // reachable
 		subsGood.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
+		latch.setExpectedCount(1);
 		mySubscriptionDao.update(subsGood, mySrd);
+		// FIXME: remove timeout
+		latch.awaitExpectedWithTimeout(1000000);
 
 		Subscription subsBad = new Subscription();
 		subsBad.setId("BAD");
@@ -75,17 +92,71 @@ public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test 
 		subsBad.setCriteria("Observation?identifier=123");
 		subsBad.getChannel().setEndpoint("http://this-does-not-exist"); // can't reach
 		subsBad.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
-		PreconditionFailedException e = assertThrows(PreconditionFailedException.class, () -> mySubscriptionDao.update(subsBad, mySrd));
+		assertThatThrownBy(() -> mySubscriptionDao.update(subsBad, mySrd))
+			.hasMessage("REST HOOK endpoint is not reachable: http://this-does-not-exist");
 
 		// Verify
-		await().until(() -> mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd).getStatus(), t -> t == Subscription.SubscriptionStatus.ACTIVE);
-		assertEquals("REST HOOK endpoint is not reachable: http://this-does-not-exist", e.getMessage());
-
 		subsGood = mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd);
 		assertEquals(Subscription.SubscriptionStatus.ACTIVE, subsGood.getStatus());
 		assertNull(subsGood.getReason());
 
 		assertThat(mySubscriptionRegistry.getAll()).hasSize(1);
 	}
+
+	@Test
+	public void testR4SubscriptionTopic_NotAcceptable() {
+		// Setup
+		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
+		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
+		registerInterceptor(interceptor);
+
+		R4SubscriptionTopicBuilder builder = new R4SubscriptionTopicBuilder()
+			.setUrl("http://foo")
+			.setStatus(Enumerations.PublicationStatus.ACTIVE)
+			.addResourceTrigger()
+			.setResourceTriggerResource("Encounter")
+			.addResourceTriggerQueryCriteria()
+			.setResourceTriggerQueryCriteriaCurrent("Encounter?");
+		Basic subscriptionTopic = builder.build();
+
+		// Test and Verify
+		assertThatThrownBy(()->myBasicDao.create(subscriptionTopic, mySrd))
+			.hasMessage("Criteria is not permitted on this server: Encounter?");
+	}
+
+	@Test
+	public void testR4SubscriptionTopic_Acceptable() {
+		// Setup
+		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
+		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
+		registerInterceptor(interceptor);
+
+		R4SubscriptionTopicBuilder builder = new R4SubscriptionTopicBuilder()
+			.setUrl("http://foo")
+			.setStatus(Enumerations.PublicationStatus.ACTIVE)
+			.addResourceTrigger()
+			.setResourceTriggerResource("Encounter")
+			.addResourceTriggerQueryCriteria()
+			.setResourceTriggerQueryCriteriaCurrent("Encounter?code=active");
+		Basic subscriptionTopic = builder.build();
+
+		// Test and Verify
+		assertDoesNotThrow(()->myBasicDao.create(subscriptionTopic, mySrd));
+	}
+
+	@Test
+	public void testR4SubscriptionTopic_NotSubscriptionTopic() {
+		// Setup
+		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
+		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
+		registerInterceptor(interceptor);
+
+		Basic subscriptionTopic = new Basic();
+		subscriptionTopic.getCode().setText("Hello");
+
+		// Test and Verify
+		assertDoesNotThrow(()->myBasicDao.create(subscriptionTopic, mySrd));
+	}
+
 
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/SubscriptionRulesInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/SubscriptionRulesInterceptorR4Test.java
@@ -1,0 +1,91 @@
+package ca.uhn.fhir.jpa.provider.r4;
+
+import ca.uhn.fhir.jpa.subscription.util.SubscriptionRulesInterceptor;
+import ca.uhn.fhir.jpa.subscription.BaseSubscriptionsR4Test;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Subscription;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SubscriptionRulesInterceptorR4Test extends BaseSubscriptionsR4Test {
+
+	@ParameterizedTest
+	@ValueSource(strings = {"REQUESTED", "ACTIVE"})
+	public void testCriteriaFilter(Subscription.SubscriptionStatus theInitialStatus) {
+		// Setup
+		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
+		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
+		registerInterceptor(interceptor);
+
+		// Test
+		Subscription subsGood = new Subscription();
+		subsGood.setId("GOOD");
+		subsGood.setStatus(theInitialStatus);
+		subsGood.setCriteria("Observation?identifier=123"); // acceptable
+		subsGood.getChannel().setEndpoint("http://localhost:8888");
+		subsGood.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
+		mySubscriptionDao.update(subsGood, mySrd);
+
+		Subscription subsBad = new Subscription();
+		subsBad.setId("BAD");
+		subsBad.setStatus(theInitialStatus);
+		subsBad.setCriteria("Observation?"); // not acceptable
+		subsBad.getChannel().setEndpoint("http://localhost:8888");
+		subsBad.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
+		PreconditionFailedException e = assertThrows(PreconditionFailedException.class, () -> mySubscriptionDao.update(subsBad, mySrd));
+
+		// Verify
+		await().until(() -> mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd).getStatus(), t -> t == Subscription.SubscriptionStatus.ACTIVE);
+		assertEquals("Criteria is not permitted on this server: Observation?", e.getMessage());
+
+		subsGood = mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd);
+		assertEquals(Subscription.SubscriptionStatus.ACTIVE, subsGood.getStatus());
+		assertNull(subsGood.getReason());
+
+		assertThat(mySubscriptionRegistry.getAll()).hasSize(1);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"REQUESTED", "ACTIVE"})
+	public void testValidateEndpoint(Subscription.SubscriptionStatus theInitialStatus) {
+		// Setup
+		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
+		interceptor.setValidateRestHookEndpointIsReachable(true);
+		registerInterceptor(interceptor);
+
+		// Test
+		Subscription subsGood = new Subscription();
+		subsGood.setId("GOOD");
+		subsGood.setStatus(theInitialStatus);
+		subsGood.setCriteria("Observation?identifier=123");
+		subsGood.getChannel().setEndpoint(ourRestfulServer.getBaseUrl()); // reachable
+		subsGood.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
+		mySubscriptionDao.update(subsGood, mySrd);
+
+		Subscription subsBad = new Subscription();
+		subsBad.setId("BAD");
+		subsBad.setStatus(theInitialStatus);
+		subsBad.setCriteria("Observation?identifier=123");
+		subsBad.getChannel().setEndpoint("http://this-does-not-exist"); // can't reach
+		subsBad.getChannel().setType(Subscription.SubscriptionChannelType.RESTHOOK);
+		PreconditionFailedException e = assertThrows(PreconditionFailedException.class, () -> mySubscriptionDao.update(subsBad, mySrd));
+
+		// Verify
+		await().until(() -> mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd).getStatus(), t -> t == Subscription.SubscriptionStatus.ACTIVE);
+		assertEquals("REST HOOK endpoint is not reachable: http://this-does-not-exist", e.getMessage());
+
+		subsGood = mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd);
+		assertEquals(Subscription.SubscriptionStatus.ACTIVE, subsGood.getStatus());
+		assertNull(subsGood.getReason());
+
+		assertThat(mySubscriptionRegistry.getAll()).hasSize(1);
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/BaseJpaR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/BaseJpaR5Test.java
@@ -118,6 +118,7 @@ import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.ServiceRequest;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.Subscription;
+import org.hl7.fhir.r5.model.SubscriptionTopic;
 import org.hl7.fhir.r5.model.Substance;
 import org.hl7.fhir.r5.model.Task;
 import org.hl7.fhir.r5.model.ValueSet;
@@ -349,6 +350,9 @@ public abstract class BaseJpaR5Test extends BaseJpaTest implements ITestDataBuil
 	@Autowired
 	@Qualifier("mySubscriptionDaoR5")
 	protected IFhirResourceDaoSubscription<Subscription> mySubscriptionDao;
+	@Autowired
+	@Qualifier("mySubscriptionTopicDaoR5")
+	protected IFhirResourceDao<SubscriptionTopic> mySubscriptionTopicDao;
 	@Autowired
 	@Qualifier("mySubstanceDaoR5")
 	protected IFhirResourceDao<Substance> mySubstanceDao;

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR5Test.java
@@ -62,15 +62,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Disabled("abstract")
 public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test {
-	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BaseSubscriptionsR5Test.class);
 	public static final String SUBSCRIPTION_TOPIC_TEST_URL = "http://example.com/topic/test";
-
-
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BaseSubscriptionsR5Test.class);
+	private static final SubscriptionTopicR5Test.TestSystemProvider ourTestSystemProvider = new SubscriptionTopicR5Test.TestSystemProvider();
 	protected static int ourListenerPort;
+	protected static RestfulServer ourListenerRestServer;
 	private static Server ourListenerServer;
 	private static SingleQueryCountHolder ourCountHolder;
 	private static String ourListenerServerBase;
-	protected static RestfulServer ourListenerRestServer;
+	protected final PointcutLatch mySubscriptionTopicsCheckedLatch = new PointcutLatch(Pointcut.SUBSCRIPTION_TOPIC_AFTER_PERSISTED_RESOURCE_CHECKED);
+	protected final PointcutLatch mySubscriptionDeliveredLatch = new PointcutLatch(Pointcut.SUBSCRIPTION_AFTER_REST_HOOK_DELIVERY);
 	@Autowired
 	protected SubscriptionTestUtil mySubscriptionTestUtil;
 	@Autowired
@@ -78,17 +79,14 @@ public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test
 	protected CountingInterceptor myCountingInterceptor;
 	protected List<IIdType> mySubscriptionIds = Collections.synchronizedList(new ArrayList<>());
 	@Autowired
-	private SingleQueryCountHolder myCountHolder;
-	@Autowired
 	protected SubscriptionTopicRegistry mySubscriptionTopicRegistry;
 	@Autowired
 	protected SubscriptionTopicLoader mySubscriptionTopicLoader;
+	protected IFhirResourceDao<SubscriptionTopic> mySubscriptionTopicDao;
+	@Autowired
+	private SingleQueryCountHolder myCountHolder;
 	@Autowired
 	private IInterceptorService myInterceptorService;
-	private static final SubscriptionTopicR5Test.TestSystemProvider ourTestSystemProvider = new SubscriptionTopicR5Test.TestSystemProvider();
-	protected IFhirResourceDao<SubscriptionTopic> mySubscriptionTopicDao;
-	protected final PointcutLatch mySubscriptionTopicsCheckedLatch = new PointcutLatch(Pointcut.SUBSCRIPTION_TOPIC_AFTER_PERSISTED_RESOURCE_CHECKED);
-	protected final PointcutLatch mySubscriptionDeliveredLatch = new PointcutLatch(Pointcut.SUBSCRIPTION_AFTER_REST_HOOK_DELIVERY);
 
 	@Override
 	@BeforeEach
@@ -186,18 +184,6 @@ public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test
 		return subscription;
 	}
 
-	@Nonnull
-	protected Subscription putSubscription(Subscription subscription) throws InterruptedException {
-		mySubscriptionTopicsCheckedLatch.setExpectedCount(1);
-		MethodOutcome methodOutcome = myClient.update().resource(subscription).execute();
-		mySubscriptionTopicsCheckedLatch.awaitExpected();
-
-		subscription.setId(methodOutcome.getId().toVersionless());
-		mySubscriptionIds.add(methodOutcome.getId());
-
-		return subscription;
-	}
-
 	protected Subscription newTopicSubscription(String theTopicUrl, String thePayload, String... theFilters) {
 
 		Subscription subscription = new Subscription();
@@ -277,16 +263,6 @@ public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test
 		return retval;
 	}
 
-	@AfterAll
-	public static void reportTotalSelects() {
-		ourLog.info("Total database select queries: {}", getQueryCount().getSelect());
-	}
-
-	private static QueryCount getQueryCount() {
-		return ourCountHolder.getQueryCountMap().get("");
-	}
-
-
 	protected void waitForRegisteredSubscriptionTopicCount(int theTarget) {
 		await().until(() -> subscriptionTopicRegistryHasSize(theTarget));
 	}
@@ -305,6 +281,15 @@ public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test
 		SubscriptionTopic retval = (SubscriptionTopic) myClient.create().resource(theSubscriptionTopic).execute().getResource();
 		mySubscriptionTopicsCheckedLatch.awaitExpected();
 		return retval;
+	}
+
+	@AfterAll
+	public static void reportTotalSelects() {
+		ourLog.info("Total database select queries: {}", getQueryCount().getSelect());
+	}
+
+	private static QueryCount getQueryCount() {
+		return ourCountHolder.getQueryCountMap().get("");
 	}
 
 	protected static void validateSubscriptionStatus(Subscription subscription, IBaseResource sentResource, SubscriptionStatus ss, Long theExpectedEventNumber) {
@@ -347,10 +332,10 @@ public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test
 
 
 	static class TestSystemProvider {
-		AtomicInteger count = new AtomicInteger(0);
 		final List<Bundle> receivedBundles = new ArrayList<>();
 		final List<String> receivedContentTypes = new ArrayList<>();
 		final List<String> myHeaders = new ArrayList<>();
+		AtomicInteger count = new AtomicInteger(0);
 
 		@Transaction
 		public Bundle transaction(@TransactionParam Bundle theBundle, HttpServletRequest theRequest) {

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR5Test.java
@@ -186,6 +186,18 @@ public abstract class BaseSubscriptionsR5Test extends BaseResourceProviderR5Test
 		return subscription;
 	}
 
+	@Nonnull
+	protected Subscription putSubscription(Subscription subscription) throws InterruptedException {
+		mySubscriptionTopicsCheckedLatch.setExpectedCount(1);
+		MethodOutcome methodOutcome = myClient.update().resource(subscription).execute();
+		mySubscriptionTopicsCheckedLatch.awaitExpected();
+
+		subscription.setId(methodOutcome.getId().toVersionless());
+		mySubscriptionIds.add(methodOutcome.getId());
+
+		return subscription;
+	}
+
 	protected Subscription newTopicSubscription(String theTopicUrl, String thePayload, String... theFilters) {
 
 		Subscription subscription = new Subscription();

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionRulesInterceptorR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionRulesInterceptorR5Test.java
@@ -1,0 +1,77 @@
+package ca.uhn.fhir.jpa.subscription;
+
+import ca.uhn.fhir.jpa.subscription.util.SubscriptionRulesInterceptor;
+import ca.uhn.fhir.jpa.subscription.model.CanonicalSubscriptionChannelType;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import org.hl7.fhir.r5.model.Enumerations;
+import org.hl7.fhir.r5.model.IdType;
+import org.hl7.fhir.r5.model.Subscription;
+import org.hl7.fhir.r5.model.SubscriptionTopic;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SubscriptionRulesInterceptorR5Test extends BaseSubscriptionsR5Test {
+
+	@Test
+	public void testCriteriaFilter() {
+		// Setup
+		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
+		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
+		registerInterceptor(interceptor);
+
+		// Test
+		SubscriptionTopic topicGood = new SubscriptionTopic();
+		topicGood.setId("GOOD");
+		topicGood.setUrl("http://good");
+		topicGood.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		SubscriptionTopic.SubscriptionTopicResourceTriggerComponent topicGoodTrigger = topicGood.addResourceTrigger()
+			.setResource("Patient")
+			.addSupportedInteraction(SubscriptionTopic.InteractionTrigger.CREATE)
+			.addSupportedInteraction(SubscriptionTopic.InteractionTrigger.UPDATE);
+		topicGoodTrigger.getQueryCriteria()
+			.setCurrent("Observation?code=http://foo|123") // acceptable
+			.setRequireBoth(false);
+		mySubscriptionTopicDao.update(topicGood, mySrd);
+
+		Subscription subsGood = new Subscription();
+		subsGood.setId("GOOD");
+		subsGood.setStatus(Enumerations.SubscriptionStatusCodes.REQUESTED);
+		subsGood.getChannelType()
+			.setSystem(CanonicalSubscriptionChannelType.RESTHOOK.getSystem())
+			.setCode(CanonicalSubscriptionChannelType.RESTHOOK.toCode());
+		subsGood.setTopic("http://good");
+		subsGood.setContentType(Constants.CT_FHIR_JSON_NEW);
+		subsGood.setEndpoint("http://localhost" + ourListenerPort);
+		mySubscriptionDao.update(subsGood, mySrd);
+
+		SubscriptionTopic topicBad = new SubscriptionTopic();
+		topicBad.setId("BAD");
+		topicBad.setUrl("http://bad");
+		topicBad.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		SubscriptionTopic.SubscriptionTopicResourceTriggerComponent topicBadTrigger = topicBad.addResourceTrigger()
+			.setResource("Patient")
+			.addSupportedInteraction(SubscriptionTopic.InteractionTrigger.CREATE)
+			.addSupportedInteraction(SubscriptionTopic.InteractionTrigger.UPDATE);
+		topicBadTrigger.getQueryCriteria()
+			.setCurrent("Observation?") // not acceptable
+			.setRequireBoth(false);
+		PreconditionFailedException topicCreateException = assertThrows(PreconditionFailedException.class, () -> mySubscriptionTopicDao.update(topicBad, mySrd));
+
+		// Verify
+		await().until(() -> mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd).getStatus(), t -> t == Enumerations.SubscriptionStatusCodes.ACTIVE);
+		assertEquals("Criteria is not permitted on this server: Observation?", topicCreateException.getMessage());
+
+		subsGood = mySubscriptionDao.read(new IdType("Subscription/GOOD"), mySrd);
+		assertEquals(Enumerations.SubscriptionStatusCodes.ACTIVE, subsGood.getStatus());
+		assertNull(subsGood.getReason());
+
+		assertThat(mySubscriptionRegistry.getAll()).hasSize(1);
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionRulesInterceptorR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/SubscriptionRulesInterceptorR5Test.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class SubscriptionRulesInterceptorR5Test extends BaseSubscriptionsR5Test {
 
 	@Test
-	public void testCriteriaFilter() {
+	public void testCriteriaFilter() throws InterruptedException {
 		// Setup
 		SubscriptionRulesInterceptor interceptor = new SubscriptionRulesInterceptor(myFhirContext, mySubscriptionSettings);
 		interceptor.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
@@ -37,7 +37,7 @@ public class SubscriptionRulesInterceptorR5Test extends BaseSubscriptionsR5Test 
 		topicGoodTrigger.getQueryCriteria()
 			.setCurrent("Observation?code=http://foo|123") // acceptable
 			.setRequireBoth(false);
-		mySubscriptionTopicDao.update(topicGood, mySrd);
+		createResource(topicGood, false);
 
 		Subscription subsGood = new Subscription();
 		subsGood.setId("GOOD");
@@ -48,7 +48,7 @@ public class SubscriptionRulesInterceptorR5Test extends BaseSubscriptionsR5Test 
 		subsGood.setTopic("http://good");
 		subsGood.setContentType(Constants.CT_FHIR_JSON_NEW);
 		subsGood.setEndpoint("http://localhost" + ourListenerPort);
-		mySubscriptionDao.update(subsGood, mySrd);
+		putSubscription(subsGood);
 
 		SubscriptionTopic topicBad = new SubscriptionTopic();
 		topicBad.setId("BAD");

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
@@ -127,6 +127,7 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.Appointment;
 import org.hl7.fhir.r4.model.AuditEvent;
+import org.hl7.fhir.r4.model.Basic;
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.BodyStructure;
 import org.hl7.fhir.r4.model.Bundle;
@@ -491,6 +492,9 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 	@Autowired
 	@Qualifier("mySubscriptionDaoR4")
 	protected IFhirResourceDaoSubscription<Subscription> mySubscriptionDao;
+	@Autowired
+	@Qualifier("myBasicDaoR4")
+	protected IFhirResourceDao<Basic> myBasicDao;
 	@Autowired
 	@Qualifier("mySubstanceDaoR4")
 	protected IFhirResourceDao<Substance> mySubstanceDao;

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -1038,6 +1038,7 @@ public abstract class BaseJpaTest extends BaseTest {
 	protected void afterResetInterceptors() {
 		myRegisteredInterceptors.forEach(t -> myInterceptorRegistry.unregisterInterceptor(t));
 		myRegisteredInterceptors.clear();
+		myInterceptorRegistry.unregisterAllAnonymousInterceptors();
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -176,6 +176,7 @@ import static ca.uhn.fhir.rest.api.Constants.HEADER_CACHE_CONTROL;
 import static ca.uhn.fhir.util.TestUtil.doRandomizeLocaleAndTimezone;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.in;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/TestRestfulServer.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/TestRestfulServer.java
@@ -13,7 +13,6 @@ import ca.uhn.fhir.jpa.delete.ThreadSafeResourceDeleterSvc;
 import ca.uhn.fhir.jpa.fql.provider.HfqlRestProvider;
 import ca.uhn.fhir.jpa.graphql.GraphQLProvider;
 import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
-import ca.uhn.fhir.jpa.subscription.util.SubscriptionRulesInterceptor;
 import ca.uhn.fhir.jpa.ips.provider.IpsOperationProvider;
 import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.jpa.provider.DiffProvider;
@@ -26,6 +25,7 @@ import ca.uhn.fhir.jpa.provider.ValueSetOperationProvider;
 import ca.uhn.fhir.jpa.provider.dstu3.JpaConformanceProviderDstu3;
 import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
 import ca.uhn.fhir.jpa.subscription.match.config.WebsocketDispatcherConfig;
+import ca.uhn.fhir.jpa.subscription.util.SubscriptionRulesInterceptor;
 import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.openapi.OpenApiInterceptor;
@@ -366,11 +366,12 @@ public class TestRestfulServer extends RestfulServer {
 		registerInterceptor(myAppCtx.getBean(SqlCaptureInterceptor.class));
 
 		// Subscription Validation
-		SubscriptionRulesInterceptor subscriptionCriteriaValidation = new SubscriptionRulesInterceptor(myAppCtx.getBean(FhirContext.class), myAppCtx.getBean(SubscriptionSettings.class));
-		subscriptionCriteriaValidation.addAllowedCriteriaPattern(SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
+		SubscriptionRulesInterceptor subscriptionCriteriaValidation = new SubscriptionRulesInterceptor(
+				myAppCtx.getBean(FhirContext.class), myAppCtx.getBean(SubscriptionSettings.class));
+		subscriptionCriteriaValidation.addAllowedCriteriaPattern(
+				SubscriptionRulesInterceptor.CRITERIA_WITH_AT_LEAST_ONE_PARAM);
 		subscriptionCriteriaValidation.setValidateRestHookEndpointIsReachable(true);
 		registerInterceptor(subscriptionCriteriaValidation);
-
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/CommonConfig.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/CommonConfig.java
@@ -137,6 +137,11 @@ public class CommonConfig {
 		return new FhirTestAutoMigrator();
 	}
 
+	@Bean
+	public SubscriptionExpiryService transactionExpiryService() {
+		return new SubscriptionExpiryService();
+	}
+
 	public static boolean isLocalTestMode() {
 		return "true".equalsIgnoreCase(System.getProperty("testmode.local"));
 	}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/SubscriptionExpiryService.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/SubscriptionExpiryService.java
@@ -27,6 +27,12 @@ import java.util.Date;
 
 import static ca.uhn.fhir.rest.api.Constants.PARAM_LASTUPDATED;
 
+/**
+ * This service automatically moves subscriptions to "off" status one hour
+ * after they are created. This is currently just intended to be a
+ * failsafe/cleanup for the public server, but could be promoted to being
+ * a feature in the library if there was interest in the future.
+ */
 public class SubscriptionExpiryService {
 	private static final Logger ourLog = LoggerFactory.getLogger(SubscriptionExpiryService.class);
 

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/SubscriptionExpiryService.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/SubscriptionExpiryService.java
@@ -1,0 +1,77 @@
+package ca.uhn.fhirtest.config;
+
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.model.sched.HapiJob;
+import ca.uhn.fhir.jpa.model.sched.ISchedulerService;
+import ca.uhn.fhir.jpa.model.sched.ScheduledJobDefinition;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.model.dstu2.resource.Subscription;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.param.DateParam;
+import ca.uhn.fhir.rest.param.ParamPrefixEnum;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.subscription.SubscriptionConstants;
+import ca.uhn.fhir.util.SubscriptionUtil;
+import org.apache.commons.lang3.time.DateUtils;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.quartz.JobExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+
+import java.util.Date;
+
+import static ca.uhn.fhir.rest.api.Constants.PARAM_LASTUPDATED;
+
+public class SubscriptionExpiryService {
+	private static final Logger ourLog = LoggerFactory.getLogger(SubscriptionExpiryService.class);
+
+	@Autowired
+	private ISchedulerService mySchedulerSvc;
+
+	@Autowired
+	private DaoRegistry myDaoRegistry;
+
+	@EventListener(ContextRefreshedEvent.class)
+	public void start() {
+		ScheduledJobDefinition jobDetail = new ScheduledJobDefinition();
+		jobDetail.setId(SubscriptionExpiryServiceJob.class.getName());
+		jobDetail.setJobClass(SubscriptionExpiryServiceJob.class);
+		mySchedulerSvc.scheduleLocalJob(DateUtils.MILLIS_PER_HOUR, jobDetail);
+
+		doPass();
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private void doPass() {
+		Date cutoff = DateUtils.addHours(new Date(), -1);
+
+		SearchParameterMap params = new SearchParameterMap();
+		params.setLoadSynchronousUpTo(1000);
+		params.add(Subscription.SP_STATUS, new TokenParam("active"));
+		params.add(PARAM_LASTUPDATED, new DateParam(ParamPrefixEnum.LESSTHAN, cutoff));
+
+		IFhirResourceDao subscriptionDao = myDaoRegistry.getResourceDao("Subscription");
+		IBundleProvider results = subscriptionDao.search(params, new SystemRequestDetails());
+		for (IBaseResource subscriptionToDeactivate : results.getAllResources()) {
+			ourLog.info("Deactivating Subscription (status=off): {}", subscriptionToDeactivate.getIdElement());
+			SubscriptionUtil.setStatus(myDaoRegistry.getFhirContext(), subscriptionToDeactivate, SubscriptionConstants.OFF_STATUS);
+			subscriptionDao.update(subscriptionToDeactivate, new SystemRequestDetails());
+		}
+	}
+
+	public static class SubscriptionExpiryServiceJob implements HapiJob {
+
+		@Autowired
+		private SubscriptionExpiryService mySvc;
+
+		@Override
+		public void execute(JobExecutionContext context) {
+			mySvc.doPass();
+		}
+	}
+}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/SubscriptionExpiryService.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/SubscriptionExpiryService.java
@@ -59,7 +59,8 @@ public class SubscriptionExpiryService {
 		IBundleProvider results = subscriptionDao.search(params, new SystemRequestDetails());
 		for (IBaseResource subscriptionToDeactivate : results.getAllResources()) {
 			ourLog.info("Deactivating Subscription (status=off): {}", subscriptionToDeactivate.getIdElement());
-			SubscriptionUtil.setStatus(myDaoRegistry.getFhirContext(), subscriptionToDeactivate, SubscriptionConstants.OFF_STATUS);
+			SubscriptionUtil.setStatus(
+					myDaoRegistry.getFhirContext(), subscriptionToDeactivate, SubscriptionConstants.OFF_STATUS);
 			subscriptionDao.update(subscriptionToDeactivate, new SystemRequestDetails());
 		}
 	}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestDstu2Config.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestDstu2Config.java
@@ -53,9 +53,7 @@ public class TestDstu2Config extends BaseConfig {
 	@Bean
 	public SubscriptionSettings subscriptionSettings() {
 		SubscriptionSettings retVal = new SubscriptionSettings();
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.EMAIL);
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.RESTHOOK);
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		retVal.setWebsocketContextPath("/");
 		return retVal;
 	}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestDstu3Config.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestDstu3Config.java
@@ -48,9 +48,7 @@ public class TestDstu3Config extends BaseConfig {
 	@Bean
 	public SubscriptionSettings subscriptionSettings() {
 		SubscriptionSettings retVal = new SubscriptionSettings();
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.EMAIL);
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.RESTHOOK);
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		retVal.setWebsocketContextPath("/websocketDstu3");
 		return retVal;
 	}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestR4BConfig.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestR4BConfig.java
@@ -117,9 +117,7 @@ public class TestR4BConfig extends BaseConfig {
 	@Bean
 	public SubscriptionSettings subscriptionSettings() {
 		SubscriptionSettings retVal = new SubscriptionSettings();
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.EMAIL);
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.RESTHOOK);
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		retVal.setWebsocketContextPath("/websocketR4B");
 		return retVal;
 	}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestR4Config.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestR4Config.java
@@ -54,9 +54,7 @@ public class TestR4Config extends BaseConfig {
 	@Bean
 	public SubscriptionSettings subscriptionSettings() {
 		SubscriptionSettings retVal = new SubscriptionSettings();
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.EMAIL);
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.RESTHOOK);
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		retVal.setWebsocketContextPath("/websocketR4");
 		return retVal;
 	}

--- a/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestR5Config.java
+++ b/hapi-fhir-jpaserver-uhnfhirtest/src/main/java/ca/uhn/fhirtest/config/TestR5Config.java
@@ -53,9 +53,7 @@ public class TestR5Config extends BaseConfig {
 	@Bean
 	public SubscriptionSettings subscriptionSettings() {
 		SubscriptionSettings retVal = new SubscriptionSettings();
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.EMAIL);
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.RESTHOOK);
-		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		retVal.setWebsocketContextPath("/websocketR5");
 		return retVal;
 	}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/LoggingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/LoggingInterceptor.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.rest.server.interceptor;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -114,6 +115,10 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * <td>The HTTP verb of the request</td>
  * </tr>
  * <tr>
+ * <td>${responseId}</td>
+ * <td>For operations which write a resource (create/update/patch), provides the ID of that resource as supplied in the <code>Location</code> header.</td>
+ * </tr>
+ * <tr>
  * <td>${exceptionMessage}</td>
  * <td>Applies only to an error message: The message from {@link Exception#getMessage()}</td>
  * </tr>
@@ -126,7 +131,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 @Interceptor
 public class LoggingInterceptor {
 
-	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(LoggingInterceptor.class);
+	private static final Logger ourLog = LoggerFactory.getLogger(LoggingInterceptor.class);
 
 	private String myErrorMessageFormat = "ERROR - ${operationType} - ${idOrResourceName}";
 	private boolean myLogExceptions = true;
@@ -156,7 +161,7 @@ public class LoggingInterceptor {
 			throws ServletException, IOException {
 		if (myLogExceptions) {
 			// Perform any string substitutions from the message format
-			StringLookup lookup = new MyLookup(theServletRequest, theException, theRequestDetails);
+			StringLookup lookup = new MyLookup(theServletRequest, theServletResponse, theException, theRequestDetails);
 			StringSubstitutor subs = new StringSubstitutor(lookup, "${", "}", '\\');
 
 			// Actually log the line
@@ -169,7 +174,8 @@ public class LoggingInterceptor {
 	@Hook(Pointcut.SERVER_PROCESSING_COMPLETED_NORMALLY)
 	public void processingCompletedNormally(ServletRequestDetails theRequestDetails) {
 		// Perform any string substitutions from the message format
-		StringLookup lookup = new MyLookup(theRequestDetails.getServletRequest(), theRequestDetails);
+		StringLookup lookup = new MyLookup(
+				theRequestDetails.getServletRequest(), theRequestDetails.getServletResponse(), theRequestDetails);
 		StringSubstitutor subs = new StringSubstitutor(lookup, "${", "}", '\\');
 
 		// Actually log the line
@@ -222,20 +228,25 @@ public class LoggingInterceptor {
 		private final Throwable myException;
 		private final HttpServletRequest myRequest;
 		private final RequestDetails myRequestDetails;
+		private final HttpServletResponse myResponse;
 
-		private MyLookup(HttpServletRequest theRequest, RequestDetails theRequestDetails) {
+		private MyLookup(
+				HttpServletRequest theRequest, HttpServletResponse theResponse, RequestDetails theRequestDetails) {
 			myRequest = theRequest;
+			myResponse = theResponse;
 			myRequestDetails = theRequestDetails;
 			myException = null;
 		}
 
 		MyLookup(
 				HttpServletRequest theServletRequest,
+				HttpServletResponse theResponse,
 				BaseServerResponseException theException,
 				RequestDetails theRequestDetails) {
 			myException = theException;
 			myRequestDetails = theRequestDetails;
 			myRequest = theServletRequest;
+			myResponse = theResponse;
 		}
 
 		@Override
@@ -245,96 +256,109 @@ public class LoggingInterceptor {
 			 * TODO: this method could be made more efficient through some sort of lookup map
 			 */
 
-			if ("operationType".equals(theKey)) {
-				if (myRequestDetails.getRestOperationType() != null) {
-					return myRequestDetails.getRestOperationType().getCode();
-				}
-				return "";
-			} else if ("operationName".equals(theKey)) {
-				if (myRequestDetails.getRestOperationType() != null) {
-					switch (myRequestDetails.getRestOperationType()) {
-						case EXTENDED_OPERATION_INSTANCE:
-						case EXTENDED_OPERATION_SERVER:
-						case EXTENDED_OPERATION_TYPE:
-							return myRequestDetails.getOperation();
-						default:
-							return "";
+			switch (theKey) {
+				case "operationType":
+					if (myRequestDetails.getRestOperationType() != null) {
+						return myRequestDetails.getRestOperationType().getCode();
 					}
-				}
-				return "";
-			} else if ("id".equals(theKey)) {
-				if (myRequestDetails.getId() != null) {
-					return myRequestDetails.getId().getValue();
-				}
-				return "";
-			} else if ("servletPath".equals(theKey)) {
-				return StringUtils.defaultString(myRequest.getServletPath());
-			} else if ("idOrResourceName".equals(theKey)) {
-				if (myRequestDetails.getId() != null) {
-					return myRequestDetails.getId().getValue();
-				}
-				if (myRequestDetails.getResourceName() != null) {
-					return myRequestDetails.getResourceName();
-				}
-				return "";
-			} else if (theKey.equals("requestParameters")) {
-				StringBuilder b = new StringBuilder();
-				for (Entry<String, String[]> next :
-						myRequestDetails.getParameters().entrySet()) {
-					for (String nextValue : next.getValue()) {
-						if (b.length() == 0) {
-							b.append('?');
-						} else {
-							b.append('&');
+					return "";
+				case "operationName":
+					if (myRequestDetails.getRestOperationType() != null) {
+						//noinspection EnumSwitchStatementWhichMissesCases
+						switch (myRequestDetails.getRestOperationType()) {
+							case EXTENDED_OPERATION_INSTANCE:
+							case EXTENDED_OPERATION_SERVER:
+							case EXTENDED_OPERATION_TYPE:
+								return myRequestDetails.getOperation();
+							default:
+								return "";
 						}
-						b.append(UrlUtil.escapeUrlParam(next.getKey()));
-						b.append('=');
-						b.append(UrlUtil.escapeUrlParam(nextValue));
 					}
-				}
-				return b.toString();
-			} else if (theKey.startsWith("requestHeader.")) {
-				String val = myRequest.getHeader(theKey.substring("requestHeader.".length()));
-				return StringUtils.defaultString(val);
-			} else if (theKey.startsWith("remoteAddr")) {
-				return StringUtils.defaultString(myRequest.getRemoteAddr());
-			} else if (theKey.equals("responseEncodingNoDefault")) {
-				ResponseEncoding encoding = RestfulServerUtils.determineResponseEncodingNoDefault(
-						myRequestDetails, myRequestDetails.getServer().getDefaultResponseEncoding());
-				if (encoding != null) {
-					return encoding.getEncoding().name();
-				}
-				return "";
-			} else if (theKey.equals("exceptionMessage")) {
-				return myException != null ? myException.getMessage() : null;
-			} else if (theKey.equals("requestUrl")) {
-				return myRequest.getRequestURL().toString();
-			} else if (theKey.equals("requestVerb")) {
-				return myRequest.getMethod();
-			} else if (theKey.equals("requestBodyFhir")) {
-				String contentType = myRequest.getContentType();
-				if (isNotBlank(contentType)) {
-					int colonIndex = contentType.indexOf(';');
-					if (colonIndex != -1) {
-						contentType = contentType.substring(0, colonIndex);
+					return "";
+				case "id":
+					if (myRequestDetails.getId() != null) {
+						return myRequestDetails.getId().getValue();
 					}
-					contentType = contentType.trim();
-
-					EncodingEnum encoding = EncodingEnum.forContentType(contentType);
+					return "";
+				case "servletPath":
+					return StringUtils.defaultString(myRequest.getServletPath());
+				case "idOrResourceName":
+					if (myRequestDetails.getId() != null) {
+						return myRequestDetails.getId().getValue();
+					}
+					if (myRequestDetails.getResourceName() != null) {
+						return myRequestDetails.getResourceName();
+					}
+					return "";
+				case "requestParameters":
+					StringBuilder b = new StringBuilder();
+					for (Entry<String, String[]> next :
+							myRequestDetails.getParameters().entrySet()) {
+						for (String nextValue : next.getValue()) {
+							if (b.length() == 0) {
+								b.append('?');
+							} else {
+								b.append('&');
+							}
+							b.append(UrlUtil.escapeUrlParam(next.getKey()));
+							b.append('=');
+							b.append(UrlUtil.escapeUrlParam(nextValue));
+						}
+					}
+					return b.toString();
+				case "remoteAddr":
+					return StringUtils.defaultString(myRequest.getRemoteAddr());
+				case "responseEncodingNoDefault": {
+					ResponseEncoding encoding = RestfulServerUtils.determineResponseEncodingNoDefault(
+							myRequestDetails, myRequestDetails.getServer().getDefaultResponseEncoding());
 					if (encoding != null) {
-						byte[] requestContents = myRequestDetails.loadRequestContents();
-						return new String(requestContents, Constants.CHARSET_UTF8);
+						return encoding.getEncoding().name();
 					}
+					return "";
 				}
-				return "";
-			} else if ("processingTimeMillis".equals(theKey)) {
-				Date startTime = (Date) myRequest.getAttribute(RestfulServer.REQUEST_START_TIME);
-				if (startTime != null) {
-					long time = System.currentTimeMillis() - startTime.getTime();
-					return Long.toString(time);
+				case "exceptionMessage":
+					return myException != null ? myException.getMessage() : null;
+				case "requestUrl":
+					return myRequest.getRequestURL().toString();
+				case "requestVerb":
+					return myRequest.getMethod();
+				case "requestBodyFhir": {
+					String contentType = myRequest.getContentType();
+					if (isNotBlank(contentType)) {
+						int colonIndex = contentType.indexOf(';');
+						if (colonIndex != -1) {
+							contentType = contentType.substring(0, colonIndex);
+						}
+						contentType = contentType.trim();
+
+						EncodingEnum encoding = EncodingEnum.forContentType(contentType);
+						if (encoding != null) {
+							byte[] requestContents = myRequestDetails.loadRequestContents();
+							return new String(requestContents, Constants.CHARSET_UTF8);
+						}
+					}
+					return "";
 				}
-			} else if ("requestId".equals(theKey)) {
-				return myRequestDetails.getRequestId();
+				case "processingTimeMillis":
+					Date startTime = (Date) myRequest.getAttribute(RestfulServer.REQUEST_START_TIME);
+					if (startTime != null) {
+						long time = System.currentTimeMillis() - startTime.getTime();
+						return Long.toString(time);
+					}
+					break;
+				case "requestId":
+					return myRequestDetails.getRequestId();
+				case "responseId":
+					String locationHeader = myResponse.getHeader(Constants.HEADER_LOCATION);
+					if (isNotBlank(locationHeader)) {
+						return new IdDt(locationHeader).toUnqualified().getValue();
+					}
+					return "";
+				default:
+					if (theKey.startsWith("requestHeader.")) {
+						String val = myRequest.getHeader(theKey.substring("requestHeader.".length()));
+						return StringUtils.defaultString(val);
+					}
 			}
 
 			return "!VAL!";

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/subscription/SubscriptionConstants.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/subscription/SubscriptionConstants.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.subscription;
 
 public final class SubscriptionConstants {
+
 	private SubscriptionConstants() {}
 
 	/**
@@ -45,6 +46,7 @@ public final class SubscriptionConstants {
 	public static final String REQUESTED_STATUS = "requested";
 	public static final String ACTIVE_STATUS = "active";
 	public static final String ERROR_STATUS = "error";
+	public static final String OFF_STATUS = "off";
 	public static final String SUBSCRIPTION_TOPIC_PROFILE_URL =
 			"http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-subscription";
 	public static final String SUBSCRIPTION_TOPIC_FILTER_URL =

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -65,6 +65,11 @@
 			<artifactId>hapi-fhir-caching-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-converter</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<!-- TODO KHS remove jpa stuff from here -->
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
@@ -246,7 +246,10 @@ public abstract class BaseResourceCacheSynchronizer implements IResourceChangeLi
 
 		/*
 		 * We are pretty lenient here, because any failure will block the server
-		 * from starting up.
+		 * from starting up. We should generally never fail to load here, but it
+		 * can potentially happen if a resource is manually deleted in the database
+		 * (ie. marked with a deletion time manually) but the indexes aren't cleaned
+		 * up.
 		 */
 		for (IIdType id : theResourceIds) {
 			IBaseResource read;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
@@ -30,6 +30,7 @@ import ca.uhn.fhir.jpa.cache.IResourceChangeListenerRegistry;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.retry.Retrier;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.util.IResourceRepositoryCache;
 import com.google.common.annotations.VisibleForTesting;
@@ -47,11 +48,11 @@ import org.springframework.context.event.ContextStartedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public abstract class BaseResourceCacheSynchronizer implements IResourceChangeListener, IResourceRepositoryCache {
 	private static final Logger ourLog = LoggerFactory.getLogger(BaseResourceCacheSynchronizer.class);
@@ -241,9 +242,22 @@ public abstract class BaseResourceCacheSynchronizer implements IResourceChangeLi
 		}
 		IFhirResourceDao<?> resourceDao = getResourceDao();
 		SystemRequestDetails systemRequestDetails = SystemRequestDetails.forAllPartitions();
-		List<IBaseResource> resourceList = theResourceIds.stream()
-				.map(n -> resourceDao.read(n, systemRequestDetails))
-				.collect(Collectors.toList());
+		List<IBaseResource> resourceList = new ArrayList<>();
+
+		/*
+		 * We are pretty lenient here, because any failure will block the server
+		 * from starting up.
+		 */
+		for (IIdType id : theResourceIds) {
+			IBaseResource read;
+			try {
+				read = resourceDao.read(id, systemRequestDetails);
+			} catch (BaseServerResponseException e) {
+				ourLog.warn("Unable to fetch resource {}", id, e);
+				continue;
+			}
+			resourceList.add(read);
+		}
 		handleInit(resourceList);
 	}
 

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/interceptor/LoggingInterceptorDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/interceptor/LoggingInterceptorDstu2Test.java
@@ -250,7 +250,7 @@ public class LoggingInterceptorDstu2Test {
 	public void testRequestBodyCreate() throws Exception {
 
 		LoggingInterceptor interceptor = new LoggingInterceptor();
-		interceptor.setMessageFormat("${operationType} - ${operationName} - ${idOrResourceName} - ${requestBodyFhir}");
+		interceptor.setMessageFormat("${operationType} - ${operationName} - ${idOrResourceName} - ${requestBodyFhir} - ${responseId}");
 		ourServer.getInterceptorService().registerInterceptor(interceptor);
 
 		Logger logger = mock(Logger.class);
@@ -270,7 +270,7 @@ public class LoggingInterceptorDstu2Test {
 		
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		verify(logger, timeout(1000).times(1)).info(captor.capture());
-		assertEquals("create -  - Patient - <Patient xmlns=\"http://hl7.org/fhir\"><identifier><value value=\"VAL\"/></identifier></Patient>", captor.getValue());
+		assertEquals("create -  - Patient - <Patient xmlns=\"http://hl7.org/fhir\"><identifier><value value=\"VAL\"/></identifier></Patient> - Patient/1", captor.getValue());
 	}
 
 	@Test

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/DefaultProfileValidationSupportR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/DefaultProfileValidationSupportR4Test.java
@@ -3,8 +3,14 @@ package org.hl7.fhir.dstu3.hapi.validation;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.fhirpath.BaseValidationTestWithInlineMocks;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ValidationResult;
+import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -12,9 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DefaultProfileValidationSupportR4Test extends BaseValidationTestWithInlineMocks {
 
+	private static final Logger ourLog = LoggerFactory.getLogger(DefaultProfileValidationSupportR4Test.class);
 	private static FhirContext ourCtx = FhirContext.forR4Cached();
 	private DefaultProfileValidationSupport mySvc = new DefaultProfileValidationSupport(ourCtx);
-	
+
 	@Test
 	public void testGetStructureDefinitionsWithRelativeUrls() {
 		assertNotNull(mySvc.fetchStructureDefinition("http://hl7.org/fhir/StructureDefinition/Extension"));
@@ -26,7 +33,7 @@ public class DefaultProfileValidationSupportR4Test extends BaseValidationTestWit
 		assertNull(mySvc.fetchStructureDefinition("Extension2"));
 
 	}
-	
+
 	@Test
 	public void testLoadCodeSystemWithVersion() {
 		CodeSystem cs = (CodeSystem) mySvc.fetchCodeSystem("http://terminology.hl7.org/CodeSystem/v2-0291");
@@ -40,4 +47,19 @@ public class DefaultProfileValidationSupportR4Test extends BaseValidationTestWit
 		cs = (CodeSystem) mySvc.fetchCodeSystem("http://terminology.hl7.org/CodeSystem/v2-0291|999");
 		assertNotNull(cs);
 	}
+
+	@Test
+	public void testValidateBuiltInProfile() {
+		IBaseResource address = mySvc.fetchStructureDefinition("http://hl7.org/fhir/StructureDefinition/Address");
+		ourLog.info("SD: {}", ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(address));
+
+		FhirValidator val = ourCtx.newValidator();
+		val.registerValidatorModule(new FhirInstanceValidator(ourCtx));
+
+		ValidationResult result = val.validateWithResult(address);
+		ourLog.info("Validation: {}", ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(result.toOperationOutcome()));
+		assertEquals(true, result.isSuccessful());
+	}
+
+
 }


### PR DESCRIPTION
This PR adds a few bits of hardening to the hapi.fhir.org public server:

* A new built-in interceptor called `SubscriptionRulesInterceptor` has been added, which can enforce rules on newly created subscriptions, such as mandatory criteria patterns and ensuring that target URLs are reachable.
* The Subscription registry has been made more resiliant to failures fetching Subscriptions on startup
* The server LoggingInterceptor now has a substitution variable `responseId` which contains the value of the `Location` header for write operations