### PR TITLE
feat: enhance partition settings to manage non-partitionable resourcetypes

### DIFF
--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/config/PartitionSettings.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/config/PartitionSettings.java
@@ -21,11 +21,42 @@ package ca.uhn.fhir.jpa.model.config;
 
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
  * @since 5.0.0
  */
 public class PartitionSettings {
 
+	public static final Set<String> DEFAULT_NON_PARTITIONABLE_RESOURCE_TYPES;
+
+	static {
+		Set<String> defaults = new LinkedHashSet<>();
+
+		// Infrastructure
+		defaults.add("SearchParameter");
+
+		// Validation and Conformance
+		defaults.add("StructureDefinition");
+		defaults.add("Questionnaire");
+		defaults.add("CapabilityStatement");
+		defaults.add("CompartmentDefinition");
+		defaults.add("OperationDefinition");
+		defaults.add("Library");
+
+		// Terminology
+		defaults.add("ConceptMap");
+		defaults.add("CodeSystem");
+		defaults.add("ValueSet");
+		defaults.add("NamingSystem");
+		defaults.add("StructureMap");
+
+		DEFAULT_NON_PARTITIONABLE_RESOURCE_TYPES = Collections.unmodifiableSet(defaults);
+	}
+
+	private Set<String> myNonPartitionableResourceTypes = new LinkedHashSet<>(DEFAULT_NON_PARTITIONABLE_RESOURCE_TYPES);
 	private boolean myPartitioningEnabled = false;
 	private CrossPartitionReferenceMode myAllowReferencesAcrossPartitions = CrossPartitionReferenceMode.NOT_ALLOWED;
 	private boolean myIncludePartitionInSearchHashes = false;
@@ -242,5 +273,34 @@ public class PartitionSettings {
 		 * will be managed by the database.
 		 */
 		ALLOWED_UNQUALIFIED,
+	}
+
+	/**
+	 * List of resource types that are considered non-partitionable.
+	 * Defaults to {@link #DEFAULT_NON_PARTITIONABLE_RESOURCE_TYPES}.
+	 *
+	 * @since 8.1.5
+	 */
+	public Set<String> getNonPartitionableResourceTypes() {
+		return myNonPartitionableResourceTypes;
+	}
+
+	/**
+	 * Overrides the list of resource types considered non-partitionable.
+	 * If you want to allow partitioning for types like {@code "Questionnaire"} remove them from this set.
+	 * <p>
+	 * <strong>Warning:</strong> Allowing partitioning of infrastructure or conformance resources (such as {@code StructureDefinition},
+	 * {@code CodeSystem}, {@code ValueSet}, etc.) may lead to unexpected behavior:
+	 * <ul>
+	 *   <li>Validation logic typically only accesses resources from the default partition.</li>
+	 *   <li>Terminology services (e.g., {@code expandValueSet}, {@code validateCode}) may fail or return incomplete results.</li>
+	 *   <li>Cross-partition references to these resources may not be resolved correctly.</li>
+	 * </ul>
+	 * Proceed with caution and test thoroughly if enabling partitioning for these resource types.
+	 *
+	 * @since 8.1.5
+	 */
+	public void setNonPartitionableResourceTypes(Set<String> theNonPartitionableResourceTypes) {
+		myNonPartitionableResourceTypes = new LinkedHashSet<>(theNonPartitionableResourceTypes);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/partition/BaseRequestPartitionHelperSvc.java
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -53,7 +52,6 @@ import java.util.stream.Collectors;
 public abstract class BaseRequestPartitionHelperSvc implements IRequestPartitionHelperSvc {
 
 	public static final Logger ourLog = Logs.getPartitionTroubleshootingLog();
-	private final HashSet<Object> myNonPartitionableResourceNames;
 
 	@Autowired
 	protected FhirContext myFhirContext;
@@ -63,29 +61,6 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 
 	@Autowired
 	PartitionSettings myPartitionSettings;
-
-	protected BaseRequestPartitionHelperSvc() {
-		myNonPartitionableResourceNames = new HashSet<>();
-
-		// Infrastructure
-		myNonPartitionableResourceNames.add("SearchParameter");
-
-		// Validation and Conformance
-		myNonPartitionableResourceNames.add("StructureDefinition");
-		myNonPartitionableResourceNames.add("Questionnaire");
-		myNonPartitionableResourceNames.add("CapabilityStatement");
-		myNonPartitionableResourceNames.add("CompartmentDefinition");
-		myNonPartitionableResourceNames.add("OperationDefinition");
-
-		myNonPartitionableResourceNames.add("Library");
-
-		// Terminology
-		myNonPartitionableResourceNames.add("ConceptMap");
-		myNonPartitionableResourceNames.add("CodeSystem");
-		myNonPartitionableResourceNames.add("ValueSet");
-		myNonPartitionableResourceNames.add("NamingSystem");
-		myNonPartitionableResourceNames.add("StructureMap");
-	}
 
 	/**
 	 * Invoke the {@link Pointcut#STORAGE_PARTITION_IDENTIFY_READ} interceptor pointcut to determine the tenant for a read request.
@@ -414,7 +389,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 
 	@Override
 	public boolean isResourcePartitionable(String theResourceType) {
-		return theResourceType != null && !myNonPartitionableResourceNames.contains(theResourceType);
+		return theResourceType != null && !myPartitionSettings.getNonPartitionableResourceTypes().contains(theResourceType);
 	}
 
 	@Override
@@ -424,7 +399,7 @@ public abstract class BaseRequestPartitionHelperSvc implements IRequestPartition
 	}
 
 	private boolean isResourceNonPartitionable(String theResourceType) {
-		return theResourceType != null && !isResourcePartitionable(theResourceType);
+		return !isResourcePartitionable(theResourceType);
 	}
 
 	private void validatePartitionForCreate(RequestPartitionId theRequestPartitionId, String theResourceName) {


### PR DESCRIPTION
# 🔧 Make List of Non-Partitionable Resource Types Configurable

**Fixes #6875**

## 📜 Problem

HAPI FHIR currently hardcodes a list of resource types that cannot be partitioned (e.g., `Questionnaire`, `StructureDefinition`, `CodeSystem`, etc.) inside `BaseRequestPartitionHelperSvc`.  
In multi-tenant environments, this restricts flexibility — for example, tenants might require tenant-specific `Questionnaire` resources.

Overriding this behavior previously required:

- Subclassing `RequestPartitionHelperSvc`
- Using reflection to modify internal fields
- Overriding Spring beans manually

This approach is brittle, non-obvious, and not guaranteed to be compatible across HAPI versions.

---

## ✅ Proposed Solution

This PR introduces a **configurable list** of non-partitionable resource types:

- Defines a new static default list in `PartitionSettings.DEFAULT_NON_PARTITIONABLE_RESOURCE_TYPES`
- Adds a field `nonPartitionableResourceTypes` with corresponding getter/setter in `PartitionSettings`
- Updates `BaseRequestPartitionHelperSvc` to use the configured list instead of a hardcoded set

This change preserves current defaults but allows full customization via configuration.

Closes #6875