### PR TITLE
Fix/expunge historical version exception message

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
@@ -69,6 +69,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -229,7 +230,11 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 			ResourceHistoryTablePk theNextVersionId,
 			AtomicInteger theRemainingCount) {
 		ResourceHistoryTable version =
-				myResourceHistoryTableDao.findById(theNextVersionId).orElseThrow(IllegalArgumentException::new);
+			myResourceHistoryTableDao.findById(theNextVersionId).orElseThrow(() ->
+				new IllegalArgumentException(
+					MessageFormat.format("No historical version found for ResourceHistoryTablePk: {0} (partition {1})",
+						theNextVersionId.getId(), theNextVersionId.getPartitionId())));
+
 		IdDt id = version.getIdDt();
 		ourLog.info("Deleting resource version {}", id.getValue());
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
@@ -229,10 +229,10 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 			RequestDetails theRequestDetails,
 			ResourceHistoryTablePk theNextVersionId,
 			AtomicInteger theRemainingCount) {
-		ResourceHistoryTable version =
-			myResourceHistoryTableDao.findById(theNextVersionId).orElseThrow(() ->
-				new IllegalArgumentException(
-					MessageFormat.format("No historical version found for ResourceHistoryTablePk: {0} (partition {1})",
+		ResourceHistoryTable version = myResourceHistoryTableDao
+				.findById(theNextVersionId)
+				.orElseThrow(() -> new IllegalArgumentException(MessageFormat.format(
+						"No historical version found for ResourceHistoryTablePk: {0} (partition {1})",
 						theNextVersionId.getId(), theNextVersionId.getPartitionId())));
 
 		IdDt id = version.getIdDt();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeServiceTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTableDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTablePk;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -16,9 +17,13 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -55,5 +60,33 @@ public class JpaResourceExpungeServiceTest {
 		when(resourceTable.getId()).thenReturn(new JpaPid());
 		myService.expungeCurrentVersionOfResource(myRequestDetails, JpaPid.fromId(1L), new AtomicInteger(1));
 		verify(myService, never()).deleteAllSearchParams(any());
+	}
+
+
+	@Test
+	public void testExpungeHistoricalVersions_missingEntry_throwsWithContextualMessage() throws NoSuchFieldException, IllegalAccessException {
+		// given a primary key with no existing history
+		ResourceHistoryTablePk pk = new ResourceHistoryTablePk();
+		pk.setPartitionIdValue(42);
+		// set versionId via reflection to avoid null in message
+		Field versionIdField = ResourceHistoryTablePk.class.getDeclaredField("myVersionId");
+		versionIdField.setAccessible(true);
+		versionIdField.set(pk, 123L);
+
+		when(myResourceHistoryTableDao.findById(pk)).thenReturn(Optional.empty());
+
+		AtomicInteger remaining = new AtomicInteger(1);
+		IllegalArgumentException ex = assertThrows(
+			IllegalArgumentException.class,
+			() -> myService.expungeHistoricalVersions(myRequestDetails, Collections.singletonList(pk), remaining)
+		);
+
+		String msg = ex.getMessage();
+		assertTrue(msg.contains("No historical version found"),
+			"Expected exception message to contain 'No historical version found'");
+		assertTrue(msg.contains("ResourceHistoryTablePk: 123"),
+			"Expected message to include 'ResourceHistoryTablePk: 123'");
+		assertTrue(msg.contains("partition 42"),
+			"Expected message to include partition id '42'");
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
@@ -126,7 +126,10 @@ public class PartitionRunner {
 			Thread.currentThread().interrupt();
 		} catch (ExecutionException e) {
 			ourLog.error("Error while " + myProcessName, e);
-			throw new InternalErrorException(Msg.code(1085) + e);
+			Throwable cause = e.getCause() != null ? e.getCause() : e;
+			throw new InternalErrorException(
+				Msg.code(1085) + cause.getMessage(),
+				cause);
 		} finally {
 			executorService.shutdown();
 		}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/expunge/PartitionRunner.java
@@ -127,9 +127,7 @@ public class PartitionRunner {
 		} catch (ExecutionException e) {
 			ourLog.error("Error while " + myProcessName, e);
 			Throwable cause = e.getCause() != null ? e.getCause() : e;
-			throw new InternalErrorException(
-				Msg.code(1085) + cause.getMessage(),
-				cause);
+			throw new InternalErrorException(Msg.code(1085) + cause.getMessage(), cause);
 		} finally {
 			executorService.shutdown();
 		}


### PR DESCRIPTION
## Summary
Improve exception handling in the asynchronous Expunge job so that missing historical versions throw a clear, contextual error instead of HAPI‑2223: null.

## Changes

In JpaResourceExpungeService.expungeHistoricalVersion(), replace orElseThrow(IllegalArgumentException::new) with a lambda that includes the missing version’s ID and partition in the exception message.

Update PartitionRunner’s error‑handling to extract cause.getMessage() and propagate it, ensuring the logged and thrown InternalErrorException carries the real root‑cause text.

Add a simple unit test to verify that an absent history entry yields a non‑null, descriptive exception message.

Related issue
Closes #6879