### PR TITLE
Jd 20250417 fix validation unknown code system

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6882-fix-validation-of-unknown-codesystem.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6882-fix-validation-of-unknown-codesystem.yaml
@@ -3,4 +3,4 @@ type: fix
 issue: 6882
 jira: SMILE-9997
 title: "Previously, submitting a resource for validation with an unknown CodeSystem would always result in a validation 
-error, irregardless of the defined binding strength. This has now been fixed."
+error, regardless of the defined binding strength. This has now been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6882-fix-validation-of-unknown-codesystem.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6882-fix-validation-of-unknown-codesystem.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 6882
+jira: SMILE-9997
+title: "Previously, submitting a resource for validation with an unknown CodeSystem would always result in a validation 
+error, irregardless of the defined binding strength. This has now been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6882-fix-validation-of-unknown-codesystem.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6882-fix-validation-of-unknown-codesystem.yaml
@@ -3,4 +3,10 @@ type: fix
 issue: 6882
 jira: SMILE-9997
 title: "Previously, submitting a resource for validation with an unknown CodeSystem would always result in a validation 
-error, regardless of the defined binding strength. This has now been fixed."
+error, regardless of the defined binding strength. This has now been fixed such that, given an unknown CodeSystem: 
+    <ul>
+        <li>A <code>required</code> binding strength will still result in a validation error.</li>
+        <li>An <code>extensible</code> binding strength will now result in a validation warning.</li>
+        <li>A <code>preferred</code> binding strength will now result in a validation warning.</li>
+        <li>An <code>example</code> binding strength will result in no issues.</li>
+    </ul>"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -2215,8 +2215,8 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 				.addIssue(new CodeValidationIssue(
 						theMessage,
 						IssueSeverity.ERROR,
-						CodeValidationIssueCode.CODE_INVALID,
-						CodeValidationIssueCoding.INVALID_CODE));
+						CodeValidationIssueCode.NOT_FOUND,
+						CodeValidationIssueCoding.NOT_FOUND));
 	}
 
 	private List<TermValueSetConcept> findByValueSetResourcePidSystemAndCode(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -2202,12 +2202,13 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 			append = " - " + unknownCodeMessage + ". " + preExpansionMessage;
 		}
 
-		return createFailureCodeValidationResult(theSystem, theCode, null, append);
+		return createCodeNotFoundErrorForValidationResult(theSystem, theCode, null, append);
 	}
 
-	private CodeValidationResult createFailureCodeValidationResult(
+	private CodeValidationResult createCodeNotFoundErrorForValidationResult(
 			String theSystem, String theCode, String theCodeSystemVersion, String theAppend) {
 		String theMessage = "Unable to validate code " + theSystem + "#" + theCode + theAppend;
+		// The validator will change the severity based on the binding strength
 		return new CodeValidationResult()
 				.setSeverity(IssueSeverity.ERROR)
 				.setCodeSystemVersion(theCodeSystemVersion)
@@ -2905,7 +2906,7 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 			}
 		}
 
-		return createFailureCodeValidationResult(
+		return createCodeNotFoundErrorForValidationResult(
 				theCodeSystemUrl, theCode, null, createMessageAppendForCodeNotFoundInCodeSystem(theCodeSystemUrl));
 	}
 
@@ -2955,7 +2956,7 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 						valueSet);
 			} else {
 				String append = " - Unable to locate ValueSet[" + theValueSetUrl + "]";
-				retVal = createFailureCodeValidationResult(theCodeSystem, theCode, null, append);
+				retVal = createCodeNotFoundErrorForValidationResult(theCodeSystem, theCode, null, append);
 			}
 		}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -2208,7 +2208,7 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 	private CodeValidationResult createCodeNotFoundErrorForValidationResult(
 			String theSystem, String theCode, String theCodeSystemVersion, String theAppend) {
 		String theMessage = "Unable to validate code " + theSystem + "#" + theCode + theAppend;
-		// The validator will change the severity based on the binding strength
+		// The InstanceValidator (core) will change the severity based on the binding strength
 		return new CodeValidationResult()
 				.setSeverity(IssueSeverity.ERROR)
 				.setCodeSystemVersion(theCodeSystemVersion)

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/r4/test-validation-unknown-codesystem-organization.json
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/r4/test-validation-unknown-codesystem-organization.json
@@ -1,0 +1,41 @@
+{
+	"resourceType": "Organization",
+	"meta": {
+		"profile": [
+			"http://mytest/StructureDefinition/organization-sample"
+		]
+	},
+	"text": {
+		"status": "generated",
+		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      \n      <p>XYZ Insurance</p>\n    \n    </div>"
+	},
+	"identifier": [
+		{
+			"system": "urn:oid:2.16.840.1.113883.3.19.2.3",
+			"value": "666666"
+		}
+	],
+	"name": "XYZ Insurance",
+	"alias": [
+		"ABC Insurance"
+	],
+	"contact": [
+		{
+			"purpose": {
+				"coding": [
+
+					{
+						"system": "http://mylocalcodesystem",
+						"code": "mylocalcode"
+					}
+				]
+			},
+			"telecom": [
+				{
+					"system": "phone",
+					"value": "022-655 2334"
+				}
+			]
+		}
+	]
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/r4/test-validation-unknown-codesystem-structure-def.json
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/r4/test-validation-unknown-codesystem-structure-def.json
@@ -1,0 +1,30 @@
+{
+	"resourceType" : "StructureDefinition",
+	"id" : "organization-sample",
+	"url" : "http://mytest/StructureDefinition/organization-sample",
+	"name" : "Organization Sample",
+	"title" : "Sample profile to test extensibility",
+	"status" : "active",
+	"date" : "2022-09-29T10:00:22-05:00",
+	"fhirVersion" : "4.0.1",
+	"kind" : "resource",
+	"abstract" : false,
+	"type" : "Organization",
+	"baseDefinition" : "http://hl7.org/fhir/StructureDefinition/Organization",
+	"derivation" : "constraint",
+	"differential" : {
+		"element" : [{
+			"id" : "Organization",
+			"path" : "Organization"
+		},
+			{
+				"id": "Organization.contact.purpose",
+				"path": "Organization.contact.purpose",
+				"binding": {
+					"strength": "extensible",
+					"description": "The purpose for which you would contact a contact party.",
+					"valueSet": "http://mytest/ValueSet/OrgContactSampleVS"
+				}
+			}]
+	}
+}


### PR DESCRIPTION
**What was done:**
- Change the `CodeValidationResult` to a `NOT_FOUND` code. Core changes the severity of such results accordingly based on the binding strength (see `InstanceValidator.class`). 
- Tests/changelog

closes #6882 