### PR TITLE
If a resource is not found, throw a ResourceNotFoundException instead of returning null

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6885-npm-find-package-asset-throw-resource-not-found.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6885-npm-find-package-asset-throw-resource-not-found.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 6885
+title: "When querying for an NPM resource that is not found, the error is not clear.
+        This has been fixed with a proper HAPI error code and a clear message."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -618,7 +618,13 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 				theRequest.getVersion());
 
 		if (npmPackageVersionResourceEntities.isEmpty()) {
-			return null;
+			throw new ResourceNotFoundException("%s Could not find asset for FHIR version: %s, canonical URL: %s, package ID: %s and package version: %s"
+				.formatted(
+					Msg.code(2644),
+					theRequest.getFhirVersion(),
+					theRequest.getCanonicalUrl(),
+					theRequest.getPackageId(),
+					Optional.ofNullable(theRequest.getVersion()).orElse("[none]")));
 		} else {
 			if (npmPackageVersionResourceEntities.size() > 1) {
 				ourLog.warn(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -618,13 +618,14 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 				theRequest.getVersion());
 
 		if (npmPackageVersionResourceEntities.isEmpty()) {
-			throw new ResourceNotFoundException("%s Could not find asset for FHIR version: %s, canonical URL: %s, package ID: %s and package version: %s"
-				.formatted(
-					Msg.code(2644),
-					theRequest.getFhirVersion(),
-					theRequest.getCanonicalUrl(),
-					theRequest.getPackageId(),
-					Optional.ofNullable(theRequest.getVersion()).orElse("[none]")));
+			throw new ResourceNotFoundException(
+					"%s Could not find asset for FHIR version: %s, canonical URL: %s, package ID: %s and package version: %s"
+							.formatted(
+									Msg.code(2644),
+									theRequest.getFhirVersion(),
+									theRequest.getCanonicalUrl(),
+									theRequest.getPackageId(),
+									Optional.ofNullable(theRequest.getVersion()).orElse("[none]")));
 		} else {
 			if (npmPackageVersionResourceEntities.size() > 1) {
 				ourLog.warn(

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheDuplicateResourcesTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/JpaPackageCacheDuplicateResourcesTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.packages;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.CanonicalType;
@@ -17,9 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -272,8 +275,9 @@ public class JpaPackageCacheDuplicateResourcesTest extends BaseJpaR4Test {
 				thePackageId,
 				theVersionId);
 
-		final IBaseResource resource = myPackageCacheManager.findPackageAsset(request);
-
-		assertThat(resource).isNull();
+		assertThatExceptionOfType(ResourceNotFoundException.class)
+			.isThrownBy(() -> myPackageCacheManager.findPackageAsset(request))
+			.withMessage("HAPI-2644:  Could not find asset for FHIR version: R4, canonical URL: %s, package ID: %s and package version: %s"
+				.formatted(theCanonicalUrl, thePackageId, Optional.ofNullable(theVersionId).orElse("[none]")));
 	}
 }


### PR DESCRIPTION
- If a resource is not found, throw a ResourceNotFoundException instead of returning null