### PR TITLE
request header partition interceptor

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -206,6 +206,8 @@ public class HapiExtensions {
 	 */
 	public static final String EXTENSION_REPLACED_BY = "http://hapifhir.io/fhir/StructureDefinition/replaced-by";
 
+	public static final String EXTENSION_TRANSACTION_ENTRY_PARTITION_IDS =
+			"http://hapifhir.io/fhir/ns/StructureDefinition/request-partition-ids";
 	/**
 	 * Non instantiable
 	 */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -206,6 +206,12 @@ public class HapiExtensions {
 	 */
 	public static final String EXTENSION_REPLACED_BY = "http://hapifhir.io/fhir/StructureDefinition/replaced-by";
 
+	/**
+	 * This extension is to specify the partition IDs for a request entry in a transaction bundle.
+	 * This allows overriding partition id for a request entry in a transaction bundle so that a single transaction can
+	 * have entries destined for different storage partitions. The expected value is a comma-separated string
+	 * of partition IDs.
+	 */
 	public static final String EXTENSION_TRANSACTION_ENTRY_PARTITION_IDS =
 			"http://hapifhir.io/fhir/ns/StructureDefinition/request-partition-ids";
 	/**

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_0_0/6887-request-header-partition-interceptor.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_0_0/6887-request-header-partition-interceptor.yaml
@@ -1,0 +1,11 @@
+---
+type: add
+issue: 6887
+title: "A new partition interceptor that can be used to identify partitions based on a specific 
+request header called `X-Request-Partition-IDs` is added. The header value is expected to be a comma separated list
+of partition ids. Also, a mechanism is introduced for overriding this header in a transaction bundle for individual 
+request entries if needed. This allows writing different transaction entries to different partitions 
+in the same transaction."
+
+
+

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_0_0/6887-request-header-partition-interceptor.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_0_0/6887-request-header-partition-interceptor.yaml
@@ -2,10 +2,7 @@
 type: add
 issue: 6887
 title: "A new partition interceptor that can be used to identify partitions based on a specific 
-request header called `X-Request-Partition-IDs` is added. The header value is expected to be a comma separated list
-of partition ids. Also, a mechanism is introduced for overriding this header in a transaction bundle for individual 
-request entries if needed. This allows writing different transaction entries to different partitions 
+request header called `X-Request-Partition-IDs` has been added. The header value is expected to be a comma-separated 
+list of partition ids. Also, a mechanism was introduced for overriding this header in a transaction bundle for 
+individual request entries if needed. This allows writing different transaction entries to different partitions 
 in the same transaction."
-
-
-

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessorVersionAdapterDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessorVersionAdapterDstu2.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.dao;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.model.api.ExtensionDt;
 import ca.uhn.fhir.model.api.IResource;
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.model.dstu2.resource.Bundle;
@@ -32,6 +33,7 @@ import ca.uhn.fhir.model.dstu2.valueset.IssueTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -172,5 +174,11 @@ public class TransactionProcessorVersionAdapterDstu2
 	@Override
 	public void setRequestUrl(Bundle.Entry theEntry, String theUrl) {
 		theEntry.getRequest().setUrl(theUrl);
+	}
+
+	@Override
+	public IBaseExtension<?, ?> getEntryRequestExtensionByUrl(Bundle.Entry theEntry, String theUrl) {
+		List<ExtensionDt> extensions = theEntry.getRequest().getUndeclaredExtensionsByUrl(theUrl);
+		return extensions.isEmpty() ? null : extensions.get(0);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessorVersionAdapterDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessorVersionAdapterDstu2.java
@@ -39,6 +39,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public class TransactionProcessorVersionAdapterDstu2
 		implements ITransactionProcessorVersionAdapter<Bundle, Bundle.Entry> {
@@ -177,8 +178,8 @@ public class TransactionProcessorVersionAdapterDstu2
 	}
 
 	@Override
-	public IBaseExtension<?, ?> getEntryRequestExtensionByUrl(Bundle.Entry theEntry, String theUrl) {
+	public Optional<IBaseExtension<?, ?>> getEntryRequestExtensionByUrl(Bundle.Entry theEntry, String theUrl) {
 		List<ExtensionDt> extensions = theEntry.getRequest().getUndeclaredExtensionsByUrl(theUrl);
-		return extensions.isEmpty() ? null : extensions.get(0);
+		return extensions.isEmpty() ? Optional.empty() : Optional.ofNullable(extensions.get(0));
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4b/TransactionProcessorVersionAdapterR4B.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4b/TransactionProcessorVersionAdapterR4B.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4b.model.Bundle;
+import org.hl7.fhir.r4b.model.Extension;
 import org.hl7.fhir.r4b.model.OperationOutcome;
 import org.hl7.fhir.r4b.model.Resource;
 
@@ -169,5 +170,10 @@ public class TransactionProcessorVersionAdapterR4B
 	@Override
 	public void setRequestUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
 		theEntry.getRequest().setUrl(theUrl);
+	}
+
+	@Override
+	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return theEntry.getRequest().getExtensionByUrl(theUrl);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4b/TransactionProcessorVersionAdapterR4B.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r4b/TransactionProcessorVersionAdapterR4B.java
@@ -25,15 +25,16 @@ import ca.uhn.fhir.jpa.dao.ITransactionProcessorVersionAdapter;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4b.model.Bundle;
-import org.hl7.fhir.r4b.model.Extension;
 import org.hl7.fhir.r4b.model.OperationOutcome;
 import org.hl7.fhir.r4b.model.Resource;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public class TransactionProcessorVersionAdapterR4B
 		implements ITransactionProcessorVersionAdapter<Bundle, Bundle.BundleEntryComponent> {
@@ -173,7 +174,8 @@ public class TransactionProcessorVersionAdapterR4B
 	}
 
 	@Override
-	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
-		return theEntry.getRequest().getExtensionByUrl(theUrl);
+	public Optional<IBaseExtension<?, ?>> getEntryRequestExtensionByUrl(
+			Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return Optional.ofNullable(theEntry.getRequest().getExtensionByUrl(theUrl));
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/TransactionProcessorVersionAdapterR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/TransactionProcessorVersionAdapterR5.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.Extension;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.Resource;
 
@@ -169,5 +170,10 @@ public class TransactionProcessorVersionAdapterR5
 	@Override
 	public void setRequestUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
 		theEntry.getRequest().setUrl(theUrl);
+	}
+
+	@Override
+	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return theEntry.getRequest().getExtensionByUrl(theUrl);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/TransactionProcessorVersionAdapterR5.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/r5/TransactionProcessorVersionAdapterR5.java
@@ -25,15 +25,16 @@ import ca.uhn.fhir.jpa.dao.ITransactionProcessorVersionAdapter;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r5.model.Bundle;
-import org.hl7.fhir.r5.model.Extension;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.Resource;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public class TransactionProcessorVersionAdapterR5
 		implements ITransactionProcessorVersionAdapter<Bundle, Bundle.BundleEntryComponent> {
@@ -173,7 +174,8 @@ public class TransactionProcessorVersionAdapterR5
 	}
 
 	@Override
-	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
-		return theEntry.getRequest().getExtensionByUrl(theUrl);
+	public Optional<IBaseExtension<?, ?>> getEntryRequestExtensionByUrl(
+			Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return Optional.ofNullable(theEntry.getRequest().getExtensionByUrl(theUrl));
 	}
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ConcurrentWriteTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ConcurrentWriteTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
 
 import jakarta.annotation.Nonnull;
@@ -792,6 +793,7 @@ public class FhirResourceDaoR4ConcurrentWriteTest extends BaseJpaR4Test {
 		when(srd.getUserData()).thenReturn(new HashMap<>());
 		when(srd.getServer()).thenReturn(new RestfulServer(myFhirContext));
 		when(srd.getInterceptorBroadcaster()).thenReturn(new InterceptorService());
+		when(srd.getServletRequest()).thenReturn(new MockHttpServletRequest());
 
 		List<Future<?>> futures = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {
@@ -844,6 +846,7 @@ public class FhirResourceDaoR4ConcurrentWriteTest extends BaseJpaR4Test {
 		when(srd.getUserData()).thenReturn(new HashMap<>());
 		when(srd.getServer()).thenReturn(new RestfulServer(myFhirContext));
 		when(srd.getInterceptorBroadcaster()).thenReturn(new InterceptorService());
+		when(srd.getServletRequest()).thenReturn(new MockHttpServletRequest());
 
 		List<Future<?>> futures = new ArrayList<>();
 		int repetitionCount = 3;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4VersionedReferenceTest.java
@@ -1221,8 +1221,7 @@ public class FhirResourceDaoR4VersionedReferenceTest extends BaseJpaR4Test {
 
 		try {
 			// test
-			mySystemDao.transaction(new ServletRequestDetails(),
-				bundle);
+			mySystemDao.transaction(new SystemRequestDetails(), bundle);
 			fail("We expect invalid full urls to fail");
 		} catch (InvalidRequestException ex) {
 			assertThat(ex.getMessage()).contains("Unable to perform POST, URL provided is invalid:");

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RequestHeaderPartitionTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RequestHeaderPartitionTest.java
@@ -1,0 +1,255 @@
+package ca.uhn.fhir.jpa.interceptor;
+
+import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+/**
+ * This test class is used to test the partitioning functionality
+ * when using the {@link RequestHeaderPartitionInterceptor}.
+ */
+public class RequestHeaderPartitionTest  extends BaseJpaR4Test {
+
+	private static final String PARTITION_EXTENSION_URL = "http://hapifhir.io/fhir/ns/StructureDefinition/request-partition-ids";
+
+	private IIdType myPatientIdInPartition1;
+
+	@BeforeEach
+	public void beforeEach() {
+		myPartitionSettings.setPartitioningEnabled(true);
+		myPartitionSettings.setUnnamedPartitionMode(true);
+		RequestHeaderPartitionInterceptor myPartitionInterceptor = new RequestHeaderPartitionInterceptor();
+		mySrdInterceptorService.registerInterceptor(myPartitionInterceptor);
+
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader("1");
+		myPatientIdInPartition1 = myPatientDao.create(new Patient(), requestDetails).getId().toVersionless();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		//this test tries to read the resource created in partition 1,
+		// so the following combinations should succeed
+		"1",
+		"1,2",
+		"2,1",
+		"DEFAULT,1",
+		"_ALL",
+		"2,_ALL"
+	})
+	public void testReadResourceFromTheRightPartition_SuccessfulRead(String theCommaSeparatedPartitionIds) {
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader(theCommaSeparatedPartitionIds);
+		Patient patientRead = myPatientDao.read(myPatientIdInPartition1, requestDetails);
+
+		assertThat(patientRead.getIdElement().toVersionless()).isEqualTo(myPatientIdInPartition1);
+	}
+
+	@Test
+	public void testCreateUpdateAndDeleteResourceFromTheRightPartition_Successful() {
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader("2");
+		Patient createdPatient = (Patient) myPatientDao.create(new Patient(), requestDetails).getResource();
+		IIdType patientId = createdPatient.getIdElement().toVersionless();
+
+		createdPatient.setGender(Enumerations.AdministrativeGender.MALE);
+
+		DaoMethodOutcome methodOutcome = myPatientDao.update(createdPatient, requestDetails);
+		assertThat(methodOutcome.isNop()).isFalse();
+
+		myPatientDao.delete(patientId, requestDetails);
+	}
+
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		//this test tries to read a resource created in partition 1,
+		//so the following combinations should fail to read
+		"2",
+		"2,DEFAULT",
+		"DEFAULT"
+	})
+	public void testReadResourceFromWrongPartition_ThrowsResourceNotFound(String theCommaSeparatedPartitionIds) {
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader(theCommaSeparatedPartitionIds);
+		assertThrows(ResourceNotFoundException.class, () -> myPatientDao.read(myPatientIdInPartition1, requestDetails));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"ALL", //the correct name for all partitions is _ALL
+		"default", //the correct name is DEFAULT
+		"null", //DEFAULT should be used for default partition, null is not acceptable
+		"1a", // not a number
+		"a", // not a number
+		"1,a", // not a number
+		"1.1", // not an int
+		"1, 1.1", // not an int
+		",1", // empty data
+		"1,,2" //another empty data
+	})
+	public void testInvalidPartitionsInHeader_ThrowsInvalidRequest(String theCommaSeparatedPartitionIds) {
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader(theCommaSeparatedPartitionIds);
+		InvalidRequestException ex = assertThrows(InvalidRequestException.class, () -> myPatientDao.read(myPatientIdInPartition1, requestDetails));
+		assertThat(ex.getMessage()).contains("HAPI-2643: Invalid partition ID");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		",",
+		",,",
+	})
+	public void testHeaderExistsButDoesNotContainAnyDataBesidesTheCommas_ThrowsInvalidRequest(String theCommaSeparatedPartitionIds) {
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader(theCommaSeparatedPartitionIds);
+		InvalidRequestException ex = assertThrows(InvalidRequestException.class, () -> myPatientDao.read(myPatientIdInPartition1, requestDetails));
+		assertThat(ex.getMessage()).contains("HAPI-2645: No partition IDs provided in header: X-Request-Partition-IDs");
+	}
+
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"1,3",
+		"3,1,DEFAULT",
+		"DEFAULT,2,1",
+		"3,1,2",
+	})
+	public void testCreateResourceSendingMultipleIds_CreatesResourceInTheFirstPartition(String thePartitionHeaderForCreate) {
+		RequestDetails requestDetails = createRequestDetailsWithPartitionHeader(thePartitionHeaderForCreate);
+		IIdType createdPatientId = myPatientDao.create(new Patient(), requestDetails).getId().toVersionless();
+
+
+		String[] firstIdAndRemainingIds = thePartitionHeaderForCreate.split(",", 2);
+		String firstId = firstIdAndRemainingIds[0];
+		String remainingIds = firstIdAndRemainingIds[1];
+
+		//read from the first partition id, where the resource is expected to be created in
+		requestDetails = createRequestDetailsWithPartitionHeader(firstId);
+		Patient patientRead = myPatientDao.read(createdPatientId, requestDetails);
+		assertThat(patientRead.getIdElement().toVersionless()).isEqualTo(createdPatientId);
+
+		//try reading the same resource from the remaining partitions
+		RequestDetails requestDetailsForReadingWithRemainingIds = createRequestDetailsWithPartitionHeader(remainingIds);
+		assertThrows(ResourceNotFoundException.class, () -> myPatientDao.read(createdPatientId, requestDetailsForReadingWithRemainingIds));
+	}
+
+	@Test
+	public void testMissingHeader_InvalidRequestException() {
+		final String expectedMsg = "HAPI-2642: X-Request-Partition-IDs header is missing or blank, it is required to identify the storage partition";
+		RequestDetails requestDetailsWithoutPartitionHeader = createRequestDetails();
+		// try create
+		InvalidRequestException ex = assertThrows(InvalidRequestException.class, () -> myPatientDao.create(new Patient(), requestDetailsWithoutPartitionHeader));
+		assertThat(ex.getMessage()).isEqualTo(expectedMsg);
+		//try read
+		ex = assertThrows(InvalidRequestException.class, () -> myPatientDao.read(myPatientIdInPartition1, requestDetailsWithoutPartitionHeader));
+		assertThat(ex.getMessage()).isEqualTo(expectedMsg);
+
+		//try a transaction
+		Bundle transactionBundle = new Bundle();
+		transactionBundle.setType(Bundle.BundleType.TRANSACTION);
+		Bundle.BundleEntryComponent entry = transactionBundle.addEntry();
+		entry.setResource(new Patient());
+		entry.getRequest().setMethod(Bundle.HTTPVerb.POST);
+		entry.getRequest().setUrl("/Patient");
+		ex = assertThrows(InvalidRequestException.class, () -> mySystemDao.transaction(requestDetailsWithoutPartitionHeader, transactionBundle));
+		assertThat(ex.getMessage()).isEqualTo(expectedMsg);
+
+	}
+
+	@Test
+	public void testTransactionBundle_WithSingleResourceRequestEntryExtension_OverridesPartitionIdsFromHeader() {
+
+		// in this test, we submit a transaction bundle with partition id 1 in the header
+		// but override it with partition 2 for an entry in the bundle
+		RequestDetails requestDetailsWithPartition1 = createRequestDetailsWithPartitionHeader("1");
+
+		Bundle transactionBundle = new Bundle();
+		transactionBundle.setType(Bundle.BundleType.TRANSACTION);
+		Bundle.BundleEntryComponent entry = transactionBundle.addEntry();
+		entry.setResource(new Patient());
+		entry.getRequest().setMethod(Bundle.HTTPVerb.POST);
+		entry.getRequest().setUrl("Patient");
+		entry.getRequest().addExtension(PARTITION_EXTENSION_URL, new StringType("2"));
+		Bundle transactionResponseBundle = mySystemDao.transaction(requestDetailsWithPartition1, transactionBundle);
+
+		assertThat(transactionResponseBundle).isNotNull();
+		assertThat(transactionResponseBundle.getEntry()).hasSize(1);
+		String createdResourceLocation = transactionResponseBundle.getEntry().get(0).getResponse().getLocation();
+
+
+		//reading the resource from partition 2 should succeed
+		RequestDetails requestDetailsWithPartition2 = createRequestDetailsWithPartitionHeader("2");
+		myPatientDao.read(new IdType(createdResourceLocation), requestDetailsWithPartition2);
+	}
+
+
+	@Test
+	public void testTransactionBundle_WithMultipleResourcesAndSomeRequestEntryExtension_EntriesWithExtensionOverridesPartition() {
+
+		// in this test, we submit a transaction bundle with 2 resources. We specify partition id 1 in the req header
+		// but override it to partition 2 for one of the resource entries in the bundle.
+		RequestDetails requestDetailsWithPartition1 = createRequestDetailsWithPartitionHeader("1");
+
+		Bundle transactionBundle = new Bundle();
+		transactionBundle.setType(Bundle.BundleType.TRANSACTION);
+		Bundle.BundleEntryComponent entryWithOverride = transactionBundle.addEntry();
+		Patient p1 = new Patient();
+		p1.addName().addGiven("patientWithOverride");
+		entryWithOverride.setResource(p1);
+		entryWithOverride.getRequest().setMethod(Bundle.HTTPVerb.POST);
+		entryWithOverride.getRequest().setUrl("Patient");
+		entryWithOverride.getRequest().addExtension(PARTITION_EXTENSION_URL, new StringType("2"));
+
+		Bundle.BundleEntryComponent entryWithoutOverride = transactionBundle.addEntry();
+		Patient p2 = new Patient();
+		p2.addName().addGiven("patientWithoutOverride");
+		entryWithoutOverride.setResource(p2);
+		entryWithoutOverride.getRequest().setMethod(Bundle.HTTPVerb.POST);
+		entryWithoutOverride.getRequest().setUrl("Patient");
+
+		Bundle transactionResponseBundle = mySystemDao.transaction(requestDetailsWithPartition1, transactionBundle);
+
+		assertThat(transactionResponseBundle).isNotNull();
+		assertThat(transactionResponseBundle.getEntry()).hasSize(2);
+		String createdResourceLocation1 = transactionResponseBundle.getEntry().get(0).getResponse().getLocation();
+		String createdResourceLocation2 = transactionResponseBundle.getEntry().get(1).getResponse().getLocation();
+
+
+		RequestDetails requestDetailsWithPartition2 = createRequestDetailsWithPartitionHeader("2");
+
+		//resource 1 is expected to be in partition 2
+		Patient firstPatient = myPatientDao.read(new IdType(createdResourceLocation1), requestDetailsWithPartition2);
+		assertThat(firstPatient.getName().get(0).getNameAsSingleString()).isEqualTo("patientWithOverride");
+		//resource 2 is expected to be in partition 1
+		Patient secondsPatient = myPatientDao.read(new IdType(createdResourceLocation2), requestDetailsWithPartition1);
+		assertThat(secondsPatient.getName().get(0).getNameAsSingleString()).isEqualTo("patientWithoutOverride");
+	}
+
+	private ServletRequestDetails createRequestDetails() {
+		ServletRequestDetails requestDetails = new ServletRequestDetails(mySrdInterceptorService);
+		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+		requestDetails.setServletRequest(mockHttpServletRequest);
+		requestDetails.setServer(new RestfulServer(myFhirContext));
+		return requestDetails;
+	}
+
+	private RequestDetails createRequestDetailsWithPartitionHeader(String theCommaSeparatedPartitionIds) {
+		ServletRequestDetails requestDetails = createRequestDetails();
+		requestDetails.addHeader(RequestHeaderPartitionInterceptor.PARTITIONS_HEADER, theCommaSeparatedPartitionIds);
+		return requestDetails;
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RequestHeaderPartitionTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RequestHeaderPartitionTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 public class RequestHeaderPartitionTest  extends BaseJpaR4Test {
 
 	private static final String PARTITION_EXTENSION_URL = "http://hapifhir.io/fhir/ns/StructureDefinition/request-partition-ids";
+	private static RestfulServer ourServer = new RestfulServer();
 
 	private IIdType myPatientIdInPartition1;
 
@@ -243,7 +244,7 @@ public class RequestHeaderPartitionTest  extends BaseJpaR4Test {
 		ServletRequestDetails requestDetails = new ServletRequestDetails(mySrdInterceptorService);
 		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
 		requestDetails.setServletRequest(mockHttpServletRequest);
-		requestDetails.setServer(new RestfulServer(myFhirContext));
+		requestDetails.setServer(ourServer);
 		return requestDetails;
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/stresstest/GiantTransactionPerfTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/stresstest/GiantTransactionPerfTest.java
@@ -44,6 +44,7 @@ import ca.uhn.fhir.jpa.searchparam.registry.SearchParamRegistryImpl;
 import ca.uhn.fhir.jpa.searchparam.registry.SearchParameterCanonicalizer;
 import ca.uhn.fhir.jpa.sp.SearchParamPresenceSvcImpl;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.util.IMetaTagSorter;
@@ -293,6 +294,7 @@ public class GiantTransactionPerfTest {
 		}
 
 		ServletRequestDetails requestDetails = new ServletRequestDetails(myInterceptorSvc);
+		requestDetails.setServer(new RestfulServer());
 		requestDetails.setServletRequest(new MockServletRequest());
 
 		mySystemDao.transaction(requestDetails, input);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/SystemRequestDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/SystemRequestDetails.java
@@ -78,6 +78,10 @@ public class SystemRequestDetails extends RequestDetails {
 		}
 	}
 
+	/**
+	 * Copy constructor
+	 * @param theOther The request details to copy from
+	 */
 	public SystemRequestDetails(SystemRequestDetails theOther) {
 		super(theOther);
 		if (nonNull(theOther.getServer())) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/SystemRequestDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/SystemRequestDetails.java
@@ -78,6 +78,19 @@ public class SystemRequestDetails extends RequestDetails {
 		}
 	}
 
+	public SystemRequestDetails(SystemRequestDetails theOther) {
+		super(theOther);
+		if (nonNull(theOther.getServer())) {
+			myServer = theOther.getServer();
+			myFhirContext = theOther.getFhirContext();
+		}
+		if (nonNull(theOther.myHeaders)) {
+			initHeaderMap();
+			myHeaders.putAll(theOther.myHeaders);
+		}
+		myRequestPartitionId = theOther.myRequestPartitionId;
+	}
+
 	// TODO KHS use this everywhere we create a srd with only one partition
 	public static SystemRequestDetails forRequestPartitionId(RequestPartitionId thePartitionId) {
 		SystemRequestDetails retVal = new SystemRequestDetails();

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/servlet/ServletSubRequestDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/servlet/ServletSubRequestDetails.java
@@ -34,7 +34,8 @@ public class ServletSubRequestDetails extends ServletRequestDetails {
 	/**
 	 * Map with case-insensitive keys
 	 */
-	private final ListMultimap<String, String> myHeaders = MultimapBuilder.treeKeys(String.CASE_INSENSITIVE_ORDER)
+	private final ListMultimap<String, String> myHeaderOverrides = MultimapBuilder.treeKeys(
+					String.CASE_INSENSITIVE_ORDER)
 			.arrayListValues()
 			.build();
 
@@ -45,13 +46,7 @@ public class ServletSubRequestDetails extends ServletRequestDetails {
 	 */
 	public ServletSubRequestDetails(@Nonnull ServletRequestDetails theRequestDetails) {
 		super(theRequestDetails.getInterceptorBroadcaster());
-
 		myWrap = theRequestDetails;
-
-		Map<String, List<String>> headers = theRequestDetails.getHeaders();
-		for (Map.Entry<String, List<String>> next : headers.entrySet()) {
-			myHeaders.putAll(next.getKey(), next.getValue());
-		}
 	}
 
 	@Override
@@ -66,25 +61,31 @@ public class ServletSubRequestDetails extends ServletRequestDetails {
 
 	@Override
 	public void addHeader(String theName, String theValue) {
-		myHeaders.put(theName, theValue);
+		myHeaderOverrides.put(theName, theValue);
 	}
 
 	@Override
 	public String getHeader(String theName) {
-		List<String> list = myHeaders.get(theName);
+		List<String> list = myHeaderOverrides.get(theName);
 		if (list.isEmpty()) {
-			return null;
+			return myWrap.getHeader(theName);
 		}
 		return list.get(0);
 	}
 
 	@Override
 	public List<String> getHeaders(String theName) {
-		List<String> list = myHeaders.get(theName.toLowerCase());
+		List<String> list = myHeaderOverrides.get(theName.toLowerCase());
 		if (list.isEmpty()) {
-			return null;
+			return myWrap.getHeaders(theName);
 		}
 		return list;
+	}
+
+	@Override
+	public void setHeaders(String theName, List<String> theValues) {
+		myHeaderOverrides.removeAll(theName);
+		myHeaderOverrides.putAll(theName, theValues);
 	}
 
 	@Override

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/servlet/ServletSubRequestDetails.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/servlet/ServletSubRequestDetails.java
@@ -28,11 +28,31 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This class wraps a {@link ServletRequestDetails} object for
+ * processing sub-requests, such as processing individual
+ * entries in a transaction or batch bundle. An instance of this class is used for modifying some of the data
+ * in the request details, such as the request headers, for an individual entry,
+ * without affecting the original ServletRequestDetails.
+ */
 public class ServletSubRequestDetails extends ServletRequestDetails {
 
 	private final ServletRequestDetails myWrap;
+
 	/**
 	 * Map with case-insensitive keys
+	 * This map contains only the headers modified by the user after this object is created.
+	 * If a header is not modified, the original value from the wrapped RequestDetails is returned by the
+	 * getters in this class.
+	 * <p>
+	 * The reason for implementing the map this way, which is just keeping track of the overrides, as opposed
+	 * to creating a copy of the header map of the wrapped RequestDetails at the time this object is created,
+	 * is that there some test code where the header values are stubbed for the wrapped details using Mockito
+	 * like `when(requestDetails.getHeader("headerName")).thenReturn("headerValue")`.
+	 * Creating a copy of the headers by iterating the map of the wrapped instance wouldn't satisfy such stubbing,
+	 * the stubbed values are not actually in the map.
+	 * For stubbing to work we have to make a call the getHeader method of the wrapped RequestDetails.
+	 * This is what the getters in this class do.
 	 */
 	private final ListMultimap<String, String> myHeaderOverrides = MultimapBuilder.treeKeys(
 					String.CASE_INSENSITIVE_ORDER)

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ServletRequestUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/util/ServletRequestUtil.java
@@ -32,11 +32,15 @@ import java.util.Map;
 
 public class ServletRequestUtil {
 	public static ServletSubRequestDetails getServletSubRequestDetails(
-			ServletRequestDetails theRequestDetails, String url, ArrayListMultimap<String, String> theParamValues) {
+			ServletRequestDetails theRequestDetails,
+			String url,
+			String theVerb,
+			ArrayListMultimap<String, String> theParamValues) {
 		ServletSubRequestDetails requestDetails = new ServletSubRequestDetails(theRequestDetails);
 		requestDetails.setServletRequest(theRequestDetails.getServletRequest());
-		requestDetails.setRequestType(RequestTypeEnum.GET);
+		requestDetails.setRequestType(RequestTypeEnum.valueOf(theVerb));
 		requestDetails.setServer(theRequestDetails.getServer());
+		requestDetails.setRestOperationType(theRequestDetails.getRestOperationType());
 
 		int qIndex = url.indexOf('?');
 		requestDetails.setParameters(new HashMap<>());

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/api/server/SystemRequestDetailsTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/api/server/SystemRequestDetailsTest.java
@@ -1,0 +1,30 @@
+package ca.uhn.fhir.rest.api.server;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SystemRequestDetailsTest {
+
+	@Test
+	void testCopyConstructor_CopiesHeaders_ModifyingTheHeadersInOriginalDoesNotAffectTheCopy () {
+		SystemRequestDetails original = new SystemRequestDetails();
+		original.addHeader("header1", "value1");
+		original.addHeader("header1", "value2");
+		original.addHeader("header2", "value3");
+
+		SystemRequestDetails copy = new SystemRequestDetails(original);
+		assertThat(copy.getHeaders("header1")).containsExactly("value1", "value2");
+		assertThat(copy.getHeaders("header2")).containsExactly("value3");
+
+		//now modify the original headers
+		original.addHeader("header1", "value4");
+		original.addHeader("header2", "value5");
+		original.addHeader("headerNew", "valueNew");
+
+		//the copy should not be affected
+		assertThat(copy.getHeaders("header1")).containsExactly("value1", "value2");
+		assertThat(copy.getHeaders("header2")).containsExactly("value3");
+		assertThat(copy.getHeader("headerNew")).isNull();
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -762,7 +762,13 @@ public abstract class BaseTransactionProcessor {
 	private RequestDetails createRequestDetailsForWriteEntry(
 			RequestDetails theRequestDetails, IBase theEntry, String theUrl, String theVerb) {
 
-		RequestDetails newRequestDetails = null;
+		if (theRequestDetails == null) {
+			ourLog.warn(
+					"The RequestDetails passed in to the transaction is null. Cannot create a new RequestDetails for transaction entry.");
+			return null;
+		}
+
+		RequestDetails newRequestDetails;
 		if (theRequestDetails instanceof ServletRequestDetails) {
 			newRequestDetails = ServletRequestUtil.getServletSubRequestDetails(
 					(ServletRequestDetails) theRequestDetails, theUrl, theVerb, ArrayListMultimap.create());
@@ -2274,8 +2280,8 @@ public abstract class BaseTransactionProcessor {
 
 	/**
 	 * Extracts the transaction url from the entry and verifies it's:
-	 *  <li>not null or blank (unless it is a POST), and</li>
-	 *  <li>is a relative url matching the resourceType it is about</li>
+	 * <li>not null or blank (unless it is a POST), and</li>
+	 * <li>is a relative url matching the resourceType it is about</li>
 	 * <p>
 	 * For POST requests, the url is allowed to be blank to preserve the existing behavior.
 	 * <p>

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -739,10 +739,12 @@ public abstract class BaseTransactionProcessor {
 	 * If the extension is present, this method will set the partition ids header in the given request details.
 	 */
 	private void setRequestPartitionHeaderIfEntryHasTheExtension(IBase theReqEntry, RequestDetails theRequestDetails) {
-		IBaseExtension<?, ?> partitionIdsExtension =
+		Optional<IBaseExtension<?, ?>> partitionIdsExtensionOptional =
 				myVersionAdapter.getEntryRequestExtensionByUrl(theReqEntry, EXTENSION_TRANSACTION_ENTRY_PARTITION_IDS);
-		if (partitionIdsExtension != null && partitionIdsExtension.getValue() instanceof IPrimitiveType<?>) {
-			IPrimitiveType<?> valueAsPrimitiveType = (IPrimitiveType<?>) partitionIdsExtension.getValue();
+		if (partitionIdsExtensionOptional.isPresent()
+				&& partitionIdsExtensionOptional.get().getValue() instanceof IPrimitiveType<?>) {
+			IPrimitiveType<?> valueAsPrimitiveType =
+					(IPrimitiveType<?>) partitionIdsExtensionOptional.get().getValue();
 			String value = valueAsPrimitiveType.getValueAsString();
 			theRequestDetails.setHeaders(RequestHeaderPartitionInterceptor.PARTITIONS_HEADER, List.of(value));
 		}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -80,7 +80,6 @@ import ca.uhn.fhir.rest.server.method.BaseMethodBinding;
 import ca.uhn.fhir.rest.server.method.BaseResourceReturningMethodBinding;
 import ca.uhn.fhir.rest.server.method.UpdateMethodBinding;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
-import ca.uhn.fhir.rest.server.servlet.ServletSubRequestDetails;
 import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
 import ca.uhn.fhir.rest.server.util.ServletRequestUtil;
 import ca.uhn.fhir.util.AsyncUtil;
@@ -698,9 +697,10 @@ public abstract class BaseTransactionProcessor {
 				IBase nextRespEntry =
 						(IBase) myVersionAdapter.getEntries(theResponse).get(originalOrder);
 
+				String entryReqUrl = extractTransactionUrlOrThrowException(nextReqEntry, "GET");
 				ArrayListMultimap<String, String> paramValues = ArrayListMultimap.create();
-				ServletSubRequestDetails requestDetailsForEntry =
-						getRequestDetailsForReadEntry(srd, nextReqEntry, paramValues);
+				RequestDetails requestDetailsForEntry =
+						getRequestDetailsForEntry(srd, nextReqEntry, entryReqUrl, "GET", paramValues);
 
 				String url = requestDetailsForEntry.getRequestPath();
 
@@ -752,20 +752,26 @@ public abstract class BaseTransactionProcessor {
 
 	/**
 	 * Creates a new RequestDetails object based on the given RequestDetails. The new RequestDetails is to be used
-	 * when processing a write entry.
-	 * If the entry.request has the extension to override the partition ids, this method
+	 * when processing a transaction entry.
+	 * It sets the headers in the newly request details according to the information from entry.request if needed.
+	 * Especially, If the entry.request has the extension to override the partition ids, this method
 	 * sets the partition ids header in the newly created request details with the values from extension.
 	 * This allows using different partitions for different entries in the same transaction.
 	 *
+	 * @param theQueryParameters this is an output parameter that will be filled with the query parameters of the entry request url
 	 * @return the newly created request details
 	 */
-	private RequestDetails getRequestDetailsForWriteEntry(
-			RequestDetails theRequestDetails, IBase theEntry, String theUrl, String theVerb) {
+	private RequestDetails getRequestDetailsForEntry(
+			RequestDetails theRequestDetails,
+			IBase theEntry,
+			String theUrl,
+			String theVerb,
+			ArrayListMultimap<String, String> theQueryParameters) {
 
 		RequestDetails newRequestDetails = null;
 		if (theRequestDetails instanceof ServletRequestDetails) {
 			newRequestDetails = ServletRequestUtil.getServletSubRequestDetails(
-					(ServletRequestDetails) theRequestDetails, theUrl, theVerb, ArrayListMultimap.create());
+					(ServletRequestDetails) theRequestDetails, theUrl, theVerb, theQueryParameters);
 		} else if (theRequestDetails instanceof SystemRequestDetails) {
 			newRequestDetails = new SystemRequestDetails((SystemRequestDetails) theRequestDetails);
 		} else {
@@ -774,40 +780,21 @@ public abstract class BaseTransactionProcessor {
 			// modifications
 			return theRequestDetails;
 		}
-		setRequestPartitionHeaderIfEntryHasTheExtension(theEntry, newRequestDetails);
-		return newRequestDetails;
-	}
 
-	/**
-	 * Creates a new RequestDetails based on the given one. The returned RequestDetails is to be used when processing
-	 * a GET entry of transaction.
-	 * It sets the headers in the newly request details according to the information from entry.request if needed.
-	 * Currently, GET entries only support ServletRequestDetails so it handles only that type.
-	 */
-	private ServletSubRequestDetails getRequestDetailsForReadEntry(
-			ServletRequestDetails theRequestDetails, IBase theEntry, ArrayListMultimap<String, String> theParamValues) {
-
-		final String verb = "GET";
-		String transactionUrl = extractTransactionUrlOrThrowException(theEntry, verb);
-
-		ServletSubRequestDetails subRequestDetails =
-				ServletRequestUtil.getServletSubRequestDetails(theRequestDetails, transactionUrl, verb, theParamValues);
-
+		// modify the request details based on the entry.request
 		if (isNotBlank(myVersionAdapter.getEntryRequestIfMatch(theEntry))) {
-			subRequestDetails.addHeader(Constants.HEADER_IF_MATCH, myVersionAdapter.getEntryRequestIfMatch(theEntry));
+			newRequestDetails.addHeader(Constants.HEADER_IF_MATCH, myVersionAdapter.getEntryRequestIfMatch(theEntry));
 		}
 		if (isNotBlank(myVersionAdapter.getEntryRequestIfNoneExist(theEntry))) {
-			subRequestDetails.addHeader(
+			newRequestDetails.addHeader(
 					Constants.HEADER_IF_NONE_EXIST, myVersionAdapter.getEntryRequestIfNoneExist(theEntry));
 		}
 		if (isNotBlank(myVersionAdapter.getEntryRequestIfNoneMatch(theEntry))) {
-			subRequestDetails.addHeader(
+			newRequestDetails.addHeader(
 					Constants.HEADER_IF_NONE_MATCH, myVersionAdapter.getEntryRequestIfNoneMatch(theEntry));
 		}
-
-		setRequestPartitionHeaderIfEntryHasTheExtension(theEntry, subRequestDetails);
-
-		return subRequestDetails;
+		setRequestPartitionHeaderIfEntryHasTheExtension(theEntry, newRequestDetails);
+		return newRequestDetails;
 	}
 
 	/**
@@ -926,7 +913,8 @@ public abstract class BaseTransactionProcessor {
 		RequestPartitionId nextWriteEntryRequestPartitionId = null;
 		String verb = myVersionAdapter.getEntryRequestVerb(myContext, nextEntry);
 		String url = extractTransactionUrlOrThrowException(nextEntry, verb);
-		RequestDetails requestDetailsForEntry = getRequestDetailsForWriteEntry(theRequestDetails, nextEntry, url, verb);
+		RequestDetails requestDetailsForEntry =
+				getRequestDetailsForEntry(theRequestDetails, nextEntry, url, verb, ArrayListMultimap.create());
 		if (isNotBlank(verb)) {
 			BundleEntryTransactionMethodEnum verbEnum = BundleEntryTransactionMethodEnum.valueOf(verb);
 			switch (verbEnum) {
@@ -1306,9 +1294,9 @@ public abstract class BaseTransactionProcessor {
 					continue;
 				}
 
-				String url = extractAndVerifyTransactionUrlForEntry(nextReqEntry, verb);
-				RequestDetails requestDetailsForEntry =
-						getRequestDetailsForWriteEntry(theRequest, nextReqEntry, url, verb);
+				String entryReqUrl = extractAndVerifyTransactionUrlForEntry(nextReqEntry, verb);
+				RequestDetails requestDetailsForEntry = getRequestDetailsForEntry(
+						theRequest, nextReqEntry, entryReqUrl, verb, ArrayListMultimap.create());
 
 				IBaseResource res = myVersionAdapter.getResource(nextReqEntry);
 				IIdType nextResourceId = getNextResourceIdFromBaseResource(res, nextReqEntry, theAllIds, verb);
@@ -1368,8 +1356,8 @@ public abstract class BaseTransactionProcessor {
 					}
 					case "DELETE": {
 						// DELETE
-						UrlUtil.UrlParts parts = UrlUtil.parseUrl(url);
-						IFhirResourceDao<? extends IBaseResource> dao = toDao(parts, verb, url);
+						UrlUtil.UrlParts parts = UrlUtil.parseUrl(entryReqUrl);
+						IFhirResourceDao<? extends IBaseResource> dao = toDao(parts, verb, entryReqUrl);
 						int status = Constants.STATUS_HTTP_204_NO_CONTENT;
 						if (parts.getResourceId() != null) {
 							IIdType deleteId = newIdType(parts.getResourceType(), parts.getResourceId());
@@ -1412,7 +1400,7 @@ public abstract class BaseTransactionProcessor {
 						IFhirResourceDao resourceDao = getDaoOrThrowException(res.getClass());
 
 						DaoMethodOutcome outcome;
-						UrlUtil.UrlParts parts = UrlUtil.parseUrl(url);
+						UrlUtil.UrlParts parts = UrlUtil.parseUrl(entryReqUrl);
 						if (isNotBlank(parts.getResourceId())) {
 							String version = null;
 							if (isNotBlank(myVersionAdapter.getEntryRequestIfMatch(nextReqEntry))) {
@@ -1467,7 +1455,7 @@ public abstract class BaseTransactionProcessor {
 						// PATCH
 						validateResourcePresent(res, order, verb);
 
-						UrlUtil.UrlParts parts = UrlUtil.parseUrl(url);
+						UrlUtil.UrlParts parts = UrlUtil.parseUrl(entryReqUrl);
 
 						String matchUrl = toMatchUrl(nextReqEntry);
 						matchUrl = performIdSubstitutionsInMatchUrl(theIdSubstitutions, matchUrl);
@@ -1506,13 +1494,13 @@ public abstract class BaseTransactionProcessor {
 							}
 						}
 
-						IFhirResourceDao<? extends IBaseResource> dao = toDao(parts, verb, url);
+						IFhirResourceDao<? extends IBaseResource> dao = toDao(parts, verb, entryReqUrl);
 						IIdType patchId =
 								myContext.getVersion().newIdType(parts.getResourceType(), parts.getResourceId());
 
 						String conditionalUrl;
 						if (isNull(patchId.getIdPart())) {
-							conditionalUrl = url;
+							conditionalUrl = entryReqUrl;
 						} else {
 							conditionalUrl = matchUrl;
 							String ifMatch = myVersionAdapter.getEntryRequestIfMatch(nextReqEntry);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -700,7 +700,7 @@ public abstract class BaseTransactionProcessor {
 
 				ArrayListMultimap<String, String> paramValues = ArrayListMultimap.create();
 				ServletSubRequestDetails requestDetailsForEntry =
-						getRequestDetailsForReadEntry(srd, nextReqEntry, paramValues);
+						createRequestDetailsForReadEntry(srd, nextReqEntry, paramValues);
 
 				String url = requestDetailsForEntry.getRequestPath();
 
@@ -759,7 +759,7 @@ public abstract class BaseTransactionProcessor {
 	 *
 	 * @return the newly created request details
 	 */
-	private RequestDetails getRequestDetailsForWriteEntry(
+	private RequestDetails createRequestDetailsForWriteEntry(
 			RequestDetails theRequestDetails, IBase theEntry, String theUrl, String theVerb) {
 
 		RequestDetails newRequestDetails = null;
@@ -772,6 +772,10 @@ public abstract class BaseTransactionProcessor {
 			// RequestDetails is not a ServletRequestDetails or SystemRequestDetails, and I don't know how to properly
 			// clone such a RequestDetails. Use the original RequestDetails without making any entry specific
 			// modifications
+			ourLog.warn(
+					"Cannot create a new RequestDetails for transaction entry out of the existing RequestDetails which is of type '{}'"
+							+ "Using the original RequestDetails for transaction entries without any entry specific modifications.",
+					theRequestDetails.getClass().getSimpleName());
 			return theRequestDetails;
 		}
 		setRequestPartitionHeaderIfEntryHasTheExtension(theEntry, newRequestDetails);
@@ -784,7 +788,7 @@ public abstract class BaseTransactionProcessor {
 	 * It sets the headers in the newly request details according to the information from entry.request if needed.
 	 * Currently, GET entries only support ServletRequestDetails so it handles only that type.
 	 */
-	private ServletSubRequestDetails getRequestDetailsForReadEntry(
+	private ServletSubRequestDetails createRequestDetailsForReadEntry(
 			ServletRequestDetails theRequestDetails, IBase theEntry, ArrayListMultimap<String, String> theParamValues) {
 
 		final String verb = "GET";
@@ -926,7 +930,8 @@ public abstract class BaseTransactionProcessor {
 		RequestPartitionId nextWriteEntryRequestPartitionId = null;
 		String verb = myVersionAdapter.getEntryRequestVerb(myContext, nextEntry);
 		String url = extractTransactionUrlOrThrowException(nextEntry, verb);
-		RequestDetails requestDetailsForEntry = getRequestDetailsForWriteEntry(theRequestDetails, nextEntry, url, verb);
+		RequestDetails requestDetailsForEntry =
+				createRequestDetailsForWriteEntry(theRequestDetails, nextEntry, url, verb);
 		if (isNotBlank(verb)) {
 			BundleEntryTransactionMethodEnum verbEnum = BundleEntryTransactionMethodEnum.valueOf(verb);
 			switch (verbEnum) {
@@ -1308,7 +1313,7 @@ public abstract class BaseTransactionProcessor {
 
 				String url = extractAndVerifyTransactionUrlForEntry(nextReqEntry, verb);
 				RequestDetails requestDetailsForEntry =
-						getRequestDetailsForWriteEntry(theRequest, nextReqEntry, url, verb);
+						createRequestDetailsForWriteEntry(theRequest, nextReqEntry, url, verb);
 
 				IBaseResource res = myVersionAdapter.getResource(nextReqEntry);
 				IIdType nextResourceId = getNextResourceIdFromBaseResource(res, nextReqEntry, theAllIds, verb);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/ITransactionProcessorVersionAdapter.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/ITransactionProcessorVersionAdapter.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -76,4 +77,6 @@ public interface ITransactionProcessorVersionAdapter<BUNDLE extends IBaseBundle,
 	void setRequestVerb(BUNDLEENTRY theEntry, String theVerb);
 
 	void setRequestUrl(BUNDLEENTRY theEntry, String theUrl);
+
+	IBaseExtension<?, ?> getEntryRequestExtensionByUrl(BUNDLEENTRY theEntry, String theUrl);
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/ITransactionProcessorVersionAdapter.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/ITransactionProcessorVersionAdapter.java
@@ -29,6 +29,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public interface ITransactionProcessorVersionAdapter<BUNDLE extends IBaseBundle, BUNDLEENTRY extends IBase> {
 
@@ -78,5 +79,5 @@ public interface ITransactionProcessorVersionAdapter<BUNDLE extends IBaseBundle,
 
 	void setRequestUrl(BUNDLEENTRY theEntry, String theUrl);
 
-	IBaseExtension<?, ?> getEntryRequestExtensionByUrl(BUNDLEENTRY theEntry, String theUrl);
+	Optional<IBaseExtension<?, ?>> getEntryRequestExtensionByUrl(BUNDLEENTRY theEntry, String theUrl);
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/TransactionProcessorVersionAdapterDstu3.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/TransactionProcessorVersionAdapterDstu3.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.BundleUtil;
 import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -185,5 +186,10 @@ public class TransactionProcessorVersionAdapterDstu3
 	@Override
 	public void setRequestUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
 		theEntry.getRequest().setUrl(theUrl);
+	}
+
+	@Override
+	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return theEntry.getRequest().getExtensionByUrl(theUrl);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/TransactionProcessorVersionAdapterDstu3.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/dstu3/TransactionProcessorVersionAdapterDstu3.java
@@ -26,15 +26,16 @@ import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.BundleUtil;
 import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -189,7 +190,8 @@ public class TransactionProcessorVersionAdapterDstu3
 	}
 
 	@Override
-	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
-		return theEntry.getRequest().getExtensionByUrl(theUrl);
+	public Optional<IBaseExtension<?, ?>> getEntryRequestExtensionByUrl(
+			Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return Optional.ofNullable(theEntry.getRequest().getExtensionByUrl(theUrl));
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/r4/TransactionProcessorVersionAdapterR4.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/r4/TransactionProcessorVersionAdapterR4.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Resource;
 
@@ -169,5 +170,10 @@ public class TransactionProcessorVersionAdapterR4
 	@Override
 	public void setRequestUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
 		theEntry.getRequest().setUrl(theUrl);
+	}
+
+	@Override
+	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return theEntry.getRequest().getExtensionByUrl(theUrl);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/r4/TransactionProcessorVersionAdapterR4.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/r4/TransactionProcessorVersionAdapterR4.java
@@ -25,15 +25,16 @@ import ca.uhn.fhir.jpa.dao.ITransactionProcessorVersionAdapter;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Resource;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public class TransactionProcessorVersionAdapterR4
 		implements ITransactionProcessorVersionAdapter<Bundle, Bundle.BundleEntryComponent> {
@@ -173,7 +174,8 @@ public class TransactionProcessorVersionAdapterR4
 	}
 
 	@Override
-	public Extension getEntryRequestExtensionByUrl(Bundle.BundleEntryComponent theEntry, String theUrl) {
-		return theEntry.getRequest().getExtensionByUrl(theUrl);
+	public Optional<IBaseExtension<?, ?>> getEntryRequestExtensionByUrl(
+			Bundle.BundleEntryComponent theEntry, String theUrl) {
+		return Optional.ofNullable(theEntry.getRequest().getExtensionByUrl(theUrl));
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/RequestHeaderPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/RequestHeaderPartitionInterceptor.java
@@ -1,0 +1,125 @@
+/*-
+ * #%L
+ * HAPI FHIR - Server Framework
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.interceptor;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static ca.uhn.fhir.interceptor.api.Pointcut.STORAGE_PARTITION_IDENTIFY_CREATE;
+import static ca.uhn.fhir.interceptor.api.Pointcut.STORAGE_PARTITION_IDENTIFY_READ;
+import static ca.uhn.fhir.rest.server.provider.ProviderConstants.ALL_PARTITIONS_TENANT_NAME;
+import static ca.uhn.fhir.rest.server.provider.ProviderConstants.DEFAULT_PARTITION_NAME;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * This is an interceptor to identify the partition ID from a request header.
+ * It reads the value of the X-Request-Partition-IDs header, which is expected to be a comma separated partition ids.
+ * For the read operations it uses all the partitions specified in the header.
+ * The create operations it uses the first partition ID from the header.
+ *
+ * The tests for the functionality of this interceptor can be found in the
+ * ca.uhn.fhir.jpa.interceptor.RequestHeaderPartitionTest class.
+ */
+@Interceptor
+public class RequestHeaderPartitionInterceptor {
+
+	public static final String PARTITIONS_HEADER = "X-Request-Partition-IDs";
+
+	/**
+	 * This method is called to identify the partition ID for create operations.
+	 * It reads the value of the X-Request-Partition-IDs header, and parses and returns the first partition ID
+	 * from the header value.
+	 */
+	@Hook(STORAGE_PARTITION_IDENTIFY_CREATE)
+	public RequestPartitionId identifyPartitionForCreate(RequestDetails theRequestDetails) {
+		String partitionHeader = getPartitionHeaderOrThrowIfBlank(theRequestDetails);
+		return parseRequestPartitionIdsFromCommaSeparatedString(partitionHeader, true);
+	}
+
+	/**
+	 * This method is called to identify the partition ID for read operations.
+	 * Parses all the partition IDs from the header into a RequestPartitionId object.
+	 */
+	@Hook(STORAGE_PARTITION_IDENTIFY_READ)
+	public RequestPartitionId identifyPartitionForRead(RequestDetails theRequestDetails) {
+		String partitionHeader = getPartitionHeaderOrThrowIfBlank(theRequestDetails);
+		return parseRequestPartitionIdsFromCommaSeparatedString(partitionHeader, false);
+	}
+
+	private String getPartitionHeaderOrThrowIfBlank(RequestDetails theRequestDetails) {
+		String partitionHeader = theRequestDetails.getHeader(PARTITIONS_HEADER);
+		if (isBlank(partitionHeader)) {
+			String msg = String.format(
+					"%s header is missing or blank, it is required to identify the storage partition",
+					PARTITIONS_HEADER);
+			throw new InvalidRequestException(Msg.code(2642) + msg);
+		}
+		return partitionHeader;
+	}
+
+	private RequestPartitionId parseRequestPartitionIdsFromCommaSeparatedString(
+			String thePartitionIds, boolean theIncludeOnlyTheFirst) {
+		String[] partitionIdStrings = thePartitionIds.split(",");
+		List<Integer> partitionIds = new ArrayList<>();
+
+		for (String partitionIdString : partitionIdStrings) {
+
+			String trimmedPartitionId = partitionIdString.trim();
+
+			if (trimmedPartitionId.equals(ALL_PARTITIONS_TENANT_NAME)) {
+				return RequestPartitionId.allPartitions();
+			}
+
+			if (trimmedPartitionId.equals(DEFAULT_PARTITION_NAME)) {
+				partitionIds.add(RequestPartitionId.defaultPartition().getFirstPartitionIdOrNull());
+			} else {
+				try {
+					int partitionId = Integer.parseInt(trimmedPartitionId);
+					partitionIds.add(partitionId);
+				} catch (NumberFormatException e) {
+					String msg = String.format(
+							"Invalid partition ID: '%s' provided in header: %s", trimmedPartitionId, PARTITIONS_HEADER);
+					throw new InvalidRequestException(Msg.code(2643) + msg);
+				}
+			}
+
+			// return early if we only need the first partition ID
+			if (theIncludeOnlyTheFirst) {
+				return RequestPartitionId.fromPartitionIds(partitionIds);
+			}
+		}
+
+		if (partitionIds.isEmpty()) {
+			// this case happens only when the header contains nothing but commas
+			// since we already checked for blank header before calling this function
+			String msg = String.format("No partition IDs provided in header: %s", PARTITIONS_HEADER);
+			throw new InvalidRequestException(Msg.code(2645) + msg);
+		}
+
+		return RequestPartitionId.fromPartitionIds(partitionIds);
+	}
+}


### PR DESCRIPTION
closes: #6887

This MR adds 

- a new partition interceptor that can be used to identify partitions based on a specific request header called `X-Request-Partition-IDs` which is expected to be a comma separated list of partition Ids. 

- a mechanism for overriding this header in a transaction bundle for individual request entries if needed. This can potentially allow writing to different resources to  different partitions in the same transaction. 

 
For read operations, the interceptor returns a RequestParitionId object that contains all the partition ids passed in the header. 

The words `DEFAULT` and `_ALL` can be used to specify the default and all partitions respectively.

For create operations, only the first id from the list is returned. So a resource would be written to the first partition in the list. 

An example to override a partition header for a transaction entry: 
```
{
      "fullUrl": "http://example.com/fhir4/Patient/444",
      "resource": {
        "resourceType": "Patient"
      },
      "request": {
        "method": "POST",
        "url": "Patient",
        "extension": [
          {
            "url": "http://hapifhir.io/fhir/ns/StructureDefinition/request-partition-ids",
            "valueString": "3"
          }
        ]
 }
```
 