### PR TITLE
feat: Add full support for ValueSet filter operators in InMemoryTerminologyServerValidationSupport

### DIFF
--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ValueSetTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ValueSetTest.java
@@ -141,17 +141,10 @@ public class FhirResourceDaoR4ValueSetTest extends BaseJpaR4Test {
 		ValidationSupportContext ctx = new ValidationSupportContext(myValidationSupport);
 		ConceptValidationOptions options = new ConceptValidationOptions();
 
-		// In memory - Hierarchy in existing CS
-
-		outcome = myValidationSupport.validateCode(ctx, options, "http://cs", "child10", null, "http://vs");
-		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals("Code was validated against in-memory expansion of ValueSet: http://vs", outcome.getSourceDetails());
-
 		outcome = myValidationSupport.validateCode(ctx, options, "http://cs", "childX", null, "http://vs");
 		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertThat(outcome.getMessage()).contains("Unknown code 'http://cs#childX' for in-memory expansion of ValueSet 'http://vs'");
+		assertThat(outcome.getMessage()).contains("cannot apply filters");
 
 		// In memory - Enumerated in non-present CS
 
@@ -248,13 +241,13 @@ public class FhirResourceDaoR4ValueSetTest extends BaseJpaR4Test {
 
 		outcome = myValidationSupport.validateCode(ctx, options, "http://cs", "child10", null, "http://vs");
 		assertNotNull(outcome);
-		assertTrue(outcome.isOk());
-		assertEquals("Code was validated against in-memory expansion of ValueSet: http://vs", outcome.getSourceDetails());
+		assertFalse(outcome.isOk());
+		assertThat(outcome.getMessage()).contains("cannot apply filters");
 
 		outcome = myValidationSupport.validateCode(ctx, options, "http://cs", "childX", null, "http://vs");
 		assertNotNull(outcome);
 		assertFalse(outcome.isOk());
-		assertThat(outcome.getMessage()).contains("Unknown code 'http://cs#childX' for in-memory expansion of ValueSet 'http://vs'");
+		assertThat(outcome.getMessage()).contains("cannot apply filters");
 
 		// In memory - Enumerated in non-present CS
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.java
@@ -1021,21 +1021,24 @@ public class InMemoryTerminologyServerValidationSupport implements IValidationSu
 			boolean isIncludeCodeSystemIgnored = includeOrExcludeSystemResource != null
 					&& includeOrExcludeSystemResource.getContent() == Enumerations.CodeSystemContentMode.NOTPRESENT;
 
-			boolean isIncludeFromSystem = isNotBlank(theInclude.getSystem()) && theInclude.getValueSet().isEmpty();
+			boolean isIncludeFromSystem = isNotBlank(theInclude.getSystem())
+					&& theInclude.getValueSet().isEmpty();
 			boolean isIncludeWithFilter = !theInclude.getFilter().isEmpty();
 
 			// if we can’t load the CS and we’re configured to ignore it...
 			if (isIncludeCodeSystemIgnored && !theInclude.getFilter().isEmpty()) {
 				// We can’t apply any structural (ISA/DESCENDENT-OF/etc..) filters if the CS is absent → fail
-				String msg = "Unable to expand ValueSet: cannot apply filters '" +
-					theInclude.getFilter() + "' because CodeSystem '" +
-					theInclude.getSystem() + "' is ignored/not-present";
+				String msg = "Unable to expand ValueSet: cannot apply filters '" + theInclude.getFilter()
+						+ "' because CodeSystem '" + theInclude.getSystem()
+						+ "' is ignored/not-present";
 
 				throw new ExpansionCouldNotBeCompletedInternallyException(
-					Msg.code(2646) + msg,
-					new CodeValidationIssue(msg, IssueSeverity.ERROR,
-						CodeValidationIssueCode.NOT_FOUND,
-						CodeValidationIssueCoding.NOT_FOUND));
+						Msg.code(2646) + msg,
+						new CodeValidationIssue(
+								msg,
+								IssueSeverity.ERROR,
+								CodeValidationIssueCode.NOT_FOUND,
+								CodeValidationIssueCoding.NOT_FOUND));
 			}
 
 			if (includeOrExcludeSystemResource == null || isIncludeCodeSystemIgnored) {

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.java
@@ -1180,22 +1180,24 @@ public class InMemoryTerminologyServerValidationSupport implements IValidationSu
 		}
 
 		boolean retVal = false;
+		ValueSetExpansionFilterContext valueSetExpansionFilterContext =
+				new ValueSetExpansionFilterContext(includeOrExcludeSystemResource, theInclude.getFilter());
 
 		for (FhirVersionIndependentConcept next : nextCodeList) {
 			if (includeOrExcludeSystemResource != null && theWantCode != null) {
-				boolean matches;
-				if (includeOrExcludeSystemResource.getCaseSensitive()) {
-					matches = theWantCode.equals(next.getCode());
-				} else {
-					matches = theWantCode.equalsIgnoreCase(next.getCode());
-				}
+				boolean matches = includeOrExcludeSystemResource.getCaseSensitive()
+						? theWantCode.equals(next.getCode())
+						: theWantCode.equalsIgnoreCase(next.getCode());
+
 				if (!matches) {
 					continue;
 				}
 			}
 
-			theConsumer.accept(next);
-			retVal = true;
+			if (!valueSetExpansionFilterContext.isFiltered(next)) {
+				theConsumer.accept(next);
+				retVal = true;
+			}
 		}
 
 		return retVal;

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContext.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContext.java
@@ -1,0 +1,331 @@
+package org.hl7.fhir.common.hapi.validation.support;
+
+import ca.uhn.fhir.util.FhirVersionIndependentConcept;
+import org.hl7.fhir.r5.model.CodeSystem;
+import org.hl7.fhir.r5.model.ValueSet;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Class to apply ValueSet filters during in-memory expansion.
+ * Will only work on 'code', 'concept' and 'display' property types.
+ *
+ * Supports: equal | is-a | descendent-of | is-not-a | regex | in | not-in | generalizes | child-of | descendent-leaf | exists
+ */
+public class ValueSetExpansionFilterContext {
+	private final Map<String, Map<String, String>> propertyIndex = new HashMap<>();
+
+	private final Map<String, Set<String>> conceptCodeTree = new HashMap<>();
+	private final Set<String> allCodes = new HashSet<>();
+	private final Set<String> allCodesLower = new HashSet<>();
+	private final Map<String, Set<String>> inSetsMap = new HashMap<>();
+	private final Map<String, Pattern> regexCache = new HashMap<>();
+	private final CodeSystem codeSystem;
+	private final List<ValueSet.ConceptSetFilterComponent> filters;
+	private boolean hasIndexRun = false;
+
+	public ValueSetExpansionFilterContext(CodeSystem codeSystem, List<ValueSet.ConceptSetFilterComponent> filters) {
+		this.codeSystem = codeSystem;
+		this.filters = filters;
+	}
+
+	public boolean isFiltered(FhirVersionIndependentConcept concept) {
+		if (filters == null || filters.isEmpty()) {
+			return false;
+		}
+
+		// buildChildrenMap() once in ctor or lazily here
+		for (ValueSet.ConceptSetFilterComponent filter : filters) {
+			if (!passesFilter(filter, concept)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public boolean passesFilter(ValueSet.ConceptSetFilterComponent filter, FhirVersionIndependentConcept concept) {
+		if (filter.hasOp()) {
+			// Lazy load the index, if there are any filters to process.
+			buildIndexes();
+
+			// The 'property' element is required by the FHIR spec, but we default to "concept" (the code)
+			// when it's missing, for backwards-compatibility with legacy HAPI clients.
+			String theFilterProperty =
+					filter.hasProperty() ? filter.getProperty().toLowerCase(Locale.ROOT) : "concept";
+			boolean onCode = theFilterProperty.equals("concept") || theFilterProperty.equals("code");
+			boolean onDisplay = theFilterProperty.equals("display");
+
+			/**
+			 * Only code/display supported in the in-memory validation support, so reject any custom concept properties,
+			 * even though that should technically be supported by the FHIR spec.
+			 *
+			 * @see <a href="https://build.fhir.org/codesystem.html#properties">
+			 *      FHIR CodeSystem Concept Properties (4.8.11)</a>
+			 * @see <a href="https://build.fhir.org/codesystem.html#defined-props">
+			 *      FHIR CodeSystem Defined Concept Properties (4.8.12)</a>
+			 */
+			if (!onCode && !onDisplay) {
+				return false;
+			}
+
+			String theFilterValue = filter.getValue();
+			String theConceptCode = concept.getCode();
+			String theConceptPropertyValue = onCode
+					? concept.getCode()
+					: propertyIndex
+							.getOrDefault("display", Collections.emptyMap())
+							.get(theConceptCode);
+
+			switch (filter.getOp()) {
+				case EQUAL:
+					// if we’re filtering on display but there is none, it’s not a match
+					if (theConceptPropertyValue == null) {
+						return false;
+					}
+
+					return isEqualsWithOptionalCaseSensitive(theFilterValue, theConceptPropertyValue);
+				case ISA:
+					// 1) structural filter guards
+					if (failsStructuralFilterGuard(theFilterValue, onCode)) {
+						return false;
+					}
+
+					// 2) accept the code itself
+					if (isEqualsWithOptionalCaseSensitive(theFilterValue, theConceptCode)) {
+						return true;
+					}
+
+					// 3) accept any true descendant
+					return isDescendantOf(theFilterValue, theConceptCode);
+				case DESCENDENTOF:
+					// 1) structural filter guards
+					if (failsStructuralFilterGuard(theFilterValue, onCode)) {
+						return false;
+					}
+
+					// 2) accept only any true descendant
+					return isDescendantOf(theFilterValue, theConceptCode);
+				case ISNOTA:
+					// 1) structural filter guards
+					if (failsStructuralFilterGuard(theFilterValue, onCode)) {
+						return false;
+					}
+
+					// 2) Exclude the filter value itself
+					if (isEqualsWithOptionalCaseSensitive(theFilterValue, theConceptCode)) {
+						return false;
+					}
+
+					// 3) Exclude any true descendant
+					if (isDescendantOf(theFilterValue, theConceptCode)) {
+						return false;
+					}
+
+					// 5) Everything else passes
+					return true;
+				case REGEX:
+					// 1) If there's no target text (e.g. display missing), we can’t match
+					if (theConceptPropertyValue == null) {
+						return false;
+					}
+
+					// 2) Delegate to our cached helper (which handles invalid patterns)
+					return matchesRegex(theFilterValue, theConceptPropertyValue);
+				case IN:
+					// 1) If there's no target text (e.g. display missing), we can’t match
+					if (theConceptPropertyValue == null) {
+						return false;
+					}
+
+					// 2) Match
+					return csvFilterListContains(theFilterValue, theConceptPropertyValue);
+				case NOTIN:
+					// If there is no property value, then it’s trivially “not in” any list → pass
+					if (theConceptPropertyValue == null) {
+						return true;
+					}
+
+					// 2) Match
+					return !csvFilterListContains(theFilterValue, theConceptPropertyValue);
+				case GENERALIZES: {
+					// 1) structural filter guards
+					if (failsStructuralFilterGuard(theFilterValue, onCode)) {
+						return false;
+					}
+
+					// 2) Include X itself
+					if (isEqualsWithOptionalCaseSensitive(theFilterValue, theConceptCode)) {
+						return true;
+					}
+
+					// 3) Include any true ancestor of X:
+					//    i.e. those codes C for which X is in C's subtree.
+					if (isDescendantOf(theConceptCode, theFilterValue)) {
+						return true;
+					}
+
+					// 5) Everything else is outside the ancestor chain → filtered out
+					return false;
+				}
+				case CHILDOF: {
+					// 1) structural filter guards
+					if (failsStructuralFilterGuard(theFilterValue, onCode)) {
+						return false;
+					}
+
+					// 2) Look up the direct children of X
+					Set<String> directKids = conceptCodeTree.getOrDefault(theFilterValue, Collections.emptySet());
+
+					// 3) Accept only if our candidate code matches one of those children
+					return directKids.stream()
+							.anyMatch(childCode -> isEqualsWithOptionalCaseSensitive(childCode, theConceptCode));
+				}
+				case DESCENDENTLEAF: {
+					// 1) structural filter guards
+					if (failsStructuralFilterGuard(theFilterValue, onCode)) {
+						return false;
+					}
+
+					// 2) It must be a true descendant (not X itself)
+					if (!isDescendantOf(theFilterValue, theConceptCode)) {
+						return false;
+					}
+
+					// 3) It must have no children of its own → is a leaf
+					Set<String> kids = conceptCodeTree.getOrDefault(theConceptCode, Collections.emptySet());
+					return kids.isEmpty();
+				}
+				case EXISTS: {
+					// filter.getValue() will be "true" or "false"
+					boolean wantExists = Boolean.parseBoolean(theFilterValue);
+
+					if (onCode) {
+						// Every concept always has a code, so:
+						//  exists=true  ⇒ include all (pass filter)
+						//  exists=false ⇒ include none (fail filter)
+
+						// Also check whether the *code* is actually defined in the CodeSystem
+						boolean hasCode = !isFilterPropertyValueNotInCodeSystem(theConceptCode);
+
+						return wantExists == hasCode;
+					}
+
+					// Otherwise we’re on display
+					// theConceptPropertyValue was set to concept.getDisplay() above
+					boolean hasDisplay = theConceptPropertyValue != null;
+					return wantExists == hasDisplay;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return false if we should even _try_ a structural filter on this property + value:
+	 *   1) Must be on the code (not display)
+	 *   2) The filter value must actually exist in the CodeSystem
+	 */
+	private boolean failsStructuralFilterGuard(String theFilterValue, boolean onCode) {
+		return !onCode || isFilterPropertyValueNotInCodeSystem(theFilterValue);
+	}
+
+	private boolean isDescendantOf(String theParentCode, String theCandidatePropertyValue) {
+		Deque<String> stack = new ArrayDeque<>(conceptCodeTree.getOrDefault(theParentCode, Set.of()));
+		while (!stack.isEmpty()) {
+			String theChildCode = stack.pop();
+			if (isEqualsWithOptionalCaseSensitive(theChildCode, theCandidatePropertyValue)) {
+				return true;
+			}
+			stack.addAll(conceptCodeTree.getOrDefault(theChildCode, Set.of()));
+		}
+
+		return false;
+	}
+
+	private boolean isEqualsWithOptionalCaseSensitive(String a, String b) {
+		return codeSystem.getCaseSensitive()
+				? a.equals(b) // case-sensitive
+				: a.equalsIgnoreCase(b); // case-insensitive
+	}
+
+	/**
+	 * Return true if 'code' appears in the comma-separated list 'csv'
+	 */
+	private boolean csvFilterListContains(String theCsvFilter, String theCandidatePropertyValue) {
+		// lazily parse & cache the comma-list
+		Set<String> values = inSetsMap.computeIfAbsent(
+				theCsvFilter, filter -> new HashSet<>(Arrays.asList(filter.split("\\s*,\\s*"))));
+
+		// Now just test membership, respecting case‐sensitivity
+		return values.stream().anyMatch(part -> isEqualsWithOptionalCaseSensitive(part, theCandidatePropertyValue));
+	}
+
+	private boolean isFilterPropertyValueNotInCodeSystem(String theFilterPropertyValue) {
+		// Fast O(1) existence check, respecting case sensitivity
+		if (codeSystem.getCaseSensitive()) {
+			return !allCodes.contains(theFilterPropertyValue);
+		} else {
+			return !allCodesLower.contains(theFilterPropertyValue.toLowerCase());
+		}
+	}
+
+	/**
+	 * Match `text` against the regex `expr`, respecting caseSensitivity.
+	 * Returns false if the pattern is invalid.
+	 */
+	private boolean matchesRegex(String expr, String text) {
+		try {
+			Pattern p = regexCache.computeIfAbsent(
+					expr, key -> Pattern.compile(key, codeSystem.getCaseSensitive() ? 0 : Pattern.CASE_INSENSITIVE));
+			return p.matcher(text).matches();
+		} catch (PatternSyntaxException e) {
+			// Invalid regex → treat as “no match”
+			return false;
+		}
+	}
+
+	private void buildIndexes() {
+		if (!hasIndexRun) {
+			buildIndexes(codeSystem.getConcept());
+			hasIndexRun = true;
+		}
+	}
+
+	private void buildIndexes(List<CodeSystem.ConceptDefinitionComponent> defs) {
+		for (var def : defs) {
+			String code = def.getCode();
+			String display = def.getDisplay();
+
+			// 1) Index existence
+			allCodes.add(code);
+			allCodesLower.add(code.toLowerCase());
+
+			// 2) Index immediate children
+			for (var child : def.getConcept()) {
+				conceptCodeTree.computeIfAbsent(code, k -> new HashSet<>()).add(child.getCode());
+			}
+
+			// 3) Index the "code" property
+			propertyIndex.computeIfAbsent("code", k -> new HashMap<>()).put(code, code);
+
+			// 4) Index the "display" property
+			propertyIndex.computeIfAbsent("display", k -> new HashMap<>()).put(code, display);
+
+			// 5) Recurse
+			buildIndexes(def.getConcept());
+		}
+	}
+}

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContextTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContextTest.java
@@ -1,0 +1,610 @@
+package org.hl7.fhir.common.hapi.validation.support;
+
+import ca.uhn.fhir.util.FhirVersionIndependentConcept;
+import org.hl7.fhir.r5.model.CodeSystem;
+import org.hl7.fhir.r5.model.Enumerations.FilterOperator;
+import org.hl7.fhir.r5.model.ValueSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ValueSetExpansionFilterContextTest {
+
+	/**
+	 * Helper: build a flat CodeSystem with the given codes.
+	 */
+	private static CodeSystem flatCodeSystem(boolean caseSensitive, String... codes) {
+		CodeSystem cs = new CodeSystem()
+			.setUrl("http://example.org/flat")
+			.setCaseSensitive(caseSensitive);
+		for (String c : codes) {
+			cs.addConcept().setCode(c);
+		}
+		return cs;
+	}
+
+	/**
+	 * Helper: build a simple hierarchy P → C1 → C2 and sibling P → C3.
+	 */
+	private static CodeSystem hierarchicalCS(boolean caseSensitive) {
+		CodeSystem cs = new CodeSystem()
+			.setUrl("http://example.org/hier")
+			.setCaseSensitive(caseSensitive);
+		var p = cs.addConcept().setCode("P");
+		p.addConcept().setCode("C1").addConcept().setCode("C2");
+		p.addConcept().setCode("C3");
+		return cs;
+	}
+
+	/**
+	 * Invoke isFiltered() for a single filter + concept.
+	 */
+	private static boolean isFiltered(
+		CodeSystem cs,
+		FilterOperator op,
+		String filterValue,
+		FhirVersionIndependentConcept testConcept) {
+		ValueSet.ConceptSetFilterComponent filter = new ValueSet.ConceptSetFilterComponent()
+			.setOp(op).setValue(filterValue);
+		var ctx = new ValueSetExpansionFilterContext(cs, List.of(filter));
+		return ctx.isFiltered(testConcept);
+	}
+
+	/**
+	 * Like isFiltered(...) but also sets filter.property.
+	 */
+	private static boolean isFilteredWithProperty(
+		CodeSystem cs,
+		String property,
+		FilterOperator op,
+		String filterValue,
+		FhirVersionIndependentConcept testConcept
+	) {
+		ValueSet.ConceptSetFilterComponent filter = new ValueSet.ConceptSetFilterComponent()
+			.setProperty(property)
+			.setOp(op)
+			.setValue(filterValue);
+		var ctx = new ValueSetExpansionFilterContext(cs, List.of(filter));
+		return ctx.isFiltered(testConcept);
+	}
+
+	/**
+	 * Build a flat CodeSystem and assign displays to each code.
+	 *
+	 * @param caseSensitive    whether the CS should be case‐sensitive
+	 * @param codeDisplayPairs alternating code, display, code, display, …
+	 */
+	private static CodeSystem flatCodeSystemWithDisplay(boolean caseSensitive, String... codeDisplayPairs) {
+		// Extract just the codes for the flat system
+		String[] codes = new String[codeDisplayPairs.length / 2];
+		for (int i = 0; i < codeDisplayPairs.length; i += 2) {
+			codes[i / 2] = codeDisplayPairs[i];
+		}
+		CodeSystem cs = flatCodeSystem(caseSensitive, codes);
+		// Assign each display
+		for (int i = 0; i < codeDisplayPairs.length; i += 2) {
+			String code = codeDisplayPairs[i];
+			String display = codeDisplayPairs[i + 1];
+			cs.getConcept().stream()
+				.filter(d -> d.getCode().equals(code))
+				.findFirst()
+				.ifPresent(d -> d.setDisplay(display));
+		}
+		return cs;
+	}
+
+	@ParameterizedTest(name = "[equal-display] cs={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// caseSensitive, displayFilter,    testCode, expectedIsFiltered
+		"false, Hello,              X,       false",  // matches Hello
+		"false, hello,              X,       false",  // ignore case
+		"false, Hello,              Y,       true",   // Y’s display != Hello
+		"true,  hello,              X,       true"    // case-sensitive → no match
+	})
+	void testEqualOnDisplay(
+		boolean caseSensitive,
+		String displayFilter,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		// Build CS with code X,Y and set displays
+		CodeSystem cs = flatCodeSystemWithDisplay(caseSensitive,
+			"X", "Hello",
+			"Y", "World");
+
+		boolean actual = isFilteredWithProperty(
+			cs,
+			"display",
+			FilterOperator.EQUAL,
+			displayFilter,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("EQUAL[display=%s] on code '%s' (caseSensitive=%b)",
+				displayFilter, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[in-display] cs={0}, values={1}, code={2} ⇒ filtered={3}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+			// caseSensitive | values         | testCode | expectedIsFiltered
+			"false          | Hello,World    | X        | false", // Hello
+			"false          | Hello,World    | Y        | false", // World
+			"false          | Hello,World    | Z        | true",  // no such concept
+			"true           | hello,world    | X        | true"   // case-sensitive
+		})
+	void testInOnDisplay(
+		boolean caseSensitive,
+		String csvValues,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = flatCodeSystemWithDisplay(caseSensitive,
+			"X", "Hello",
+			"Y", "World");
+
+		boolean actual = isFilteredWithProperty(
+			cs,
+			"display",
+			FilterOperator.IN,
+			csvValues,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("IN[display in %s] on code '%s' (caseSensitive=%b)",
+				csvValues, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[notin-display] cs={0}, values={1}, code={2} ⇒ filtered={3}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+			// caseSensitive | values       | testCode | expectedIsFiltered
+			"false          | Hello,World  | X        | true",   // Hello → excluded
+			"false          | Hello,World  | Y        | true",   // World → excluded
+			"false          | Hello,World  | Z        | false",  // Z not in display → included
+			"true           | hello,world  | X        | false"   // case-sensitive → Hello not matched → included
+		}
+	)
+	void testNotInOnDisplay(
+		boolean caseSensitive,
+		String csvValues,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = flatCodeSystemWithDisplay(caseSensitive,
+			"X", "Hello",
+			"Y", "World");
+
+		boolean actual = isFilteredWithProperty(
+			cs,
+			"display",
+			FilterOperator.NOTIN,
+			csvValues,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("NOTIN[display not in %s] on code '%s' (caseSensitive=%b)",
+				csvValues, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[regex-display] cs={0}, pattern={1}, code={2} ⇒ filtered={3}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+			// caseSensitive | pattern      | testCode | expectedIsFiltered
+			"false          | '^H.*'        | X        | false", // Hello
+			"false          | '^H.*'        | Y        | true",  // World
+			"true           | '^h.*'        | X        | true",  // case-sensitive
+			"true           | '[A-Z]orld$'  | Y        | false"  // matches World
+		})
+	void testRegexOnDisplay(
+		boolean caseSensitive,
+		String pattern,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = flatCodeSystem(caseSensitive, "X", "Y");
+		cs.getConcept().get(0).setDisplay("Hello");
+		cs.getConcept().get(1).setDisplay("World");
+
+		boolean actual = isFilteredWithProperty(
+			cs,
+			"display",
+			FilterOperator.REGEX,
+			pattern,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("REGEX[display ~ %s] on code '%s' (caseSensitive=%b)",
+				pattern, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@Test
+	void unsupportedPropertyYieldsEmpty() {
+		CodeSystem cs = flatCodeSystem(false, "A", "B");
+		ValueSet.ConceptSetFilterComponent f = new ValueSet.ConceptSetFilterComponent()
+			.setProperty("severity")   // not code/display
+			.setOp(FilterOperator.EQUAL)
+			.setValue("A");
+		boolean filtered = new ValueSetExpansionFilterContext(cs, List.of(f))
+			.isFiltered(new FhirVersionIndependentConcept(cs.getUrl(), "A"));
+		assertThat(filtered).isTrue();  // always filtered out
+	}
+
+
+	@ParameterizedTest(name = "[equal] cs={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// caseSensitive, filterValue, testCode, expectedIsFiltered
+		"false, A, A, false",
+		"false, A, a, false",
+		"false, A, B, true",
+		"true,  A, A, false",
+		"true,  A, a, true"
+	})
+	void testEqualFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered) {
+
+		CodeSystem cs = flatCodeSystem(caseSensitive, "A", "B");
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.EQUAL,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("EQUAL[%s] on code %s (caseSensitive=%b)", filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[isa] caseSensitive={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// include parent, all descendants; exclude unknown and off-branch
+		"false, P,   P,    false",
+		"false, P,   C1,   false",
+		"false, P,   C2,   false",
+		"false, P,   C3,   false",
+		"false, P,   XXX,  true",
+		// is-a C1 should include C1, C2 but exclude P and C3
+		"false, C1,  C1,   false",
+		"false, C1,  C2,   false",
+		"false, C1,  P,    true",
+		"false, C1,  C3,   true",
+		// case-sensitive: wrong‐case filter or code → filtered
+		"true,  P,   P,    false",
+		"true,  P,   p,    true",
+		"true,  C1,  c2,   true",
+		// filterValue not in CS → no “branch” to include → everything filtered
+		"false, Q,   P,    true",
+		"true,  q,   P,    true"
+	})
+	void testIsaFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = hierarchicalCS(caseSensitive);
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.ISA,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("ISA[%s] on code '%s' (caseSensitive=%b)",
+				filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[descendent-of] cs={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// caseSensitive, filterValue, testCode, expectedFiltered
+		"false, P, P,   true",   // parent is always excluded
+		"false, P, C1,  false",  // direct child
+		"false, P, C2,  false",  // grandchild
+		"false, P, C3,  false",  // sibling branch
+		"false, P, XXX, true",   // not in CS
+		"true,  P, P,   true",   // parent excluded (case exactly matches)
+		"true,  P, C2,  false",  // descendant works
+		"true,  p, P,   true",   // wrong-case filter: no descendants → all filtered
+		"true,  P, c1,  true",   // wrong-case concept: filtered
+		// filterValue not in CS → no descendants → everything filtered
+		"false, Q,   P,    true",
+		"true,  q,   P,    true"
+	})
+	void testDescendentOfFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered) {
+
+		CodeSystem cs = hierarchicalCS(caseSensitive);
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.DESCENDENTOF,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("DESCENDENTOF[%s] on code %s (caseSensitive=%b)", filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[is-not-a] caseSensitive={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// exclude parent + descendants; include off-branch and unknown
+		"false, P,   P,    true",
+		"false, P,   C1,   true",
+		"false, P,   C2,   true",
+		"false, P,   C3,   true",
+		"false, P,   XXX,  false",
+		// is-not-a C1 excludes C1 & C2, but keeps P and C3
+		"false, C1,  P,    false",
+		"false, C1,  C1,   true",
+		"false, C1,  C2,   true",
+		"false, C1,  C3,   false",
+		// case-sensitive: wrong‐case filter or code → filtered only when it matches/excludes
+		"true,  C1,  C2,   true",
+		"true,  p,   C1,   true",  // filterValue wrong-case excludes everything
+		"true,  P,   p,    false",  // filterValue correct, code wrong-case → included
+		// filterValue not in CS → exclude all codes
+		"false, Q,   P,    true",
+		"true,  q,   P,    true"
+	})
+	void testIsNotAFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = hierarchicalCS(caseSensitive);
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.ISNOTA,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("ISNOTA[%s] on code '%s' (caseSensitive=%b)",
+				filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[regex] caseSensitive={0}, pattern={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// caseSensitive, pattern,    testCode, expectedIsFiltered
+		"false,       '^A.*',       A,         false",  // matches A, so not filtered
+		"false,       '^A.*',       a,         false",  // ignore case, matches a
+		"false,       '^B.*',       a,         true",   // ignore case, doesn't match B*
+		"true,        '^A.*',       A,         false",  // case exact, matches A
+		"true,        '^A.*',       a,         true"    // case exact, 'a' ≠ 'A'
+	})
+	void testRegexFilterBehavior(
+		boolean caseSensitive,
+		String pattern,
+		String testCode,
+		boolean expectedIsFiltered) {
+
+		// Build a flat CS containing at least A, a and B
+		CodeSystem cs = flatCodeSystem(caseSensitive, "A", "a", "B");
+
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.REGEX,
+			pattern,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("REGEX[%s] on code '%s' (caseSensitive=%b)", pattern, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[in] caseSensitive={0}, values={1}, code={2} ⇒ filtered={3}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+			// caseSensitive | values | testCode | expectedIsFiltered
+			"false        | A,B    | A | false",  // in list → not filtered
+			"false        | A,B    | a | false",  // ignore case → not filtered
+			"false        | A,B    | B | false",  // in list → not filtered
+			"false        | A,B    | C | true",   // not in list → filtered
+			"true         | A,B    | A | false",  // exact match → not filtered
+			"true         | A,B    | a | true",   // wrong case → filtered
+			"true         | A,B    | B | false",  // exact match → not filtered
+			"true         | X,Y,Z  | W | true",    // not in list → filtered
+			// values none in CS → nothing included → all filtered
+			"false        | Q,R    | A | true",
+			"true         | q,r    | A | true"
+		}
+	)
+	void testInFilterBehavior(
+		boolean caseSensitive,
+		String csvValues,
+		String testCode,
+		boolean expectedIsFiltered) {
+
+		// Build a flat CodeSystem containing at least the listed values
+		CodeSystem cs = flatCodeSystem(caseSensitive, "A", "B", "C", "X", "Y", "Z");
+
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.IN,
+			csvValues,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("IN[%s] on code '%s' (caseSensitive=%b)", csvValues, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[generalizes] cs={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// cs,    filter, code, expectedFiltered
+		"false, P,      P,    false",  // self
+		"false, P,      C1,   true",   // off-branch from P’s ancestor set
+		"false, P,      C2,   true",
+		"false, P,      C3,   true",
+		"false, P,      XXX,  true",   // unknown code
+		"false, Q,      P,    true",   // non-existent filter → empty
+		"true,  q,      P,    true",
+		"true,  P,      p,    true",   // wrong-case filter → empty
+		"true,  p,      P,    true",
+		"true,  P,      C1,   true",   // still excluded under P
+		// --------------------------------------------------------------------
+		// Now test generalizes = C2 → should include C2 + its ancestors (C1, P)
+		"false, C2,     C2,   false",
+		"false, C2,     C1,   false",
+		"false, C2,     P,    false",
+		"false, C2,     C3,   true",   // off-branch
+		"false, C2,     XXX,  true",   // unknown code
+		// case-sensitivity for C2
+		"true,  C2,     C2,   false",
+		"true,  C2,     C1,   false",
+		"true,  C2,     P,    false",
+		"true,  C2,     c1,   true"    // wrong-case ancestor filtered out
+	})
+	void testGeneralizesFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = hierarchicalCS(caseSensitive);
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.GENERALIZES,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+		assertThat(actual)
+			.as("GENERALIZES[%s] on code '%s' (caseSensitive=%b)",
+				filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[child-of] cs={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		"false, P,   C1,  false",  // immediate child
+		"false, P,   C2,  true",   // grandchild → filtered
+		"false, P,   P,   true",   // parent itself → filtered
+		"false, P,   C3,  false",  // sibling also immediate child
+		"false, P,   XXX, true",   // unknown → filtered
+		// case‐sensitive
+		"true,  P,   c1,  true"    // wrong-case → filtered
+	})
+	void testChildOfFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = hierarchicalCS(caseSensitive);
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.CHILDOF,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+		assertThat(actual)
+			.as("CHILD-OF[%s] on code '%s' (caseSensitive=%b)",
+				filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[descendent-leaf] cs={0}, filter={1}, code={2} ⇒ filtered={3}")
+	@CsvSource({
+		// caseSensitive, filterValue, code, expectedIsFiltered
+		"false, P,   P,    true",   // P is not a descendant → filtered
+		"false, P,   C1,   true",   // C1 has children → filtered
+		"false, P,   C2,   false",  // C2 is a leaf descendant → not filtered
+		"false, P,   C3,   false",  // C3 is a leaf descendant → not filtered
+		"false, P,   XXX,  true",   // unknown → filtered
+		// non-existent filter → empty result
+		"false, Q,   C2,   true",
+		"true,  q,   C2,   true",
+		// case-sensitivity on real values
+		"true,  P,   c2,   true",   // wrong case concept → filtered
+		"true,  p,   C2,   true",   // wrong case filter → filtered
+		"true,  P,   C2,   false"   // correct-case leaf → not filtered
+	})
+	void testDescendentLeafFilterBehavior(
+		boolean caseSensitive,
+		String filterValue,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = hierarchicalCS(caseSensitive);
+		boolean actual = isFiltered(
+			cs,
+			FilterOperator.DESCENDENTLEAF,
+			filterValue,
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+		assertThat(actual)
+			.as("DESCENDENT-LEAF[%s] on code '%s' (caseSensitive=%b)",
+				filterValue, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[exists] cs={0}, property={1}, want={2}, code={3} ⇒ filtered={4}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+		// caseSensitive | property  | wantExists | code | expectedIsFiltered
+		"false          | code      | true       | A    | false",  // code always exists
+		"false          | code      | false      | A    | true",   // code never missing
+		"false          | display   | true       | A    | false",  // A has display
+		"false          | display   | true       | B    | true",   // B no display
+		"false          | display   | false      | A    | true",   // A has display → filtered
+		"false          | display   | false      | B    | false",  // B no display → not filtered
+		// case‐sensitive DOES affect code existence for wrong‐case
+		"true           | code      | true       | a    | true"    // 'a' != 'A' under case‐sensitive
+	})
+	void testExistsFilterBehavior(
+		boolean caseSensitive,
+		String property,
+		boolean wantExists,
+		String testCode,
+		boolean expectedIsFiltered
+	) {
+		CodeSystem cs = flatCodeSystem(caseSensitive, "A", "B");
+		// give A a display only
+		cs.getConcept().get(0).setDisplay("LabelA");
+
+		boolean actual = isFilteredWithProperty(
+			cs,
+			property,
+			FilterOperator.EXISTS,
+			Boolean.toString(wantExists),
+			new FhirVersionIndependentConcept(cs.getUrl(), testCode)
+		);
+
+		assertThat(actual)
+			.as("EXISTS[%s=%s] on code '%s' (caseSensitive=%b)",
+				property, wantExists, testCode, caseSensitive)
+			.isEqualTo(expectedIsFiltered);
+	}
+}


### PR DESCRIPTION
### 💬 **Pull Request Description** 
This PR enhances `InMemoryTerminologyServerValidationSupport` to support all ValueSet filter operators defined in the FHIR spec, including structural and existence-based filters. This allows for more accurate behavior when running validation/expansion using preloaded in-memory terminology, such as during unit testing, CLI tools, or bootstrapped deployments.

#### 🔧 Features Implemented 
* `=`, `in`, `not-in`, `regex` filters on code & display 
* `is-a`, `descendent-of`, `generalizes`, `is-not-a`, `child-of`, `descendent-leaf` filters on code 
* `exists` filter support (only for `code` and `display` properties) 
* Case sensitivity respected per CodeSystem definition

#### 🧪 Test Coverage
A complete parameterized test suite validates all filter combinations using realistic hierarchical CodeSystems. Tests are version-aware and toggle R4 vs. R5 model usage accordingly.

#### 💡 Motivation
The FHIR ValueSet filter operator descendent-of is currently not handled by HAPI FHIR’s in-memory validation/expansion chain. When a ValueSet compose includes a filter like property = "concept", op = "descendent-of", value = X, the existing logic fails to apply it. This leads to incorrect expansions – notably, the ancestor concept X itself ends up included in the expansion (or an error is thrown) instead of only its descendants. In other words, the in-memory expander does not distinguish descendent-of from is-a, causing validation tests to incorrectly include the parent code in the expanded results. This issue has been observed in unit tests for custom profiles that define ValueSets using descendent-of filters. Those tests currently either fail or require workarounds (like forcing JPA-based expansion via $reindex) because the in-memory expander doesn’t support descendent-of. This also causes confusing behavior in validation and made it hard to rely on FHIR profile tests without spinning up full persistence layers.

This change enables full correctness out-of-the-box using only PrePopulatedValidationSupport.

#### ⚙️ Performance Considerations
Concept tree indexing is lazily initialized and cached internally per expansion, making repeated filtering efficient. Matching is short-circuiting and avoids unnecessary traversal for filters like in and equal.

#### 🤔 Optional vs. Default Behavior
The new logic applies automatically to in-memory expansions. If needed, this could be guarded via ValueSetExpansionOptions, but current design keeps behavior spec-compliant by default.
