### PR TITLE
removed fhircontext param from CdsPrefetchService constructor

### DIFF
--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/config/CdsHooksConfig.java
@@ -218,14 +218,12 @@ public class CdsHooksConfig {
 			CdsPrefetchDaoSvc theResourcePrefetchDao,
 			CdsPrefetchFhirClientSvc theResourcePrefetchFhirClient,
 			ICdsHooksDaoAuthorizationSvc theCdsHooksDaoAuthorizationSvc,
-			FhirContext theFhirContext,
 			@Nullable IInterceptorBroadcaster theInterceptorBroadcaster) {
 		return new CdsPrefetchSvc(
 				theCdsResolutionStrategySvc,
 				theResourcePrefetchDao,
 				theResourcePrefetchFhirClient,
 				theCdsHooksDaoAuthorizationSvc,
-				theFhirContext,
 				theInterceptorBroadcaster);
 	}
 

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
@@ -61,13 +61,12 @@ public class CdsPrefetchSvc {
 			CdsPrefetchDaoSvc theResourcePrefetchDao,
 			CdsPrefetchFhirClientSvc theResourcePrefetchFhirClient,
 			ICdsHooksDaoAuthorizationSvc theCdsHooksDaoAuthorizationSvc,
-			FhirContext theFhirContext,
 			@Nullable IInterceptorBroadcaster theInterceptorBroadcaster) {
 		myCdsResolutionStrategySvc = theCdsResolutionStrategySvc;
 		myResourcePrefetchDao = theResourcePrefetchDao;
 		myResourcePrefetchFhirClient = theResourcePrefetchFhirClient;
 		myCdsHooksDaoAuthorizationSvc = theCdsHooksDaoAuthorizationSvc;
-		myFhirContext = theFhirContext;
+		myFhirContext = theResourcePrefetchDao.getFhirContext();
 		myInterceptorBroadcaster = theInterceptorBroadcaster;
 	}
 
@@ -167,7 +166,7 @@ public class CdsPrefetchSvc {
 				continue;
 			}
 			String url = PrefetchTemplateUtil.substituteTemplate(
-					template, theCdsServiceRequestJson.getContext(), myResourcePrefetchDao.getFhirContext());
+					template, theCdsServiceRequestJson.getContext(), myFhirContext);
 			ourLog.info("missing: {}.  Fetching with {}", theMissingPrefetch, url);
 
 			CdsHookPrefetchPointcutContextJson cdsHookPrefetchPointcutContext =

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvcTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvcTest.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.OperationOutcome;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,7 +38,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,8 +58,14 @@ class CdsPrefetchSvcTest {
 	private ICdsServiceMethod myServiceMethodMock;
 	@Mock
 	private IInterceptorBroadcaster myInterceptorBroadcasterMock;
-	@InjectMocks
+
 	private CdsPrefetchSvc myCdsPrefetchSvc;
+
+	@BeforeEach
+	void setUp() {
+		when(myCdsPrefetchDaoSvc.getFhirContext()).thenReturn(myFhirContext);
+		myCdsPrefetchSvc = new CdsPrefetchSvc(myCdsResolutionStrategySvc, myCdsPrefetchDaoSvc, myCdsPrefetchFhirClientSvc, myCdsHooksDaoAuthorizationSvc, myInterceptorBroadcasterMock);
+	}
 
 	@Test
 	void testFindMissingPrefetch() {
@@ -162,7 +169,7 @@ class CdsPrefetchSvcTest {
 			assertThat(request.getPrefetchKeys()).doesNotContain("patient");
 		}
 
-		verifyNoInteractions(myCdsPrefetchFhirClientSvc, myCdsPrefetchDaoSvc);
+		verifyNoMoreInteractions(myCdsPrefetchFhirClientSvc, myCdsPrefetchDaoSvc);
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
I had recently added the FhirContext as a parameter to the CDSPrefetchSvc constructor, but I noticed that broke some projects like [hapi-fhir-jpaserver-starter](https://github.com/hapifhir/hapi-fhir-jpaserver-starter/blob/master/src/main/java/ca/uhn/fhir/jpa/starter/cdshooks/ModuleConfigurationPrefetchSvc.java#L78) and [clinical reasoning](https://github.com/cqframework/clinical-reasoning/blob/710efbe154cd2239a70cc63ea2ef54802db4a27a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/test/TestCdsHooksConfig.java#L101). 

So rather than updating all the projects that use the constructor, in this MR I removed the parameter from the constructor and  get the fhirContext through the CdsPrefetchDaoSvc that is already passed in to the constructor. I noticed that the class is already using this approach when it needs to access the FhirContext. 