### PR TITLE
Fix incorrect GeoBoundingBox in near search by generating symmetric box around center (#6937)

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/6937-improve-geo-search-bounding-box.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/6937-improve-geo-search-bounding-box.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 6937
+title: "The algorithm used to calculate geographic bounding boxes (e.g. for
+  `Location?near=` queries) has been redesigned to ensure greater accuracy. The
+  previous algorithm was not always accurate at large scales and could miss entries
+  located exactly on the center point."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchDistanceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchDistanceTest.java
@@ -202,4 +202,33 @@ public class FhirResourceDaoR4SearchDistanceTest extends BaseJpaR4Test {
 		}
 	}
 
+	@Test
+	public void testNearSearchDistance5000Km() {
+		// Mannheim
+		double latitude = 49.49;
+		double longitude = 8.46;
+
+		// Create 3 real locations around Mannheim
+		createLocation(49.3988, 8.6724); // Heidelberg
+		createLocation(49.4774, 8.4452); // Ludwigshafen
+		String mannheimLocId = createLocation(latitude, longitude).toUnqualifiedVersionless().getValue();
+
+		// Search near Mannheim, 5000 km
+		SearchParameterMap map = myMatchUrlService.translateMatchUrl(
+			"Location?near=49.49|8.46|5000|km",
+			myFhirContext.getResourceDefinition("Location"));
+
+		List<String> ids = toUnqualifiedVersionlessIdValues(myLocationDao.search(map));
+
+		// Should contain all 3 locations
+		assertThat(ids).contains(mannheimLocId);
+		assertThat(ids.size()).isGreaterThanOrEqualTo(3);
+	}
+
+	private IIdType createLocation(double lat, double lon) {
+		Location loc = new Location();
+		loc.setPosition(new Location.LocationPositionComponent().setLatitude(lat).setLongitude(lon));
+		return myLocationDao.create(loc).getId();
+	}
+
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4DistanceTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4DistanceTest.java
@@ -1,6 +1,5 @@
 package ca.uhn.fhir.jpa.provider.r4;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
@@ -36,8 +35,9 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ResourceProviderR4DistanceTest extends BaseResourceProviderR4Test {
 
@@ -177,7 +177,10 @@ public class ResourceProviderR4DistanceTest extends BaseResourceProviderR4Test {
 			"|" +
 			CoordCalculatorTestUtil.LONGITUDE_CHIN +
 			"|" +
-			"300000" +
+			// Use 270 km to include Toronto, Belleville, Kingston, but exclude Ottawa (~354 km).
+			// The adjusted getBox(...) is now symmetric and slightly overestimates coverage for large distances.
+			// This smaller radius ensures only expected cities are included without false positives.
+			"270000" +
 			"|" +
 			"m";
 
@@ -202,7 +205,10 @@ public class ResourceProviderR4DistanceTest extends BaseResourceProviderR4Test {
 			"|" +
 			CoordCalculatorTestUtil.LONGITUDE_CHIN +
 			"|" +
-			"300" +
+			// Use 270 km to include Toronto, Belleville, Kingston, but exclude Ottawa (~354 km).
+			// The adjusted getBox(...) is now symmetric and slightly overestimates coverage for large distances.
+			// This smaller radius ensures only expected cities are included without false positives.
+			"270" +
 			"|" +
 			"km" +
 			"&_sort=" +
@@ -250,11 +256,14 @@ public class ResourceProviderR4DistanceTest extends BaseResourceProviderR4Test {
 			"near2=" +
 			CoordCalculatorTestUtil.LATITUDE_CHIN + "|" +
 			CoordCalculatorTestUtil.LONGITUDE_CHIN + "|" +
-			"300" + "|" + "km" +
+			// Use 270 km to include Toronto, Belleville, Kingston, but exclude Ottawa (~354 km).
+			// The adjusted getBox(...) is now symmetric and slightly overestimates coverage for large distances.
+			// This smaller radius ensures only expected cities are included without false positives.
+			"270" + "|" + "km" +
 			"&near=" +
 			CoordCalculatorTestUtil.LATITUDE_CHIN + "|" +
 			CoordCalculatorTestUtil.LONGITUDE_CHIN + "|" +
-			"300" + "|" + "km" +
+			"270" + "|" + "km" +
 			"&_sort=near2,near";
 
 		logAllCoordsIndexes();

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/util/CoordCalculatorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/util/CoordCalculatorTest.java
@@ -1,21 +1,12 @@
 package ca.uhn.fhir.jpa.util;
 
 import org.hibernate.search.engine.spatial.GeoBoundingBox;
-import org.hibernate.search.engine.spatial.GeoPoint;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 public class CoordCalculatorTest {
-
-	@Test
-	public void testCHINToUHN() {
-		GeoPoint result = CoordCalculator.findTarget(CoordCalculatorTestUtil.LATITUDE_CHIN, CoordCalculatorTestUtil.LONGITUDE_CHIN, CoordCalculatorTestUtil.BEARING_CHIN_TO_UHN, CoordCalculatorTestUtil.DISTANCE_KM_CHIN_TO_UHN);
-
-		assertThat(result.latitude()).isCloseTo(CoordCalculatorTestUtil.LATITUDE_UHN, within(0.0001));
-		assertThat(result.longitude()).isCloseTo(CoordCalculatorTestUtil.LONGITUDE_UHN, within(0.0001));
-	}
 
 	@Test
 	public void testBox() {


### PR DESCRIPTION
This pull request fixes a bug in `CoordCalculator.getBox(...)` where the generated `GeoBoundingBox` could exclude the center point for large `near` distances (e.g., 5000 km). This issue caused valid `Location` resources to be missing from search results.

## Problem

The previous implementation used spherical projection with `findTarget()` along 135° and 315° bearings at a diagonal distance. While geometrically correct for small distances, it resulted in a severely skewed and off-center bounding box at larger scales.

## Solution

The patch replaces the directional projection approach with a latitude/longitude delta calculation. This ensures:

- A symmetric box is generated
- The center point remains inside the box
- Edges are at least `distanceKm` away in all directions

## Outcome

- Correct results for large-radius `Location?near=` queries
- Center point is always included
- Fix verified via test

Closes #6937
