### PR TITLE
initialize requestdetails earlier in cache synchronizer

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6939-initialize-RequestDetails-BaseResourceCacheSynhronizer.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6939-initialize-RequestDetails-BaseResourceCacheSynhronizer.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 6939
+title: "BaseResourceCacheSynchronizer class, which is mainly used for caching Subscription and 
+SubscriptionTopic resources, was using a null RequestDetails object when querying the database, if its 
+`requestRefresh` method is called before the `registerListener` method during initialization. This has now been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6939-initialize-RequestDetails-BaseResourceCacheSynhronizer.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_2_0/6939-initialize-RequestDetails-BaseResourceCacheSynhronizer.yaml
@@ -1,6 +1,5 @@
 ---
 type: fix
 issue: 6939
-title: "BaseResourceCacheSynchronizer class, which is mainly used for caching Subscription and 
-SubscriptionTopic resources, was using a null RequestDetails object when querying the database, if its 
-`requestRefresh` method is called before the `registerListener` method during initialization. This has now been fixed."
+title: "Previously, the Subscription module could fail to boot due to a race condition happening during its initialisation sequence.
+The issue has been fixed."

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
@@ -68,7 +68,7 @@ public abstract class BaseResourceCacheSynchronizer implements IResourceChangeLi
 	private DaoRegistry myDaoRegistry;
 
 	private SearchParameterMap mySearchParameterMap;
-	private SystemRequestDetails mySystemRequestDetails;
+	private final SystemRequestDetails mySystemRequestDetails = SystemRequestDetails.forAllPartitions();
 	private boolean myStopping;
 	private final Semaphore mySyncResourcesSemaphore = new Semaphore(1);
 	private final Object mySyncResourcesLock = new Object();
@@ -99,7 +99,6 @@ public abstract class BaseResourceCacheSynchronizer implements IResourceChangeLi
 			ourLog.info("No resource DAO found for resource type {}, not registering listener", myResourceName);
 			return;
 		}
-		mySystemRequestDetails = SystemRequestDetails.forAllPartitions();
 
 		IResourceChangeListenerCache resourceCache =
 				myResourceChangeListenerRegistry.registerResourceResourceChangeListener(


### PR DESCRIPTION
issue: #6939 

[BaseResourceCacheSynhronizer](https://github.com/hapifhir/hapi-fhir/blob/5f18274f90a595f0b83dafc1cce542678e08f95e/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java#L57-L57) has a public `requestRefresh` method which eventually makes use of the `mySystemRequestDetails` field in the same class to make a db call. The problem is `mySystemRequestDetails` is only initialized in the same class' `registerListener` method. It means that if `requestRefresh` is called before `registerListener` then `mySystemRequestDetails` is null, which is not the expected behaviour. 

This MR initializes `mySystemRequestDetails` field earlier. 