### PR TITLE
mySystemRequestDetails not initialized in BaseResourceCacheSynchronizer when booting MDM with Partitions

### DIFF
--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/cache/BaseResourceCacheSynchronizer.java
@@ -99,12 +99,18 @@ public abstract class BaseResourceCacheSynchronizer implements IResourceChangeLi
 			ourLog.info("No resource DAO found for resource type {}, not registering listener", myResourceName);
 			return;
 		}
-		mySystemRequestDetails = SystemRequestDetails.forAllPartitions();
+		initializeRequestDetails();
 
 		IResourceChangeListenerCache resourceCache =
 				myResourceChangeListenerRegistry.registerResourceResourceChangeListener(
 						myResourceName, provideSearchParameterMap(), this, REFRESH_INTERVAL);
 		resourceCache.forceRefresh();
+	}
+
+	private void initializeRequestDetails() {
+		if (mySystemRequestDetails == null) {
+			mySystemRequestDetails = SystemRequestDetails.forAllPartitions();
+		}
 	}
 
 	private SearchParameterMap provideSearchParameterMap() {
@@ -178,6 +184,7 @@ public abstract class BaseResourceCacheSynchronizer implements IResourceChangeLi
 	}
 
 	synchronized int doSyncResourcesWithRetry() {
+		initializeRequestDetails();
 		// retry runs MAX_RETRIES times
 		// and if errors result every time, it will fail
 		Retrier<Integer> syncResourceRetrier = new Retrier<>(this::doSyncResources, getMaxRetries());


### PR DESCRIPTION
Greetings, 

Had an issue building a server with MDM in a partitioned environment: 

-  I couldn't load my MDM subscriptions, the mySystemRequestDetails being initialized only after AFTER_SUBSCRIPTION_INITIALIZED in Boot order. 

Proposition for a fix: 

- added a method to avoid redundancy in defining the RequestDetail, 
- Called in registerListener() where it was previously initialized
- Called in doSyncResourcesWithRetry() before syncResourceRetrier creation