### PR TITLE
Validation Error should return 422 - Unprocessable Entity

### DIFF
--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptor.java
@@ -25,7 +25,7 @@ import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.OperationOutcomeUtil;
 import com.google.common.collect.ArrayListMultimap;
@@ -155,8 +155,8 @@ public class RepositoryValidatingInterceptor {
 		if (theOutcome.getOperationOutcome() != null) {
 			String firstIssue =
 					OperationOutcomeUtil.getFirstIssueDiagnostics(myFhirContext, theOutcome.getOperationOutcome());
-			throw new PreconditionFailedException(Msg.code(574) + firstIssue, theOutcome.getOperationOutcome());
+			throw new UnprocessableEntityException(Msg.code(574) + firstIssue, theOutcome.getOperationOutcome());
 		}
-		throw new PreconditionFailedException(Msg.code(575) + theOutcome.getFailureDescription());
+		throw new UnprocessableEntityException(Msg.code(575) + theOutcome.getFailureDescription());
 	}
 }


### PR DESCRIPTION
Replaced PreconditionFailedException with UnprocessableEntityException in RepositoryValidatingInterceptor. This aligns exception usage with the appropriate HTTP status code for validation errors, eg **422 - Unprocessable Entity.**


From the documentation:

**3.1.0.4.2 Rejecting Updates** 
Servers are permitted to reject update interactions because of integrity concerns or other business rules, and return HTTP status codes accordingly (usually a 422). Note that there are potential security issues relating to how rejections are handled. See the [security page](https://hl7.org/fhir/R4/security.html#AccessDenied) for more information.

Common HTTP Status codes returned on FHIR-related errors (in addition to normal HTTP errors related to security, header and content type negotiation issues):

- 400 Bad Request - resource could not be parsed or failed basic FHIR validation rules (or multiple matches were found for conditional criteria)
- 401 Not Authorized - authorization is required for the interaction that was attempted
- 404 Not Found - resource type not supported, or not a FHIR end-point
- 405 Method Not allowed - the resource did not exist prior to the update, and the server does not allow client defined ids
- 409/412 - version conflict management - see [below](https://hl7.org/fhir/R4/http.html#concurrency)
- _422 Unprocessable Entity - the proposed resource violated applicable FHIR profiles or server business rules_