### PR TITLE
DO NOT MERGE - Use 6.5.18.1 of core to test changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1003,7 +1003,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.5.18</fhir_core_version>
+		<fhir_core_version>6.5.18.1</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>
 		<surefire_version>3.5.2</surefire_version>


### PR DESCRIPTION
This PR tests the impact of the changes to https://github.com/hapifhir/org.hl7.fhir.core/compare/master...do-20250515-test-domain-resource-modifier-extensions

The issue this addresses is described here: https://github.com/hapifhir/org.hl7.fhir.core/issues/1914

If this results in failing tests in HAPI, the solution may require additional changes in core or HAPI.
