### PR TITLE
Validation OperationOutcome should use issue.expression instead of deprecated issue.location

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
@@ -231,6 +231,7 @@ public class OperationOutcomeUtil {
 		diagnosticsChild.getMutator().setValue(theIssue, string);
 
 		addLocationToIssue(theCtx, theIssue, theLocation);
+		addExpressionToIssue(theCtx, theIssue, theLocation);
 
 		if (isNotBlank(theDetailSystem)) {
 			BaseRuntimeChildDefinition detailsChild = issueElement.getChildByName("details");
@@ -251,6 +252,9 @@ public class OperationOutcomeUtil {
 		}
 	}
 
+	/**
+	 * The FHIR element {@literal OperationOutcome.location} has been deprecated since FHIR version R4.
+	 */
 	public static void addLocationToIssue(FhirContext theContext, IBase theIssue, String theLocation) {
 		if (isNotBlank(theLocation)) {
 			BaseRuntimeElementCompositeDefinition<?> issueElement =
@@ -261,6 +265,24 @@ public class OperationOutcomeUtil {
 					.newInstance(locationChild.getInstanceConstructorArguments());
 			locationElem.setValueAsString(theLocation);
 			locationChild.getMutator().addValue(theIssue, locationElem);
+		}
+	}
+
+	/**
+	 * The FHIR element {@literal OperationOutcome.expression} is the recommended replacement for
+	 * {@literal OperationOutcome.location}.
+	 */
+	public static void addExpressionToIssue(FhirContext theContext, IBase theIssue, String theExpression) {
+		if (isNotBlank(theExpression) && isIssueExpressionSupported(theContext)) {
+			BaseRuntimeElementCompositeDefinition<?> issueElement =
+					(BaseRuntimeElementCompositeDefinition<?>) theContext.getElementDefinition(theIssue.getClass());
+			BaseRuntimeChildDefinition expressionChild = issueElement.getChildByName("expression");
+
+			IPrimitiveType<?> expressionElm = (IPrimitiveType<?>) expressionChild
+					.getChildByName("expression")
+					.newInstance(expressionChild.getInstanceConstructorArguments());
+			expressionElm.setValueAsString(theExpression);
+			expressionChild.getMutator().addValue(theIssue, expressionElm);
 		}
 	}
 
@@ -357,5 +379,13 @@ public class OperationOutcomeUtil {
 					"string",
 					theMessageId);
 		}
+	}
+
+	public static boolean isIssueExpressionSupported(FhirContext theCtx) {
+		FhirVersionEnum fhirVersion = theCtx.getVersion().getVersion();
+		return fhirVersion == FhirVersionEnum.DSTU3
+				|| fhirVersion == FhirVersionEnum.R4
+				|| fhirVersion == FhirVersionEnum.R4B
+				|| fhirVersion == FhirVersionEnum.R5;
 	}
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
@@ -199,6 +199,7 @@ public class ValidationResult {
 				OperationOutcomeUtil.addIssueColExtensionToIssue(myCtx, issue, col);
 				String locationString = "Line[" + line + "] Col[" + col + "]";
 				OperationOutcomeUtil.addLocationToIssue(myCtx, issue, locationString);
+				OperationOutcomeUtil.addExpressionToIssue(myCtx, issue, locationString);
 			}
 		}
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/3661-add-issue-expression-to-operation-outcome.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/3661-add-issue-expression-to-operation-outcome.yaml
@@ -1,4 +1,4 @@
 ---
 type: add
 issue: 3661
-title: "Added support of `issue.expression` element to validation `OperationOutcome` for FHIR version DSTU3, R4, R4B and R5."
+title: "Populated `issue.expression` element in resource validation result `OperationOutcome` for FHIR version DSTU3, R4, R4B and R5."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/3661-add-issue-expression-to-operation-outcome.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/3661-add-issue-expression-to-operation-outcome.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 3661
+title: "Added support of `issue.expression` element to validation `OperationOutcome` for FHIR version DSTU3, R4, R4B and R5."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/OperationOutcomeUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/OperationOutcomeUtilTest.java
@@ -42,8 +42,6 @@ public class OperationOutcomeUtilTest {
 		OperationOutcomeUtil.addExpressionToIssue(myCtx, issue, "");
 		OperationOutcomeUtil.addExpressionToIssue(myCtx, issue, "line 3");
 
-		System.out.println(myCtx.newJsonParser().encodeResourceToString(oo));
-
 		assertEquals("{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"throttled\",\"diagnostics\":\"Help i'm a bug\",\"location\":[\"/Patient\",\"line 3\"],\"expression\":[\"/Patient\",\"line 3\"]}]}",
 			 myCtx.newJsonParser().encodeResourceToString(oo));
 	}


### PR DESCRIPTION
The `OperationOutcome` generated by HAPI in the [ca.uhn.fhir.validation.ValidationResult](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java#L130) class, as a result of resource validation, should use the `issue.expression` field instead of the [deprecated since FHIR 3.5.0](http://hl7.org/fhir/2018Sep/operationoutcome.html) `issue.location`.

**Solution Design**

- Start populating OperationOutcome.issue.expression
- Continue populating OperationOutcome.issue.location for backwards compatibility

Support both issue.location and issue.expression and they will have the same value.

Closes #3661 
