### PR TITLE
Populate OperationOutcome.issue.expression

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
@@ -264,6 +264,19 @@ public class OperationOutcomeUtil {
 		}
 	}
 
+	public static void addExpressionToIssue(FhirContext theContext, IBase theIssue, String theLocationExpression) {
+		if (isNotBlank(theLocationExpression) && theContext.getVersion().getVersion().isEqualOrNewerThan(FhirVersionEnum.R4)) {
+			BaseRuntimeElementCompositeDefinition<?> issueElement =
+				(BaseRuntimeElementCompositeDefinition<?>) theContext.getElementDefinition(theIssue.getClass());
+			BaseRuntimeChildDefinition locationChild = issueElement.getChildByName("expression");
+			IPrimitiveType<?> locationElem = (IPrimitiveType<?>) locationChild
+				.getChildByName("expression")
+				.newInstance(locationChild.getInstanceConstructorArguments());
+			locationElem.setValueAsString(theLocationExpression);
+			locationChild.getMutator().addValue(theIssue, locationElem);
+		}
+	}
+
 	public static IBase addIssueWithMessageId(
 			FhirContext myCtx,
 			IBaseOperationOutcome theOperationOutcome,
@@ -358,4 +371,5 @@ public class OperationOutcomeUtil {
 					theMessageId);
 		}
 	}
+
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
@@ -264,6 +264,14 @@ public class OperationOutcomeUtil {
 		}
 	}
 
+	/**
+	 * Given an instance of <code>OperationOutcome.issue</code>, adds a new instance of
+	 * <code>OperationOutcome.issue.expression</code> with the given string value.
+	 *
+	 * @param theContext            The FhirContext for the appropriate FHIR version
+	 * @param theIssue              The <code>OperationOutcome.issue</code> to add to
+	 * @param theLocationExpression The string to use as content
+	 */
 	public static void addExpressionToIssue(FhirContext theContext, IBase theIssue, String theLocationExpression) {
 		if (isNotBlank(theLocationExpression)
 				&& theContext.getVersion().getVersion().isEqualOrNewerThan(FhirVersionEnum.R4)) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
@@ -265,13 +265,14 @@ public class OperationOutcomeUtil {
 	}
 
 	public static void addExpressionToIssue(FhirContext theContext, IBase theIssue, String theLocationExpression) {
-		if (isNotBlank(theLocationExpression) && theContext.getVersion().getVersion().isEqualOrNewerThan(FhirVersionEnum.R4)) {
+		if (isNotBlank(theLocationExpression)
+				&& theContext.getVersion().getVersion().isEqualOrNewerThan(FhirVersionEnum.R4)) {
 			BaseRuntimeElementCompositeDefinition<?> issueElement =
-				(BaseRuntimeElementCompositeDefinition<?>) theContext.getElementDefinition(theIssue.getClass());
+					(BaseRuntimeElementCompositeDefinition<?>) theContext.getElementDefinition(theIssue.getClass());
 			BaseRuntimeChildDefinition locationChild = issueElement.getChildByName("expression");
 			IPrimitiveType<?> locationElem = (IPrimitiveType<?>) locationChild
-				.getChildByName("expression")
-				.newInstance(locationChild.getInstanceConstructorArguments());
+					.getChildByName("expression")
+					.newInstance(locationChild.getInstanceConstructorArguments());
 			locationElem.setValueAsString(theLocationExpression);
 			locationChild.getMutator().addValue(theIssue, locationElem);
 		}
@@ -371,5 +372,4 @@ public class OperationOutcomeUtil {
 					theMessageId);
 		}
 	}
-
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
@@ -118,7 +118,7 @@ public class ValidationResult {
 	}
 
 	/**
-	 * Create an OperationOutcome resource which contains all of the messages found as a result of this validation
+	 * Create an OperationOutcome resource which contains all the messages found as a result of this validation
 	 */
 	public IBaseOperationOutcome toOperationOutcome() {
 		IBaseOperationOutcome oo = (IBaseOperationOutcome)
@@ -171,18 +171,16 @@ public class ValidationResult {
 
 	private void addIssueToOperationOutcome(
 			IBaseOperationOutcome theOperationOutcome,
-			String location,
+			String theLocationExpression,
 			Integer locationLine,
 			Integer locationCol,
 			ResultSeverityEnum issueSeverity,
 			String message,
 			String messageId) {
-		if (isBlank(location) && locationLine != null && locationCol != null) {
-			location = "Line[" + locationLine + "] Col[" + locationCol + "]";
-		}
+
 		String severity = issueSeverity != null ? issueSeverity.getCode() : null;
 		IBase issue = OperationOutcomeUtil.addIssueWithMessageId(
-				myCtx, theOperationOutcome, severity, message, messageId, location, Constants.OO_INFOSTATUS_PROCESSING);
+				myCtx, theOperationOutcome, severity, message, messageId, theLocationExpression, Constants.OO_INFOSTATUS_PROCESSING);
 
 		if (locationLine != null || locationCol != null) {
 			String unknown = UNKNOWN;
@@ -200,6 +198,10 @@ public class ValidationResult {
 				String locationString = "Line[" + line + "] Col[" + col + "]";
 				OperationOutcomeUtil.addLocationToIssue(myCtx, issue, locationString);
 			}
+		}
+
+		if (isNotBlank(theLocationExpression)) {
+			OperationOutcomeUtil.addExpressionToIssue(myCtx, issue, theLocationExpression);
 		}
 
 		if (isNotBlank(messageId)) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
@@ -28,7 +28,6 @@ import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
@@ -180,7 +179,13 @@ public class ValidationResult {
 
 		String severity = issueSeverity != null ? issueSeverity.getCode() : null;
 		IBase issue = OperationOutcomeUtil.addIssueWithMessageId(
-				myCtx, theOperationOutcome, severity, message, messageId, theLocationExpression, Constants.OO_INFOSTATUS_PROCESSING);
+				myCtx,
+				theOperationOutcome,
+				severity,
+				message,
+				messageId,
+				theLocationExpression,
+				Constants.OO_INFOSTATUS_PROCESSING);
 
 		if (locationLine != null || locationCol != null) {
 			String unknown = UNKNOWN;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/validation/ValidationResult.java
@@ -108,8 +108,8 @@ public class ValidationResult {
 
 	/**
 	 * @deprecated Use {@link #toOperationOutcome()} instead since this method returns a view.
-	 * {@link #toOperationOutcome()} is identical to this method, but has a more suitable name so this method
-	 * will be removed at some point.
+	 *    {@link #toOperationOutcome()} is identical to this method, but has a more suitable name so this method
+	 * 	will be removed at some point.
 	 */
 	@Deprecated
 	public IBaseOperationOutcome getOperationOutcome() {
@@ -168,34 +168,46 @@ public class ValidationResult {
 		}
 	}
 
+	/**
+	 * Adds a repetition of <code>OperationOutcome.issue</code> to an
+	 * <code>OperationOutcome</code> instance.
+	 *
+	 * @param theOperationOutcome   The OperationOutcome to add to
+	 * @param theLocationExpression The FHIRPath expression describing where the issue was found
+	 * @param theLocationLine       The line number in the source where the issue was found
+	 * @param theLocationCol        The column number in the source where the issue was found
+	 * @param theIssueSeverity      The severity code (must be a valid value for <code>OperationOutcome.issue.severity</code>
+	 * @param theMessage            The validation message
+	 * @param theMessageId          The java validator message ID
+	 */
 	private void addIssueToOperationOutcome(
 			IBaseOperationOutcome theOperationOutcome,
 			String theLocationExpression,
-			Integer locationLine,
-			Integer locationCol,
-			ResultSeverityEnum issueSeverity,
-			String message,
-			String messageId) {
+			Integer theLocationLine,
+			Integer theLocationCol,
+			ResultSeverityEnum theIssueSeverity,
+			String theMessage,
+			String theMessageId) {
 
-		String severity = issueSeverity != null ? issueSeverity.getCode() : null;
+		String severity = theIssueSeverity != null ? theIssueSeverity.getCode() : null;
 		IBase issue = OperationOutcomeUtil.addIssueWithMessageId(
 				myCtx,
 				theOperationOutcome,
 				severity,
-				message,
-				messageId,
+				theMessage,
+				theMessageId,
 				theLocationExpression,
 				Constants.OO_INFOSTATUS_PROCESSING);
 
-		if (locationLine != null || locationCol != null) {
+		if (theLocationLine != null || theLocationCol != null) {
 			String unknown = UNKNOWN;
 			String line = unknown;
-			if (locationLine != null && locationLine != -1) {
-				line = locationLine.toString();
+			if (theLocationLine != null && theLocationLine != -1) {
+				line = theLocationLine.toString();
 			}
 			String col = unknown;
-			if (locationCol != null && locationCol != -1) {
-				col = locationCol.toString();
+			if (theLocationCol != null && theLocationCol != -1) {
+				col = theLocationCol.toString();
 			}
 			if (!unknown.equals(line) || !unknown.equals(col)) {
 				OperationOutcomeUtil.addIssueLineExtensionToIssue(myCtx, issue, line);
@@ -209,8 +221,8 @@ public class ValidationResult {
 			OperationOutcomeUtil.addExpressionToIssue(myCtx, issue, theLocationExpression);
 		}
 
-		if (isNotBlank(messageId)) {
-			OperationOutcomeUtil.addMessageIdExtensionToIssue(myCtx, issue, messageId);
+		if (isNotBlank(theMessageId)) {
+			OperationOutcomeUtil.addMessageIdExtensionToIssue(myCtx, issue, theMessageId);
 		}
 	}
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/3661-populate-operationoutcome-expression.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/3661-populate-operationoutcome-expression.yaml
@@ -1,0 +1,11 @@
+---
+type: add
+issue: 3661
+title: "When performing a resource validation on R4+ servers, the generated
+   OperationOutcome resource containing the validation results will now have
+   the `OperationOutcome.issue.expression` element populated. This element
+   contains a FHIRPath expression to the element containing the issue. The
+   FHIR specification has deprecated the `OperationOutcome.issue.location`
+   element. At this time, no change to the values placed in that element have
+   been made, although it may no longer be populated in a future release of
+   HAPI FHIR."

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
@@ -819,6 +819,7 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 		assertEquals("Unrecognized property 'foo'", operationOutcome.getIssue().get(0).getDiagnostics());
 		assertEquals("Patient", operationOutcome.getIssue().get(0).getLocation().get(0).getValue());
 		assertEquals("Line[5] Col[23]", operationOutcome.getIssue().get(0).getLocation().get(1).getValue());
+		assertEquals("Patient", operationOutcome.getIssue().get(0).getExpression().get(0).getValue());
 	}
 
 	@Test
@@ -942,19 +943,26 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 
 	@Test
 	public void testValidateRawXmlResourceWithEmptyPrimitive() {
-		String input = "<Patient xmlns=\"http://hl7.org/fhir\">" +
-			"  <text>\n" +
-			"    <status value=\"generated\"/>\n" +
-			"    <div xmlns=\"http://www.w3.org/1999/xhtml\">AAA</div>\n" +
-			"  </text>" +
-			"<name><given/></name>" +
-			"</Patient>";
+		String input = """
+			<Patient xmlns="http://hl7.org/fhir">\
+			  <text>
+			    <status value="generated"/>
+			    <div xmlns="http://www.w3.org/1999/xhtml">AAA</div>
+			  </text>\
+			<name><given/></name>\
+			</Patient>""";
 
 		ValidationResult output = myFhirValidator.validateWithResult(input);
 		List<SingleValidationMessage> messages = logResultsAndReturnNonInformationalOnes(output);
 		assertThat(messages.size()).as(output.toString()).isEqualTo(3);
 		assertThat(messages.get(0).getMessage()).contains("Element must have some content");
 		assertThat(messages.get(2).getMessage()).contains("Primitive types must have a value or must have child extensions");
+
+		OperationOutcome oo = (OperationOutcome) output.toOperationOutcome();
+		ourLog.info(ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(oo));
+
+		assertEquals(1, oo.getIssue().get(2).getExpression().size());
+		assertEquals("Patient.name[0].given[0]", oo.getIssue().get(2).getExpression().get(0).getValue());
 	}
 
 	@Test


### PR DESCRIPTION
When performing validation, `OperationOutcome.issue.expression` is not currently populated even though this element is intended to replce the deprecated `OperationOutcome.issue.location` element. This PR starts populating the former, but does not touch the latter.