### PR TITLE
DRAFT: #6953 VersionSpecificWorkerContextWrapper: using cache to return stru…

### DIFF
--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
@@ -1733,19 +1733,6 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 
 		final ValidationResult output = myFhirValidator.validateWithResult(encoded);
 		final List<SingleValidationMessage> errors = logResultsAndReturnNonInformationalOnes(output);
-		assertThat(errors).isEmpty();
-	}
-
-	@Test
-	void testValidate_ResourceContainedSameResourceIsValid() throws IOException {
-		final String encoded = loadResource("medication-with-contained-medication-ingredient.json");
-
-//		var jsonParser = ourCtx.newJsonParser();
-//		var result = jsonParser.parseResource(encoded);
-//		assertThat(result).isInstanceOf(Medication.class);
-
-		final ValidationResult output = myFhirValidator.validateWithResult(encoded);
-		final List<SingleValidationMessage> errors = logResultsAndReturnNonInformationalOnes(output);
 		assertThat(errors.stream().noneMatch(e -> e.getSeverity() == ResultSeverityEnum.ERROR)).isTrue();
 	}
 

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
@@ -1768,7 +1768,6 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 		);
 		myValidationSupport = chain.setCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid(theLogicalAnd);
 		myInstanceVal = new FhirInstanceValidator(myValidationSupport);
-		myInstanceVal.setValidatorPolicyAdvisor(new CustomPolicyAdvisor());
 		myFhirValidator.registerValidatorModule(myInstanceVal);
 	}
 
@@ -1791,23 +1790,5 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 	@AfterAll
 	public static void afterClassClearContext() throws IOException, NoSuchFieldException {
 		TestUtil.randomizeLocaleAndTimezone();
-	}
-
-	private class CustomPolicyAdvisor extends FhirDefaultPolicyAdvisor {
-
-		@Override
-		public ContainedReferenceValidationPolicy policyForContained(
-			IResourceValidator validator,
-			Object appContext,
-			org.hl7.fhir.r5.model.StructureDefinition structure,
-			ElementDefinition element,
-			String containerType,
-			String containerId,
-			Element.SpecialElement containingResourceType,
-			String path,
-			String url) {
-			return ContainedReferenceValidationPolicy.IGNORE;
-		}
-
 	}
 }

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
@@ -23,9 +23,7 @@ import org.hl7.fhir.MockValidationSupport;
 import org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService;
 import org.hl7.fhir.common.hapi.validation.support.InMemoryTerminologyServerValidationSupport;
 import org.hl7.fhir.common.hapi.validation.support.PrePopulatedValidationSupport;
-import org.hl7.fhir.common.hapi.validation.support.SnapshotGeneratingValidationSupport;
 import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
-import org.hl7.fhir.common.hapi.validation.validator.FhirDefaultPolicyAdvisor;
 import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
 import org.hl7.fhir.common.hapi.validation.validator.VersionSpecificWorkerContextWrapper;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -40,7 +38,6 @@ import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.CodeType;
-import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Consent;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.DateTimeType;
@@ -48,7 +45,6 @@ import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Media;
-import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r4.model.Narrative;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Observation.ObservationStatus;
@@ -66,12 +62,8 @@ import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.StructureDefinition.StructureDefinitionKind;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionComponent;
-import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.elementmodel.JsonParser;
-import org.hl7.fhir.r5.model.ElementDefinition;
-import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r5.test.utils.ClassesLoadedFlags;
-import org.hl7.fhir.r5.utils.validation.IResourceValidator;
 import org.hl7.fhir.r5.utils.validation.IValidationPolicyAdvisor;
 import org.hl7.fhir.r5.utils.validation.IValidatorResourceFetcher;
 import org.hl7.fhir.r5.utils.validation.constants.BestPracticeWarningLevel;
@@ -1763,8 +1755,7 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 			myMockSupport,
 			new CommonCodeSystemsTerminologyService(ourCtx),
 			ourCtx.getValidationSupport(),
-			new InMemoryTerminologyServerValidationSupport(ourCtx),
-			new SnapshotGeneratingValidationSupport(ourCtx)
+			new InMemoryTerminologyServerValidationSupport(ourCtx)
 		);
 		myValidationSupport = chain.setCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid(theLogicalAnd);
 		myInstanceVal = new FhirInstanceValidator(myValidationSupport);


### PR DESCRIPTION
fix for the described problem. The main change was to use the cache of canonicals with snapshots in fetchResource method instead of the original structuredefinitions from the validationsupportchain