### PR TITLE
Refactor to only boot the DBs when needed during testing

### DIFF
--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/H2EmbeddedDatabase.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/H2EmbeddedDatabase.java
@@ -43,10 +43,20 @@ public class H2EmbeddedDatabase extends JpaEmbeddedDatabase {
 	private String myUrl;
 
 	public H2EmbeddedDatabase() {
+		// Don't initialize here - defer until first access
+	}
+
+	@Override
+	protected void doInitialize() {
 		deleteDatabaseDirectoryIfExists();
 		String databasePath = DATABASE_DIRECTORY + SCHEMA_NAME;
 		myUrl = "jdbc:h2:" + new File(databasePath).getAbsolutePath();
 		super.initialize(DriverTypeEnum.H2_EMBEDDED, myUrl, USERNAME, PASSWORD);
+	}
+
+	@Override
+	public DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.H2_EMBEDDED;
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/JpaContainerDatabase.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/JpaContainerDatabase.java
@@ -25,15 +25,23 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
  * Wrapper to support JPA tests.
  */
 public abstract class JpaContainerDatabase extends JpaEmbeddedDatabase {
-	protected final JdbcDatabaseContainer<?> myContainer;
+	protected JdbcDatabaseContainer<?> myContainer;
 
 	protected JpaContainerDatabase(JdbcDatabaseContainer<?> theContainer) {
 		myContainer = theContainer;
-		myContainer.start();
+		// Don't start container here - defer until first access
+	}
+
+	protected void startContainer() {
+		if (myContainer != null && !myContainer.isRunning()) {
+			myContainer.start();
+		}
 	}
 
 	@Override
 	public void stop() {
-		myContainer.stop();
+		if (myContainer != null) {
+			myContainer.stop();
+		}
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/MsSqlEmbeddedDatabase.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/MsSqlEmbeddedDatabase.java
@@ -41,10 +41,14 @@ import java.util.Map;
 public class MsSqlEmbeddedDatabase extends JpaEmbeddedDatabase {
 	private static final Logger ourLog = LoggerFactory.getLogger(MsSqlEmbeddedDatabase.class);
 
-	private final MSSQLServerContainer myContainer;
+	private MSSQLServerContainer myContainer;
 
 	public MsSqlEmbeddedDatabase() {
+		// Don't start container here - defer until first access
+	}
 
+	@Override
+	protected void doInitialize() {
 		// azure-sql-edge docker image does not support kernel 6.7+
 		// as a result, mssql container fails to start most of the time
 		// mssql/server:2019 image support kernel 6.7+, so use it for amd64 architecture
@@ -66,8 +70,15 @@ public class MsSqlEmbeddedDatabase extends JpaEmbeddedDatabase {
 	}
 
 	@Override
+	public DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.MSSQL_2012;
+	}
+
+	@Override
 	public void stop() {
-		myContainer.stop();
+		if (myContainer != null) {
+			myContainer.stop();
+		}
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/OracleEmbeddedDatabase.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/OracleEmbeddedDatabase.java
@@ -36,9 +36,14 @@ import java.util.Map;
  */
 public class OracleEmbeddedDatabase extends JpaEmbeddedDatabase {
 
-	private final OracleContainer myContainer;
+	private OracleContainer myContainer;
 
 	public OracleEmbeddedDatabase() {
+		// Don't start container here - defer until first access
+	}
+
+	@Override
+	protected void doInitialize() {
 		myContainer = new OracleContainer("gvenzl/oracle-xe:21-slim-faststart").withPrivilegedMode(true);
 		myContainer.start();
 		super.initialize(
@@ -49,8 +54,15 @@ public class OracleEmbeddedDatabase extends JpaEmbeddedDatabase {
 	}
 
 	@Override
+	public DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.ORACLE_12C;
+	}
+
+	@Override
 	public void stop() {
-		myContainer.stop();
+		if (myContainer != null) {
+			myContainer.stop();
+		}
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/PostgresEmbeddedDatabase.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/embedded/PostgresEmbeddedDatabase.java
@@ -43,11 +43,22 @@ public class PostgresEmbeddedDatabase extends JpaContainerDatabase {
 
 	public PostgresEmbeddedDatabase(PostgreSQLContainer<?> theContainer) {
 		super(theContainer);
+		// Don't initialize here - defer until first access
+	}
+
+	@Override
+	protected void doInitialize() {
+		startContainer();
 		super.initialize(
 				DriverTypeEnum.POSTGRES_9_4,
 				myContainer.getJdbcUrl(),
 				myContainer.getUsername(),
 				myContainer.getPassword());
+	}
+
+	@Override
+	public DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.POSTGRES_9_4;
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationH2Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationH2Test.java
@@ -1,0 +1,21 @@
+package ca.uhn.fhir.jpa.embedded;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class HapiSchemaMigrationH2Test extends BaseHapiSchemaMigrationTest {
+
+	@RegisterExtension
+	static HapiEmbeddedDatabasesExtension myEmbeddedServersExtension = 
+		HapiEmbeddedDatabasesExtension.forDatabase(DriverTypeEnum.H2_EMBEDDED);
+
+	@Override
+	protected HapiEmbeddedDatabasesExtension getEmbeddedDatabasesExtension() {
+		return myEmbeddedServersExtension;
+	}
+
+	@Override
+	protected DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.H2_EMBEDDED;
+	}
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationMsSqlTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationMsSqlTest.java
@@ -1,0 +1,21 @@
+package ca.uhn.fhir.jpa.embedded;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class HapiSchemaMigrationMsSqlTest extends BaseHapiSchemaMigrationTest {
+
+	@RegisterExtension
+	static HapiEmbeddedDatabasesExtension myEmbeddedServersExtension = 
+		HapiEmbeddedDatabasesExtension.forDatabase(DriverTypeEnum.MSSQL_2012);
+
+	@Override
+	protected HapiEmbeddedDatabasesExtension getEmbeddedDatabasesExtension() {
+		return myEmbeddedServersExtension;
+	}
+
+	@Override
+	protected DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.MSSQL_2012;
+	}
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationOracleTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationOracleTest.java
@@ -1,0 +1,21 @@
+package ca.uhn.fhir.jpa.embedded;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class HapiSchemaMigrationOracleTest extends BaseHapiSchemaMigrationTest {
+
+	@RegisterExtension
+	static HapiEmbeddedDatabasesExtension myEmbeddedServersExtension = 
+		HapiEmbeddedDatabasesExtension.forDatabase(DriverTypeEnum.ORACLE_12C);
+
+	@Override
+	protected HapiEmbeddedDatabasesExtension getEmbeddedDatabasesExtension() {
+		return myEmbeddedServersExtension;
+	}
+
+	@Override
+	protected DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.ORACLE_12C;
+	}
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationPostgresTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/embedded/HapiSchemaMigrationPostgresTest.java
@@ -1,0 +1,21 @@
+package ca.uhn.fhir.jpa.embedded;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class HapiSchemaMigrationPostgresTest extends BaseHapiSchemaMigrationTest {
+
+	@RegisterExtension
+	static HapiEmbeddedDatabasesExtension myEmbeddedServersExtension = 
+		HapiEmbeddedDatabasesExtension.forDatabase(DriverTypeEnum.POSTGRES_9_4);
+
+	@Override
+	protected HapiEmbeddedDatabasesExtension getEmbeddedDatabasesExtension() {
+		return myEmbeddedServersExtension;
+	}
+
+	@Override
+	protected DriverTypeEnum getDriverType() {
+		return DriverTypeEnum.POSTGRES_9_4;
+	}
+}


### PR DESCRIPTION
- Refactor to make it so that using the EmbeddedDatabasesExtension doesnt create and boot them all at once. 