### PR TITLE
Restore fhir timezone header, which used by clinical-reasoning.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
@@ -98,6 +98,8 @@ public class Constants {
 	public static final String HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
 	public static final String HEADER_X_FORWARDED_PREFIX = "X-Forwarded-Prefix";
 	public static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
+	// This is used by clinical-reasoning to pass the timezone of the client
+	public static final String HEADER_CLIENT_TIMEZONE = "Timezone";
 
 	// ==============================================================
 	// Proprietary HAPI HTTP headers


### PR DESCRIPTION
- Add back ca.uhn.fhir.rest.api.Constants.HEADER_CLIENT_TIMEZONE, which is used by clinical-reasoning for operations that take a FHIR timezone request header.
- See https://github.com/hapifhir/hapi-fhir/pull/7016 where this and other headers were removed.
- See https://github.com/hapifhir/hapi-fhir/pull/6358 and https://github.com/hapifhir/hapi-fhir/commit/161a077f2a1d032785aac260275c536ab2c16c3e, where this header was originally added.
- Also, the FHIR standard does allude to a client timezone:
    - See:  https://build.fhir.org/http.html#timezones
    - See: https://datatracker.ietf.org/doc/html/draft-sharhalakis-httptz-05