### PR TITLE
Respect URL parameters on POST operation invocations

### DIFF
--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/BaseMethodBinding.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/BaseMethodBinding.java
@@ -70,10 +70,10 @@ import java.util.TreeSet;
 public abstract class BaseMethodBinding<T> implements IClientResponseHandler<T> {
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BaseMethodBinding.class);
-	private FhirContext myContext;
-	private Method myMethod;
+	private final FhirContext myContext;
+	private final Method myMethod;
 	private List<IParameter> myParameters;
-	private Object myProvider;
+	private final Object myProvider;
 	private boolean mySupportsConditional;
 	private boolean mySupportsConditionalMultiple;
 
@@ -343,8 +343,7 @@ public abstract class BaseMethodBinding<T> implements IClientResponseHandler<T> 
 		} else if (history != null) {
 			return new HistoryMethodBinding(theMethod, theContext, theProvider);
 		} else if (validate != null) {
-			return new ValidateMethodBindingDstu2Plus(
-					returnType, returnTypeFromRp, theMethod, theContext, theProvider, validate);
+			return new ValidateMethodBindingDstu2Plus(returnTypeFromRp, theMethod, theContext, theProvider, validate);
 		} else if (transaction != null) {
 			return new TransactionMethodBinding(theMethod, theContext, theProvider);
 		} else if (operation != null) {

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/ValidateMethodBindingDstu2Plus.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/ValidateMethodBindingDstu2Plus.java
@@ -36,7 +36,6 @@ import java.util.List;
 public class ValidateMethodBindingDstu2Plus extends OperationMethodBinding {
 
 	public ValidateMethodBindingDstu2Plus(
-			Class<?> theReturnResourceType,
 			Class<? extends IBaseResource> theReturnTypeFromRp,
 			Method theMethod,
 			FhirContext theContext,
@@ -53,7 +52,7 @@ public class ValidateMethodBindingDstu2Plus extends OperationMethodBinding {
 				theAnnotation.type(),
 				BundleTypeEnum.COLLECTION);
 
-		List<IParameter> newParams = new ArrayList<IParameter>();
+		List<IParameter> newParams = new ArrayList<>();
 		int idx = 0;
 		for (IParameter next : getParameters()) {
 			if (next instanceof ResourceParameter) {
@@ -86,8 +85,7 @@ public class ValidateMethodBindingDstu2Plus extends OperationMethodBinding {
 		String resourceName = theContext.getResourceType(theResource);
 		String resourceId = theResource.getIdElement().getIdPart();
 
-		BaseHttpClientInvocation retVal = createOperationInvocation(
+		return createOperationInvocation(
 				theContext, resourceName, resourceId, null, Constants.EXTOP_VALIDATE, parameters, false);
-		return retVal;
 	}
 }

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/provider/r5/ResourceProviderR5ValidationTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/provider/r5/ResourceProviderR5ValidationTest.java
@@ -1,0 +1,66 @@
+package ca.uhn.fhir.jpa.provider.r5;
+
+import ca.uhn.fhir.rest.client.apache.ResourceEntity;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.hl7.fhir.r5.model.Patient;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class ResourceProviderR5ValidationTest extends BaseResourceProviderR5Test {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(ResourceProviderR5ValidationTest.class);
+
+	@ParameterizedTest
+	@EnumSource(LevelEnum.class)
+	void testValidateAgainstProfileSpecifiedInRequest(LevelEnum theLevel) throws IOException {
+		// Setup - Create a profile which bans names
+		StructureDefinition sd = new StructureDefinition();
+		sd.setId("StructureDefinition/profile-noname-patient");
+		sd.setUrl("http://profile-noname-patient");
+		sd.setType("Patient");
+		sd.setBaseDefinition("http://hl7.org/fhir/StructureDefinition/Patient");
+		sd.setDerivation(StructureDefinition.TypeDerivationRule.CONSTRAINT);
+		sd.getDifferential().addElement().setPath("Patient.name").setMax("0");
+		myStructureDefinitionDao.update(sd, mySrd);
+
+		Patient patient = new Patient();
+		patient.setActive(true);
+		patient.addName().setFamily("Simpson"); // Banned by the profile!
+
+		if (theLevel == LevelEnum.INSTANCE) {
+			patient.setId("Patient/P");
+			myPatientDao.update(patient, mySrd);
+		}
+
+		// Test
+		HttpUriRequest request = switch (theLevel) {
+			case TYPE -> {
+				HttpPost post = new HttpPost(myServerBase + "/Patient/$validate?profile=http://profile-noname-patient");
+				post.setEntity(new ResourceEntity(myFhirContext, patient));
+				yield post;
+			}
+			case INSTANCE -> new HttpGet(myServerBase + "/Patient/P/$validate?profile=http://profile-noname-patient");
+		};
+
+		try (CloseableHttpResponse outcome = ourHttpClient.execute(request)) {
+			String response = IOUtils.toString(outcome.getEntity().getContent(), StandardCharsets.UTF_8);
+			ourLog.info(response);
+		}
+	}
+
+	enum LevelEnum {
+		TYPE,
+		INSTANCE
+	}
+
+}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/MethodUtil.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/MethodUtil.java
@@ -368,7 +368,7 @@ public class MethodUtil {
 									}
 								});
 					} else if (nextAnnotation instanceof Validate.Profile) {
-						if (parameterType.equals(String.class) == false) {
+						if (!parameterType.equals(String.class)) {
 							throw new ConfigurationException(Msg.code(407) + "Parameter annotated with @"
 									+ Validate.class.getSimpleName() + "." + Validate.Profile.class.getSimpleName()
 									+ " must be of type " + String.class.getName());

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/OperationParameter.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/OperationParameter.java
@@ -277,13 +277,16 @@ public class OperationParameter implements IParameter {
 
 		OperationMethodBinding method = (OperationMethodBinding) theMethodBinding;
 
-		if (theRequest.getRequestType() == RequestTypeEnum.GET
-				|| method.isManualRequestMode()
-				|| method.isDeleteEnabled()) {
-			translateQueryParametersIntoServerArgumentForGet(theRequest, matchingParamValues);
-		} else {
+		// If the request body is a Parameters resource, check if it has any
+		// values for us
+		if (theRequest.getRequestType() != RequestTypeEnum.GET
+				&& !method.isManualRequestMode()
+				&& !method.isDeleteEnabled()) {
 			translateQueryParametersIntoServerArgumentForPost(theRequest, matchingParamValues);
 		}
+
+		// We always look at the URL to see if any matching parameters were provided there
+		translateQueryParametersIntoServerArgumentForGet(theRequest, matchingParamValues);
 
 		if (matchingParamValues.isEmpty()) {
 			return null;


### PR DESCRIPTION
When performing an HTTP POST in order to invoke a FHIR operation, any URL parameters are ignored. This is bad for operations like `$validate`, where people will want to POST the body of the resource to validate, but then include parameters such as `profile` and `mode`.