### PR TITLE
Avoid `Resource.meta.source` string matching an illegal fragment

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/MetaUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/MetaUtil.java
@@ -102,13 +102,13 @@ public class MetaUtil {
 
 	public static <R extends IBaseResource> void populateResourceSource(
 			FhirContext theFhirContext, String theProvenanceSourceUri, String theProvenanceRequestId, R theRetVal) {
-		String provenanceString = cleanProvenanceSourceUriOrEmpty(theProvenanceSourceUri);
+		String cleanedProvenanceSourceUri = cleanProvenanceSourceUriOrEmpty(theProvenanceSourceUri);
 		String sourceString = "";
 
-		if (isBlank(provenanceString)) {
+		if (isBlank(cleanedProvenanceSourceUri)) {
 			sourceString = theProvenanceRequestId;
 		} else {
-			sourceString = provenanceString + "#" + theProvenanceRequestId;
+			sourceString = cleanedProvenanceSourceUri + "#" + theProvenanceRequestId;
 		}
 
 		if (isNotBlank(sourceString)) {


### PR DESCRIPTION
When creating a resource, if no `Resource.meta.source` is provided, it is auto-generated by HAPI:

> Source has the form: < Source URI >#< request ID >.

https://smilecdr.com/docs/fhir_repository/tracing_and_provenance.html#request-tracing

However, if the SourceURI is blank, that means it'll have the form `#<requestID>` which looks like a fragment, i.e. a reference to a contained resource. Therefor, resource validation will fail. We see this on our running server.

Likely a related issue: https://github.com/hapifhir/hapi-fhir/issues/6960

To avoid this, if the `<SourceURI>` is blank, we no longer prefix with `#`. I am not convinced this is a good solution.

### Alternatives
* The resource validator could avoid checking for fragments in `Resource.meta.source`
* We could infer, or require, a `theProvenanceSourceUri`
* We could avoid setting the `Resource.meta.source` if `theProvenanceSourceUri` is empty