### PR TITLE
Do not swallow errors

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/OperationOutcomeUtil.java
@@ -36,6 +36,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -112,6 +113,18 @@ public class OperationOutcomeUtil {
 
 	public static String getFirstIssueDiagnostics(FhirContext theCtx, IBaseOperationOutcome theOutcome) {
 		return getIssueStringPart(theCtx, theOutcome, "diagnostics", 0);
+	}
+
+	public static List<String> getAllIssueDiagnostics(FhirContext theCtx, IBaseOperationOutcome theOutcome) {
+		int nIssues = OperationOutcomeUtil.getIssueCount(theCtx, theOutcome);
+
+		List<String> issueStrings = new ArrayList<>();
+		for (int i = 0; i < nIssues; i++) {
+			String diag = OperationOutcomeUtil.getIssueDiagnostics(theCtx, theOutcome, i);
+			issueStrings.add(diag);
+		}
+
+		return issueStrings;
 	}
 
 	public static String getIssueDiagnostics(FhirContext theCtx, IBaseOperationOutcome theOutcome, int theIndex) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptor.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.util.ExtensionUtil;
@@ -36,9 +37,12 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static ca.uhn.fhir.util.HapiExtensions.EXT_RESOURCE_PLACEHOLDER;
 
@@ -153,9 +157,9 @@ public class RepositoryValidatingInterceptor {
 
 	protected void handleFailure(IRepositoryValidatingRule.RuleEvaluation theOutcome) {
 		if (theOutcome.getOperationOutcome() != null) {
-			String firstIssue =
-					OperationOutcomeUtil.getFirstIssueDiagnostics(myFhirContext, theOutcome.getOperationOutcome());
-			throw new PreconditionFailedException(Msg.code(574) + firstIssue, theOutcome.getOperationOutcome());
+			List<String> allIssues = OperationOutcomeUtil.getAllIssueDiagnostics(myFhirContext, theOutcome.getOperationOutcome())
+			String concatenatedIssues = String.join("\n", allIssues);
+			throw new PreconditionFailedException(Msg.code(574) + concatenatedIssues, theOutcome.getOperationOutcome());
 		}
 		throw new PreconditionFailedException(Msg.code(575) + theOutcome.getFailureDescription());
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/validation/RepositoryValidatingInterceptor.java
@@ -157,7 +157,7 @@ public class RepositoryValidatingInterceptor {
 
 	protected void handleFailure(IRepositoryValidatingRule.RuleEvaluation theOutcome) {
 		if (theOutcome.getOperationOutcome() != null) {
-			List<String> allIssues = OperationOutcomeUtil.getAllIssueDiagnostics(myFhirContext, theOutcome.getOperationOutcome())
+			List<String> allIssues = OperationOutcomeUtil.getAllIssueDiagnostics(myFhirContext, theOutcome.getOperationOutcome());
 			String concatenatedIssues = String.join("\n", allIssues);
 			throw new PreconditionFailedException(Msg.code(574) + concatenatedIssues, theOutcome.getOperationOutcome());
 		}


### PR DESCRIPTION
Currently, the `RepositoryValidatingInterceptor` outputs only the **first** issue, whether or not that is the issue that triggers the operation to fail validation. E.g. if the first issue is `INFO`, the user will not be informed why the validation failed.

This is a simple improvement that outputs diagnostics for all issues. 

Ideally, I think we'd sort the issues by severity, but I am not certain whether this information is available in `OperationOutcomeUtil.getIssueStringPart`.