### PR TITLE
Return when trying to set validationSupport to the existing value

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
@@ -169,6 +169,9 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 	 * Provides the {@link IValidationSupport} module that backs this adapter.
 	 */
 	public void setValidationSupport(IValidationSupport theValidationSupport) {
+		if (myValidationSupport == theValidationSupport) {
+			return;
+		}
 		Validate.isTrue(
 				myValidationSupport == null, "Can not set the validation support after it has already been set");
 		myValidationSupport = theValidationSupport;

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapterTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapterTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -174,6 +175,24 @@ public class WorkerContextValidationSupportAdapterTest extends BaseValidationTes
 		assertThat(actual.getSnapshot().getElementFirstRep().getId()).isEqualTo("FOO");
 		PackageInformation sourcePackage = actual.getSourcePackage();
 		assertThat(sourcePackage.getId()).isEqualTo("hl7.fhir.r999.core");
+	}
+
+	@Test
+	public void testSettingDifferentValidationSupportFails() {
+		WorkerContextValidationSupportAdapter adapter = new WorkerContextValidationSupportAdapter();
+		IValidationSupport mockValidationSupport = mockValidationSupport();
+		adapter.setValidationSupport(mockValidationSupport);
+		IValidationSupport differentMockValidationSupport = mockValidationSupport();
+		assertThrows(IllegalArgumentException.class, () ->
+		adapter.setValidationSupport(differentMockValidationSupport));
+	}
+
+	@Test
+	public void testSettingSameValidationSupportDoesntFail() {
+		WorkerContextValidationSupportAdapter adapter = new WorkerContextValidationSupportAdapter();
+		IValidationSupport mockValidationSupport = mockValidationSupport();
+		adapter.setValidationSupport(mockValidationSupport);
+		adapter.setValidationSupport(mockValidationSupport);
 	}
 
 	private List<StructureDefinition> createPrimitiveStructureDefinitions() {


### PR DESCRIPTION
During configuration in JPA Server Starter, setValidationSupport is called twice, which triggers the "Can not set the validation support after it has already been set" error, even for working configurations.

However, in that instance, `myValidationSupport` does not actually change, as it is the same instance as the passed `theValidationSupport`. 

In this case, we should just return early.