### PR TITLE
Add hapi-fhir-storage-batch2-test-utilities to bom.

### DIFF
--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -121,6 +121,11 @@
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>
+				<artifactId>hapi-fhir-storage-batch2-test-utilities</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>hapi-fhir-server</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
- Expose hapi-fhir-storage-batch2-test-utilities in the bom
- This means that consumers of the bom can now make use of test utilities, such as InlineJobCoordinator to test batch2 JobDefinitions in a streamlined way