### PR TITLE
67121: Stop sorting the RuntimeSearchParams based on name.

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/util/JpaParamUtil.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/util/JpaParamUtil.java
@@ -146,13 +146,7 @@ public enum JpaParamUtil {
 
 	public static List<RuntimeSearchParam> resolveComponentParameters(
 			ISearchParamRegistry theSearchParamRegistry, RuntimeSearchParam theParamDef) {
-		List<RuntimeSearchParam> compositeList =
-				resolveCompositeComponentsDeclaredOrder(theSearchParamRegistry, theParamDef);
-
-		// todo mb why is this sorted?  Is the param order flipped too during query-time?
-		compositeList.sort((Comparator.comparing(RuntimeSearchParam::getName)));
-
-		return compositeList;
+		return resolveCompositeComponentsDeclaredOrder(theSearchParamRegistry, theParamDef);
 	}
 
 	@Nonnull

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
@@ -157,6 +157,7 @@ import org.hl7.fhir.r4.model.ExplanationOfBenefit;
 import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.Immunization;
 import org.hl7.fhir.r4.model.ImmunizationRecommendation;
+import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.ListResource;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Media;
@@ -525,6 +526,8 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 	@Autowired
 	@Qualifier("myValueSetDaoR4")
 	protected IFhirResourceDaoValueSet<ValueSet> myValueSetDao;
+	@Autowired
+	protected IFhirResourceDao<Library> myLibraryDao;
 	@Autowired
 	protected ITermValueSetDao myTermValueSetDao;
 	@Autowired


### PR DESCRIPTION
They are in declared order, which should match the positional order of the request parameters.

Also added a test to replicate the issue and verify the fix.