### PR TITLE
Add interceptor hook to customize auto-created placeholder reference targets

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -1087,6 +1087,44 @@ public enum Pointcut implements IPointcut {
 
 	/**
 	 * <b>Storage Hook:</b>
+	 * Invoked when we are about to <a href="https://smilecdr.com/docs/fhir_repository/creating_data.html#auto-create-placeholder-reference-targets">Auto-Create a Placeholder Reference</a>.
+	 * Hooks may modify/enhance the placeholder reference target that is about to be created, or
+	 * reject the creation of the resource, which generally means that the transaction will be
+	 * rejected instead (because of the invalid reference).
+	 * <p>
+	 * Hooks may accept the following parameters:
+	 * </p>
+	 * <ul>
+	 * <li>
+	 * ca.uhn.fhir.storage.interceptor.AutoCreatePlaceholderReferenceTargetRequest - Contains details about the placeholder that is about to be created, including the source resource whose reference is being fulfilled, as well as the candidate placeholder resource that will be created.
+	 * </li>
+	 * <li>
+	 * ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is about to be processed, including details such as the
+	 * resource type and logical ID (if any) and other FHIR-specific aspects of the request which have been
+	 * pulled out of the servlet request. Note that the bean
+	 * properties are not all guaranteed to be populated, depending on how early during processing the
+	 * exception occurred. <b>Note that this parameter may be null in contexts where the request is not
+	 * known, such as while processing searches</b>
+	 * </li>
+	 * <li>
+	 * ca.uhn.fhir.rest.server.servlet.ServletRequestDetails - A bean containing details about the request that is about to be processed, including details such as the
+	 * resource type and logical ID (if any) and other FHIR-specific aspects of the request which have been
+	 * pulled out of the servlet request. This parameter is identical to the RequestDetails parameter above but will
+	 * only be populated when operating in a RestfulServer implementation. It is provided as a convenience.
+	 * </li>
+	 * </ul>
+	 * <p>
+	 * Hooks may return <code>void</code>, an object of type <code>ca.uhn.fhir.storage.interceptor.AutoCreatePlaceholderReferenceTargetResponse</code>, and can throw exceptions.
+	 * </p>
+	 */
+	STORAGE_PRE_AUTO_CREATE_PLACEHOLDER_REFERENCE(
+		"ca.uhn.fhir.storage.interceptor.AutoCreatePlaceholderReferenceTargetResponse",
+		"ca.uhn.fhir.storage.interceptor.AutoCreatePlaceholderReferenceTargetRequest",
+		"ca.uhn.fhir.rest.api.server.RequestDetails",
+		"ca.uhn.fhir.rest.server.servlet.ServletRequestDetails"),
+
+	/**
+	 * <b>Storage Hook:</b>
 	 * Invoked when a Bulk Export job is being kicked off, but before any permission checks
 	 * have been done.
 	 * This hook can be used to modify or update parameters as need be before

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/built_in_server_interceptors.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/built_in_server_interceptors.md
@@ -326,6 +326,13 @@ If the JPA server has [partitioning](/docs/server_jpa_partitioning/partitioning.
 
 The UserRequestRetryVersionConflictsInterceptor allows clients to request that the server avoid version conflicts (HTTP 409) when two concurrent client requests attempt to modify the same resource. See [Version Conflicts](/docs/server_jpa/configuration.html#retry-on-version-conflict) for more information. 
 
+# JPA Server: Selective Auto-Create Placeholder Reference Targets
+
+The `AutoCreatePlaceholderReferenceEnabledByTypeInterceptor` can be used in combination with [Auto-Create Placeholder Reference Targets](/hapi-fhir/apidocs/hapi-fhir-jpaserver-model/ca/uhn/fhir/jpa/model/entity/StorageSettings.html#setAutoCreatePlaceholderReferenceTargets(boolean)) in order to specify that only reference targets with specific resource types should be created.
+
+* [AutoCreatePlaceholderReferenceEnabledByTypeInterceptor Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceEnabledByTypeInterceptor.java)
+
+
 # JPA Server: Validate Data Being Stored
 
 The RepositoryValidatingInterceptor can be used to enforce validation rules on data stored in a HAPI FHIR JPA Repository. See [Repository Validating Interceptor](/docs/validation/repository_validating_interceptor.html) for more information. 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoCreatePlaceholdersR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoCreatePlaceholdersR4Test.java
@@ -1,25 +1,30 @@
 package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
 import ca.uhn.fhir.jpa.dao.TransactionUtil;
+import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.jpa.util.TransactionSemanticsHeader;
 import ca.uhn.fhir.model.api.StorageResponseCodeEnum;
-import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.storage.interceptor.AutoCreatePlaceholderReferenceTargetRequest;
+import ca.uhn.fhir.storage.interceptor.AutoCreatePlaceholderReferenceTargetResponse;
 import ca.uhn.fhir.util.BundleBuilder;
 import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.google.common.collect.Sets;
+import jakarta.persistence.Id;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.AuditEvent;
@@ -49,15 +54,18 @@ import java.util.concurrent.Executors;
 
 import static ca.uhn.fhir.util.HapiExtensions.EXT_RESOURCE_PLACEHOLDER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doAnswer;
 
 
-@SuppressWarnings({"ConstantConditions"})
+@SuppressWarnings({"ConstantConditions", "LoggingSimilarMessage"})
 public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(FhirResourceDaoCreatePlaceholdersR4Test.class);
@@ -106,7 +114,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		task.addPartOf().setReference("Task/AAA");
 		task.addPartOf().setReference("Task/AAA");
 		task.addPartOf().setReference("Task/AAA");
-		DaoMethodOutcome methodOutcome = myTaskDao.create(task);
+		DaoMethodOutcome methodOutcome = myTaskDao.create(task, mySrd);
 
 		OperationOutcome oo = (OperationOutcome) methodOutcome.getOperationOutcome();
 		ourLog.info(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(oo));
@@ -115,7 +123,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		assertEquals("Automatically created placeholder resource with ID: Task/AAA/_history/1", oo.getIssue().get(1).getDiagnostics());
 
 		IIdType id = methodOutcome.getId().toUnqualifiedVersionless();
-		task = myTaskDao.read(id);
+		task = myTaskDao.read(id, mySrd);
 		assertThat(task.getPartOf()).hasSize(3);
 		assertEquals("Task/AAA", task.getPartOf().get(0).getReference());
 		assertEquals("Task/AAA", task.getPartOf().get(1).getReference());
@@ -127,7 +135,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 
 		SearchParameterMap params = new SearchParameterMap();
 		params.add(Task.SP_PART_OF, new ReferenceParam("Task/AAA"));
-		List<String> found = toUnqualifiedVersionlessIdValues(myTaskDao.search(params));
+		List<String> found = toUnqualifiedVersionlessIdValues(myTaskDao.search(params, mySrd));
 		assertThat(found).containsExactly(id.getValue());
 	}
 
@@ -142,9 +150,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		o.setStatus(ObservationStatus.FINAL);
 		o.getSubject().setReference("Patient/FOO");
 
-		Exception ex = Assertions.assertThrows(InvalidRequestException.class, () -> {
-			myObservationDao.update(o, mySrd);
-		});
+		Exception ex = Assertions.assertThrows(InvalidRequestException.class, () -> myObservationDao.update(o, mySrd));
 		assertThat(ex.getMessage()).startsWith(Msg.code(1094) + "Resource Patient/FOO not found, specified in path: Observation.subject");
 	}
 
@@ -158,7 +164,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType id = myObservationDao.create(o, mySrd).getId();
 
 		try {
-			myPatientDao.read(new IdType("Patient/FOO"));
+			myPatientDao.read(new IdType("Patient/FOO"), mySrd);
 			fail();
 		} catch (ResourceNotFoundException e) {
 			// good
@@ -170,7 +176,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		o.getSubject().setReference("Patient/FOO");
 		myObservationDao.update(o, mySrd);
 
-		myPatientDao.read(new IdType("Patient/FOO"));
+		myPatientDao.read(new IdType("Patient/FOO"), mySrd);
 
 	}
 
@@ -189,12 +195,12 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		myCaptureQueriesListener.logAllQueries();
 
 		runInTransaction(() -> {
-			ResourceTable entity = myResourceTableDao.findById(id.getIdPartAsLong()).orElseThrow(() -> new IllegalArgumentException());
+			ResourceTable entity = myResourceTableDao.findById(JpaPid.fromId(id.getIdPartAsLong())).orElseThrow(IllegalArgumentException::new);
 			assertEquals(1, entity.getVersion());
 		});
 
 		try {
-			myPatientDao.read(new IdType("Patient/999999999999999"));
+			myPatientDao.read(new IdType("Patient/999999999999999"), mySrd);
 			fail();
 		} catch (ResourceNotFoundException e) {
 			// good
@@ -207,16 +213,16 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		myObservationDao.update(o, mySrd);
 
 		runInTransaction(() -> {
-			ResourceTable entity = myResourceTableDao.findById(id.getIdPartAsLong()).orElseThrow(() -> new IllegalArgumentException());
+			ResourceTable entity = myResourceTableDao.findById(JpaPid.fromId(id.getIdPartAsLong())).orElseThrow(IllegalArgumentException::new);
 			assertEquals(2, entity.getVersion());
 		});
 
-		myPatientDao.read(new IdType("Patient/999999999999999"));
+		myPatientDao.read(new IdType("Patient/999999999999999"), mySrd);
 
 		SearchParameterMap map = new SearchParameterMap();
 		map.setLoadSynchronous(true);
 		map.add("_id", new TokenParam("999999999999999"));
-		IBundleProvider outcome = myPatientDao.search(map);
+		IBundleProvider outcome = myPatientDao.search(map, mySrd);
 		assertEquals(1, outcome.size().intValue());
 		assertEquals("Patient/999999999999999", outcome.getResources(0, 1).get(0).getIdElement().toUnqualifiedVersionless().getValue());
 	}
@@ -232,16 +238,15 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType id = myObservationDao.create(obsToCreate, mySrd).getId();
 
 		// Read the Observation
-		Observation createdObs = myObservationDao.read(id);
-		ourLog.debug("\nObservation created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		Observation createdObs = myObservationDao.read(id, mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
 		/*
 		 * Read the placeholder Patient referenced by the Observation
 		 * Placeholder extension should exist and be true
 		 */
-		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
-		IIdType placeholderPatId = placeholderPat.getIdElement();
-		ourLog.debug("\nPlaceholder Patient created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
 		assertThat(placeholderPat.getIdentifier()).isEmpty();
 		Extension extension = placeholderPat.getExtensionByUrl(EXT_RESOURCE_PLACEHOLDER);
 		assertNotNull(extension);
@@ -252,14 +257,14 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		Patient patToUpdate = new Patient();
 		patToUpdate.setId("Patient/AAA");
 		patToUpdate.addIdentifier().setSystem("http://foo").setValue("123");
-		IIdType updatedPatId = myPatientDao.update(patToUpdate).getId();
+		IIdType updatedPatId = myPatientDao.update(patToUpdate, mySrd).getId();
 
 		/*
 		 * Read the updated Patient
 		 * Placeholder extension should not exist
 		 */
-		Patient updatedPat = myPatientDao.read(updatedPatId);
-		ourLog.debug("\nUpdated Patient:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(updatedPat));
+		Patient updatedPat = myPatientDao.read(updatedPatId, mySrd);
+		ourLog.debug("\nUpdated Patient:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(updatedPat));
 		assertThat(updatedPat.getIdentifier()).hasSize(1);
 		extension = updatedPat.getExtensionByUrl(EXT_RESOURCE_PLACEHOLDER);
 		assertNull(extension);
@@ -277,10 +282,10 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		obsToCreate.getSubject().getIdentifier().setSystem("http://foo").setValue("123");
 		IIdType id = myObservationDao.create(obsToCreate, mySrd).getId();
 
-		Observation createdObs = myObservationDao.read(id);
+		Observation createdObs = myObservationDao.read(id, mySrd);
 		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
-		Patient patient = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
+		Patient patient = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
 		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(patient));
 		assertThat(patient.getIdentifier()).isEmpty();
 	}
@@ -308,11 +313,11 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
 
 		// Read the Observation
-		Observation createdObs = myObservationDao.read(obsId);
+		Observation createdObs = myObservationDao.read(obsId, mySrd);
 
 		//Read the Placeholder Patient
-		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
-		ourLog.debug("\nObservation created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
 		//Ensure the Obs has the right placeholder ID.
 		IIdType placeholderPatId = placeholderPat.getIdElement();
@@ -321,7 +326,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		/*
 		 * Should have a single identifier populated.
 		 */
-		ourLog.debug("\nPlaceholder Patient created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
 		assertThat(placeholderPat.getIdentifier()).hasSize(1);
 		List<Identifier> identifiers = placeholderPat.getIdentifier();
 		Identifier identifier = identifiers.get(0);
@@ -353,11 +358,11 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
 
 		// Read the Observation
-		Observation createdObs = myObservationDao.read(obsId);
+		Observation createdObs = myObservationDao.read(obsId, mySrd);
 
 		//Read the Placeholder Patient
-		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
-		ourLog.debug("\nObservation created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
 		//Ensure the Obs has the right placeholder ID.
 		IIdType placeholderPatId = placeholderPat.getIdElement();
@@ -366,7 +371,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		/*
 		 * Should have a single identifier populated.
 		 */
-		ourLog.debug("\nPlaceholder Patient created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
 		assertThat(placeholderPat.getIdentifier()).hasSize(1);
 		List<Identifier> identifiers = placeholderPat.getIdentifier();
 		Identifier identifier = identifiers.get(0);
@@ -399,11 +404,11 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
 
 		// Read the Observation
-		Observation createdObs = myObservationDao.read(obsId);
+		Observation createdObs = myObservationDao.read(obsId, mySrd);
 
 		//Read the Placeholder Patient
-		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
-		ourLog.debug("\nObservation created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
 		//Ensure the Obs has the right placeholder ID.
 		IIdType placeholderPatId = placeholderPat.getIdElement();
@@ -412,7 +417,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		/*
 		 * Should have a single identifier populated.
 		 */
-		ourLog.debug("\nPlaceholder Patient created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
 		assertThat(placeholderPat.getIdentifier()).hasSize(1);
 		List<Identifier> identifiers = placeholderPat.getIdentifier();
 		Identifier identifier = identifiers.get(0);
@@ -518,11 +523,11 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
 
 		// Read the Observation
-		Observation createdObs = myObservationDao.read(obsId);
+		Observation createdObs = myObservationDao.read(obsId, mySrd);
 
 		//Read the Placeholder Patient
-		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
-		ourLog.debug("\nObservation created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
 		//Ensure the Obs has the right placeholder ID.
 		IIdType placeholderPatId = placeholderPat.getIdElement();
@@ -531,7 +536,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		/*
 		 * Placeholder Identifiers should both be populated since they were both provided, and did not match
 		 */
-		ourLog.debug("\nPlaceholder Patient created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
 		assertThat(placeholderPat.getIdentifier()).hasSize(2);
 		List<Identifier> identifiers = placeholderPat.getIdentifier();
 
@@ -551,16 +556,16 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType conditionalUpdatePatId = myPatientDao.update(patToConditionalUpdate, "Patient?identifier=http://foo|123", mySrd).getId();
 
 		// Read the conditionally updated Patient
-		Patient conditionalUpdatePat = myPatientDao.read(conditionalUpdatePatId);
-		ourLog.debug("\nConditionally updated Patient:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(conditionalUpdatePat));
+		Patient conditionalUpdatePat = myPatientDao.read(conditionalUpdatePatId, mySrd);
+		ourLog.debug("\nConditionally updated Patient:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(conditionalUpdatePat));
 		assertThat(conditionalUpdatePat.getIdentifier()).hasSize(1);
 
 		/*
 		 * Observation should reference conditionally updated Patient
 		 * ID of placeholder Patient should match ID of conditionally updated Patient
 		 */
-		createdObs = myObservationDao.read(obsId);
-		ourLog.debug("\nObservation read after Patient update:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		createdObs = myObservationDao.read(obsId, mySrd);
+		ourLog.debug("\nObservation read after Patient update:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 		assertEquals(createdObs.getSubject().getReference(), conditionalUpdatePatId.toUnqualifiedVersionless().getValueAsString());
 		assertEquals(placeholderPatId.toUnqualifiedVersionless().getValueAsString(), conditionalUpdatePatId.toUnqualifiedVersionless().getValueAsString());
 	}
@@ -581,16 +586,16 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
 
 		// Read the Observation
-		Observation createdObs = myObservationDao.read(obsId);
-		ourLog.debug("\nObservation created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		Observation createdObs = myObservationDao.read(obsId, mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
 		/*
 		 * Read the placeholder Patient referenced by the Observation
 		 * Identifier should be populated since it was provided
 		 */
-		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
 		IIdType placeholderPatId = placeholderPat.getIdElement();
-		ourLog.debug("\nPlaceholder Patient created:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
 		assertThat(placeholderPat.getIdentifier()).hasSize(1);
 		assertEquals(createdObs.getSubject().getReference(), placeholderPatId.toUnqualifiedVersionless().getValueAsString());
 
@@ -601,16 +606,16 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		IIdType conditionalUpdatePatId = myPatientDao.update(patToConditionalUpdate, "Patient?identifier=http://foo|123", mySrd).getId();
 
 		// Read the conditionally updated Patient
-		Patient conditionalUpdatePat = myPatientDao.read(conditionalUpdatePatId);
-		ourLog.debug("\nConditionally updated Patient:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(conditionalUpdatePat));
+		Patient conditionalUpdatePat = myPatientDao.read(conditionalUpdatePatId, mySrd);
+		ourLog.debug("\nConditionally updated Patient:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(conditionalUpdatePat));
 		assertThat(conditionalUpdatePat.getIdentifier()).hasSize(1);
 
 		/*
 		 * Observation should reference conditionally updated Patient
 		 * ID of placeholder Patient should match ID of conditionally updated Patient
 		 */
-		createdObs = myObservationDao.read(obsId);
-		ourLog.debug("\nObservation read after Patient update:\n" + myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+		createdObs = myObservationDao.read(obsId, mySrd);
+		ourLog.debug("\nObservation read after Patient update:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 		assertEquals(createdObs.getSubject().getReference(), conditionalUpdatePatId.toUnqualifiedVersionless().getValueAsString());
 		assertEquals(placeholderPatId.toUnqualifiedVersionless().getValueAsString(), conditionalUpdatePatId.toUnqualifiedVersionless().getValueAsString());
 	}
@@ -626,10 +631,10 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		obsToCreate.getSubject().getIdentifier().setSystem("http://foo").setValue("123");
 		IIdType id = myObservationDao.create(obsToCreate, mySrd).getId();
 
-		Observation createdObs = myObservationDao.read(id);
+		Observation createdObs = myObservationDao.read(id, mySrd);
 		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
 
-		Patient patient = myPatientDao.read(new IdType(createdObs.getSubject().getReference()));
+		Patient patient = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
 		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(patient));
 		assertThat(patient.getIdentifier()).hasSize(1);
 		assertEquals("http://foo", patient.getIdentifier().get(0).getSystem());
@@ -649,7 +654,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		what.getIdentifier().setValue("123");
 		IIdType id = myAuditEventDao.create(eventToCreate, mySrd).getId();
 
-		AuditEvent createdEvent = myAuditEventDao.read(id);
+		AuditEvent createdEvent = myAuditEventDao.read(id, mySrd);
 		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdEvent));
 	}
 
@@ -661,7 +666,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		Patient patient = new Patient();
 		patient.setId("ABC");
 		patient.addIdentifier().setSystem("http://foo").setValue("123");
-		myPatientDao.update(patient);
+		myPatientDao.update(patient, mySrd);
 
 		Observation obsToCreate = new Observation();
 		obsToCreate.setStatus(ObservationStatus.FINAL);
@@ -669,9 +674,64 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		obsToCreate.getSubject().getIdentifier().setSystem("http://foo").setValue("123");
 		IIdType id = myObservationDao.create(obsToCreate, mySrd).getId();
 
-		Observation createdObs = myObservationDao.read(id);
+		Observation createdObs = myObservationDao.read(id, mySrd);
 		assertEquals("Patient/ABC", createdObs.getSubject().getReference());
 	}
+
+	@Test
+	public void testInterceptor_DoNotCreateTarget() {
+		//Setup
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		Object interceptor = new Object() {
+			@Hook(Pointcut.STORAGE_PRE_AUTO_CREATE_PLACEHOLDER_REFERENCE)
+			public AutoCreatePlaceholderReferenceTargetResponse autoCreatePlaceholderReferenceTarget(AutoCreatePlaceholderReferenceTargetRequest theRequest) {
+
+				// Verify
+				Patient target = (Patient) theRequest.getTargetResourceToCreate();
+				assertEquals("Patient/ABC", target.getIdElement().getValue());
+				assertEquals("true", target.getExtensionByUrl(HapiExtensions.EXT_RESOURCE_PLACEHOLDER).getValueAsPrimitive().getValueAsString());
+
+				return AutoCreatePlaceholderReferenceTargetResponse.doNotCreateTarget();
+			}
+		};
+		registerInterceptor(interceptor);
+
+		// Test
+		Observation obs = new Observation();
+		obs.setStatus(ObservationStatus.AMENDED);
+		obs.setSubject(new Reference("Patient/ABC"));
+		assertThatThrownBy(()->myObservationDao.create(obs, mySrd))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("Resource Patient/ABC not found, specified in path: Observation.subject");
+	}
+
+	@Test
+	public void testInterceptor_ModifyTarget() {
+		//Setup
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		Object interceptor = new Object() {
+			@Hook(Pointcut.STORAGE_PRE_AUTO_CREATE_PLACEHOLDER_REFERENCE)
+			public AutoCreatePlaceholderReferenceTargetResponse autoCreatePlaceholderReferenceTarget(AutoCreatePlaceholderReferenceTargetRequest theRequest) {
+				Patient target = (Patient) theRequest.getTargetResourceToCreate();
+				target.setActive(false);
+				return AutoCreatePlaceholderReferenceTargetResponse.proceed();
+			}
+		};
+		registerInterceptor(interceptor);
+
+		// Test
+		Observation obs = new Observation();
+		obs.setStatus(ObservationStatus.AMENDED);
+		obs.setSubject(new Reference("Patient/ABC"));
+		myObservationDao.create(obs, mySrd);
+
+		// Verify
+		Patient actual = myPatientDao.read(new IdType("Patient/ABC"), mySrd);
+		assertEquals("Patient/ABC/_history/1", actual.getIdElement().getValue());
+		assertFalse(actual.getActive());
+	}
+
+
 
 	@Test
 	public void testSearchForPlaceholder() {
@@ -807,7 +867,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		BundleBuilder builder = new BundleBuilder(myFhirContext);
 		builder.addTransactionUpdateEntry(obs);
 
-		Bundle transaction = mySystemDao.transaction(new SystemRequestDetails(), (Bundle) builder.getBundle());
+		mySystemDao.transaction(new SystemRequestDetails(), (Bundle) builder.getBundle());
 
 		Patient returned = myPatientDao.read(patientRef.getReferenceElement(), mySrd);
 		assertNotNull(returned);
@@ -870,11 +930,11 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 	 * Both threads are trying to create the same resource in parallel with retry functionality.
 	 */
 	@Test
-	void runBundleBatchInParallelThreads() throws Exception {
+	void runBundleBatchInParallelThreads() {
 		// setup
 		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
 		myStorageSettings.setAllowInlineMatchUrlReferences(true);
-		final Bundle searchParameters  = ClasspathUtil.loadResource(myFhirContext, Bundle.class, "/r4/patient-identifier-unique-sp-bundle.json");
+		final Bundle searchParameters = ClasspathUtil.loadResource(myFhirContext, Bundle.class, "/r4/patient-identifier-unique-sp-bundle.json");
 		mySystemDao.transaction(new SystemRequestDetails(), searchParameters);
 		final Bundle patientBundle = ClasspathUtil.loadResource(myFhirContext, Bundle.class, "/r4/patient-with-conditional-update.json");
 		final Bundle observationBundle = ClasspathUtil.loadResource(myFhirContext, Bundle.class, "/r4/observation-with-conditional-update-and-inline-reference.json");
@@ -894,13 +954,10 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		// execute
 		executor.shutdown();
 		// validate
-		while (!executor.isTerminated()) {
-			Thread.sleep(100);// Wait for tasks to complete
-			ourLog.atInfo().setMessage("Shutting down thread 1 and 2.... ").log();
-		}
-		final Integer patientResultCount = myPatientDao.search(withPatientIdentifierSp(),  new SystemRequestDetails()).size();
+		await().until(executor::isTerminated);
+		final Integer patientResultCount = myPatientDao.search(withPatientIdentifierSp(), new SystemRequestDetails()).size();
 		assertThat(patientResultCount).isEqualTo(1);
-		final Integer observationResultCount = myObservationDao.search(withObservationCodeSp(),  new SystemRequestDetails()).size();
+		final Integer observationResultCount = myObservationDao.search(withObservationCodeSp(), new SystemRequestDetails()).size();
 		assertThat(observationResultCount).isEqualTo(1);
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoResourceLinkResolver.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoResourceLinkResolver.java
@@ -57,6 +57,7 @@ import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.TerserUtil;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.Validate;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -72,6 +73,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class DaoResourceLinkResolver<T extends IResourcePersistentId<?>> implements IResourceLinkResolver {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(DaoResourceLinkResolver.class);
@@ -329,6 +332,12 @@ public class DaoResourceLinkResolver<T extends IResourcePersistentId<?>> impleme
 					}
 				}
 
+				// Sanity check: Make sure that interceptors haven't changed the ID
+				if (theIdToAssignToPlaceholder != null) {
+					Validate.isTrue(theIdToAssignToPlaceholder.equals(newResource.getIdElement().getIdPart()), "Interceptors must not modify the ID of auto-created placeholder reference targets");
+				} else {
+					Validate.isTrue(isBlank(newResource.getIdElement().getIdPart()), "Interceptors must not modify the ID of auto-created placeholder reference targets");
+				}
 			}
 
 			if (theIdToAssignToPlaceholder != null) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceEnabledByTypeInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceEnabledByTypeInterceptor.java
@@ -1,0 +1,48 @@
+package ca.uhn.fhir.storage.interceptor;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+
+import java.util.Set;
+
+/**
+ * This interceptor can be used on systems with
+ * {@link ca.uhn.fhir.jpa.api.config.JpaStorageSettings#setAutoCreatePlaceholderReferenceTargets(boolean) Auto-Create Placeholder Reference Targets}
+ * enabled in order to cause these placeholder resources to only be created for specific resource types.
+ *
+ * @since 8.4.0
+ */
+@Interceptor
+public class AutoCreatePlaceholderReferenceEnabledByTypeInterceptor {
+
+	private final Set<String> myResourceTypesToAllow;
+
+	/**
+	 * Constructor
+	 *
+	 * @param theResourceTypesToAllow The resource types to allow. For example, if you pass in the strings "Patient"
+	 *                                and "Observation", then placeholder reference target resources will be created
+	 *                                with these resource types but not with any other resource types.
+	 */
+	public AutoCreatePlaceholderReferenceEnabledByTypeInterceptor(String... theResourceTypesToAllow) {
+		myResourceTypesToAllow = Set.of(theResourceTypesToAllow);
+	}
+
+	/**
+	 * This method will be called automatically before each auto-created placeholder
+	 * reference target resource.
+	 */
+	@Hook(Pointcut.STORAGE_PRE_AUTO_CREATE_PLACEHOLDER_REFERENCE)
+	public AutoCreatePlaceholderReferenceTargetResponse autoCreatePlaceholderReferenceTarget(AutoCreatePlaceholderReferenceTargetRequest theRequest) {
+
+		String resourceType = theRequest.getTargetResourceToCreate().getIdElement().getResourceType();
+		if (!myResourceTypesToAllow.contains(resourceType)) {
+			return AutoCreatePlaceholderReferenceTargetResponse.doNotCreateTarget();
+		}
+
+		return AutoCreatePlaceholderReferenceTargetResponse.proceed();
+	}
+
+
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetRequest.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetRequest.java
@@ -1,0 +1,17 @@
+package ca.uhn.fhir.storage.interceptor;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+// FIXME: document both
+public class AutoCreatePlaceholderReferenceTargetRequest {
+
+	private final IBaseResource myTargetResourceToCreate;
+
+	public AutoCreatePlaceholderReferenceTargetRequest(IBaseResource theTargetResourceToCreate) {
+		myTargetResourceToCreate = theTargetResourceToCreate;
+	}
+
+	public IBaseResource getTargetResourceToCreate() {
+		return myTargetResourceToCreate;
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetRequest.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetRequest.java
@@ -2,15 +2,28 @@ package ca.uhn.fhir.storage.interceptor;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
-// FIXME: document both
+/**
+ * This object is used as a method parameter for interceptor hook methods implementing the
+ * {@link ca.uhn.fhir.interceptor.api.Pointcut#STORAGE_PRE_AUTO_CREATE_PLACEHOLDER_REFERENCE}
+ * pointcut.
+ *
+ * @since 8.4.0
+ */
 public class AutoCreatePlaceholderReferenceTargetRequest {
 
 	private final IBaseResource myTargetResourceToCreate;
 
+	/**
+	 * Constructor
+	 */
 	public AutoCreatePlaceholderReferenceTargetRequest(IBaseResource theTargetResourceToCreate) {
 		myTargetResourceToCreate = theTargetResourceToCreate;
 	}
 
+	/**
+	 * Provides the resource that is going to be automatically created. Interceptors may make changes
+	 * to the resource, but they must not modify its ID.
+	 */
 	public IBaseResource getTargetResourceToCreate() {
 		return myTargetResourceToCreate;
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetResponse.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetResponse.java
@@ -1,0 +1,36 @@
+package ca.uhn.fhir.storage.interceptor;
+
+public class AutoCreatePlaceholderReferenceTargetResponse {
+
+	private boolean myDoNotCreateTarget;
+
+	/**
+	 * Use static factory methods to create this object
+	 */
+	private AutoCreatePlaceholderReferenceTargetResponse(boolean theDoNotCreateTarget) {
+		myDoNotCreateTarget = theDoNotCreateTarget;
+	}
+
+	/**
+	 * Should the placeholder resource not be created?
+	 */
+	public boolean isDoNotCreateTarget() {
+		return myDoNotCreateTarget;
+	}
+
+	/**
+	 * Create response: The placeholder reference target should <b>not</b> be created.
+	 * Under most circumstances this will cause the operation to be aborted due to
+	 * the invalid reference.
+	 */
+	public static AutoCreatePlaceholderReferenceTargetResponse doNotCreateTarget() {
+		return new AutoCreatePlaceholderReferenceTargetResponse(true);
+	}
+
+	/**
+	 * Create response: The placeholder reference target should be created.
+	 */
+	public static AutoCreatePlaceholderReferenceTargetResponse proceed() {
+		return new AutoCreatePlaceholderReferenceTargetResponse(false);
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetResponse.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/AutoCreatePlaceholderReferenceTargetResponse.java
@@ -1,11 +1,20 @@
 package ca.uhn.fhir.storage.interceptor;
 
+/**
+ * This object is used as a return type for interceptor hook methods implementing the
+ * {@link ca.uhn.fhir.interceptor.api.Pointcut#STORAGE_PRE_AUTO_CREATE_PLACEHOLDER_REFERENCE}
+ * pointcut.
+ *
+ * @since 8.4.0
+ * @see #doNotCreateTarget()
+ * @see #proceed()
+ */
 public class AutoCreatePlaceholderReferenceTargetResponse {
 
 	private boolean myDoNotCreateTarget;
 
 	/**
-	 * Use static factory methods to create this object
+	 * Use the static factory methods to create this object
 	 */
 	private AutoCreatePlaceholderReferenceTargetResponse(boolean theDoNotCreateTarget) {
 		myDoNotCreateTarget = theDoNotCreateTarget;


### PR DESCRIPTION
This PR adds a new interceptor hook which can be used to prevent specific auto-created placeholder reference targets from being created, or to modify those resources.