### PR TITLE
Bug Fix in PackageInstallerSvcImpl when using MultiTenancy

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -184,7 +184,8 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 
 				boolean exists = myTxService
 						.withSystemRequest()
-						.withRequestPartitionId(RequestPartitionId.defaultPartition())
+						.withRequestPartitionId(
+								RequestPartitionId.fromPartitionId(myPartitionSettings.getDefaultPartitionId()))
 						.execute(() -> {
 							Optional<NpmPackageVersionEntity> existing = myPackageVersionDao.findByPackageIdAndVersion(
 									theInstallationSpec.getName(), theInstallationSpec.getVersion());
@@ -524,7 +525,8 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 	private RequestDetails createRequestDetails() {
 		SystemRequestDetails requestDetails = new SystemRequestDetails();
 		if (myPartitionSettings.isPartitioningEnabled()) {
-			requestDetails.setRequestPartitionId(RequestPartitionId.defaultPartition());
+			requestDetails.setRequestPartitionId(
+					RequestPartitionId.fromPartitionId(myPartitionSettings.getDefaultPartitionId()));
 		}
 		return requestDetails;
 	}


### PR DESCRIPTION
My issue: https://github.com/hapifhir/hapi-fhir/issues/7091 explains the issue. 

This PR removes deprecated code in this service and more properly determines the default partition ID using the partition settings. 

Includes some basic tests to verify the install occurs on the correct partition. 

I couldn't figure out how to write a test that incorporates _BaseRequestPartitionHelperSvc_ from `hapi-fhir-storage`, which produces the error. 

@tadgh (author of #6564)