### PR TITLE
Bump to core 6.5.27

### DIFF
--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/context/MyEpisodeOfCareFHIR.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/context/MyEpisodeOfCareFHIR.java
@@ -478,12 +478,6 @@ public class MyEpisodeOfCareFHIR extends EpisodeOfCare {
 
 	@Override
 	@Deprecated
-	public List getAccountTarget() {
-		throw new UnsupportedOperationException("Deprecated method");
-	}
-
-	@Override
-	@Deprecated
 	public List getDiagnosis() {
 		throw new UnsupportedOperationException("Deprecated method");
 	}
@@ -500,11 +494,6 @@ public class MyEpisodeOfCareFHIR extends EpisodeOfCare {
 		throw new UnsupportedOperationException("Deprecated method");
 	}
 
-	@Override
-	@Deprecated
-	public List getReferralRequestTarget() {
-		throw new UnsupportedOperationException("Deprecated method");
-	}
 
 	@Override
 	@Deprecated
@@ -518,21 +507,10 @@ public class MyEpisodeOfCareFHIR extends EpisodeOfCare {
 		throw new UnsupportedOperationException("Deprecated method");
 	}
 
-	@Override
-	@Deprecated
-	public List getTeamTarget() {
-		throw new UnsupportedOperationException("Deprecated method");
-	}
 
 	@Override
 	@Deprecated
 	public List getType() {
-		throw new UnsupportedOperationException("Deprecated method");
-	}
-
-	@Override
-	@Deprecated
-	public Account addAccountTarget() {
 		throw new UnsupportedOperationException("Deprecated method");
 	}
 
@@ -563,12 +541,6 @@ public class MyEpisodeOfCareFHIR extends EpisodeOfCare {
 	@Override
 	@Deprecated
 	public Base[] getProperty(int p0, String p1, boolean p2) {
-		throw new UnsupportedOperationException("Deprecated method");
-	}
-
-	@Override
-	@Deprecated
-	public CareTeam addTeamTarget() {
 		throw new UnsupportedOperationException("Deprecated method");
 	}
 
@@ -845,12 +817,6 @@ public class MyEpisodeOfCareFHIR extends EpisodeOfCare {
 	@Override
 	@Deprecated
 	public Reference getTeamFirstRep() {
-		throw new UnsupportedOperationException("Deprecated method");
-	}
-
-	@Override
-	@Deprecated
-	public ReferralRequest addReferralRequestTarget() {
 		throw new UnsupportedOperationException("Deprecated method");
 	}
 

--- a/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
@@ -22,6 +22,7 @@ import org.hl7.fhir.r5.model.CodeableConcept;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent;
 import org.hl7.fhir.r5.model.NamingSystem;
+import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.Resource;
@@ -43,8 +44,6 @@ import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -536,12 +535,6 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
 	}
 
 	@Override
-	public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader, Set<String> types)
-			throws FileNotFoundException, IOException, FHIRException {
-		throw new UnsupportedOperationException(Msg.code(2328));
-	}
-
-	@Override
 	public int loadFromPackageAndDependencies(NpmPackage pi, IContextResourceLoader loader, BasePackageCacheManager pcm)
 			throws FHIRException {
 		throw new UnsupportedOperationException(Msg.code(235));
@@ -663,5 +656,10 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
 	@Override
 	public boolean isServerSideSystem(String url) {
 		return false;
+	}
+
+	@Override
+	public OperationOutcome validateTxResource(ValidationOptions options, Resource resource) {
+		throw new UnsupportedOperationException(Msg.code(2733));
 	}
 }

--- a/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
@@ -660,6 +660,6 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
 
 	@Override
 	public OperationOutcome validateTxResource(ValidationOptions options, Resource resource) {
-		throw new UnsupportedOperationException(Msg.code(2733));
+		throw new UnsupportedOperationException(Msg.code(2734));
 	}
 }

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
@@ -201,11 +201,6 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 	}
 
 	@Override
-	public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader, Set<String> types) throws FHIRException {
-		throw new UnsupportedOperationException(Msg.code(653));
-	}
-
-	@Override
 	public int loadFromPackageAndDependencies(NpmPackage pi, IContextResourceLoader loader, BasePackageCacheManager pcm)
 			throws FHIRException {
 		throw new UnsupportedOperationException(Msg.code(654));
@@ -1152,5 +1147,10 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 	public static WorkerContextValidationSupportAdapter newVersionSpecificWorkerContextWrapper(
 			IValidationSupport theValidationSupport) {
 		return new WorkerContextValidationSupportAdapter(theValidationSupport);
+	}
+
+	@Override
+	public OperationOutcome validateTxResource(ValidationOptions options, Resource resource) {
+		throw new UnsupportedOperationException(Msg.code(2734));
 	}
 }

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
@@ -1151,6 +1151,6 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 
 	@Override
 	public OperationOutcome validateTxResource(ValidationOptions options, Resource resource) {
-		throw new UnsupportedOperationException(Msg.code(2734));
+		throw new UnsupportedOperationException(Msg.code(2735));
 	}
 }

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
@@ -567,8 +567,8 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 		String input = ClasspathUtil.loadResource("/r4/diagnosticreport-example-gingival-mass.json");
 		ValidationResult output = myFhirValidator.validateWithResult(input);
 		List<SingleValidationMessage> messages = logResultsAndReturnAll(output);
-		assertThat(messages).hasSize(1);
-		assertEquals("Base64 encoded values SHOULD not contain any whitespace (per RFC 4648). Note that non-validating readers are encouraged to accept whitespace anyway", messages.get(0).getMessage());
+		assertThat(messages).hasSize(2);
+		assertEquals("Base64 encoded values SHOULD not contain any whitespace (per RFC 4648). Note that non-validating readers are encouraged to accept whitespace anyway", messages.get(1).getMessage());
 	}
 
 	@Test

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4b/validation/FhirInstanceValidatorR4BTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4b/validation/FhirInstanceValidatorR4BTest.java
@@ -524,8 +524,8 @@ public class FhirInstanceValidatorR4BTest extends BaseTest {
 		String input = IOUtils.toString(FhirInstanceValidatorR4BTest.class.getResourceAsStream("/r4/diagnosticreport-example-gingival-mass.json"), Constants.CHARSET_UTF8);
 		ValidationResult output = myFhirValidator.validateWithResult(input);
 		List<SingleValidationMessage> messages = logResultsAndReturnAll(output);
-		assertThat(messages).hasSize(1);
-		assertEquals("Base64 encoded values SHOULD not contain any whitespace (per RFC 4648). Note that non-validating readers are encouraged to accept whitespace anyway", messages.get(0).getMessage());
+		assertThat(messages).hasSize(2);
+		assertEquals("Base64 encoded values SHOULD not contain any whitespace (per RFC 4648). Note that non-validating readers are encouraged to accept whitespace anyway", messages.get(1).getMessage());
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -985,7 +985,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.5.26</fhir_core_version>
+		<fhir_core_version>6.5.27-SNAPSHOT</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<spotless.exclude.pattern>**/test/**/*.java</spotless.exclude.pattern>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>

--- a/pom.xml
+++ b/pom.xml
@@ -985,7 +985,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.5.27-SNAPSHOT</fhir_core_version>
+		<fhir_core_version>6.5.27</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<spotless.exclude.pattern>**/test/**/*.java</spotless.exclude.pattern>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>


### PR DESCRIPTION
This removes several long deprecated methods that were finally deleted from org.hl7.fhir.core

It also introduces an unimplemented validateTxResource() method now present in org.hl7.fhir.core and accounts for some new error messaging regarding base64 validation.