### PR TITLE
[7095] With persistence database_partition_mode enabled, a create with update issued on another partition can overwrite the initial resource

### DIFF
--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -90,7 +90,7 @@ ca.uhn.fhir.jpa.binary.interceptor.BinaryStorageInterceptor.externalizedBinarySt
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.cantUndeleteWithDeletesDisabled=Unable to restore previously deleted resource as deletes are disabled on this server.
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.incomingNoopInTransaction=Transaction contains resource with operation NOOP. This is only valid as a response operation, not in a request
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.invalidMatchUrlInvalidResourceType=Invalid match URL "{0}" - Unknown resource type: "{1}"
-ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.resourceTypeAndFhirIdConflictAcrossPartitions=Failed to create/update resource "{0}/{1}" in partition {2} because the same resource type and ID exist in another partition
+ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.resourceTypeAndFhirIdConflictAcrossPartitions=Failed to create/update resource [{0}/{1}] in partition {2} because a resource of the same type and ID is found in another partition
 ca.uhn.fhir.jpa.dao.BaseStorageDao.invalidMatchUrlNoMatches=Invalid match URL "{0}" - No resources match this search
 ca.uhn.fhir.jpa.dao.BaseStorageDao.inlineMatchNotSupported=Inline match URLs are not supported on this server. Cannot process reference: "{0}"
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithMultipleMatchFailure=Failed to {0} {1} with match URL "{2}" because this search matched {3} resources

--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -95,6 +95,7 @@ ca.uhn.fhir.jpa.dao.BaseStorageDao.inlineMatchNotSupported=Inline match URLs are
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithMultipleMatchFailure=Failed to {0} {1} with match URL "{2}" because this search matched {3} resources
 ca.uhn.fhir.jpa.dao.BaseStorageDao.deleteByUrlThresholdExceeded=Failed to DELETE resources with match URL "{0}" because the resolved number of resources: {1} exceeds the threshold of {2}
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithIdNotMatchFailure=Failed to {0} resource with match URL "{1}" because the matching resource does not match the provided ID
+ca.uhn.fhir.jpa.dao.BaseStorageDao.resourceTypeAndFhirIdConflictAcrossPartitions=Failed to create resource {0}/{1} in partition {2} because the same resource type and ID exist in another partition
 ca.uhn.fhir.jpa.dao.BaseTransactionProcessor.multiplePartitionAccesses=Can not process transaction with {0} entries: Entries require access to multiple/conflicting partitions
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.transactionOperationFailedNoId=Failed to {0} resource in transaction because no ID was provided
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.transactionOperationFailedUnknownId=Failed to {0} resource in transaction because no resource could be found with ID {1}

--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -90,12 +90,12 @@ ca.uhn.fhir.jpa.binary.interceptor.BinaryStorageInterceptor.externalizedBinarySt
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.cantUndeleteWithDeletesDisabled=Unable to restore previously deleted resource as deletes are disabled on this server.
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.incomingNoopInTransaction=Transaction contains resource with operation NOOP. This is only valid as a response operation, not in a request
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.invalidMatchUrlInvalidResourceType=Invalid match URL "{0}" - Unknown resource type: "{1}"
+ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.resourceTypeAndFhirIdConflictAcrossPartitions=Failed to create/update resource "{0}/{1}" in partition {2} because the same resource type and ID exist in another partition
 ca.uhn.fhir.jpa.dao.BaseStorageDao.invalidMatchUrlNoMatches=Invalid match URL "{0}" - No resources match this search
 ca.uhn.fhir.jpa.dao.BaseStorageDao.inlineMatchNotSupported=Inline match URLs are not supported on this server. Cannot process reference: "{0}"
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithMultipleMatchFailure=Failed to {0} {1} with match URL "{2}" because this search matched {3} resources
 ca.uhn.fhir.jpa.dao.BaseStorageDao.deleteByUrlThresholdExceeded=Failed to DELETE resources with match URL "{0}" because the resolved number of resources: {1} exceeds the threshold of {2}
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithIdNotMatchFailure=Failed to {0} resource with match URL "{1}" because the matching resource does not match the provided ID
-ca.uhn.fhir.jpa.dao.BaseStorageDao.resourceTypeAndFhirIdConflictAcrossPartitions=Failed to create resource {0}/{1} in partition {2} because the same resource type and ID exist in another partition
 ca.uhn.fhir.jpa.dao.BaseTransactionProcessor.multiplePartitionAccesses=Can not process transaction with {0} entries: Entries require access to multiple/conflicting partitions
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.transactionOperationFailedNoId=Failed to {0} resource in transaction because no ID was provided
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.transactionOperationFailedUnknownId=Failed to {0} resource in transaction because no resource could be found with ID {1}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7095-fix-resource-overwritten-when-creating-in-a-different-partition.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7095-fix-resource-overwritten-when-creating-in-a-different-partition.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7095
+title: "When database partition mode was enabled and the cross-partition reference mode was set to ALLOWED_UNQUALIFIED, 
+creating a resource with a forced ID that already existed for the same resource type in a different partition would 
+overwrite the existing resource. This issue has now been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -2850,6 +2850,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	 * @param theEntity             The entity being updated
 	 * @throws InvalidRequestException if the partition IDs do not match for the same resource type and FHIR ID
 	 */
+	@VisibleForTesting
 	protected void validatePartitionIdMatch(
 			@Nonnull IIdType theResourceIdType,
 			@Nonnull RequestPartitionId theRequestPartitionId,
@@ -2860,9 +2861,8 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 
 		boolean sameResType = StringUtils.equals(theEntity.getResourceType(), theResourceIdType.getResourceType());
 		boolean sameFhirId = StringUtils.equals(theResourceIdType.getIdPart(), theEntity.getFhirId());
-		boolean differentPartition = !Objects.equals(
-				theRequestPartitionId.getFirstPartitionIdOrNull(),
-				theEntity.getPartitionId().getPartitionId());
+		boolean differentPartition =
+				!theRequestPartitionId.isPartition(theEntity.getPartitionId().getPartitionId());
 
 		if (sameResType && sameFhirId && differentPartition) {
 			String msg = getContext()

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -2845,9 +2845,9 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 	 * and FHIR ID of the entity match those of the provided resource ID type, and that the partition IDs are equal.
 	 * If there is a mismatch, an {@link InvalidRequestException} is thrown.
 	 *
-	 * @param theResourceIdType      The resource ID type being processed
-	 * @param theRequestPartitionId  The partition ID from the request
-	 * @param theEntity              The entity being updated
+	 * @param theResourceIdType     The resource ID type being processed
+	 * @param theRequestPartitionId The partition ID from the request
+	 * @param theEntity             The entity being updated
 	 * @throws InvalidRequestException if the partition IDs do not match for the same resource type and FHIR ID
 	 */
 	protected void validatePartitionIdMatch(
@@ -2868,7 +2868,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			String msg = getContext()
 					.getLocalizer()
 					.getMessageSanitized(
-							BaseStorageDao.class,
+							BaseHapiFhirDao.class,
 							"resourceTypeAndFhirIdConflictAcrossPartitions",
 							theEntity.getResourceType(),
 							theResourceIdType.getIdPart(),

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
@@ -305,7 +305,8 @@ class BaseHapiFhirResourceDaoTest {
 
 		// Verify
 		assertThat(exception.getMessage()).isEqualTo(
-			"HAPI-2733: Failed to create/update resource \"%s/%s\" in partition %s because the same resource type and ID exist in another partition"
+			("HAPI-2733: Failed to create/update resource [%s/%s] in partition %s because a resource of " +
+				"the same type and ID is found in another partition")
 				.formatted(RESOURCE_TYPE, RESOURCE_ID, requestPartitionId.getFirstPartitionNameOrNull()
 			));
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
@@ -76,10 +76,10 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -265,13 +265,10 @@ class BaseHapiFhirResourceDaoTest {
 		entity.setResourceType(RESOURCE_TYPE);
 		entity.setFhirId(RESOURCE_ID);
 
-		// Execute
-		mySvc.validatePartitionIdMatch(requestId, requestPartitionId, entity);
-
-		// Verify
-		assertTrue(true, "No exception should be thrown when resource type, Id and partition all match");
-
+		// Execute/Verify
+		assertDoesNotThrow(() -> mySvc.validatePartitionIdMatch(requestId, requestPartitionId, entity));
 	}
+
 	@Test
 	public void testValidatePartitionIdMatch_doNothingOnAllPartitions() {
 		// set up
@@ -280,10 +277,7 @@ class BaseHapiFhirResourceDaoTest {
 		ResourceTable entity = new ResourceTable();
 
 		// Execute
-		mySvc.validatePartitionIdMatch(requestId, requestPartitionId, entity);
-
-		// Verify
-		assertTrue(true, "No exception should be thrown when partition ID is all partitions");
+		assertDoesNotThrow(() -> mySvc.validatePartitionIdMatch(requestId, requestPartitionId, entity));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDaoTest.java
@@ -255,7 +255,7 @@ class BaseHapiFhirResourceDaoTest {
 	}
 
 	@Test
-	public void testValidatePartitionIdMatch_validOnMatchedResourceTypeAndIdAndPartitionMatch() {
+	public void testValidatePartitionIdMatch_validOnMatchedResourceTypeAndIdAndPartition() {
 		// set up
 		IIdType requestId = new IdDt(RESOURCE_TYPE, RESOURCE_ID);
 		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(1);
@@ -287,7 +287,7 @@ class BaseHapiFhirResourceDaoTest {
 	}
 
 	@Test
-	public void testCreateValidatePartitionIdMatch_throwsExceptionOnPartitionMismatch() {
+	public void testValidatePartitionIdMatch_throwExceptionOnPartitionMismatch() {
 		// set up
 		ResourceTable entity = new ResourceTable();
 		entity.setPartitionId(new PartitionablePartitionId(1, LocalDate.now()));
@@ -305,7 +305,7 @@ class BaseHapiFhirResourceDaoTest {
 
 		// Verify
 		assertThat(exception.getMessage()).isEqualTo(
-			"HAPI-2733: Failed to create resource %s/%s in partition %s because the same resource type and ID exist in another partition"
+			"HAPI-2733: Failed to create/update resource \"%s/%s\" in partition %s because the same resource type and ID exist in another partition"
 				.formatted(RESOURCE_TYPE, RESOURCE_ID, requestPartitionId.getFirstPartitionNameOrNull()
 			));
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitioningAllowedUnqualifiedR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/PartitioningAllowedUnqualifiedR4Test.java
@@ -1,0 +1,96 @@
+package ca.uhn.fhir.jpa.dao.r4;
+
+import ca.uhn.fhir.jpa.model.config.PartitionSettings;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static ca.uhn.fhir.jpa.model.config.PartitionSettings.CrossPartitionReferenceMode.ALLOWED_UNQUALIFIED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PartitioningAllowedUnqualifiedR4Test extends BasePartitioningR4Test {
+	@BeforeEach
+	public void beforeEach() {
+		myPartitionSettings.setAllowReferencesAcrossPartitions(ALLOWED_UNQUALIFIED);
+	}
+
+	@AfterEach
+	@Override
+	public void after() {
+		PartitionSettings defaultPartitionSettings = new PartitionSettings();
+		myPartitionSettings.setIncludePartitionInSearchHashes(defaultPartitionSettings.isIncludePartitionInSearchHashes());
+		myPartitionSettings.setPartitioningEnabled(defaultPartitionSettings.isPartitioningEnabled());
+		myPartitionSettings.setAllowReferencesAcrossPartitions(defaultPartitionSettings.getAllowReferencesAcrossPartitions());
+		myPartitionSettings.setDefaultPartitionId(defaultPartitionSettings.getDefaultPartitionId());
+
+		mySrdInterceptorService.unregisterInterceptorsIf(MyReadWriteInterceptor.class::isInstance);
+
+	}
+
+	@Test
+	public void testCreate_differentForcedIdInDifferentPartition_created() {
+		// Set up
+		addNextTargetPartitionForCreateWithId(myPartitionId, myPartitionDate);
+		Patient p1 = createPatient("Patient/P1");
+		addNextTargetPartitionForCreateWithId(myPartitionId2, myPartitionDate2);
+		Patient p2 = createPatient("Patient/P2");
+
+		// Execute/Verify
+		runInTransaction(() -> {
+			IIdType p1Id = myPatientDao.update(p1, mySrd).getId();
+			assertNotNull(p1Id);
+			assertThat(p1Id.getIdPart()).isEqualTo("P1");
+
+			IIdType p2Id = myPatientDao.update(p2, mySrd).getId();
+			assertNotNull(p2Id);
+			assertThat(p2Id.getIdPart()).isEqualTo("P2");
+
+			// Verify that the resources are created in the correct partition
+			ResourceTable entity1 = myResourceTableDao.findByTypeAndFhirId(p1Id.getResourceType(), p1Id.getIdPart())
+				.orElseThrow(IllegalArgumentException::new);
+			ResourceTable entity2 = myResourceTableDao.findByTypeAndFhirId(p1Id.getResourceType(), p2Id.getIdPart())
+				.orElseThrow(IllegalArgumentException::new);
+
+			assertThat(entity1.getPartitionId().getPartitionId()).isEqualTo(myPartitionId);
+			assertThat(entity2.getPartitionId().getPartitionId()).isEqualTo(myPartitionId2);
+		});
+	}
+
+	@Test
+	public void testCreate_reuseForcedIdInDifferentPartition_throwException() {
+		// Set up
+		addNextTargetPartitionForCreateWithId(myPartitionId, myPartitionDate);
+		Patient p1 = createPatient("Patient/P");
+		IIdType idType = myPatientDao.update(p1, mySrd).getId();
+
+		assertNotNull(idType);
+		assertThat(idType.getIdPart()).isEqualTo("P");
+
+		// Create the same resource in a different partition
+		addNextTargetPartitionForCreateWithId(myPartitionId2, myPartitionDate2);
+		Patient p2 = createPatient("Patient/P");
+
+		// Execute
+		InvalidRequestException exception = assertThrows(
+			InvalidRequestException.class,
+			() -> myPatientDao.update(p2, mySrd)
+		);
+
+		// Verify
+		assertThat(exception.getMessage()).isEqualTo("HAPI-2733: Failed to create/update resource [Patient/P] " +
+			"in partition PART-2 because a resource of the same type and ID is found in another partition");
+	}
+
+	private Patient createPatient(String theId) {
+		Patient p = new Patient();
+		p.setId(theId);
+		p.setActive(true);
+		return p;
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
@@ -1,8 +1,6 @@
 package ca.uhn.fhir.jpa.interceptor;
 
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
@@ -17,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PatientCompartmentEnforcingInterceptorTest extends BaseResourceProviderR4Test {
@@ -77,9 +76,12 @@ public class PatientCompartmentEnforcingInterceptorTest extends BaseResourceProv
 		// try updating observation's patient, which would cross partition boundaries
 		obs.getSubject().setReference("Patient/B");
 
-		InvalidRequestException thrown = assertThrows(InvalidRequestException.class, () -> myObservationDao.update(obs, new SystemRequestDetails()));
-		assertEquals("HAPI-2733: Failed to create/update resource \"Observation/" + obsId +
-				"\" in partition B because the same resource type and ID exist in another partition",
+		InvalidRequestException thrown = assertThrows(
+			InvalidRequestException.class,
+			() -> myObservationDao.update(obs, new SystemRequestDetails())
+		);
+		assertEquals("HAPI-2733: Failed to create/update resource [Observation/" + obsId + "] " +
+				"in partition B because a resource of the same type and ID is found in another partition",
 			thrown.getMessage()
 		);
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
@@ -10,11 +10,14 @@ import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Annotation;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,13 +77,16 @@ public class PatientCompartmentEnforcingInterceptorTest extends BaseResourceProv
 
 		Observation obs = new Observation();
 		obs.getSubject().setReference("Patient/A");
-		myObservationDao.create(obs, new SystemRequestDetails());
+		String obsId = myObservationDao.create(obs, new SystemRequestDetails()).getId().getIdPart();
 
 		// try updating observation's patient, which would cross partition boundaries
 		obs.getSubject().setReference("Patient/B");
 
-		InternalErrorException thrown = assertThrows(InternalErrorException.class, () -> myObservationDao.update(obs, new SystemRequestDetails()));
-		assertEquals("HAPI-2476: Resource compartment changed. Was a referenced Patient changed?", thrown.getMessage());
+		InvalidRequestException thrown = assertThrows(InvalidRequestException.class, () -> myObservationDao.update(obs, new SystemRequestDetails()));
+		assertEquals("HAPI-2733: Failed to create/update resource \"Observation/" + obsId +
+				"\" in partition B because the same resource type and ID exist in another partition",
+			thrown.getMessage()
+		);
 	}
 
 	@ParameterizedTest

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
@@ -1,7 +1,5 @@
 package ca.uhn.fhir.jpa.interceptor;
 
-import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
-
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -9,15 +7,12 @@ import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Annotation;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
With persistence database_partition_mode.enabled=true AND cross_partition_reference_mode =ALLOWED_UNQUALIFIED, reusing a forced id in a create with update on a different partition (say B) will overwrite the resource on partition A.  For this scenario to occur, the create with update issued on partition B needs to have a common forced Id but different properties like family Name.

### Cause

When creating a resource with forcedId and the provided partition config settings, the server searches the resource using the resource type and forced Id across all partitions. Therefore, the existing resource with the same type and Id in a different partition is found, leading to the existing resource being updated and overwritten.

### Solution

Once a resource is found by the request resource type and ID, add a validation check to ensure the partition ID matches. Since resource type and ID  are unique across partitions as per [**HAPI documentation on Partitioning**](https://hapifhir.io/hapi-fhir/docs/server_jpa_partitioning/partitioning.html):

> In a partitioned repository, it is important to understand that only a single pool of resource IDs exists. In other words, only one resource with the ID Patient/1 can exist across all partitions, and it must be in a single partition.

we can stop the new resource creation (or existing resource update in this case) if the request partition Id does not match that of the loaded resource entity. Server then returns 400 with detailed error message in the response.

Closes #7095 