### PR TITLE
added undo-replace-references operation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7101-undo-replace-references.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7101-undo-replace-references.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 7101
+title: "A new system level operation, named `$hapi.fhir.undo-replace-references` has been added. This operation
+  restores the resources that were updated by a `$hapi.fhir.replace-references` operation to their previous versions."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -186,8 +186,10 @@ import ca.uhn.fhir.jpa.validation.JpaValidationSupportChain;
 import ca.uhn.fhir.jpa.validation.ResourceLoaderImpl;
 import ca.uhn.fhir.jpa.validation.ValidationSettings;
 import ca.uhn.fhir.model.api.IPrimitiveDatatype;
+import ca.uhn.fhir.replacereferences.PreviousResourceVersionRestorer;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesPatchBundleSvc;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc;
+import ca.uhn.fhir.replacereferences.UndoReplaceReferencesSvc;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IDeleteExpungeJobSubmitter;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
@@ -1021,6 +1023,20 @@ public class JpaConfig {
 	@Bean
 	public ReplaceReferencesPatchBundleSvc replaceReferencesPatchBundleSvc(DaoRegistry theDaoRegistry) {
 		return new ReplaceReferencesPatchBundleSvc(theDaoRegistry);
+	}
+
+	@Bean
+	public PreviousResourceVersionRestorer resourceVersionRestorer(
+			DaoRegistry theDaoRegistry, HapiTransactionService theHapiTransactionService) {
+		return new PreviousResourceVersionRestorer(theDaoRegistry, theHapiTransactionService);
+	}
+
+	@Bean
+	public UndoReplaceReferencesSvc getUndoReplaceReferencesSvc(
+			DaoRegistry theDaoRegistry,
+			ReplaceReferencesProvenanceSvc theProvenanceSvc,
+			PreviousResourceVersionRestorer theResourceVersionRestorer) {
+		return new UndoReplaceReferencesSvc(theDaoRegistry, theProvenanceSvc, theResourceVersionRestorer);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaSystemProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaSystemProvider.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.search.reindex.IResourceReindexingSvc;
 import ca.uhn.fhir.jpa.term.api.ITermReadSvc;
 import ca.uhn.fhir.jpa.term.api.ReindexTerminologyResult;
+import ca.uhn.fhir.replacereferences.UndoReplaceReferencesSvc;
 import ca.uhn.fhir.rest.annotation.At;
 import ca.uhn.fhir.rest.annotation.History;
 import ca.uhn.fhir.rest.annotation.Offset;
@@ -72,6 +73,9 @@ public abstract class BaseJpaSystemProvider<T, MT> extends BaseStorageSystemProv
 	@Autowired
 	private IReplaceReferencesSvc myReplaceReferencesSvc;
 
+	@Autowired
+	private UndoReplaceReferencesSvc myUndoReplaceReferencesSvc;
+
 	public BaseJpaSystemProvider() {
 		// nothing
 	}
@@ -82,6 +86,10 @@ public abstract class BaseJpaSystemProvider<T, MT> extends BaseStorageSystemProv
 
 	public IReplaceReferencesSvc getReplaceReferencesSvc() {
 		return myReplaceReferencesSvc;
+	}
+
+	public UndoReplaceReferencesSvc getUndoReplaceReferencesSvc() {
+		return myUndoReplaceReferencesSvc;
 	}
 
 	@History

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaSystemProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaSystemProvider.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.model.api.annotation.Description;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesRequest;
+import ca.uhn.fhir.replacereferences.UndoReplaceReferencesRequest;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.annotation.Transaction;
@@ -56,6 +57,7 @@ import java.util.TreeMap;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_TASK;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_SOURCE_REFERENCE_ID;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_TARGET_REFERENCE_ID;
+import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_UNDO_REPLACE_REFERENCES;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static software.amazon.awssdk.utils.StringUtils.isBlank;
@@ -213,6 +215,48 @@ public final class JpaSystemProvider<T, MT> extends BaseJpaSystemProvider<T, MT>
 			return retval;
 		} finally {
 			endRequest(theServletRequest);
+		}
+	}
+
+	@Operation(name = OPERATION_UNDO_REPLACE_REFERENCES, global = true)
+	@Description(
+			value =
+					"This operation undoes the effects of a previous $hapi.fhir.replace-references operation by restoring "
+							+ "references that were replaced from the target back to the original source.",
+			shortDefinition =
+					"Restores references from target back to source for resources that were previously updated by a $hapi.fhir.replace-references operation.")
+	public IBaseParameters undoReplaceReferences(
+			@OperationParam(
+							name = ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_SOURCE_REFERENCE_ID,
+							min = 1,
+							typeName = "string")
+					IPrimitiveType<String> theSourceId,
+			@OperationParam(
+							name = ProviderConstants.OPERATION_REPLACE_REFERENCES_PARAM_TARGET_REFERENCE_ID,
+							min = 1,
+							typeName = "string")
+					IPrimitiveType<String> theTargetId,
+			ServletRequestDetails theRequestDetails) {
+		startRequest(theRequestDetails);
+
+		try {
+
+			validateReplaceReferencesParams(theSourceId, theTargetId);
+
+			IdDt sourceId = new IdDt(theSourceId.getValue());
+			IdDt targetId = new IdDt(theTargetId.getValue());
+
+			RequestPartitionId partitionId = myRequestPartitionHelperSvc.determineReadPartitionForRequest(
+					theRequestDetails, ReadPartitionIdRequestDetails.forRead(targetId));
+
+			int resourceLimit = myStorageSettings.getInternalSynchronousSearchSize();
+
+			UndoReplaceReferencesRequest undoReplaceReferencesRequest =
+					new UndoReplaceReferencesRequest(sourceId, targetId, partitionId, resourceLimit);
+
+			return getUndoReplaceReferencesSvc().undoReplaceReferences(undoReplaceReferencesRequest, theRequestDetails);
+		} finally {
+			endRequest(theRequestDetails);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/PatientMergeR4Test.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.provider.r4;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData;
 import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper;
 import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.model.api.IProvenanceAgent;
@@ -42,6 +43,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.provider.ReplaceReferencesSvcImpl.RESOURCE_TYPES_SYSTEM;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES;
 import static ca.uhn.fhir.rest.api.Constants.HEADER_PREFER;
 import static ca.uhn.fhir.rest.api.Constants.HEADER_PREFER_RESPOND_ASYNC;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_MERGE;
@@ -68,6 +71,8 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 	
 	ReplaceReferencesTestHelper myTestHelper;
 
+	ReplaceReferencesLargeTestData myLargeTestData;
+
 	@Override
 	@AfterEach
 	public void after() throws Exception {
@@ -88,7 +93,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		// verify that Provenance resources were saved with versioned target references
 		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
 		myTestHelper = new ReplaceReferencesTestHelper(myFhirContext, myDaoRegistry);
-		myTestHelper.beforeEach();
+		myLargeTestData = new ReplaceReferencesLargeTestData(myDaoRegistry);
 	}
 
 	private void waitForAsyncTaskCompletion(Parameters theOutParams) {
@@ -124,9 +129,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		Reference outputRef = (Reference) taskOutput.getValue();
 		Bundle patchResultBundle = (Bundle) outputRef.getResource();
 		assertTrue(containedBundle.equalsDeep(patchResultBundle));
-		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
-			ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES,
-			List.of("Observation", "Encounter", "CarePlan"));
+		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, TOTAL_EXPECTED_PATCHES, RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED);
 
 
 		OperationOutcome outcome = (OperationOutcome) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_OUTCOME).getResource();
@@ -154,7 +157,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		// In sync mode, the result patient is returned in the output,
 		// assert what is returned is the same as the one in the db
 		Patient targetPatientInOutput = (Patient) theOutParams.getParameter(OPERATION_MERGE_OUTPUT_PARAM_RESULT).getResource();
-		Patient targetPatientReadFromDB = myTestHelper.readTargetPatient();
+		Patient targetPatientReadFromDB = myTestHelper.readPatient(myLargeTestData.getTargetPatientId());
 		IParser parser = myFhirContext.newJsonParser();
 		assertThat(parser.encodeResourceToString(targetPatientInOutput)).isEqualTo(parser.encodeResourceToString(targetPatientReadFromDB));
 	}
@@ -196,12 +199,12 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 	})
 	public void testMerge(boolean withDelete, boolean withInputResultPatient, boolean withPreview, boolean isAsync) {
 		// setup
-
+		myLargeTestData.createTestResources();
 		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
-		myTestHelper.setSourceAndTarget(inParams);
+		myTestHelper.setSourceAndTarget(inParams, myLargeTestData);
 		inParams.deleteSource = withDelete;
 		if (withInputResultPatient) {
-			inParams.resultPatient = myTestHelper.createResultPatient(withDelete);
+			inParams.resultPatient = myLargeTestData.createResultPatientInput(withDelete);
 		}
 		if (withPreview) {
 			inParams.preview = true;
@@ -229,12 +232,12 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		assertTrue(input.equalsDeep(inParameters));
 
 		List<Identifier> expectedIdentifiersOnTargetAfterMerge =
-			myTestHelper.getExpectedIdentifiersForTargetAfterMerge(withInputResultPatient);
+			myLargeTestData.getExpectedIdentifiersForTargetAfterMerge(withInputResultPatient);
 
 
 		if (withPreview) {
 			validatePreviewModeOutcome(outParams);
-			myTestHelper.assertNothingChanged();
+			myTestHelper.assertReferencesHaveNotChanged(myLargeTestData);
 			//no more validation is needed in preview mode, so we can return early
 			return;
 		}
@@ -247,10 +250,10 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		}
 
 		// Check that the linked resources were updated
-		myTestHelper.assertAllReferencesUpdated(withDelete);
-		myTestHelper.assertSourcePatientUpdatedOrDeletedAfterMerge(withDelete);
-		myTestHelper.assertTargetPatientUpdatedAfterMerge(withDelete, expectedIdentifiersOnTargetAfterMerge);
-		myTestHelper.assertMergeProvenance(withDelete, null);
+		myTestHelper.assertAllReferencesUpdated(true, withDelete, myLargeTestData);
+		myTestHelper.assertSourcePatientUpdatedOrDeletedAfterMerge(myLargeTestData.getSourcePatientId(), myLargeTestData.getTargetPatientId(), withDelete);
+		myTestHelper.assertTargetPatientUpdatedAfterMerge(myLargeTestData.getTargetPatientId(), myLargeTestData.getSourcePatientId(), withDelete, expectedIdentifiersOnTargetAfterMerge);
+		myTestHelper.assertMergeProvenance(withDelete, myLargeTestData,  null);
 	}
 
 
@@ -263,7 +266,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		"true, true",
 	})
 	void testMerge_withProvenanceAgentInterceptor_Success(boolean theIsAsync, boolean theAgentInterceptorReturnsMultipleAgents) {
-
+		myLargeTestData.createTestResources();
 		List<IProvenanceAgent> agents = new ArrayList<>();
 		agents.add(myTestHelper.createTestProvenanceAgent());
 		if (theAgentInterceptorReturnsMultipleAgents) {
@@ -273,7 +276,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		ReplaceReferencesTestHelper.registerProvenanceAgentInterceptor(myServer.getRestfulServer(), agents);
 
 		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
-		myTestHelper.setSourceAndTarget(inParams);
+		myTestHelper.setSourceAndTarget(inParams, myLargeTestData);
 
 		Parameters inParameters = inParams.asParametersResource();
 
@@ -288,7 +291,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 			validateSyncOutcome(outParams);
 		}
 
-		myTestHelper.assertMergeProvenance(false, agents);
+		myTestHelper.assertMergeProvenance(false, myLargeTestData, agents);
 	}
 
 	@ParameterizedTest(name = "{index}: isAsync={0}")
@@ -302,7 +305,6 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		ReplaceReferencesTestHelper.registerProvenanceAgentInterceptor(myServer.getRestfulServer(), Collections.emptyList());
 
 		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
-		myTestHelper.setSourceAndTarget(inParams);
 
 		Parameters inParameters = inParams.asParametersResource();
 
@@ -318,8 +320,9 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	void testMerge_smallResourceLimit() {
+		myLargeTestData.createTestResources();
 		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
-		myTestHelper.setSourceAndTarget(inParams);
+		myTestHelper.setSourceAndTarget(inParams, myLargeTestData);
 
 		inParams.resourceLimit = 5;
 		Parameters inParameters = inParams.asParametersResource();
@@ -327,7 +330,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		// exec
 		assertThatThrownBy(() -> callMergeOperation(inParameters, false))
 			.isInstanceOf(PreconditionFailedException.class)
-			.satisfies(ex -> assertThat(extractFailureMessage((BaseServerResponseException) ex)).isEqualTo("HAPI-2597: Number of resources with references to "+ myTestHelper.getSourcePatientId() + " exceeds the resource-limit 5. Submit the request asynchronsly by adding the HTTP Header 'Prefer: respond-async'."));
+			.satisfies(ex -> assertThat(extractFailureMessage((BaseServerResponseException) ex)).isEqualTo("HAPI-2597: Number of resources with references to "+ myLargeTestData.getSourcePatientId() + " exceeds the resource-limit 5. Submit the request asynchronsly by adding the HTTP Header 'Prefer: respond-async'."));
 	}
 
 	@ParameterizedTest(name = "{index}: deleteSource={0}, async={1}")
@@ -337,7 +340,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		"true, true",
 		"false, true",
 	})
-	void testMerge_sourceResourceWithoutAnyReference(boolean theDeleteSource, boolean theAsync) {
+	void testMerge_SourceResourceNotReferencedByAnyResource_ShouldSucceedAndCreateProvenance(boolean theDeleteSource, boolean theAsync) {
 
 		Patient sourcePatient = new Patient();
 		sourcePatient = (Patient) myPatientDao.create(sourcePatient, mySrd).getResource();
@@ -387,8 +390,9 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	void testMerge_SourceResourceCannotBeDeletedBecauseAnotherResourceReferencingSourceWasAddedWhileJobIsRunning_JobFails() {
+		myLargeTestData.createTestResources();
 		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = new ReplaceReferencesTestHelper.PatientMergeInputParameters();
-		myTestHelper.setSourceAndTarget(inParams);
+		myTestHelper.setSourceAndTarget(inParams, myLargeTestData);
 		inParams.deleteSource = true;
 		//using a small batch size that would result in multiple chunks to ensure that
 		//the job runs a bit slowly so that we have sometime to add a resource that references the source
@@ -413,7 +417,7 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 
 		Encounter enc = new Encounter();
 		enc.setStatus(Encounter.EncounterStatus.ARRIVED);
-		enc.getSubject().setReferenceElement(myTestHelper.getSourcePatientId());
+		enc.getSubject().setReferenceElement(myLargeTestData.getSourcePatientId());
 		myEncounterDao.create(enc, mySrd);
 
 		myBatch2JobHelper.awaitJobFailure(jobId);
@@ -436,7 +440,8 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		"false, false, false",
 	})
 	public void testMultipleTargetMatchesFails(boolean withDelete, boolean withInputResultPatient, boolean withPreview) {
-		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = myTestHelper.buildMultipleTargetMatchParameters(withDelete, withInputResultPatient, withPreview);
+		myLargeTestData.createTestResources();
+		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = myTestHelper.buildMultipleTargetMatchParameters(withDelete, withInputResultPatient, withPreview, myLargeTestData);
 
 		Parameters inParameters = inParams.asParametersResource();
 
@@ -457,7 +462,8 @@ public class PatientMergeR4Test extends BaseResourceProviderR4Test {
 		"false, false, false",
 	})
 	public void testMultipleSourceMatchesFails(boolean withDelete, boolean withInputResultPatient, boolean withPreview) {
-		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = myTestHelper.buildMultipleSourceMatchParameters(withDelete, withInputResultPatient, withPreview);
+		myLargeTestData.createTestResources();
+		ReplaceReferencesTestHelper.PatientMergeInputParameters inParams = myTestHelper.buildMultipleSourceMatchParameters(withDelete, withInputResultPatient, withPreview, myLargeTestData);
 
 		Parameters inParameters = inParams.asParametersResource();
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.provider.r4;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData;
 import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper;
 import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
@@ -11,6 +12,9 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.base.Sys;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
@@ -21,6 +25,7 @@ import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.Task;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,8 +41,10 @@ import java.util.List;
 import java.util.Set;
 
 import static ca.uhn.fhir.jpa.provider.ReplaceReferencesSvcImpl.RESOURCE_TYPES_SYSTEM;
-import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper.EXPECTED_SMALL_BATCHES;
-import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.EXPECTED_SMALL_BATCHES;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.SMALL_BATCH_SIZE;
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME;
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	ReplaceReferencesTestHelper myTestHelper;
+	ReplaceReferencesLargeTestData myLargeTestData;
 
 	@Override
 	@AfterEach
@@ -65,7 +73,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		// verify that Provenance resources were saved with versioned target references
 		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
 		myTestHelper = new ReplaceReferencesTestHelper(myFhirContext, myDaoRegistry);
-		myTestHelper.beforeEach();
+		myLargeTestData = new ReplaceReferencesLargeTestData(myDaoRegistry);
 	}
 
 
@@ -74,7 +82,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		//update the source resource for it to have a different version than the target resource.
 		//The reason is to test that when creating the ReplaceReferencesJobParameters object in async mode
 		//we pass the correct versions for target and source.
-		Patient srcPatient = myTestHelper.readSourcePatient();
+		Patient srcPatient = myTestHelper.readPatient(myLargeTestData.getSourcePatientId());
 		srcPatient.setActive(!srcPatient.getActive());
 		String srcResourceVersion = myClient.update().resource(srcPatient).execute().getId().getVersionIdPart();
 		assertThat(srcResourceVersion).isEqualTo("2");
@@ -84,19 +92,16 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	@ValueSource(booleans = {false, true})
 	void testReplaceReferences(boolean isAsync) {
 
+		myLargeTestData.createTestResources();
 		updateSourcePatientToIncrementItsVersion();
 
-		Bundle patchResultBundle = executeReplaceReferences(isAsync);
+		Bundle patchResultBundle = executeReplaceReferences(myLargeTestData.getSourcePatientId(), myLargeTestData.getTargetPatientId(), isAsync);
 
 		// validate
-		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
-			ReplaceReferencesTestHelper.TOTAL_EXPECTED_PATCHES, List.of(
-				"Observation", "Encounter", "CarePlan"));
-
+		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES, RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED);
 		// Check that the linked resources were updated
-
-		myTestHelper.assertAllReferencesUpdated();
-		myTestHelper.assertReplaceReferencesProvenance("2", "1", null);
+		myTestHelper.assertAllReferencesUpdated(myLargeTestData);
+		myTestHelper.assertReplaceReferencesProvenance("2", "1", myLargeTestData, null);
 	}
 
 	@ParameterizedTest(name = "{index}: isAsync={0}, theAgentInterceptorReturnsMultipleAgents={1}")
@@ -107,7 +112,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		"true, true",
 	})
 	void testReplaceReferences_WithProvenanceAgentInterceptor_Success(boolean theIsAsync, boolean theAgentInterceptorReturnsMultipleAgents) {
-
+		myLargeTestData.createTestResources();
 		List<IProvenanceAgent> agents = new ArrayList<>();
 		agents.add(myTestHelper.createTestProvenanceAgent());
 		if (theAgentInterceptorReturnsMultipleAgents) {
@@ -116,16 +121,14 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		// this interceptor will be unregistered in @AfterEach of the base class, which unregisters all interceptors
 		ReplaceReferencesTestHelper.registerProvenanceAgentInterceptor(myServer.getRestfulServer(), agents);
 
-		Bundle patchResultBundle = executeReplaceReferences(theIsAsync);
+		Bundle patchResultBundle = executeReplaceReferences(myLargeTestData.getSourcePatientId(), myLargeTestData.getTargetPatientId(), theIsAsync);
 
 		// validate
-		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
-			TOTAL_EXPECTED_PATCHES, List.of(
-				"Observation", "Encounter", "CarePlan"));
+		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES, RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED);
 
 		// Check that the linked resources were updated
-		myTestHelper.assertAllReferencesUpdated();
-		myTestHelper.assertReplaceReferencesProvenance("1", "1", agents);
+		myTestHelper.assertAllReferencesUpdated(myLargeTestData);
+		myTestHelper.assertReplaceReferencesProvenance("1", "1", myLargeTestData, agents);
 	}
 
 
@@ -138,8 +141,9 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 
 		// this interceptor will be unregistered in @AfterEach of the base class, which unregisters all interceptors
 		ReplaceReferencesTestHelper.registerProvenanceAgentInterceptor(myServer.getRestfulServer(), Collections.emptyList());
-
-		assertThatThrownBy(() -> executeReplaceReferences(theIsAsync)
+		IIdType srcId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless();
+		IIdType targetId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless();
+		assertThatThrownBy(() -> executeReplaceReferences(srcId, targetId, theIsAsync)
 		).isInstanceOf(InternalErrorException.class)
 			.hasMessageContaining("HAPI-2723: No Provenance Agent was provided by any interceptor for Pointcut.PROVENANCE_AGENTS")
 			.extracting(InternalErrorException.class::cast)
@@ -148,9 +152,13 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	}
 
 
-	private Bundle executeReplaceReferences(boolean isAsync) {
+	private Bundle executeReplaceReferences(IIdType theSourceId, IIdType theTargetId, boolean isAsync) {
 		// exec
-		Parameters outParams = myTestHelper.callReplaceReferences(myClient, isAsync);
+		Parameters outParams = myTestHelper.callReplaceReferences(myClient,
+			theSourceId,
+			theTargetId,
+			isAsync,
+			null);
 
 		assertThat(outParams.getParameter()).hasSize(1);
 
@@ -171,6 +179,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		return patchResultBundle;
 	}
 
+
 	private JobInstance awaitJobCompletion(Task task) {
 		String jobId = myTestHelper.getJobIdFromTask(task);
 		return myBatch2JobHelper.awaitJobCompletion(jobId);
@@ -178,17 +187,27 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	void testReplaceReferencesSmallResourceLimitSync() {
-		assertThatThrownBy(() -> myTestHelper.callReplaceReferencesWithResourceLimit(myClient, false, ReplaceReferencesTestHelper.SMALL_BATCH_SIZE))
+		myLargeTestData.createTestResources();
+		assertThatThrownBy(() -> myTestHelper.callReplaceReferences(myClient,
+			myLargeTestData.getSourcePatientId().toString(),
+			myLargeTestData.getTargetPatientId().toString(),
+			false,
+			SMALL_BATCH_SIZE))
 			.isInstanceOf(PreconditionFailedException.class)
-			.hasMessage("HTTP 412 Precondition Failed: HAPI-2597: Number of resources with references to " + myTestHelper.getSourcePatientId() + " exceeds the resource-limit 5. Submit the request asynchronsly by adding the HTTP Header 'Prefer: respond-async'.");
+			.hasMessage("HTTP 412 Precondition Failed: HAPI-2597: Number of resources with references to " + myLargeTestData.getSourcePatientId() + " exceeds the resource-limit 5. Submit the request asynchronsly by adding the HTTP Header 'Prefer: respond-async'.");
 	}
 
 	@Test
 	void testReplaceReferencesSmallTransactionEntriesSize() {
+		myLargeTestData.createTestResources();
 		myStorageSettings.setDefaultTransactionEntriesForWrite(5);
 
 		// exec
-		Parameters outParams = myTestHelper.callReplaceReferencesWithResourceLimit(myClient, true, ReplaceReferencesTestHelper.SMALL_BATCH_SIZE);
+		Parameters outParams = myTestHelper.callReplaceReferences(myClient,
+			myLargeTestData.getSourcePatientId(),
+			myLargeTestData.getTargetPatientId(),
+			true,
+			SMALL_BATCH_SIZE);
 
 		assertThat(getLastHttpStatusCode()).isEqualTo(HttpServletResponse.SC_ACCEPTED);
 
@@ -234,18 +253,16 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 			int numberOfEntriesInCurrentBundle = patchResultBundle.getEntry().size();
 			// validate
 			totalPatchResultEntriesSeen += numberOfEntriesInCurrentBundle;
-			assertThat(numberOfEntriesInCurrentBundle).isBetween(1, ReplaceReferencesTestHelper.SMALL_BATCH_SIZE);
-			ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, numberOfEntriesInCurrentBundle, List.of(
-				"Observation",
-				"Encounter", "CarePlan"));
+			assertThat(numberOfEntriesInCurrentBundle).isBetween(1, SMALL_BATCH_SIZE);
+			ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, numberOfEntriesInCurrentBundle, RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED);
 		}
 
 		assertThat(totalPatchResultEntriesSeen).isEqualTo(TOTAL_EXPECTED_PATCHES);
 
 		// Check that the linked resources were updated
 
-		myTestHelper.assertAllReferencesUpdated();
-		myTestHelper.assertReplaceReferencesProvenance("1", "1", null);
+		myTestHelper.assertAllReferencesUpdated(myLargeTestData);
+		myTestHelper.assertReplaceReferencesProvenance("1", "1", myLargeTestData, null);
 	}
 
 	@ParameterizedTest
@@ -253,7 +270,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	@NullSource
 	void testReplaceReferences_MissingSourceId_ThrowsInvalidRequestException(String theSourceId) {
 		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
-			myTestHelper.callReplaceReferencesWithResourceLimit(myClient, theSourceId, "target-id", false, null);
+			myTestHelper.callReplaceReferences(myClient, theSourceId, "target-id", false, null);
 		});
 		assertThat(exception.getMessage()).contains("HAPI-2583: Parameter 'source-reference-id' is blank");
 	}
@@ -263,7 +280,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	@NullSource
 	void testReplaceReferences_MissingTargetId_ThrowsInvalidRequestException(String theTargetId) {
 		InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
-			myTestHelper.callReplaceReferencesWithResourceLimit(myClient, "source-id", theTargetId, false, null);
+			myTestHelper.callReplaceReferences(myClient, "source-id", theTargetId, false, null);
 		});
 		assertThat(exception.getMessage()).contains("HAPI-2584: Parameter 'target-reference-id' is blank");
 	}
@@ -272,9 +289,9 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	@ValueSource(booleans = {false, true})
 	void testReplaceReferences_NotExistingSourceId_ThrowsNotFoundException(boolean theIsAsync) {
 		String nonExistingSourceId = "Patient/does-not-exist";
-		String targetId = myTestHelper.getTargetPatientId().getValue();
+		String targetId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless().toString();
 		assertThatThrownBy(() -> {
-			myTestHelper.callReplaceReferencesWithResourceLimit(myClient, nonExistingSourceId, targetId, theIsAsync, null);
+			myTestHelper.callReplaceReferences(myClient, nonExistingSourceId, targetId, theIsAsync, null);
 		}).isInstanceOf(ResourceNotFoundException.class)
 			.hasMessageContaining("HAPI-2001: Resource Patient/does-not-exist is not known");
 	}
@@ -284,9 +301,9 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 	@ValueSource(booleans = {false, true})
 	void testReplaceReferences_NotExistingTargetId_ThrowsNotFoundException(boolean theIsAsync) {
 		String nonExistingTargetId = "Patient/does-not-exist";
-		String sourceId = myTestHelper.getSourcePatientId().getValue();
+		String sourceId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless().toString();
 		assertThatThrownBy(() -> {
-			myTestHelper.callReplaceReferencesWithResourceLimit(myClient, nonExistingTargetId, sourceId, theIsAsync, null);
+			myTestHelper.callReplaceReferences(myClient, nonExistingTargetId, sourceId, theIsAsync, null);
 		}).isInstanceOf(ResourceNotFoundException.class)
 			.hasMessageContaining("HAPI-2001: Resource Patient/does-not-exist is not known");
 	}
@@ -304,7 +321,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		IIdType observationId = createObservationWithPerformers(practitionerId1, practitionerId2).toUnqualifiedVersionless();
 
 		// Call $replace-references operation to replace practitionerId1 with practitionerId3
-		Parameters outParams = myTestHelper.callReplaceReferencesWithResourceLimit(myClient,
+		Parameters outParams = myTestHelper.callReplaceReferences(myClient,
 			practitionerId1.toString(),
 			practitionerId3.toString(),
 			false,
@@ -313,9 +330,7 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		// Assert operation outcome
 		Bundle patchResultBundle = (Bundle) outParams.getParameter(OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME).getResource();
 
-		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle,
-			1, List.of(
-				"Observation"));
+		ReplaceReferencesTestHelper.validatePatchResultBundle(patchResultBundle, 1, List.of( "Observation"));
 
 		// Fetch and validate updated observation
 		Observation updatedObservation = myClient
@@ -335,22 +350,14 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 
 	@Test
 	void testReplaceReferences_ShouldNotReplaceVersionedReferences() {
-		// this configuration makes preserve versioned references in the Provenance.target
-		// so that we can test that the versioned reference was not replaced
-		// but keep a copy of the original configuration to restore it after the test
-		Set<String> originalNotStrippedPaths =
-			myFhirContext.getParserOptions().getDontStripVersionsFromReferencesAtPaths();
-		myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths("Provenance.target");
-		try {
-
 			IIdType practitionerId1 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
 			IIdType practitionerId2 = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
 
 			Provenance provenance = new Provenance();
 			provenance.addTarget(new Reference(practitionerId1));
 			IIdType provenanceId = myClient.create().resource(provenance).execute().getId();
-			// Call $replace-references operation to replace practitionerId1 with practitionerId3
-			myTestHelper.callReplaceReferencesWithResourceLimit(myClient,
+			// Call $replace-references operation to replace practitionerId1 with practitionerId2
+			myTestHelper.callReplaceReferences(myClient,
 				practitionerId1.toVersionless().toString(),
 				practitionerId2.toVersionless().toString(),
 				false,
@@ -368,12 +375,8 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 				.map(ref -> ref.getReferenceElement().toString())
 				.toList();
 
-			// Assert that the versioned reference in the Provenance  was not replaced
+			// Assert that the versioned reference in the Provenance was not replaced
 			assertThat(actualTargetIds).containsExactly(practitionerId1.toString());
-
-		} finally {
-			myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths(originalNotStrippedPaths);
-		}
 	}
 
 	private IIdType createObservationWithPerformers(IIdType... performerIds) {
@@ -388,6 +391,65 @@ public class ReplaceReferencesR4Test extends BaseResourceProviderR4Test {
 		// Store the observation resource via the FHIR client
 		return myClient.create().resource(observation).execute().getId();
 
+	}
+
+	@Test
+	void testReplaceReferences_ResourceHasMultipleReferencesToTheSameResource() {
+		IIdType srcPractitionerId = myClient.create().resource(new Practitioner()).execute().getId().toUnqualifiedVersionless();
+		// Create a ServiceRequest where requester and performer refer to the practitioner
+		ServiceRequest serviceRequest = new ServiceRequest();
+		serviceRequest.setRequester(new Reference(srcPractitionerId));
+		serviceRequest.addPerformer(new Reference(srcPractitionerId));
+		IIdType serviceRequestId = myClient.create().resource(serviceRequest).execute().getId().toUnqualified();
+		IIdType targetPractitionerId = myClient.create().resource(new Practitioner()).execute().getId().toUnqualified();
+
+		// Call $replace-references operation to replace practitionerId1 with practitionerId3
+		 myTestHelper.callReplaceReferences(myClient,
+			srcPractitionerId.toVersionless().toString(),
+			targetPractitionerId.toVersionless().toString(),
+			false,
+			null);
+
+		// ensure that both references to the srcPractitionerId were replaced with the targetPractitionerId
+		ServiceRequest updatedServiceReq = myClient.read().resource(ServiceRequest.class).withId(serviceRequestId.toVersionless()).execute();
+		assertThat(updatedServiceReq.getRequester().getReference()).isEqualTo(targetPractitionerId.toVersionless().toString());
+		assertThat(updatedServiceReq.getPerformer().get(0).getReference()).isEqualTo(targetPractitionerId.toVersionless().toString());
+		// the ServiceRequest resource should have been updated only once, so it should have version 2
+		assertThat(updatedServiceReq.getIdElement().getVersionIdPart()).isEqualTo("2");
+
+		myTestHelper.assertReplaceReferencesProvenance(
+			srcPractitionerId.withVersion("1"),
+			targetPractitionerId.withVersion("1"),
+			1,
+			Set.of(serviceRequestId.withVersion("2").toString()),
+			null
+		);
+	}
+
+
+	@ParameterizedTest
+	@CsvSource (value = {
+		"false",
+		"true"
+	})
+	void testReplaceReferences_SourceResourceNotReferencedByAnyResource_SucceedAndShouldNotCreateAProvenance(boolean theIsAsync) {
+
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless();
+
+		Parameters outParams = myTestHelper.callReplaceReferences(myClient,
+			sourcePatientId,
+			targetPatientId,
+			theIsAsync,
+			null);
+
+		if (theIsAsync) {
+			Task task = (Task) outParams.getParameter(OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_TASK).getResource();
+			awaitJobCompletion(task);
+		}
+
+		List<IBaseResource> provenances = myTestHelper.searchProvenance(targetPatientId.toString());
+		assertThat(provenances).isEmpty();
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ReplaceReferencesR4Test.java
@@ -12,8 +12,6 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.jena.base.Sys;
-import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/UndoReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/UndoReplaceReferencesR4Test.java
@@ -1,0 +1,380 @@
+package ca.uhn.fhir.jpa.provider.r4;
+
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData;
+import ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesTestHelper;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInputAndPartialOutput;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Provenance;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This test class tests the $hapi.fhir.undo-replace-references operation for R4.
+ */
+public class UndoReplaceReferencesR4Test extends BaseResourceProviderR4Test {
+	ReplaceReferencesTestHelper myTestHelper;
+	ReplaceReferencesLargeTestData myLargeTestData;
+	@Override
+	@AfterEach
+	public void after() throws Exception {
+		super.after();
+	}
+
+	@Override
+	@BeforeEach
+	public void before() throws Exception {
+		super.before();
+		// we need to keep the version on Provenance.target fields to
+		// verify that Provenance resources were saved with versioned target references
+		myFhirContext.getParserOptions().setStripVersionsFromReferences(false);
+		myTestHelper = new ReplaceReferencesTestHelper(myFhirContext, myDaoRegistry);
+		myLargeTestData = new ReplaceReferencesLargeTestData(myDaoRegistry);
+	}
+
+
+
+	@Test
+	public void testUndoReplaceReferences_OneReferencingResource_Success() {
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+
+		Encounter encounter = new Encounter();
+		encounter.getSubject().setReference(sourcePatientId.getValue());
+		IIdType encounterId = myEncounterDao.create(encounter, srd).getId().toUnqualifiedVersionless();
+
+		myTestHelper.callReplaceReferences(myClient, sourcePatientId, targetPatientId, false);
+
+		Parameters outputParams = callUndoReplaceReferences(myClient, sourcePatientId, targetPatientId);
+
+		validateOutputParameters(outputParams, 1);
+
+		// --- Validation: Read Encounter and check subject and version ---
+		Encounter updatedEncounter = myEncounterDao.read(encounterId, srd);
+		// the subject reference should be reverted to the source patient
+		assertThat(updatedEncounter.getSubject().getReference()).isEqualTo(sourcePatientId.getValue());
+		assertThat(updatedEncounter.getIdElement().getVersionIdPart()).isEqualTo("3");
+	}
+
+	@Test
+	public void testUndoReplaceReferences_Success() {
+		myLargeTestData.createTestResources();
+
+		IIdType sourcePatientId = myLargeTestData.getSourcePatientId();
+		IIdType targetPatientId = myLargeTestData.getTargetPatientId();
+
+		myTestHelper.callReplaceReferences(myClient,
+			sourcePatientId,
+			targetPatientId,
+			false);
+
+		Parameters outputParams = callUndoReplaceReferences(myClient,
+			sourcePatientId,
+			targetPatientId);
+
+		validateOutputParameters(outputParams, TOTAL_EXPECTED_PATCHES);
+
+		myTestHelper.assertReferencesHaveNotChanged(myLargeTestData);
+
+		// When undo is called a second time, it should fail because resources have already been updated after the replace-references operation took place (by the first undo operation)
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, sourcePatientId, targetPatientId))
+			.isInstanceOf(ResourceVersionConflictException.class)
+			.hasMessageContaining("HAPI-2732")
+			.hasMessageContaining("does not match the expected version");
+
+		myTestHelper.assertReferencesHaveNotChanged(myLargeTestData);
+	}
+
+
+	@Test
+	public void testUndoReplaceReferences_WhenReplaceReferencesWereRunMultipleTimeOnSameTrgAndSrc_UndoesTheMostRecentOne() {
+		// In this test we run replace-references twice on the same source and target IDs.
+		// In the first run, an Encounter referencing the source patient would be updated to reference the target.
+		// After the first operation, we create another Encounter that references the source patient,
+		// and we run replace-references again, which should update this Encounter to reference the target patient too.
+		// Then we call undo. The undo would revert the second replace-references operation,
+		// so the second Encounter should reference the source patient again, but the first one should still reference the target patient.
+		// What we are testing here is that when the undo operation finds multiple Provenance resources for the same source and target IDs,
+		// and it would use the most recent one.
+
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+
+		Encounter encounter1 = new Encounter();
+		encounter1.setSubject(new Reference(sourcePatientId));
+		IIdType encounterId1 = myEncounterDao.create(encounter1, srd).getId().toUnqualifiedVersionless();
+
+		myTestHelper.callReplaceReferences(myClient, sourcePatientId, targetPatientId, false);
+
+		Encounter encounter2 = new Encounter();
+		encounter2.setSubject(new Reference(sourcePatientId));
+		IIdType encounterId2 = myEncounterDao.create(encounter2, srd).getId().toUnqualifiedVersionless();
+
+		myTestHelper.callReplaceReferences(myClient, sourcePatientId, targetPatientId, false);
+
+		callUndoReplaceReferences(myClient, sourcePatientId, targetPatientId);
+
+		// validate encounter2, references the source patient again
+		Encounter updatedEncounter2 = myEncounterDao.read(encounterId2, srd);
+		assertThat(updatedEncounter2.getSubject().getReference()).isEqualTo(sourcePatientId.getValue());
+
+		//validate encounter1, references the target patient
+		Encounter updatedEncounter1 = myEncounterDao.read(encounterId1, srd);
+		assertThat(updatedEncounter1.getSubject().getReference()).isEqualTo(targetPatientId.getValue());
+	}
+
+	@Test
+	public void testUndoReplaceReferences_ReferencingResourceGotDeletedAfterReplaceReferences_Fails() {
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+
+		// create 2 encounters referencing the source patient
+		Encounter encounter1 = new Encounter();
+		encounter1.getSubject().setReference(sourcePatientId.getValue());
+		IIdType encounterId1 = myEncounterDao.create(encounter1, srd).getId().toUnqualifiedVersionless();
+		Encounter encounter2 = new Encounter();
+		encounter2.getSubject().setReference(sourcePatientId.getValue());
+		IIdType encounterId2 = myEncounterDao.create(encounter2, srd).getId().toUnqualifiedVersionless();
+
+		myTestHelper.callReplaceReferences(myClient, sourcePatientId, targetPatientId, false);
+
+		// delete one of the encounters
+		myEncounterDao.delete(encounterId2, srd);
+
+		// calling undo should fail because one of the referencing resources was updated
+		// (deleted in this case) after the replace-references operation
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, sourcePatientId, targetPatientId))
+			.isInstanceOf(ResourceGoneException.class);
+
+		// the existing Encounter should not change because of the failed undo: the undo operation is transactional
+		Encounter existingEncounter = myEncounterDao.read(encounterId1, srd);
+		// the subject reference should be to the target patient
+		assertThat(existingEncounter.getSubject().getReference()).isEqualTo(targetPatientId.getValue());
+		assertThat(existingEncounter.getIdElement().getVersionIdPart()).isEqualTo("2");
+	}
+
+	@Test
+	void testUndoReplaceReferences_NotExistingSourceId_ThrowsNotFoundException() {
+		String nonExistingSourceId = "Patient/does-not-exist";
+		String targetId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless().toString();
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, nonExistingSourceId, targetId))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("HAPI-2001: Resource Patient/does-not-exist is not known");
+	}
+
+	@Test
+	void testUndoReplaceReferences_NotExistingTargetId_ThrowsNotFoundException() {
+		String nonExistingTargetId = "Patient/does-not-exist";
+		String srcId = myPatientDao.create(new Patient(), mySrd).getId().toUnqualifiedVersionless().toString();
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, srcId, nonExistingTargetId))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("HAPI-2001: Resource Patient/does-not-exist is not known");
+	}
+
+	@Test
+	public void testUndoReplaceReferences_ResourceLimitExceeded() {
+		myLargeTestData.createTestResources();
+
+		// Set the resource limit to a small number to trigger the exception
+		JpaStorageSettings storageSettings = myStorageSettings;
+		int originalLimit = storageSettings.getInternalSynchronousSearchSize();
+		storageSettings.setInternalSynchronousSearchSize(5);
+
+		try {
+			IIdType srcId = myLargeTestData.getSourcePatientId();
+			IIdType tgtId = myLargeTestData.getTargetPatientId();
+			myTestHelper.callReplaceReferences(myClient, srcId, tgtId, false);
+
+			assertThatThrownBy(() -> callUndoReplaceReferences(myClient, srcId, tgtId))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining("HAPI-2729")
+				.hasMessageContaining("Number of references to update (" + TOTAL_EXPECTED_PATCHES + ") exceeds the limit (5)");
+		} finally {
+			// Restore the original limit
+			storageSettings.setInternalSynchronousSearchSize(originalLimit);
+		}
+	}
+
+	@Test
+	public void testUndoReplaceReferences_WithoutReplaceReferencesProvenance_Fails() {
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualifiedVersionless();
+
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, sourcePatientId, targetPatientId))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("HAPI-2728: Unable to find a Provenance created by a $hapi.fhir.replace-references for the provided source and target IDs");
+	}
+
+
+	@Test
+	public void testUndoReplaceReferences_ProvenanceExistsButActivityIsIncorrect_Fails() {
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualified();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualified();
+
+		Provenance provenance = new Provenance();
+		provenance.addTarget(new Reference(targetPatientId));
+		provenance.addTarget(new Reference(sourcePatientId));
+
+		provenance.setActivity(new CodeableConcept().addCoding(new Coding()
+			.setSystem("http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle")
+			.setCode("some-other-activity")));
+		myProvenanceDao.create(provenance, srd);
+
+		IIdType versionlessSourceId = sourcePatientId.toVersionless();
+		IIdType versionlessTargetId = targetPatientId.toVersionless();
+
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, versionlessSourceId, versionlessTargetId))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("HAPI-2728: Unable to find a Provenance created by a $hapi.fhir.replace-references for the provided source and target IDs");
+	}
+
+
+	@Test
+	public void testUndoReplaceReferences_ProvenanceExistsButSourceAndTargetOrderIsIncorrect_Fails() {
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualified();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualified();
+
+		// in the provenance, the target resource should be the first element in the 'provenance.target' collection
+		// and the source resource the second. Create one that is in wrong order
+		Provenance provenance = new Provenance();
+		provenance.addTarget(new Reference(sourcePatientId));
+		provenance.addTarget(new Reference(targetPatientId));
+
+
+		provenance.setActivity(new CodeableConcept().addCoding(new Coding()
+			.setSystem("http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle")
+			.setCode("link")));
+		myProvenanceDao.create(provenance, srd);
+
+		IIdType versionlessSourceId = sourcePatientId.toVersionless();
+		IIdType versionlessTargetId = targetPatientId.toVersionless();
+
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, versionlessSourceId, versionlessTargetId))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("HAPI-2728: Unable to find a Provenance created by a $hapi.fhir.replace-references for the provided source and target IDs");
+	}
+
+
+	@Test
+	public void testUndoReplaceReferences_ProvenanceContainingAVersionlessTargetReference_Fails() {
+		SystemRequestDetails srd = new SystemRequestDetails();
+		IIdType sourcePatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualified();
+		IIdType targetPatientId = myPatientDao.create(new Patient(), srd).getId().toUnqualified();
+
+		Provenance provenance = new Provenance();
+		provenance.addTarget(new Reference(targetPatientId));
+		provenance.addTarget(new Reference(sourcePatientId));
+		IIdType encounterId = myEncounterDao.create(new Encounter(), srd).getId().toUnqualified();
+
+		provenance.setActivity(new CodeableConcept().addCoding(new Coding()
+			.setSystem("http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle")
+			.setCode("link")));
+
+		// add a target reference with no version
+		provenance.addTarget(new Reference(encounterId.toVersionless().toString()));
+
+		myProvenanceDao.create(provenance, srd);
+
+		IIdType versionlessSourceId = sourcePatientId.toVersionless();
+		IIdType versionlessTargetId = targetPatientId.toVersionless();
+
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, versionlessSourceId, versionlessTargetId))
+			.isInstanceOf(InternalErrorException.class)
+			.hasMessageContaining("HAPI-2730: Reference does not have a version: " + encounterId.toVersionless().toString());
+	}
+
+
+
+
+	@ParameterizedTest
+	@ValueSource(strings = {""})
+	@NullSource
+	void testUndoReplaceReferences_MissingSourceId_ThrowsInvalidRequestException(String theSourceId) {
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, theSourceId, "target-id"))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("HAPI-2583: Parameter 'source-reference-id' is blank");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {""})
+	@NullSource
+	void testUndoReplaceReferences_MissingTargetId_ThrowsInvalidRequestException(String theTargetId) {
+		assertThatThrownBy(() -> callUndoReplaceReferences(myClient, "source-id", theTargetId))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("HAPI-2584: Parameter 'target-reference-id' is blank");
+	}
+
+
+	private void validateOutputParameters(Parameters theOutputParams, int theNumberOfExpectedUpdates) {
+		assertThat(theOutputParams).isNotNull();
+		assertThat(theOutputParams.getParameter()).hasSize(1);
+		OperationOutcome outcome = (OperationOutcome) theOutputParams.getParameter("outcome").getResource();
+		String expectedMsgPattern = String.format("Successfully restored %d resources to their previous versions based on the Provenance resource: Provenance/[0-9]+/_history/1", theNumberOfExpectedUpdates) ;
+		assertThat(outcome.getIssue())
+			.hasSize(1)
+			.element(0)
+			.satisfies(issue -> {
+				assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.INFORMATION);
+				assertThat(issue.getDiagnostics()).matches(expectedMsgPattern);
+			});
+
+	}
+
+	public Parameters callUndoReplaceReferences(
+		IGenericClient theFhirClient,
+		IIdType theSourceId,
+		IIdType theTargetId) {
+		return callUndoReplaceReferences(theFhirClient, theSourceId.toString(), theTargetId.toString());
+	}
+
+	public Parameters callUndoReplaceReferences(
+		IGenericClient theFhirClient,
+		String theSourceId,
+		String theTargetId) {
+		IOperationUntypedWithInputAndPartialOutput<Parameters> request = theFhirClient
+			.operation()
+			.onServer()
+			.named("$hapi.fhir.undo-replace-references")
+			.withParameter(
+				Parameters.class,
+				"source-reference-id",
+				new StringType(theSourceId))
+			.andParameter(
+				"target-reference-id",
+				new StringType(theTargetId));
+
+		return request.returnResourceType(Parameters.class).execute();
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/UndoReplaceReferencesR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/UndoReplaceReferencesR4Test.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static ca.uhn.fhir.jpa.replacereferences.ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This test class tests the $hapi.fhir.undo-replace-references operation for R4.

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesLargeTestData.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesLargeTestData.java
@@ -1,0 +1,227 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server Test Utilities
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.replacereferences;
+
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDaoPatient;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.CarePlan;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This is class that creates many resources for the ReplaceReferences and Merge tests.
+ * The class also contains some methods that makes it easier to validate the results of the operations according to the
+ * relationships between the resources it creates.
+ */
+public class ReplaceReferencesLargeTestData {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(ReplaceReferencesLargeTestData.class);
+
+	static final Identifier pat1IdentifierA =
+			new Identifier().setSystem("SYS1A").setValue("VAL1A");
+	static final Identifier pat1IdentifierB =
+			new Identifier().setSystem("SYS1B").setValue("VAL1B");
+	static final Identifier pat2IdentifierA =
+			new Identifier().setSystem("SYS2A").setValue("VAL2A");
+	static final Identifier pat2IdentifierB =
+			new Identifier().setSystem("SYS2B").setValue("VAL2B");
+	static final Identifier patBothIdentifierC =
+			new Identifier().setSystem("SYSC").setValue("VALC");
+	public static final int TOTAL_EXPECTED_PATCHES = 23;
+	public static final int SMALL_BATCH_SIZE = 5;
+	public static final int EXPECTED_SMALL_BATCHES = (TOTAL_EXPECTED_PATCHES + SMALL_BATCH_SIZE - 1) / SMALL_BATCH_SIZE;
+	public static final List<String> RESOURCE_TYPES_EXPECTED_TO_BE_PATCHED =
+			List.of("Observation", "Encounter", "CarePlan");
+	private final IFhirResourceDaoPatient<Patient> myPatientDao;
+	private final IFhirResourceDao<Organization> myOrganizationDao;
+	private final IFhirResourceDao<Encounter> myEncounterDao;
+	private final IFhirResourceDao<CarePlan> myCarePlanDao;
+	private final IFhirResourceDao<Observation> myObservationDao;
+
+	private IIdType myOrgId;
+
+	private IIdType mySourcePatientId;
+	private IIdType mySourceCarePlanId;
+	private IIdType mySourceEncId1;
+	private IIdType mySourceEncId2;
+	private ArrayList<IIdType> mySourceObsIds;
+
+	private IIdType myTargetPatientId;
+	private IIdType myTargetEnc1;
+
+	private final Set<IIdType> myResourceIdsInitiallyReferencingSource = new HashSet<>();
+	private final Set<IIdType> myResourceIdsInitiallyReferencingTarget = new HashSet<>();
+
+	private final Set<IIdType> myResourceIdsInitiallyReferencedBySource = new HashSet<>();
+	private final Set<IIdType> myResourceIdsInitiallyReferencedByTarget = new HashSet<>();
+
+	private final SystemRequestDetails mySrd = new SystemRequestDetails();
+
+	public ReplaceReferencesLargeTestData(DaoRegistry theDaoRegistry) {
+		myPatientDao = (IFhirResourceDaoPatient<Patient>) theDaoRegistry.getResourceDao(Patient.class);
+		myOrganizationDao = theDaoRegistry.getResourceDao(Organization.class);
+		myEncounterDao = theDaoRegistry.getResourceDao(Encounter.class);
+		myCarePlanDao = theDaoRegistry.getResourceDao(CarePlan.class);
+		myObservationDao = theDaoRegistry.getResourceDao(Observation.class);
+	}
+
+	public void createTestResources() {
+
+		Organization org = new Organization();
+		org.setName("an org");
+		myOrgId = myOrganizationDao.create(org, mySrd).getId().toUnqualifiedVersionless();
+		ourLog.info("OrgId: {}", myOrgId);
+
+		Patient patient1 = new Patient();
+		patient1.getManagingOrganization().setReferenceElement(myOrgId);
+		patient1.addIdentifier(pat1IdentifierA);
+		patient1.addIdentifier(pat1IdentifierB);
+		patient1.addIdentifier(patBothIdentifierC);
+		mySourcePatientId = myPatientDao.create(patient1, mySrd).getId().toUnqualifiedVersionless();
+		myResourceIdsInitiallyReferencedBySource.add(myOrgId);
+
+		Patient patient2 = new Patient();
+		patient2.addIdentifier(pat2IdentifierA);
+		patient2.addIdentifier(pat2IdentifierB);
+		patient2.addIdentifier(patBothIdentifierC);
+		patient2.getManagingOrganization().setReferenceElement(myOrgId);
+		myTargetPatientId = myPatientDao.create(patient2, mySrd).getId().toUnqualifiedVersionless();
+		myResourceIdsInitiallyReferencedByTarget.add(myOrgId);
+
+		Encounter enc1 = new Encounter();
+		enc1.setStatus(Encounter.EncounterStatus.CANCELLED);
+		enc1.getSubject().setReferenceElement(mySourcePatientId);
+		enc1.getServiceProvider().setReferenceElement(myOrgId);
+		mySourceEncId1 = myEncounterDao.create(enc1, mySrd).getId().toUnqualifiedVersionless();
+		myResourceIdsInitiallyReferencingSource.add(mySourceEncId1);
+
+		Encounter enc2 = new Encounter();
+		enc2.setStatus(Encounter.EncounterStatus.ARRIVED);
+		enc2.getSubject().setReferenceElement(mySourcePatientId);
+		enc2.getServiceProvider().setReferenceElement(myOrgId);
+		mySourceEncId2 = myEncounterDao.create(enc2, mySrd).getId().toUnqualifiedVersionless();
+		myResourceIdsInitiallyReferencingSource.add(mySourceEncId2);
+
+		CarePlan carePlan = new CarePlan();
+		carePlan.setStatus(CarePlan.CarePlanStatus.ACTIVE);
+		carePlan.getSubject().setReferenceElement(mySourcePatientId);
+		mySourceCarePlanId = myCarePlanDao.create(carePlan, mySrd).getId().toUnqualifiedVersionless();
+		myResourceIdsInitiallyReferencingSource.add(mySourceCarePlanId);
+
+		Encounter targetEnc1 = new Encounter();
+		targetEnc1.setStatus(Encounter.EncounterStatus.ARRIVED);
+		targetEnc1.getSubject().setReferenceElement(myTargetPatientId);
+		targetEnc1.getServiceProvider().setReferenceElement(myOrgId);
+		this.myTargetEnc1 = myEncounterDao.create(targetEnc1, mySrd).getId().toUnqualifiedVersionless();
+		myResourceIdsInitiallyReferencingTarget.add(myTargetEnc1);
+
+		mySourceObsIds = new ArrayList<>();
+		for (int i = 0; i < 20; i++) {
+			Observation obs = new Observation();
+			obs.getSubject().setReferenceElement(mySourcePatientId);
+			obs.setStatus(Observation.ObservationStatus.FINAL);
+			IIdType obsId = myObservationDao.create(obs, mySrd).getId().toUnqualifiedVersionless();
+			mySourceObsIds.add(obsId);
+		}
+		myResourceIdsInitiallyReferencingSource.addAll(mySourceObsIds);
+	}
+
+	public Patient createResultPatientInput(boolean theDeleteSource) {
+		Patient resultPatient = new Patient();
+		resultPatient.setIdElement((IdType) myTargetPatientId);
+		resultPatient.addIdentifier(pat1IdentifierA);
+		if (!theDeleteSource) {
+			// add the link only if we are not deleting the source
+			Patient.PatientLinkComponent link = resultPatient.addLink();
+			link.setOther(new Reference(mySourcePatientId));
+			link.setType(Patient.LinkType.REPLACES);
+		}
+		return resultPatient;
+	}
+
+	public List<Identifier> getExpectedIdentifiersForTargetAfterMerge(boolean theWithInputResultPatient) {
+
+		List<Identifier> expectedIdentifiersOnTargetAfterMerge;
+		if (theWithInputResultPatient) {
+			expectedIdentifiersOnTargetAfterMerge =
+					List.of(new Identifier().setSystem("SYS1A").setValue("VAL1A"));
+		} else {
+			// the identifiers copied over from source should be marked as old
+			expectedIdentifiersOnTargetAfterMerge = List.of(
+					new Identifier().setSystem("SYS2A").setValue("VAL2A"),
+					new Identifier().setSystem("SYS2B").setValue("VAL2B"),
+					new Identifier().setSystem("SYSC").setValue("VALC"),
+					new Identifier().setSystem("SYS1A").setValue("VAL1A").copy().setUse(Identifier.IdentifierUse.OLD),
+					new Identifier().setSystem("SYS1B").setValue("VAL1B").copy().setUse(Identifier.IdentifierUse.OLD));
+		}
+		return expectedIdentifiersOnTargetAfterMerge;
+	}
+
+	public IIdType getSourcePatientId() {
+		return mySourcePatientId;
+	}
+
+	public IIdType getTargetPatientId() {
+		return myTargetPatientId;
+	}
+
+	public Set<IIdType> getResourceIdsInitiallyReferencingSource() {
+		return Collections.unmodifiableSet(myResourceIdsInitiallyReferencingSource);
+	}
+
+	public Set<IIdType> getResourceIdsInitiallyReferencingTarget() {
+		return Collections.unmodifiableSet(myResourceIdsInitiallyReferencingTarget);
+	}
+
+	public Set<IIdType> getResourceIdsInitiallyReferencedByTarget() {
+		return Collections.unmodifiableSet(myResourceIdsInitiallyReferencedByTarget);
+	}
+
+	public Set<IIdType> getResourceIdsInitiallyReferencedBySource() {
+		return Collections.unmodifiableSet(myResourceIdsInitiallyReferencedBySource);
+	}
+
+	public Set<String> getExpectedProvenanceTargetsForPatchedResources() {
+		return myResourceIdsInitiallyReferencingSource.stream()
+				.map(resId -> (resId.withVersion("2").toString()))
+				.collect(Collectors.toSet());
+	}
+
+	public Identifier getIdentifierCommonToBothResources() {
+		return patBothIdentifierC;
+	}
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesTestHelper.java
@@ -47,15 +47,10 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.CarePlan;
 import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Encounter;
-import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
-import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
@@ -72,8 +67,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -93,36 +86,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ReplaceReferencesTestHelper {
 	private static final Logger ourLog = LoggerFactory.getLogger(ReplaceReferencesTestHelper.class);
 
-	static final Identifier pat1IdentifierA =
-			new Identifier().setSystem("SYS1A").setValue("VAL1A");
-	static final Identifier pat1IdentifierB =
-			new Identifier().setSystem("SYS1B").setValue("VAL1B");
-	static final Identifier pat2IdentifierA =
-			new Identifier().setSystem("SYS2A").setValue("VAL2A");
-	static final Identifier pat2IdentifierB =
-			new Identifier().setSystem("SYS2B").setValue("VAL2B");
-	static final Identifier patBothIdentifierC =
-			new Identifier().setSystem("SYSC").setValue("VALC");
-	public static final int TOTAL_EXPECTED_PATCHES = 23;
-	public static final int SMALL_BATCH_SIZE = 5;
-	public static final int EXPECTED_SMALL_BATCHES = (TOTAL_EXPECTED_PATCHES + SMALL_BATCH_SIZE - 1) / SMALL_BATCH_SIZE;
 	private final IFhirResourceDaoPatient<Patient> myPatientDao;
 	private final IFhirResourceDao<Task> myTaskDao;
-	private final IFhirResourceDao<Organization> myOrganizationDao;
-	private final IFhirResourceDao<Encounter> myEncounterDao;
-	private final IFhirResourceDao<CarePlan> myCarePlanDao;
-	private final IFhirResourceDao<Observation> myObservationDao;
 	private final IFhirResourceDao<Provenance> myProvenanceDao;
 	private final IFhirResourceDao<Practitioner> myPractitionerDao;
-
-	private IIdType myOrgId;
-	private IIdType mySourcePatientId;
-	private IIdType mySourceCarePlanId;
-	private IIdType mySourceEncId1;
-	private IIdType mySourceEncId2;
-	private ArrayList<IIdType> mySourceObsIds;
-	private IIdType myTargetPatientId;
-	private IIdType myTargetEnc1;
 
 	private final FhirContext myFhirContext;
 	private final SystemRequestDetails mySrd = new SystemRequestDetails();
@@ -132,101 +99,18 @@ public class ReplaceReferencesTestHelper {
 		myFhirContext = theFhirContext;
 		myPatientDao = (IFhirResourceDaoPatient<Patient>) theDaoRegistry.getResourceDao(Patient.class);
 		myTaskDao = theDaoRegistry.getResourceDao(Task.class);
-		myOrganizationDao = theDaoRegistry.getResourceDao(Organization.class);
-		myEncounterDao = theDaoRegistry.getResourceDao(Encounter.class);
-		myCarePlanDao = theDaoRegistry.getResourceDao(CarePlan.class);
-		myObservationDao = theDaoRegistry.getResourceDao(Observation.class);
 		myProvenanceDao = theDaoRegistry.getResourceDao(Provenance.class);
 		myPractitionerDao = theDaoRegistry.getResourceDao(Practitioner.class);
 		myJsonParser = myFhirContext.newJsonParser();
 	}
 
-	public void beforeEach() {
-
-		Organization org = new Organization();
-		org.setName("an org");
-		myOrgId = myOrganizationDao.create(org, mySrd).getId().toUnqualifiedVersionless();
-		ourLog.info("OrgId: {}", myOrgId);
-
-		Patient patient1 = new Patient();
-		patient1.getManagingOrganization().setReferenceElement(myOrgId);
-		patient1.addIdentifier(pat1IdentifierA);
-		patient1.addIdentifier(pat1IdentifierB);
-		patient1.addIdentifier(patBothIdentifierC);
-		mySourcePatientId = myPatientDao.create(patient1, mySrd).getId().toUnqualifiedVersionless();
-
-		Patient patient2 = new Patient();
-		patient2.addIdentifier(pat2IdentifierA);
-		patient2.addIdentifier(pat2IdentifierB);
-		patient2.addIdentifier(patBothIdentifierC);
-		patient2.getManagingOrganization().setReferenceElement(myOrgId);
-		myTargetPatientId = myPatientDao.create(patient2, mySrd).getId().toUnqualifiedVersionless();
-
-		Encounter enc1 = new Encounter();
-		enc1.setStatus(Encounter.EncounterStatus.CANCELLED);
-		enc1.getSubject().setReferenceElement(mySourcePatientId);
-		enc1.getServiceProvider().setReferenceElement(myOrgId);
-		mySourceEncId1 = myEncounterDao.create(enc1, mySrd).getId().toUnqualifiedVersionless();
-
-		Encounter enc2 = new Encounter();
-		enc2.setStatus(Encounter.EncounterStatus.ARRIVED);
-		enc2.getSubject().setReferenceElement(mySourcePatientId);
-		enc2.getServiceProvider().setReferenceElement(myOrgId);
-		mySourceEncId2 = myEncounterDao.create(enc2, mySrd).getId().toUnqualifiedVersionless();
-
-		CarePlan carePlan = new CarePlan();
-		carePlan.setStatus(CarePlan.CarePlanStatus.ACTIVE);
-		carePlan.getSubject().setReferenceElement(mySourcePatientId);
-		mySourceCarePlanId = myCarePlanDao.create(carePlan, mySrd).getId().toUnqualifiedVersionless();
-
-		Encounter targetEnc1 = new Encounter();
-		targetEnc1.setStatus(Encounter.EncounterStatus.ARRIVED);
-		targetEnc1.getSubject().setReferenceElement(myTargetPatientId);
-		targetEnc1.getServiceProvider().setReferenceElement(myOrgId);
-		this.myTargetEnc1 = myEncounterDao.create(targetEnc1, mySrd).getId().toUnqualifiedVersionless();
-
-		mySourceObsIds = new ArrayList<>();
-		for (int i = 0; i < 20; i++) {
-			Observation obs = new Observation();
-			obs.getSubject().setReferenceElement(mySourcePatientId);
-			obs.setStatus(Observation.ObservationStatus.FINAL);
-			IIdType obsId = myObservationDao.create(obs, mySrd).getId().toUnqualifiedVersionless();
-			mySourceObsIds.add(obsId);
-		}
-	}
-
-	public void setSourceAndTarget(PatientMergeInputParameters inParams) {
-		inParams.sourcePatient = new Reference().setReferenceElement(mySourcePatientId);
-		inParams.targetPatient = new Reference().setReferenceElement(myTargetPatientId);
-	}
-
-	public Patient createResultPatient(boolean theDeleteSource) {
-		Patient resultPatient = new Patient();
-		resultPatient.setIdElement((IdType) myTargetPatientId);
-		resultPatient.addIdentifier(pat1IdentifierA);
-		if (!theDeleteSource) {
-			// add the link only if we are not deleting the source
-			Patient.PatientLinkComponent link = resultPatient.addLink();
-			link.setOther(new Reference(mySourcePatientId));
-			link.setType(Patient.LinkType.REPLACES);
-		}
-		return resultPatient;
-	}
-
-	public Patient readSourcePatient() {
-		return readPatient(mySourcePatientId);
-	}
-
-	public Patient readTargetPatient() {
-		return readPatient(myTargetPatientId);
+	public void setSourceAndTarget(PatientMergeInputParameters inParams, ReplaceReferencesLargeTestData theTestData) {
+		inParams.sourcePatient = new Reference().setReferenceElement(theTestData.getSourcePatientId());
+		inParams.targetPatient = new Reference().setReferenceElement(theTestData.getTargetPatientId());
 	}
 
 	public Patient readPatient(IIdType thePatientId) {
 		return myPatientDao.read(thePatientId, mySrd);
-	}
-
-	public IIdType getTargetPatientId() {
-		return myTargetPatientId;
 	}
 
 	public ProvenanceAgent createTestProvenanceAgent() {
@@ -247,33 +131,44 @@ public class ReplaceReferencesTestHelper {
 	}
 
 	public void assertReplaceReferencesProvenance(
-			String theExpectedSourcePatientVersion,
-			String theExpectedTargetPatientVersion,
+			String theExpectedSourceResourceVersion,
+			String theExpectedTargetResourceVersion,
+			ReplaceReferencesLargeTestData theTestData,
 			@Nullable List<IProvenanceAgent> theExpectedProvenanceAgents) {
-		List<IBaseResource> provenances =
-				searchProvenance(myTargetPatientId.toVersionless().getIdPart());
+		assertReplaceReferencesProvenance(
+				theTestData.getSourcePatientId().withVersion(theExpectedSourceResourceVersion),
+				theTestData.getTargetPatientId().withVersion(theExpectedTargetResourceVersion),
+				ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES,
+				theTestData.getExpectedProvenanceTargetsForPatchedResources(),
+				theExpectedProvenanceAgents);
+	}
+
+	public void assertReplaceReferencesProvenance(
+			IIdType theSourceResourceIdWithExpectedVersion,
+			IIdType theTargetResourceIdWithExpectedVersion,
+			int theExpectedNumberOfPatches,
+			Set<String> theExpectedPatchedResourceTargetReferences,
+			@Nullable List<IProvenanceAgent> theExpectedProvenanceAgents) {
+
+		List<IBaseResource> provenances = searchProvenance(theTargetResourceIdWithExpectedVersion.getIdPart());
 		assertThat(provenances).hasSize(1);
 		Provenance provenance = (Provenance) provenances.get(0);
 
 		// assert targets
-		int expectedNumberOfProvenanceTargets = TOTAL_EXPECTED_PATCHES + 2;
+		int expectedNumberOfProvenanceTargets = theExpectedNumberOfPatches + 2;
 		assertThat(provenance.getTarget()).hasSize(expectedNumberOfProvenanceTargets);
+
 		// the first target reference should be the target patient
 		String targetPatientReferenceInProvenance =
 				provenance.getTarget().get(0).getReference();
-		assertThat(targetPatientReferenceInProvenance)
-				.isEqualTo(myTargetPatientId
-						.withVersion(theExpectedTargetPatientVersion)
-						.toString());
+		assertThat(targetPatientReferenceInProvenance).isEqualTo(theTargetResourceIdWithExpectedVersion.toString());
+
 		// the second target reference should be the source patient
 		String sourcePatientReference = provenance.getTarget().get(1).getReference();
-		assertThat(sourcePatientReference)
-				.isEqualTo(mySourcePatientId
-						.withVersion(theExpectedSourcePatientVersion)
-						.toString());
+		assertThat(sourcePatientReference).isEqualTo(theSourceResourceIdWithExpectedVersion.toString());
 
 		Set<String> allActualTargets = extractResourceIdsFromProvenanceTarget(provenance.getTarget());
-		assertThat(allActualTargets).containsAll(getExpectedProvenanceTargetsForPatchedResources());
+		assertThat(allActualTargets).containsAll(theExpectedPatchedResourceTargetReferences);
 
 		validateAgents(theExpectedProvenanceAgents, provenance);
 
@@ -301,13 +196,15 @@ public class ReplaceReferencesTestHelper {
 	}
 
 	public void assertMergeProvenance(
-			boolean theDeleteSource, @Nullable List<IProvenanceAgent> theExpectedProvenanceAgent) {
+			boolean theDeleteSource,
+			ReplaceReferencesLargeTestData theTestData,
+			@Nullable List<IProvenanceAgent> theExpectedProvenanceAgent) {
 		assertMergeProvenance(
 				theDeleteSource,
-				mySourcePatientId.withVersion("2"),
-				myTargetPatientId.withVersion("2"),
-				TOTAL_EXPECTED_PATCHES,
-				getExpectedProvenanceTargetsForPatchedResources(),
+				theTestData.getSourcePatientId().withVersion("2"),
+				theTestData.getTargetPatientId().withVersion("2"),
+				ReplaceReferencesLargeTestData.TOTAL_EXPECTED_PATCHES,
+				theTestData.getExpectedProvenanceTargetsForPatchedResources(),
 				theExpectedProvenanceAgent);
 	}
 
@@ -319,8 +216,7 @@ public class ReplaceReferencesTestHelper {
 			Set<String> theExpectedProvenanceTargetsForPatchedResources,
 			@Nullable List<IProvenanceAgent> theExpectedProvenanceAgents) {
 
-		List<IBaseResource> provenances = searchProvenance(
-				theTargetPatientIdWithExpectedVersion.toVersionless().getIdPart());
+		List<IBaseResource> provenances = searchProvenance(theTargetPatientIdWithExpectedVersion.getIdPart());
 		assertThat(provenances).hasSize(1);
 		Provenance provenance = (Provenance) provenances.get(0);
 
@@ -367,24 +263,12 @@ public class ReplaceReferencesTestHelper {
 		assertThat(activityCoding.getCode()).isEqualTo("merge");
 	}
 
-	private Set<String> getExpectedProvenanceTargetsForPatchedResources() {
-		Set<String> allExpectedTargets = new HashSet<>();
-
-		allExpectedTargets.add(mySourceEncId1.withVersion("2").toString());
-		allExpectedTargets.add(mySourceEncId2.withVersion("2").toString());
-		allExpectedTargets.add(mySourceCarePlanId.withVersion("2").toString());
-		allExpectedTargets.addAll(mySourceObsIds.stream()
-				.map(obsId -> obsId.withVersion("2").toString())
-				.toList());
-		return allExpectedTargets;
-	}
-
-	private Set<IIdType> getTargetEverythingResourceIds() {
+	private Set<IIdType> getEverythingResourceIds(IIdType thePatientId) {
 		PatientEverythingParameters everythingParams = new PatientEverythingParameters();
 		everythingParams.setCount(new IntegerType(100));
 
 		IBundleProvider bundleProvider =
-				myPatientDao.patientInstanceEverything(null, mySrd, everythingParams, myTargetPatientId);
+				myPatientDao.patientInstanceEverything(null, mySrd, everythingParams, thePatientId);
 
 		assertNull(bundleProvider.getNextPageId());
 
@@ -404,21 +288,22 @@ public class ReplaceReferencesTestHelper {
 		return task.getIdentifierFirstRep().getValue();
 	}
 
-	public Parameters callReplaceReferences(IGenericClient theFhirClient, boolean theIsAsync) {
-		return callReplaceReferencesWithResourceLimit(theFhirClient, theIsAsync, null);
+	public Parameters callReplaceReferences(
+			IGenericClient theFhirClient, IIdType theSourceId, IIdType theTargetId, boolean theIsAsync) {
+		return callReplaceReferences(theFhirClient, theSourceId.toString(), theTargetId.toString(), theIsAsync, null);
 	}
 
-	public Parameters callReplaceReferencesWithResourceLimit(
-			IGenericClient theFhirClient, boolean theIsAsync, Integer theResourceLimit) {
-		return callReplaceReferencesWithResourceLimit(
-				theFhirClient,
-				mySourcePatientId.getValue(),
-				myTargetPatientId.getValue(),
-				theIsAsync,
-				theResourceLimit);
+	public Parameters callReplaceReferences(
+			IGenericClient theFhirClient,
+			IIdType theSourceId,
+			IIdType theTargetId,
+			boolean theIsAsync,
+			Integer theResourceLimit) {
+		return callReplaceReferences(
+				theFhirClient, theSourceId.toString(), theTargetId.toString(), theIsAsync, theResourceLimit);
 	}
 
-	public Parameters callReplaceReferencesWithResourceLimit(
+	public Parameters callReplaceReferences(
 			IGenericClient theFhirClient,
 			String theSourceId,
 			String theTargetId,
@@ -447,54 +332,120 @@ public class ReplaceReferencesTestHelper {
 		return request.returnResourceType(Parameters.class).execute();
 	}
 
-	public void assertAllReferencesUpdated() {
-		assertAllReferencesUpdated(false);
+	public void assertAllReferencesUpdated(ReplaceReferencesLargeTestData theTestData) {
+		assertAllReferencesUpdated(false, false, theTestData);
 	}
 
-	public void assertAllReferencesUpdated(boolean theWithDelete) {
+	public void assertAllReferencesUpdated(
+			boolean theIsMerge, boolean theWithDelete, ReplaceReferencesLargeTestData theTestData) {
 
-		Set<IIdType> actual = getTargetEverythingResourceIds();
+		assertReferencesToTargetAfterOperation(theIsMerge, theWithDelete, theTestData);
+		assertReferencesToSourceAfterOperation(theIsMerge, theWithDelete, theTestData);
+	}
 
-		ourLog.info("Found IDs: {}", actual);
+	private void assertReferencesToTargetAfterOperation(
+			boolean theIsMerge, boolean theWithDelete, ReplaceReferencesLargeTestData theTestData) {
+		Set<IIdType> actualTargetEverythingIds = getEverythingResourceIds(theTestData.getTargetPatientId());
 
-		if (theWithDelete) {
-			assertThat(actual).doesNotContain(mySourcePatientId);
+		ourLog.info("Target Everything Ids: {}", actualTargetEverythingIds);
+
+		// target should now be referenced by all resources that initially referenced source
+		assertThat(actualTargetEverythingIds).containsAll(theTestData.getResourceIdsInitiallyReferencingSource());
+		// everything operation returns the resources that are referenced by target as well,
+		// they should be present in the $everything output
+		assertThat(actualTargetEverythingIds).containsAll(theTestData.getResourceIdsInitiallyReferencedByTarget());
+		// the resources that initially referenced target should still reference it
+		assertThat(actualTargetEverythingIds).containsAll(theTestData.getResourceIdsInitiallyReferencingTarget());
+
+		int expectedTargetEvertghingCount = theTestData
+						.getResourceIdsInitiallyReferencingSource()
+						.size()
+				+ theTestData.getResourceIdsInitiallyReferencedByTarget().size()
+				+ theTestData.getResourceIdsInitiallyReferencingTarget().size()
+				+ 2; // +1 for the target resource itself and +1 for the Provenance resource created after the operation
+
+		if (theIsMerge && !theWithDelete) {
+			// if this is a merge and the source is not deleted,
+			// the source and target will reference each other via REPLACED_BY and REPLACES,
+			// so the source patient ID should be in the target $everything
+			assertThat(actualTargetEverythingIds).contains(theTestData.getSourcePatientId());
+			expectedTargetEvertghingCount++;
+		} else {
+			assertThat(actualTargetEverythingIds).doesNotContain(theTestData.getSourcePatientId());
 		}
-		assertThat(actual).contains(mySourceEncId1);
-		assertThat(actual).contains(mySourceEncId2);
-		assertThat(actual).contains(myOrgId);
-		assertThat(actual).contains(mySourceCarePlanId);
-		assertThat(actual).containsAll(mySourceObsIds);
-		assertThat(actual).contains(myTargetPatientId);
-		assertThat(actual).contains(myTargetEnc1);
+
+		assertThat(actualTargetEverythingIds).hasSize(expectedTargetEvertghingCount);
 	}
 
-	public void assertNothingChanged() {
-		Set<IIdType> actual = getTargetEverythingResourceIds();
+	private void assertReferencesToSourceAfterOperation(
+			boolean theIsMerge, boolean theWithDelete, ReplaceReferencesLargeTestData theTestData) {
+		if (theWithDelete) {
+			// source resource would be deleted, no need to check references
+			return;
+		}
+		Set<IIdType> actualSourceEverythingIds = getEverythingResourceIds(theTestData.getSourcePatientId());
 
-		ourLog.info("Found IDs: {}", actual);
+		ourLog.info("Source Everything Ids: {}", actualSourceEverythingIds);
 
-		assertThat(actual).doesNotContain(mySourcePatientId);
-		assertThat(actual).doesNotContain(mySourceEncId1);
-		assertThat(actual).doesNotContain(mySourceEncId2);
-		assertThat(actual).contains(myOrgId);
-		assertThat(actual).doesNotContain(mySourceCarePlanId);
-		assertThat(actual).doesNotContainAnyElementsOf(mySourceObsIds);
-		assertThat(actual).contains(myTargetPatientId);
-		assertThat(actual).contains(myTargetEnc1);
+		// the resources that initially referenced source should now reference target, so source $everything
+		// should not contain them anymore
+		assertThat(actualSourceEverythingIds)
+				.doesNotContainAnyElementsOf(theTestData.getResourceIdsInitiallyReferencingSource());
+		// $everything returns the resources that are referenced by source as well, they should be unchanged
+		assertThat(actualSourceEverythingIds).containsAll(theTestData.getResourceIdsInitiallyReferencedBySource());
+		int expectedSourceEverythingCount =
+				theTestData.getResourceIdsInitiallyReferencedBySource().size()
+						+ 2; // +1 for the source resource itself and +1 for the Provenance resource created after the
+		// operation
+		if (theIsMerge) {
+			// If this is a merge, the source patient will have reference to the target patient
+			assertThat(actualSourceEverythingIds).contains(theTestData.getTargetPatientId());
+			expectedSourceEverythingCount++;
+		}
+		assertThat(actualSourceEverythingIds).hasSize(expectedSourceEverythingCount);
+	}
 
-		// TODO ED should we also assert here that source still has the all references it had before the operation,
-		// that is in addition to the validation that target doesn't contain the references.
+	public void assertReferencesHaveNotChanged(ReplaceReferencesLargeTestData theTestData) {
+		assertTargetReferencesHaveNotChanged(theTestData);
+		assertSourceReferencesHaveNotChanged(theTestData);
+	}
+
+	public void assertTargetReferencesHaveNotChanged(ReplaceReferencesLargeTestData theTestData) {
+		Set<IIdType> actualTargetEverythingIds = getEverythingResourceIds(theTestData.getTargetPatientId());
+		ourLog.info("Found IDs for target $everything : {}", actualTargetEverythingIds);
+
+		assertThat(actualTargetEverythingIds).containsAll(theTestData.getResourceIdsInitiallyReferencingTarget());
+		assertThat(actualTargetEverythingIds).containsAll(theTestData.getResourceIdsInitiallyReferencedByTarget());
+		assertThat(actualTargetEverythingIds).contains(theTestData.getTargetPatientId());
+
+		assertThat(actualTargetEverythingIds).doesNotContain(theTestData.getSourcePatientId());
+		assertThat(actualTargetEverythingIds)
+				.doesNotContainAnyElementsOf(theTestData.getResourceIdsInitiallyReferencingSource());
+	}
+
+	public void assertSourceReferencesHaveNotChanged(ReplaceReferencesLargeTestData theTestData) {
+		Set<IIdType> actualIds = getEverythingResourceIds(theTestData.getSourcePatientId());
+		ourLog.info("Found IDs for source $everything : {}", actualIds);
+
+		assertThat(actualIds).containsAll(theTestData.getResourceIdsInitiallyReferencingSource());
+		assertThat(actualIds).containsAll(theTestData.getResourceIdsInitiallyReferencedBySource());
+		assertThat(actualIds).contains(theTestData.getSourcePatientId());
+
+		assertThat(actualIds).doesNotContain(theTestData.getTargetPatientId());
+		assertThat(actualIds).doesNotContainAnyElementsOf(theTestData.getResourceIdsInitiallyReferencingTarget());
 	}
 
 	public PatientMergeInputParameters buildMultipleTargetMatchParameters(
-			boolean theWithDelete, boolean theWithInputResultPatient, boolean theWithPreview) {
+			boolean theWithDelete,
+			boolean theWithInputResultPatient,
+			boolean theWithPreview,
+			ReplaceReferencesLargeTestData theTestData) {
 		PatientMergeInputParameters inParams = new PatientMergeInputParameters();
-		inParams.sourcePatient = new Reference().setReferenceElement(mySourcePatientId);
-		inParams.targetPatientIdentifier = patBothIdentifierC;
+		inParams.sourcePatient = new Reference().setReferenceElement(theTestData.getSourcePatientId());
+		inParams.targetPatientIdentifier = theTestData.getIdentifierCommonToBothResources();
 		inParams.deleteSource = theWithDelete;
 		if (theWithInputResultPatient) {
-			inParams.resultPatient = createResultPatient(theWithDelete);
+			inParams.resultPatient = theTestData.createResultPatientInput(theWithDelete);
 		}
 		if (theWithPreview) {
 			inParams.preview = true;
@@ -503,22 +454,21 @@ public class ReplaceReferencesTestHelper {
 	}
 
 	public PatientMergeInputParameters buildMultipleSourceMatchParameters(
-			boolean theWithDelete, boolean theWithInputResultPatient, boolean theWithPreview) {
+			boolean theWithDelete,
+			boolean theWithInputResultPatient,
+			boolean theWithPreview,
+			ReplaceReferencesLargeTestData theTestData) {
 		PatientMergeInputParameters inParams = new PatientMergeInputParameters();
-		inParams.sourcePatientIdentifier = patBothIdentifierC;
-		inParams.targetPatient = new Reference().setReferenceElement(mySourcePatientId);
+		inParams.sourcePatientIdentifier = theTestData.getIdentifierCommonToBothResources();
+		inParams.targetPatient = new Reference().setReferenceElement(theTestData.getTargetPatientId());
 		inParams.deleteSource = theWithDelete;
 		if (theWithInputResultPatient) {
-			inParams.resultPatient = createResultPatient(theWithDelete);
+			inParams.resultPatient = theTestData.createResultPatientInput(theWithDelete);
 		}
 		if (theWithPreview) {
 			inParams.preview = true;
 		}
 		return inParams;
-	}
-
-	public IIdType getSourcePatientId() {
-		return mySourcePatientId;
 	}
 
 	public static class PatientMergeInputParameters {
@@ -626,24 +576,6 @@ public class ReplaceReferencesTestHelper {
 		assertEquals(theTaskId.getIdPart(), resultTaskId.getIdPart());
 	}
 
-	public List<Identifier> getExpectedIdentifiersForTargetAfterMerge(boolean theWithInputResultPatient) {
-
-		List<Identifier> expectedIdentifiersOnTargetAfterMerge;
-		if (theWithInputResultPatient) {
-			expectedIdentifiersOnTargetAfterMerge =
-					List.of(new Identifier().setSystem("SYS1A").setValue("VAL1A"));
-		} else {
-			// the identifiers copied over from source should be marked as old
-			expectedIdentifiersOnTargetAfterMerge = List.of(
-					new Identifier().setSystem("SYS2A").setValue("VAL2A"),
-					new Identifier().setSystem("SYS2B").setValue("VAL2B"),
-					new Identifier().setSystem("SYSC").setValue("VALC"),
-					new Identifier().setSystem("SYS1A").setValue("VAL1A").copy().setUse(Identifier.IdentifierUse.OLD),
-					new Identifier().setSystem("SYS1B").setValue("VAL1B").copy().setUse(Identifier.IdentifierUse.OLD));
-		}
-		return expectedIdentifiersOnTargetAfterMerge;
-	}
-
 	/**
 	 * Asserts that the source patient with the specified ID has been updated properly or deleted
 	 * after merging with the specified target patient ID.
@@ -659,23 +591,6 @@ public class ReplaceReferencesTestHelper {
 			assertThat(link.getOther().getReferenceElement()).isEqualTo(theTargetPatientId.toUnqualifiedVersionless());
 			assertThat(link.getType()).isEqualTo(Patient.LinkType.REPLACEDBY);
 		}
-	}
-
-	/**
-	 * Asserts that the test source patient which has been created in beforeEach() has been updated properly or deleted
-	 * after a merge operation with the test target patient, which was also created in beforeEach().
-	 */
-	public void assertSourcePatientUpdatedOrDeletedAfterMerge(boolean theDeleteSource) {
-		assertSourcePatientUpdatedOrDeletedAfterMerge(getSourcePatientId(), getTargetPatientId(), theDeleteSource);
-	}
-
-	/**
-	 * Asserts that the test target patient which has been created in beforeEach() has been updated properly
-	 * after a merge operation with the test source patient, which was also created in beforeEach().
-	 */
-	public void assertTargetPatientUpdatedAfterMerge(boolean withDelete, List<Identifier> theExpectedIdentifiers) {
-		assertTargetPatientUpdatedAfterMerge(
-				getTargetPatientId(), getSourcePatientId(), withDelete, theExpectedIdentifiers);
 	}
 
 	/**

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ProviderConstants.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ProviderConstants.java
@@ -251,6 +251,11 @@ public class ProviderConstants {
 	public static final String OPERATION_REPLACE_REFERENCES = "$hapi.fhir.replace-references";
 
 	/**
+	 * Operation name for the "$hapi.fhir.undo-replace-references" operation
+	 */
+	public static final String OPERATION_UNDO_REPLACE_REFERENCES = "$hapi.fhir.undo-replace-references";
+
+	/**
 	 * Parameter for source reference of the "$hapi.fhir.replace-references" operation
 	 */
 	public static final String OPERATION_REPLACE_REFERENCES_PARAM_SOURCE_REFERENCE_ID = "source-reference-id";
@@ -272,6 +277,9 @@ public class ProviderConstants {
 	public static final String OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_TASK = "task";
 
 	public static final String OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME = "outcome";
+
+	public static final String OPERATION_UNDO_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME =
+			OPERATION_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME;
 
 	/**
 	 * Operation name for the Resource "$merge" operation

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/merge/MergeProvenanceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/merge/MergeProvenanceSvc.java
@@ -20,8 +20,16 @@
 package ca.uhn.fhir.merge;
 
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.replacereferences.ReplaceReferencesProvenanceSvc;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import jakarta.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeableConcept;
+
+import java.util.Date;
+import java.util.List;
 
 /**
  *  Handles Provenance resources for the $merge operation.
@@ -39,5 +47,26 @@ public class MergeProvenanceSvc extends ReplaceReferencesProvenanceSvc {
 		CodeableConcept retVal = new CodeableConcept();
 		retVal.addCoding().setSystem(ACTIVITY_CODE_SYSTEM).setCode(ACTIVITY_CODE_MERGE);
 		return retVal;
+	}
+
+	@Override
+	public void createProvenance(
+			IIdType theTargetId,
+			@Nullable IIdType theSourceId,
+			List<Bundle> thePatchResultBundles,
+			Date theStartTime,
+			RequestDetails theRequestDetails,
+			List<IProvenanceAgent> theProvenanceAgents) {
+
+		super.createProvenance(
+				theTargetId,
+				theSourceId,
+				thePatchResultBundles,
+				theStartTime,
+				theRequestDetails,
+				theProvenanceAgents,
+				// we need to create a Provenance resource even when there were no referencing resources,
+				// because src and target resources are always updated in $merge operation
+				true);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/PreviousResourceVersionRestorer.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/PreviousResourceVersionRestorer.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.replacereferences;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Reference;
+
+import java.util.List;
+
+/**
+ * This is a class to restore resources to their previous versions based on the provided versioned resource references.
+ * It is used in the context of undoing changes made by the $hapi.fhir.replace-references operation.
+ */
+public class PreviousResourceVersionRestorer {
+
+	private final HapiTransactionService myHapiTransactionService;
+	private final DaoRegistry myDaoRegistry;
+
+	public PreviousResourceVersionRestorer(
+			DaoRegistry theDaoRegistry, HapiTransactionService theHapiTransactionService) {
+		myDaoRegistry = theDaoRegistry;
+		myHapiTransactionService = theHapiTransactionService;
+	}
+
+	/**
+	 * Given a list of versioned resource references, this method restores each resource to its previous version
+	 * if the resource's current version is the same as specified in the given reference
+	 * (i.e. the resource was not updated since the reference was created).
+	 *
+	 * This method is transactional and will attempt to restore all resources in a single transaction.
+	 *
+	 * Note that this method updates a resource using its previous version's content,
+	 * so it will actually cause a new version to be created (i.e. it does not rewrite the history).
+	 *
+	 * @throws IllegalArgumentException if a given reference is versionless
+	 * @throws IllegalArgumentException a given reference has version 1, so it cannot have a previous version to restore to.
+	 * @throws ResourceVersionConflictException if the current version of the resource does not match the version specified in the reference.
+	 */
+	public void restoreToPreviousVersionsInTrx(
+			List<Reference> theReferences, RequestDetails theRequestDetails, RequestPartitionId thePartitionId) {
+		myHapiTransactionService
+				.withRequest(theRequestDetails)
+				.withRequestPartitionId(thePartitionId)
+				.execute(() -> restoreToPreviousVersions(theReferences, theRequestDetails));
+	}
+
+	private void restoreToPreviousVersions(List<Reference> theReferences, RequestDetails theRequestDetails) {
+		for (Reference reference : theReferences) {
+			String referenceStr = reference.getReference();
+			IIdType referenceId = new IdDt(referenceStr);
+
+			if (!referenceId.hasVersionIdPart()) {
+				throw new IllegalArgumentException(
+						Msg.code(2730) + "Reference does not have a version: " + referenceStr);
+			}
+			Long referenceVersion = referenceId.getVersionIdPartAsLong();
+
+			// Restore previous version (version - 1)
+			long previousVersion = referenceVersion - 1;
+			if (previousVersion < 1) {
+				throw new IllegalArgumentException(Msg.code(2731)
+						+ "Resource cannot be restored to a previous as the provided version is 1: " + referenceStr);
+			}
+
+			// Read the current resource
+			IFhirResourceDao<IBaseResource> dao = myDaoRegistry.getResourceDao(referenceId.getResourceType());
+			IBaseResource currentResource = dao.read(referenceId.toUnqualifiedVersionless(), theRequestDetails);
+
+			// Check current version
+			Long currentVersion = currentResource.getIdElement().getVersionIdPartAsLong();
+			if (!currentVersion.equals(referenceVersion)) {
+				String msg = String.format(
+						"The resource cannot be restored because the current version of resource %s (%s) does not match the expected version (%s)",
+						referenceStr, currentVersion, referenceVersion);
+				throw new ResourceVersionConflictException(Msg.code(2732) + msg);
+			}
+
+			IIdType previousId = referenceId.withVersion(Long.toString(previousVersion));
+			IBaseResource previousResource = dao.read(previousId, theRequestDetails);
+			previousResource.setId(previousResource.getIdElement().toUnqualifiedVersionless());
+
+			// Update the resource to the previous version's content
+			dao.update(previousResource, theRequestDetails);
+		}
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesPatchBundleSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesPatchBundleSvc.java
@@ -85,8 +85,12 @@ public class ReplaceReferencesPatchBundleSvc {
 			IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(referencingResourceId.getResourceType());
 			IBaseResource resource = dao.read(referencingResourceId, theRequestDetails);
 			Parameters patchParams = buildPatchParams(theReplaceReferencesRequest, resource);
-			IIdType resourceId = resource.getIdElement();
-			bundleBuilder.addTransactionFhirPatchEntry(resourceId, patchParams);
+			// the patchParams could be empty if the resource contains only versioned references to the source,
+			// no need to add patch entry in that case
+			if (patchParams.hasParameter()) {
+				IIdType resourceId = resource.getIdElement();
+				bundleBuilder.addTransactionFhirPatchEntry(resourceId, patchParams);
+			}
 		});
 		return bundleBuilder.getBundleTyped();
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/UndoReplaceReferencesRequest.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/UndoReplaceReferencesRequest.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.replacereferences;
+
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import org.hl7.fhir.instance.model.api.IIdType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This class models the parameters for processing a $hapi.fhir.undo-replace-references operation.
+ */
+public class UndoReplaceReferencesRequest {
+
+	/**
+	 * Unqualified source id
+	 */
+	@Nonnull
+	public final IIdType sourceId;
+
+	/**
+	 * Unqualified target id
+	 */
+	@Nonnull
+	public final IIdType targetId;
+
+	public final RequestPartitionId partitionId;
+
+	/**
+	 * The maximum number of resource that can be processed in a single undo operation.
+	 * If the undo operation requires updating more resources than this limit,
+	 * the operation will fail.
+	 * This is currently not exposed to FHIR clients and is used internally, and set based on jpaStorageSettings.
+	 */
+	public final int resourceLimit;
+
+	public UndoReplaceReferencesRequest(
+			@Nonnull IIdType theSourceId,
+			@Nonnull IIdType theTargetId,
+			RequestPartitionId thePartitionId,
+			int theResourceLimit) {
+		sourceId = theSourceId.toUnqualifiedVersionless();
+		targetId = theTargetId.toUnqualifiedVersionless();
+		partitionId = thePartitionId;
+		resourceLimit = theResourceLimit;
+	}
+}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/UndoReplaceReferencesSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/UndoReplaceReferencesSvc.java
@@ -1,0 +1,133 @@
+/*-
+ * #%L
+ * HAPI FHIR Storage api
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.replacereferences;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.provider.ProviderConstants;
+import ca.uhn.fhir.util.OperationOutcomeUtil;
+import ca.uhn.fhir.util.ParametersUtil;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Provenance;
+import org.hl7.fhir.r4.model.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_UNDO_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME;
+
+/**
+ * This service is implements the $hapi.fhir.replace-references operation.
+ * It reverts the changes made by $hapi.fhir.replace-references operation based on the Provenance resource
+ * that was created as part of the $hapi.fhir.replace-references operation.
+ *
+ *  Current limitations:
+ * - It fails if any resources to be restored have been subsequently changed since the `$hapi.fhir.replace-references` operation was performed.
+ * - It can only run synchronously.
+ * - It fails if the number of resources to restore exceeds a specified resource limit
+ * (currently set to same size as getInternalSynchronousSearchSize in JPAStorageSettings by the operation provider).
+ */
+public class UndoReplaceReferencesSvc {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(UndoReplaceReferencesSvc.class);
+
+	private final ReplaceReferencesProvenanceSvc myReplaceReferencesProvenanceSvc;
+	private final PreviousResourceVersionRestorer myResourceVersionRestorer;
+	private final FhirContext myFhirContext;
+	private final DaoRegistry myDaoRegistry;
+
+	public UndoReplaceReferencesSvc(
+			DaoRegistry theDaoRegistry,
+			ReplaceReferencesProvenanceSvc theReplaceReferencesProvenanceSvc,
+			PreviousResourceVersionRestorer theResourceVersionRestorer) {
+		myDaoRegistry = theDaoRegistry;
+		myReplaceReferencesProvenanceSvc = theReplaceReferencesProvenanceSvc;
+		myResourceVersionRestorer = theResourceVersionRestorer;
+		myFhirContext = theDaoRegistry.getFhirContext();
+	}
+
+	public IBaseParameters undoReplaceReferences(
+			UndoReplaceReferencesRequest theUndoReplaceReferencesRequest, RequestDetails theRequestDetails) {
+
+		// read source and target to ensure they still exist
+		readResource(theUndoReplaceReferencesRequest.sourceId, theRequestDetails);
+		readResource(theUndoReplaceReferencesRequest.targetId, theRequestDetails);
+
+		Provenance provenance = myReplaceReferencesProvenanceSvc.findProvenance(
+				theUndoReplaceReferencesRequest.targetId,
+				theUndoReplaceReferencesRequest.sourceId,
+				theRequestDetails,
+				ProviderConstants.OPERATION_UNDO_REPLACE_REFERENCES);
+
+		if (provenance == null) {
+			String msg =
+					"Unable to find a Provenance created by a $hapi.fhir.replace-references for the provided source and target IDs."
+							+ " Ensure that IDs are correct and were previously used as parameters in a successful $hapi.fhir.replace-references operation";
+			throw new ResourceNotFoundException(Msg.code(2728) + msg);
+		}
+
+		ourLog.info(
+				"Found Provenance resource with id: {} to be used for $undo-replace-references operation",
+				provenance.getIdElement().getValue());
+
+		List<Reference> references = provenance.getTarget();
+		// in replace-references operation provenance, the first two references are to the target and the source,
+		// and they are not updated as part of the operation so we should not restore their previous versions.
+		List<Reference> toRestore = references.subList(2, references.size());
+
+		if (toRestore.size() > theUndoReplaceReferencesRequest.resourceLimit) {
+			String msg = String.format(
+					"Number of references to update (%d) exceeds the limit (%d)",
+					toRestore.size(), theUndoReplaceReferencesRequest.resourceLimit);
+			throw new InvalidRequestException(Msg.code(2729) + msg);
+		}
+
+		myResourceVersionRestorer.restoreToPreviousVersionsInTrx(
+				toRestore, theRequestDetails, theUndoReplaceReferencesRequest.partitionId);
+
+		IBaseOperationOutcome opOutcome = OperationOutcomeUtil.newInstance(myFhirContext);
+		String msg = String.format(
+				"Successfully restored %d resources to their previous versions based on the Provenance resource: %s",
+				toRestore.size(), provenance.getIdElement().getValue());
+		OperationOutcomeUtil.addIssue(myFhirContext, opOutcome, "information", msg, null, null);
+
+		IBaseParameters outputParameters = ParametersUtil.newInstance(myFhirContext);
+
+		ParametersUtil.addParameterToParameters(
+				myFhirContext, outputParameters, OPERATION_UNDO_REPLACE_REFERENCES_OUTPUT_PARAM_OUTCOME, opOutcome);
+
+		return outputParameters;
+	}
+
+	private IBaseResource readResource(IIdType theId, RequestDetails theRequestDetails) {
+		String resourceType = theId.getResourceType();
+		IFhirResourceDao<IBaseResource> resourceDao = myDaoRegistry.getResourceDao(resourceType);
+		return resourceDao.read(theId, theRequestDetails);
+	}
+}


### PR DESCRIPTION
closes: #7101 

In this PR 
1. I added a new system level operation, named `$hapi.fhir.undo-replace-references`. This operation
  restores the resources that were updated by a `$hapi.fhir.replace-references` operation to their previous versions.

  Current limitations:
 - It fails if any resources to be restored have been subsequently changed since the `$hapi.fhir.replace-references` operation was performed.           
 - It can only run synchronously.            
 - It fails if the number of resources to restore exceeds a specified resource limit (currently set by the Provider class to the same size as getInternalSynchronousSearchSize of JPAStorageSettings , which defaults to 10000).          
 
2. I noticed that replace-references operation was creating a Provenance resource even when no resource was updated, so I added logic to prevent it. 

4. Also added logic for replace-references Provenances  to not add a resource reference to the Provenance if patch for that resource was a no-op ( so the resource was't really updated by the operation). This is not likely to happen under normal conditions but just added as a precaution, since we don't want to revert the resource a previous version if that resource wasn't really updated by replace-references.  

5. I refactored the ReplaceReferencesTestHelper by extracting the test data generation and the validation specific to that test data into a separate class called ReplaceReferencesLargeTestData. The reasons for doing this:         
  a. make tests more efficient: ReplaceReferencesTestHelper is used by various different test suites, including the tests for  replace-references, merge and undo-replace-references operations. However not all tests require the large amount of data created by default in this class.        
  b. increase code maintainability/readability.  

