### PR TITLE
improve FhirAutoConfiguration

### DIFF
--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
@@ -183,12 +183,9 @@ public class FhirAutoConfiguration {
 		})
 		static class FhirJpaStorageSettingsConfiguration {
 
-			@Autowired
-			private EntityManagerFactory emf;
-
 			@Bean
 			@Primary
-			public PlatformTransactionManager transactionManager() {
+			public PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
 				return new JpaTransactionManager(emf);
 			}
 


### PR DESCRIPTION
I'm not sure whether we're doing something wrong, but `HapiEntityManagerFactoryUtil.newEntityManagerFactory(ConfigurableListableBeanFactory, FhirContext, JpaStorageSettings)` requires `JpaStorageSettings` built in  `FhirJpaStorageSettingsConfiguration`, leading to the construction of the configuration requiring the `EntityManagerFactory` that is currently being constructed by `HapiEntityManagerFactoryUtil`. So it's a dependency circle and Spring Boot aborts.

Our current workaround is duplicating the `FhirJpaStorageSettingsConfiguration::storageSettings` method - so no big deal, but this seems cleaner either way.