### PR TITLE
Fix backward incompatible method signature change in batch2 JobDefinitionStartRequest

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7130-backward-incompatible-batch2-library.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7130-backward-incompatible-batch2-library.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7130
+title: "There is an API backward incompatibility issue with the hapi-fhir-storage-batch-2 library that may break some 
+        client applications.
+        This has been fixed."

--- a/hapi-fhir-storage-batch2-test-utilities/src/test/java/ca/uhn/hapi/fhir/batch2/test/inline/InlineJobCoordinatorTest.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/test/java/ca/uhn/hapi/fhir/batch2/test/inline/InlineJobCoordinatorTest.java
@@ -136,7 +136,8 @@ class InlineJobCoordinatorTest {
 
 		// Some sort of batch service would trigger this:
 		final InlineTestJobParams jobParams = new InlineTestJobParams(30);
-		final JobInstanceStartRequest jobInstanceStartRequest = new JobInstanceStartRequest().setParameters(jobParams).setJobDefinitionIdAndReturn(JOB_DEFINITION_ID);
+		final JobInstanceStartRequest jobInstanceStartRequest = new JobInstanceStartRequest().setParameters(jobParams);
+		jobInstanceStartRequest.setJobDefinitionId(JOB_DEFINITION_ID);
 		// This is the contract for the tests to pass their own job instance ID:
 		final SystemRequestDetails requestDetails = new SystemRequestDetails();
 		requestDetails.addHeader(InlineJobCoordinator.JOB_INSTANCE_ID_FOR_TESTING, JOB_INSTANCE_ID);

--- a/hapi-fhir-storage-batch2-test-utilities/src/test/java/ca/uhn/hapi/fhir/batch2/test/inline/InlineJobCoordinatorTest.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/test/java/ca/uhn/hapi/fhir/batch2/test/inline/InlineJobCoordinatorTest.java
@@ -136,7 +136,7 @@ class InlineJobCoordinatorTest {
 
 		// Some sort of batch service would trigger this:
 		final InlineTestJobParams jobParams = new InlineTestJobParams(30);
-		final JobInstanceStartRequest jobInstanceStartRequest = new JobInstanceStartRequest().setParameters(jobParams).setJobDefinitionId(JOB_DEFINITION_ID);
+		final JobInstanceStartRequest jobInstanceStartRequest = new JobInstanceStartRequest().setParameters(jobParams).setJobDefinitionIdAndReturn(JOB_DEFINITION_ID);
 		// This is the contract for the tests to pass their own job instance ID:
 		final SystemRequestDetails requestDetails = new SystemRequestDetails();
 		requestDetails.addHeader(InlineJobCoordinator.JOB_INSTANCE_ID_FOR_TESTING, JOB_INSTANCE_ID);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstanceStartRequest.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstanceStartRequest.java
@@ -74,11 +74,6 @@ public class JobInstanceStartRequest implements IModelJson {
 		myJobDefinitionId = theJobDefinitionId;
 	}
 
-	public JobInstanceStartRequest setJobDefinitionIdAndReturn(String theJobDefinitionId) {
-		myJobDefinitionId = theJobDefinitionId;
-		return this;
-	}
-
 	public String getParameters() {
 		return myParameters;
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstanceStartRequest.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobInstanceStartRequest.java
@@ -70,7 +70,11 @@ public class JobInstanceStartRequest implements IModelJson {
 		return myJobDefinitionId;
 	}
 
-	public JobInstanceStartRequest setJobDefinitionId(String theJobDefinitionId) {
+	public void setJobDefinitionId(String theJobDefinitionId) {
+		myJobDefinitionId = theJobDefinitionId;
+	}
+
+	public JobInstanceStartRequest setJobDefinitionIdAndReturn(String theJobDefinitionId) {
 		myJobDefinitionId = theJobDefinitionId;
 		return this;
 	}


### PR DESCRIPTION
- Restore the old method signature returning void
- Add a new method similar to the updated returning the request, but with a different name.