### PR TITLE
Batch Jobs page not rendering for Postgres-backed persistence module

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
@@ -73,8 +73,8 @@ public interface IBatch2JobInstanceRepository
 			+ "WHERE (:definitionId IS NULL OR b.myDefinitionId = :definitionId) "
 			+ "AND (:status IS NULL OR b.myStatus = :status) "
 			+ "AND (:jobId IS NULL OR b.myId = :jobId) "
-			+ "AND (:from IS NULL OR b.myCreateTime >= :from) "
-			+ "AND (:to IS NULL OR b.myCreateTime <= :to)")
+			+ "AND (cast(:from as date) IS NULL OR b.myCreateTime >= :from) "
+			+ "AND (cast(:to as date) IS NULL OR b.myCreateTime <= :to)")
 	Page<Batch2JobInstanceEntity> findByJobDefinitionIdOrStatusOrIdOrCreateTime(
 			@Param("definitionId") String theDefinitionId,
 			@Param("status") StatusEnum theStatus,


### PR DESCRIPTION
Batch Jobs page in Smile web admin doesn't work if persistence database is using Postgres.

**Solution**

Explicitly cast date type because PostgreSQL driver is unable to identify `Date` type in this case.

**Note**
No changelog and unit test in this PR as this is a follow up fix to #7062.

Closes #7129 