### PR TITLE
Support patient parameter of type reference for Patient-level bulk export

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7128-patient-parameter-for-patientexport-should-be-a-reference.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7128-patient-parameter-for-patientexport-should-be-a-reference.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 7128
+title: "Patient level Bulk export (`/Patient/$export`) now accepts the `patient` parameter of type reference.
+This is in compliance to the FHIR Bulk Data Access IG, and allows Patient level export to be performed through the FHIR gateway with the patient parameter."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7128-patient-parameter-for-patientexport-should-be-a-reference.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7128-patient-parameter-for-patientexport-should-be-a-reference.yaml
@@ -1,5 +1,5 @@
 ---
 type: add
 issue: 7128
-title: "Patient level Bulk export (`/Patient/$export`) now accepts the `patient` parameter of type reference.
-This is in compliance to the FHIR Bulk Data Access IG, and allows Patient level export to be performed through the FHIR gateway with the patient parameter."
+title: "Patient level Bulk export (`/Patient/$export`) now accepts the `patient` parameter of type reference to match the FHIR Bulk Data Access IG. 
+For backwards compatibility with earlier implementations, `patient` may also be of string type, and will be interpreted as a reference."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
@@ -48,6 +48,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -845,6 +846,8 @@ public class BulkDataExportProviderR4Test {
 		input.addParameter(JpaConstants.PARAM_EXPORT_TYPE, new StringType("Immunization, Observation"));
 		input.addParameter(JpaConstants.PARAM_EXPORT_SINCE, now);
 		input.addParameter(JpaConstants.PARAM_EXPORT_TYPE_FILTER, new StringType("Immunization?vaccine-code=foo"));
+		input.addParameter(JpaConstants.PARAM_EXPORT_PATIENT, new Reference("Patient/123"));
+		input.addParameter(JpaConstants.PARAM_EXPORT_PATIENT, new StringType("Patient/456"));
 
 		ourLog.debug(myCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(input));
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
@@ -868,6 +868,7 @@ public class BulkDataExportProviderR4Test {
 		assertThat(bp.getResourceTypes()).containsExactlyInAnyOrder("Immunization", "Observation");
 		assertNotNull(bp.getSince());
 		assertThat(bp.getFilters()).containsExactlyInAnyOrder("Immunization?vaccine-code=foo");
+		assertThat(bp.getPatientIds()).containsExactlyInAnyOrder("Patient/123", "Patient/456");
 	}
 
 	@Test

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -253,6 +253,8 @@ public class BulkDataExportProvider {
 						.map(patient -> {
 							if (patient instanceof StringType patientStringType) {
 								return patientStringType;
+							} else if (patient instanceof IIdType patientIIdType) {
+								return patientIIdType;
 							} else if (patient instanceof IBaseReference patientReference) {
 								return patientReference.getDisplayElement();
 							}

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProviderTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProviderTest.java
@@ -133,7 +133,7 @@ class BulkDataExportProviderTest {
 		List<IPrimitiveType<String>> result = BulkDataExportProvider.parsePatientList(input);
 		// then
 		assertEquals(1, result.size());
-		assertEquals(reference.getReference(), result.get(0).getValue());
+		assertEquals("Patient/456", result.get(0).getValue());
 	}
 
 	@Test


### PR DESCRIPTION
The specification of the Bulk export for Patient (Patient/$export) specifies that the `patient` parameter should be a `Reference` but it is a `String` in our implementation.

* Specification link - https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters

This PR  adds support for `patient` parameter of type reference for Patient-level bulk export.

```json
{
    "resourceType": "Parameters",
    "parameter": [
      {
        "name": "_outputFormat",
        "valueString": "application/fhir+ndjson"
      },
      {
          "name": "patient",
          "valueReference": {
              "reference" :"Patient/<patient-id>"
          }
      }
    ]
}
```
