### PR TITLE
enforce_referential_integrity_on_delete.disable_for_paths ignored for expunge

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7139-allow-delete-expunge-when-disable-for-paths-set.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7139-allow-delete-expunge-when-disable-for-paths-set.yaml
@@ -2,6 +2,6 @@
 type: fix
 issue: 7139
 jira: SMILE-9692
-title: "This change allows the deletion of resources using the delete expunge operation when the property 
-`enforceReferentialIntegrityOnDeleteDisableForPaths` is set to reference FHIR paths linking other resources 
-to the target resources."
+title: "This change allows resources to be deleted using the Delete with Expunge operation when the property 
+`enforceReferentialIntegrityOnDeleteDisableForPaths` is set to one or more FHIRPath expressions that link other 
+resources to the target resources."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7139-allow-delete-expunge-when-disable-for-paths-set.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7139-allow-delete-expunge-when-disable-for-paths-set.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7139
+jira: SMILE-9692
+title: "This change allows the deletion of resources using the delete expunge operation when the property 
+`enforceReferentialIntegrityOnDeleteDisableForPaths` is set to reference FHIR paths linking other resources 
+to the target resources."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSqlBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSqlBuilder.java
@@ -132,6 +132,12 @@ public class DeleteExpungeSqlBuilder {
 					break;
 				}
 			}
+		} else {
+			// check if the user has configured any paths to ignore
+			Set<String> pathsToIgnore = myStorageSettings.getEnforceReferentialIntegrityOnDeleteDisableForPaths();
+			if (conflictResourceLinks.stream().anyMatch(link -> pathsToIgnore.contains(link.getSourcePath()))) {
+				return;
+			}
 		}
 
 		ResourceLink firstConflict = conflictResourceLinks.get(0);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
@@ -1425,12 +1425,12 @@ public class JpaStorageSettings extends StorageSettings {
 	}
 
 	/**
-	 * When {@link #setEnforceReferentialIntegrityOnDelete(boolean)} is set to <code>true</code> and this property is
-	 * set to the FHIR paths, the referential integrity checks for the specified FHIR paths will be disabled
-	 * during Delete or Delete Expunge operations.
+	 * When {@link #setEnforceReferentialIntegrityOnDelete(boolean)} is set to <code>true</code>, this setting may
+	 * be used to selectively disable the referential integrity checking only for specific paths. It applies to
+	 * both Delete and Delete with Expunge operations.
 	 * <p>
-	 * For example, if the property contains the FHIR path <code>Encounter.subject</code> , deleting a Patient
-	 * referenced by an Encounter's subject is allowed without deleting the Encounter first.
+	 * For example, if the property contains the FHIR path expression <code>Encounter.subject</code> , deleting
+	 * the Patient referenced by an Encounter's subject is allowed without deleting the Encounter first.
 	 * </p>
 	 */
 	public Set<String> getEnforceReferentialIntegrityOnDeleteDisableForPaths() {
@@ -1438,12 +1438,12 @@ public class JpaStorageSettings extends StorageSettings {
 	}
 
 	/**
-	 * When {@link #setEnforceReferentialIntegrityOnDelete(boolean)} is set to <code>true</code> and this property is
-	 * set to the FHIR paths, the referential integrity checks for the specified FHIR paths will be disabled
-	 * during Delete or Delete Expunge operations.
+	 * When {@link #setEnforceReferentialIntegrityOnDelete(boolean)} is set to <code>true</code>, this setting
+	 * allows you to selectively disable integrity checks for specific paths. It applies to both Delete and
+	 * Delete with Expunge operations.
 	 * <p>
-	 * For example, if the property contains the FHIR path <code>Encounter.subject</code> , deleting a Patient
-	 * referenced by an Encounter's subject is allowed without deleting the Encounter first.
+	 * For example, if the property contains the FHIR path expression <code>Encounter.subject</code> , deleting
+	 * the Patient referenced by an Encounter's subject is allowed without deleting the Encounter first.
 	 * </p>
 	 */
 	public void setEnforceReferentialIntegrityOnDeleteDisableForPaths(

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
@@ -165,6 +165,7 @@ public class JpaStorageSettings extends StorageSettings {
 
 	private boolean myDeleteStaleSearches = true;
 	private boolean myEnforceReferentialIntegrityOnDelete = true;
+	private Set<String> myEnforceReferentialIntegrityOnDeleteDisableForPaths = Collections.emptySet();
 	private boolean myUniqueIndexesEnabled = true;
 	private boolean myUniqueIndexesCheckedBeforeSave = true;
 	private boolean myEnforceReferentialIntegrityOnWrite = true;
@@ -1421,6 +1422,33 @@ public class JpaStorageSettings extends StorageSettings {
 	 */
 	public void setEnforceReferentialIntegrityOnDelete(boolean theEnforceReferentialIntegrityOnDelete) {
 		myEnforceReferentialIntegrityOnDelete = theEnforceReferentialIntegrityOnDelete;
+	}
+
+	/**
+	 * When {@link #setEnforceReferentialIntegrityOnDelete(boolean)} is set to <code>true</code> and this property is
+	 * set to the FHIR paths, the referential integrity checks for the specified FHIR paths will be disabled
+	 * during Delete or Delete Expunge operations.
+	 * <p>
+	 * For example, if the property contains the FHIR path <code>Encounter.subject</code> , deleting a Patient
+	 * referenced by an Encounter's subject is allowed without deleting the Encounter first.
+	 * </p>
+	 */
+	public Set<String> getEnforceReferentialIntegrityOnDeleteDisableForPaths() {
+		return myEnforceReferentialIntegrityOnDeleteDisableForPaths;
+	}
+
+	/**
+	 * When {@link #setEnforceReferentialIntegrityOnDelete(boolean)} is set to <code>true</code> and this property is
+	 * set to the FHIR paths, the referential integrity checks for the specified FHIR paths will be disabled
+	 * during Delete or Delete Expunge operations.
+	 * <p>
+	 * For example, if the property contains the FHIR path <code>Encounter.subject</code> , deleting a Patient
+	 * referenced by an Encounter's subject is allowed without deleting the Encounter first.
+	 * </p>
+	 */
+	public void setEnforceReferentialIntegrityOnDeleteDisableForPaths(
+			Set<String> theEnforceReferentialIntegrityOnDeleteDisableForPaths) {
+		myEnforceReferentialIntegrityOnDeleteDisableForPaths = theEnforceReferentialIntegrityOnDeleteDisableForPaths;
 	}
 
 	/**


### PR DESCRIPTION
Delete_Expunge does not work when placing referential integrity exceptions using Disable Deletion Ref Checks for Paths

### To Reproduce
1. Create any Resource
2. Create an AuditEvent Resource, where "entity.what" is a reference to the Resource created in 1.
3. Do a DELETE on {base}/{resourceType}/_id={id from 1}&_expunge=true

A batch job will be created and will fail because of the reference from AuditEvent. Note that issuing the DELETE without _expunge=true succeeds.

### Cause
No property `EnforceReferentialIntegrityOnDeleteDisableForPaths` is defined when running the job of  Delete + Expunge

### Solution
Define the property `EnforceReferentialIntegrityOnDeleteDisableForPaths` and updated Delete Expunge batch job process with disabled path checks

Closes #7139 