### PR TITLE
Avoid concurrency issues on placeholder creation

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/QualifiedParamList.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/QualifiedParamList.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.rest.api;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.api.IQueryParameterOr;
 import ca.uhn.fhir.model.api.IQueryParameterType;
+import jakarta.annotation.Nonnull;
 
 import java.util.ArrayList;
 import java.util.StringTokenizer;
@@ -70,6 +71,7 @@ public class QualifiedParamList extends ArrayList<String> {
 		return retVal;
 	}
 
+	@Nonnull
 	public static QualifiedParamList splitQueryStringByCommasIgnoreEscape(String theQualifier, String theParams) {
 		QualifiedParamList retVal = new QualifiedParamList();
 		retVal.setQualifier(theQualifier);

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -321,8 +321,10 @@ public class UrlUtil {
 
 	private static void parseQueryString(String theQueryString, HashMap<String, List<String>> map) {
 		String query = defaultString(theQueryString);
-		if (query.startsWith("?")) {
-			query = query.substring(1);
+
+		int questionMarkIdx = query.indexOf('?');
+		if (questionMarkIdx != -1) {
+			query = query.substring(questionMarkIdx + 1);
 		}
 
 		StringTokenizer tok = new StringTokenizer(query, "&");

--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -83,6 +83,7 @@ ca.uhn.fhir.validation.FhirValidator.noPhError=Ph-schematron library not found o
 ca.uhn.fhir.validation.ValidationResult.noIssuesDetected=No issues detected during validation
 
 # JPA Messages
+ca.uhn.fhir.jpa.config.HapiFhirHibernateJpaDialect.conditionalCreateConstraintFailure=The operation has failed with a conditional constraint failure. This generally means that two clients/threads were trying to perform a conditional create or update at the same time which would have resulted in duplicate resources being created.
 ca.uhn.fhir.jpa.config.HapiFhirHibernateJpaDialect.resourceVersionConstraintFailure=The operation has failed with a version constraint failure. This generally means that two clients/threads were trying to update the same resource at the same time, and this request was chosen as the failing request.
 ca.uhn.fhir.jpa.config.HapiFhirHibernateJpaDialect.resourceIndexedCompositeStringUniqueConstraintFailure=The operation has failed with a unique index constraint failure. This probably means that the operation was trying to create/update a resource that would have resulted in a duplicate value for a unique index.
 ca.uhn.fhir.jpa.config.HapiFhirHibernateJpaDialect.forcedIdConstraintFailure=The operation has failed with a client-assigned ID constraint failure. This typically means that multiple client threads are trying to create a new resource with the same client-assigned ID at the same time, and this thread was chosen to be rejected. It can also happen when a request disables the Upsert Existence Check.
@@ -92,6 +93,7 @@ ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.incomingNoopInTransaction=Transaction contai
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.invalidMatchUrlInvalidResourceType=Invalid match URL "{0}" - Unknown resource type: "{1}"
 ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.resourceTypeAndFhirIdConflictAcrossPartitions=Failed to create/update resource [{0}/{1}] in partition {2} because a resource of the same type and ID is found in another partition
 ca.uhn.fhir.jpa.dao.BaseStorageDao.invalidMatchUrlNoMatches=Invalid match URL "{0}" - No resources match this search
+ca.uhn.fhir.jpa.dao.BaseStorageDao.invalidMatchUrlCantUseForAutoCreatePlaceholder=Invalid match URL "{0}" - No resources match this search and the URL is not valid for automatic placeholder reference target creation
 ca.uhn.fhir.jpa.dao.BaseStorageDao.inlineMatchNotSupported=Inline match URLs are not supported on this server. Cannot process reference: "{0}"
 ca.uhn.fhir.jpa.dao.BaseStorageDao.transactionOperationWithMultipleMatchFailure=Failed to {0} {1} with match URL "{2}" because this search matched {3} resources
 ca.uhn.fhir.jpa.dao.BaseStorageDao.deleteByUrlThresholdExceeded=Failed to DELETE resources with match URL "{0}" because the resolved number of resources: {1} exceeds the threshold of {2}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7114-auto-placeholder-targets-avoid-concurrency.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7114-auto-placeholder-targets-avoid-concurrency.yaml
@@ -1,0 +1,9 @@
+---
+type: add
+issue: 7114
+title: "When _Auto-Create Placeholder Reference Targets_ is enabled in combination 
+  with _Populate Identifier In Auto Created Placeholder Reference Targets_ 
+  and _Allow Inline Match URLs_, concurrent requests can create duplicate placeholder 
+  resources which match a given conditional URL reference. This is now prevented 
+  through the use of a database constraint like it is for other conditional 
+  create/update operations."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7114-auto-placeholder-targets-copy-multiple-identifiers.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7114-auto-placeholder-targets-copy-multiple-identifiers.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 7114
+title: "When _Populate Identifier In Auto Created Placeholder Reference Targets_ is 
+  used, the system will now copy multiple identifiers into the created placeholder 
+  resource if multiple identifiers are present on the conditional URL."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7114-auto-placeholder-targets-dont-create-non-matcing-conditional-reference-placeholder.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7114-auto-placeholder-targets-dont-create-non-matcing-conditional-reference-placeholder.yaml
@@ -1,0 +1,10 @@
+---
+type: add
+issue: 7114
+title: "When _Auto-Create Placeholder Reference Targets_ is enabled in combination 
+  with _Allow Inline Match URLs_, a placeholder reference was incorrectly created 
+  if a conditional URL reference could not be resolved, even though the placeholder 
+  reference would not actually satisfy the conditional URL. This has been corrected 
+  and no placeholder resource will be created (meaning that the operation will now 
+  fail unless _Populate Identifier In Auto Created Placeholder Reference Targets_ is 
+  also enabled)."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HapiFhirHibernateJpaDialect.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/HapiFhirHibernateJpaDialect.java
@@ -107,6 +107,11 @@ public class HapiFhirHibernateJpaDialect extends HibernateJpaDialect {
 					throw super.convertHibernateAccessException(theException);
 				}
 			}
+
+			if (theException.getMessage().contains(ResourceSearchUrlEntity.TABLE_NAME)) {
+				throw new ResourceVersionConflictException(
+						Msg.code(2745) + makeErrorMessage(messageToPrepend, "conditionalCreateConstraintFailure"));
+			}
 		}
 
 		/*

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -55,6 +55,7 @@ import ca.uhn.fhir.jpa.dao.HistoryBuilderFactory;
 import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
 import ca.uhn.fhir.jpa.dao.IJpaStorageResourceParser;
 import ca.uhn.fhir.jpa.dao.ISearchBuilder;
+import ca.uhn.fhir.jpa.dao.JpaDaoResourceLinkResolver;
 import ca.uhn.fhir.jpa.dao.JpaStorageResourceParser;
 import ca.uhn.fhir.jpa.dao.MatchResourceUrlService;
 import ca.uhn.fhir.jpa.dao.ResourceHistoryCalculator;
@@ -73,7 +74,6 @@ import ca.uhn.fhir.jpa.dao.expunge.IExpungeEverythingService;
 import ca.uhn.fhir.jpa.dao.expunge.IResourceExpungeService;
 import ca.uhn.fhir.jpa.dao.expunge.JpaResourceExpungeService;
 import ca.uhn.fhir.jpa.dao.expunge.ResourceTableFKProvider;
-import ca.uhn.fhir.jpa.dao.index.DaoResourceLinkResolver;
 import ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer;
 import ca.uhn.fhir.jpa.dao.index.IdHelperService;
 import ca.uhn.fhir.jpa.dao.index.SearchParamWithInlineReferencesExtractor;
@@ -407,7 +407,7 @@ public class JpaConfig {
 	@Bean
 	@Primary
 	public IResourceLinkResolver daoResourceLinkResolver() {
-		return new DaoResourceLinkResolver<JpaPid>();
+		return new JpaDaoResourceLinkResolver();
 	}
 
 	@Bean(name = PackageUtils.LOADER_WITH_CACHE)

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaDaoResourceLinkResolver.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaDaoResourceLinkResolver.java
@@ -1,0 +1,59 @@
+package ca.uhn.fhir.jpa.dao;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.dao.index.DaoResourceLinkResolver;
+import ca.uhn.fhir.jpa.model.cross.IBasePersistedResource;
+import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.search.ResourceSearchUrlSvc;
+import ca.uhn.fhir.util.CanonicalIdentifier;
+import ca.uhn.fhir.util.UrlUtil;
+import jakarta.annotation.Nonnull;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class JpaDaoResourceLinkResolver extends DaoResourceLinkResolver<JpaPid> {
+
+	@Autowired
+	private FhirContext myFhirContext;
+
+	@Autowired
+	private ResourceSearchUrlSvc myResourceSearchUrlSvc;
+
+	@Override
+	protected void verifyPlaceholderCanBeCreated(
+			Class<? extends IBaseResource> theType,
+			String theIdToAssignToPlaceholder,
+			IBaseReference theReference,
+			IBasePersistedResource theStoredEntity) {
+		if (isNotBlank(theIdToAssignToPlaceholder)) {
+			return;
+		}
+
+		String reference = theReference.getReferenceElement().getValue();
+		if (reference.contains("?")) {
+			String resourceType = myFhirContext.getResourceType(theType);
+
+			List<CanonicalIdentifier> referenceMatchUrlIdentifiers = extractIdentifierFromUrl(reference);
+			String matchUrl = referenceMatchUrlIdentifiers.stream()
+					.map(JpaDaoResourceLinkResolver::toUrlParam)
+					.collect(Collectors.joining("&"));
+
+			myResourceSearchUrlSvc.enforceMatchUrlResourceUniqueness(
+					resourceType, matchUrl, (ResourceTable) theStoredEntity);
+		}
+	}
+
+	@Nonnull
+	private static String toUrlParam(CanonicalIdentifier t) {
+		return "identifier=" + UrlUtil.escapeUrlParam(t.getSystemElement().getValue())
+				+ "|"
+				+ UrlUtil.escapeUrlParam(t.getValueElement().getValue());
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/ResourceSearchUrlSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/ResourceSearchUrlSvc.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import jakarta.persistence.EntityManager;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -97,10 +98,16 @@ public class ResourceSearchUrlSvc {
 	}
 
 	/**
+	 * @param theResourceName The resource name associated with the conditional URL
+	 * @param theMatchUrl The URL parameters portion of the match URL. Should not include a leading {@literal ?}, but can include {@literal &} separators.
+	 *
 	 *  We store a record of match urls with res_id so a db constraint can catch simultaneous creates that slip through.
 	 */
 	public void enforceMatchUrlResourceUniqueness(
 			String theResourceName, String theMatchUrl, ResourceTable theResourceTable) {
+		Validate.notBlank(theResourceName, "theResourceName must not be blank");
+		Validate.notBlank(theMatchUrl, "theMatchUrl must not be blank");
+
 		String canonicalizedUrlForStorage = createCanonicalizedUrlForStorage(theResourceName, theMatchUrl);
 
 		ResourceSearchUrlEntity searchUrlEntity = ResourceSearchUrlEntity.from(

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceSearchUrlEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceSearchUrlEntity.java
@@ -52,7 +52,7 @@ import java.util.Optional;
  */
 @Entity
 @Table(
-		name = "HFJ_RES_SEARCH_URL",
+		name = ResourceSearchUrlEntity.TABLE_NAME,
 		indexes = {
 			@Index(name = "IDX_RESSEARCHURL_RES", columnList = "RES_ID"),
 			@Index(name = "IDX_RESSEARCHURL_TIME", columnList = "CREATED_TIME")
@@ -61,6 +61,7 @@ public class ResourceSearchUrlEntity {
 
 	public static final String RES_SEARCH_URL_COLUMN_NAME = "RES_SEARCH_URL";
 	public static final String PARTITION_ID = "PARTITION_ID";
+	public static final String TABLE_NAME = "HFJ_RES_SEARCH_URL";
 
 	@EmbeddedId
 	private ResourceSearchUrlEntityPK myPk;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoCreatePlaceholdersR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoCreatePlaceholdersR4Test.java
@@ -2,9 +2,6 @@ package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.Hook;
-import ca.uhn.fhir.interceptor.api.HookParams;
-import ca.uhn.fhir.interceptor.api.IAnonymousInterceptor;
-import ca.uhn.fhir.interceptor.api.IPointcut;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
@@ -28,7 +25,6 @@ import ca.uhn.fhir.util.BundleBuilder;
 import ca.uhn.fhir.util.ClasspathUtil;
 import ca.uhn.fhir.util.HapiExtensions;
 import com.google.common.collect.Sets;
-import jakarta.persistence.Id;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.AuditEvent;
@@ -50,6 +46,8 @@ import org.hl7.fhir.r4.model.Task;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashSet;
 import java.util.List;
@@ -67,7 +65,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.doAnswer;
 
 
 @SuppressWarnings({"ConstantConditions", "LoggingSimilarMessage"})
@@ -85,6 +82,39 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		myStorageSettings.setBundleTypesAllowedForStorage(new JpaStorageSettings().getBundleTypesAllowedForStorage());
 		myStorageSettings.setAutoVersionReferenceAtPaths(new JpaStorageSettings().getAutoVersionReferenceAtPaths());
 	}
+
+	@Test
+	public void testCreateWithMatchUrl_MatchUrlCopyingDisabled_Fails() {
+		// Setup
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		myStorageSettings.setPopulateIdentifierInAutoCreatedPlaceholderReferenceTargets(false);
+
+		// Test & Verify
+		Patient patient = new Patient();
+		patient.addGeneralPractitioner().setReference("Practitioner?identifier=http://foo|123");
+		assertThatThrownBy(()->myPatientDao.create(patient, newSrd()))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("Invalid match URL \"Practitioner?identifier=http://foo|123\" - No resources match this search");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"Practitioner?identifier=http://foo|123,http://foo|234",
+		"Practitioner?identifier=http://foo|123&name=smith",
+	})
+	public void testCreateWithMatchUrl_MatchUrlCopyingEnabled_InvalidUrl_Fails(String theMatchUrl) {
+		// Setup
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		myStorageSettings.setPopulateIdentifierInAutoCreatedPlaceholderReferenceTargets(false);
+
+		// Test & Verify
+		Patient patient = new Patient();
+		patient.addGeneralPractitioner().setReference(theMatchUrl);
+		assertThatThrownBy(()->myPatientDao.create(patient, newSrd()))
+			.isInstanceOf(ResourceNotFoundException.class)
+			.hasMessageContaining("Invalid match URL \"" + theMatchUrl + "\" - No resources match this search and the URL is not valid for automatic placeholder reference target creation");
+	}
+
 
 	@Test
 	public void testCreateWithBadReferenceFails() {
@@ -275,26 +305,6 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		assertNull(extension);
 	}
 
-	@Test
-	public void testCreatePlaceholderWithMatchUrl_IdentifierNotCopied() {
-		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
-		myStorageSettings.setAllowInlineMatchUrlReferences(true);
-		myStorageSettings.setPopulateIdentifierInAutoCreatedPlaceholderReferenceTargets(false);
-
-		Observation obsToCreate = new Observation();
-		obsToCreate.setStatus(ObservationStatus.FINAL);
-		obsToCreate.getSubject().setReference("Patient?identifier=http://foo|123");
-		obsToCreate.getSubject().getIdentifier().setSystem("http://foo").setValue("123");
-		IIdType id = myObservationDao.create(obsToCreate, mySrd).getId();
-
-		Observation createdObs = myObservationDao.read(id, mySrd);
-		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
-
-		Patient patient = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
-		ourLog.debug(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(patient));
-		assertThat(patient.getIdentifier()).isEmpty();
-	}
-
 	//	Case 1:
 	//
 	//	IF the inline match URL does include an identifier
@@ -358,7 +368,7 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		 */
 		Observation obsToCreate = new Observation();
 		obsToCreate.setStatus(ObservationStatus.FINAL);
-		obsToCreate.getSubject().setReference("Patient?name=Johhnybravo");
+		obsToCreate.getSubject().setReference("Patient/ABC");
 		obsToCreate.getSubject().getIdentifier().setSystem("http://foo").setValue("123");
 		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
 
@@ -546,12 +556,12 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		List<Identifier> identifiers = placeholderPat.getIdentifier();
 
 		//inline match-url identifier
-		assertEquals("http://foo", identifiers.get(1).getSystem());
-		assertEquals("123", identifiers.get(1).getValue());
+		assertEquals("http://foo", identifiers.get(0).getSystem());
+		assertEquals("123", identifiers.get(0).getValue());
 
 		//subject identifier
-		assertEquals(system, identifiers.get(0).getSystem());
-		assertEquals(value, identifiers.get(0).getValue());
+		assertEquals(system, identifiers.get(1).getSystem());
+		assertEquals(value, identifiers.get(1).getValue());
 
 
 		// Conditionally update a Patient with the same identifier
@@ -574,6 +584,47 @@ public class FhirResourceDaoCreatePlaceholdersR4Test extends BaseJpaR4Test {
 		assertEquals(createdObs.getSubject().getReference(), conditionalUpdatePatId.toUnqualifiedVersionless().getValueAsString());
 		assertEquals(placeholderPatId.toUnqualifiedVersionless().getValueAsString(), conditionalUpdatePatId.toUnqualifiedVersionless().getValueAsString());
 	}
+
+	@Test
+	public void testCreatePlaceholderWithMultipleIdentifiersInConditionalUrl() {
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		myStorageSettings.setAllowInlineMatchUrlReferences(true);
+		myStorageSettings.setPopulateIdentifierInAutoCreatedPlaceholderReferenceTargets(true);
+
+		/*
+		 * Create an Observation that references a Patient
+		 */
+		Observation obsToCreate = new Observation();
+		obsToCreate.setStatus(ObservationStatus.FINAL);
+		obsToCreate.getSubject().setReference("Patient?identifier=http://foo|123&identifier=http://bar|456");
+		IIdType obsId = myObservationDao.create(obsToCreate, mySrd).getId();
+
+		// Read the Observation
+		Observation createdObs = myObservationDao.read(obsId, mySrd);
+
+		//Read the Placeholder Patient
+		Patient placeholderPat = myPatientDao.read(new IdType(createdObs.getSubject().getReference()), mySrd);
+		ourLog.debug("\nObservation created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(createdObs));
+
+		//Ensure the Obs has the right placeholder ID.
+		IIdType placeholderPatId = placeholderPat.getIdElement();
+		assertEquals(createdObs.getSubject().getReference(), placeholderPatId.toUnqualifiedVersionless().getValueAsString());
+
+		/*
+		 * Placeholder Identifiers should both be populated since they were both provided, and did not match
+		 */
+		ourLog.debug("\nPlaceholder Patient created:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(placeholderPat));
+		assertThat(placeholderPat.getIdentifier()).hasSize(2);
+		List<Identifier> identifiers = placeholderPat.getIdentifier();
+
+		//inline match-url identifier
+		assertEquals("http://foo", identifiers.get(0).getSystem());
+		assertEquals("123", identifiers.get(0).getValue());
+		assertEquals("http://bar", identifiers.get(1).getSystem());
+		assertEquals("456", identifiers.get(1).getValue());
+
+	}
+
 
 	@Test
 	public void testCreatePlaceholderWithMatchUrl_IdentifierCopiedByDefault_WithUpdateToTarget() {

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoCreatePlaceholdersConcurrencyR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoCreatePlaceholdersConcurrencyR5Test.java
@@ -1,0 +1,100 @@
+package ca.uhn.fhir.jpa.dao.r5;
+
+import ca.uhn.fhir.jpa.interceptor.UserRequestRetryVersionConflictsInterceptor;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.util.ThreadPoolUtil;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Observation.ObservationStatus;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+@SuppressWarnings({"ConstantConditions", "LoggingSimilarMessage"})
+public class FhirResourceDaoCreatePlaceholdersConcurrencyR5Test extends BaseJpaR4Test {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(FhirResourceDaoCreatePlaceholdersConcurrencyR5Test.class);
+	private ThreadPoolTaskExecutor myExecutor;
+
+	@AfterEach
+	public void after() {
+		myExecutor.shutdown();
+	}
+
+	@Override
+	@BeforeEach
+	public void before() throws Exception {
+		super.before();
+
+		myExecutor = ThreadPoolUtil.newThreadPool(10, "placeholder-worker");
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testCreateConcurrent(boolean theAutomaticRetry) {
+		// Setup
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		myStorageSettings.setPopulateIdentifierInAutoCreatedPlaceholderReferenceTargets(true);
+		if (theAutomaticRetry) {
+			registerInterceptor(new UserRequestRetryVersionConflictsInterceptor());
+		}
+
+		// Test
+		List<Future<?>> futures = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			Observation obs = new Observation();
+			obs.setStatus(ObservationStatus.FINAL);
+			obs.getSubject().setReference("Patient?identifier=http://foo|bar");
+			obs.getSubject().setIdentifier(new Identifier().setSystem("http://foo").setValue("bar"));
+			futures.add(myExecutor.submit(() -> {
+				SystemRequestDetails requestDetails = newSrd();
+				if (theAutomaticRetry) {
+					UserRequestRetryVersionConflictsInterceptor.addRetryHeader(requestDetails, 2);
+				}
+				return myObservationDao.create(obs, requestDetails);
+			}));
+		}
+
+		for (Future<?> future : futures) {
+			if (theAutomaticRetry) {
+				assertDoesNotThrow(() -> future.get());
+			} else {
+				try {
+					future.get();
+				} catch (InterruptedException | ExecutionException e) {
+					assertThat(e.toString()).contains("The operation has failed with a conditional constraint failure. This generally means that two clients/threads were trying to perform a conditional create or update at the same time which would have resulted in duplicate resources being created.");
+				}
+			}
+		}
+
+		// Verify
+		logAllResourcesOfType("Observation");
+		logAllResourcesOfType("Patient");
+
+		SearchParameterMap params = SearchParameterMap
+			.newSynchronous()
+			.add(Patient.SP_IDENTIFIER, new TokenParam("http://foo", "bar"));
+		IBundleProvider actual = myPatientDao.search(params, newSrd());
+		assertThat(toUnqualifiedVersionlessIdValues(actual)).hasSize(1);
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -97,6 +97,7 @@ import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
 import ca.uhn.fhir.jpa.search.cache.ISearchCacheSvc;
 import ca.uhn.fhir.jpa.search.cache.ISearchResultCacheSvc;
 import ca.uhn.fhir.jpa.search.reindex.IResourceReindexingSvc;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.registry.SearchParamRegistryImpl;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionLoader;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionRegistry;
@@ -570,6 +571,16 @@ public abstract class BaseJpaTest extends BaseTest {
 		runInTransaction(() -> {
 			ourLog.info("Package Versions:\n * {}", myPackageVersionDao.findAll().stream().map(t -> t.toString()).collect(Collectors.joining("\n * ")));
 		});
+	}
+
+	protected void logAllResourcesOfType(String type) {
+		IFhirResourceDao dao = myDaoRegistry.getResourceDao(type);
+		IBundleProvider allResources = dao.search(SearchParameterMap.newSynchronous().setLoadSynchronousUpTo(100), newSrd());
+		List<IBaseResource> resources = allResources.getAllResources();
+		for (int i = 0; i < resources.size(); i++) {
+			IBaseResource next = resources.get(i);
+			ourLog.info("{} #{}:\n{}", type, i, myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(next));
+		}
 	}
 
 	protected int countAllMdmLinks() {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/CanonicalIdentifier.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/CanonicalIdentifier.java
@@ -38,6 +38,21 @@ public class CanonicalIdentifier extends BaseIdentifierDt {
 	UriDt mySystem;
 	StringDt myValue;
 
+	/**
+	 * Constructor
+	 */
+	public CanonicalIdentifier() {
+		super();
+	}
+
+	/**
+	 * Constructor
+	 */
+	public CanonicalIdentifier(String theSystem, String theValue) {
+		setSystem(theSystem);
+		setValue(theValue);
+	}
+
 	@Override
 	public UriDt getSystemElement() {
 		return mySystem;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/ThreadPoolUtil.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/ThreadPoolUtil.java
@@ -30,6 +30,20 @@ import java.util.concurrent.RejectedExecutionHandler;
 public final class ThreadPoolUtil {
 	private ThreadPoolUtil() {}
 
+	/**
+	 * Creates a fixed-size thread pool with {@literal thePoolSize} threads
+	 * and an unlimited-length work queue.
+	 *
+	 * @param thePoolSize The number of threads in the pool
+	 * @param theThreadNamePrefix Threads in the pool will be named with this prefix followed by a dash and a number
+	 *
+	 * @since 8.4.0
+	 */
+	@Nonnull
+	public static ThreadPoolTaskExecutor newThreadPool(int thePoolSize, String theThreadNamePrefix) {
+		return newThreadPool(thePoolSize, thePoolSize, theThreadNamePrefix, 0);
+	}
+
 	@Nonnull
 	public static ThreadPoolTaskExecutor newThreadPool(
 			int theCorePoolSize, int theMaxPoolSize, String theThreadNamePrefix) {
@@ -70,13 +84,17 @@ public final class ThreadPoolUtil {
 		Validate.isTrue(
 				theCorePoolSize == theMaxPoolSize || theQueueCapacity == 0,
 				"If the queue capacity is greater than 0, core pool size needs to match max pool size or the system won't grow the queue");
-		Validate.isTrue(theThreadNamePrefix.endsWith("-"), "Thread pool prefix name must end with a hyphen");
+		Validate.notBlank(theThreadNamePrefix, "Thread name prefix must not be blank");
+		String threadNamePrefix = theThreadNamePrefix;
+		if (!threadNamePrefix.endsWith("-")) {
+			threadNamePrefix = threadNamePrefix + "-";
+		}
 		ThreadPoolTaskExecutor asyncTaskExecutor = new ThreadPoolTaskExecutor();
 		asyncTaskExecutor.setCorePoolSize(theCorePoolSize);
 		asyncTaskExecutor.setMaxPoolSize(theMaxPoolSize);
 		asyncTaskExecutor.setQueueCapacity(theQueueCapacity);
 		asyncTaskExecutor.setAllowCoreThreadTimeOut(true);
-		asyncTaskExecutor.setThreadNamePrefix(theThreadNamePrefix);
+		asyncTaskExecutor.setThreadNamePrefix(threadNamePrefix);
 		asyncTaskExecutor.setRejectedExecutionHandler(theRejectedExecutionHandler);
 		asyncTaskExecutor.setTaskDecorator(taskDecorator);
 		asyncTaskExecutor.initialize();

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/dao/index/DaoResourceLinkResolverTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/dao/index/DaoResourceLinkResolverTest.java
@@ -3,34 +3,74 @@ package ca.uhn.fhir.jpa.dao.index;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.util.CanonicalIdentifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DaoResourceLinkResolverTest {
 
-	@Test
-	public void testLinkResolution() {
-		DaoResourceLinkResolver resolver = new DaoResourceLinkResolver<JpaPid>();
-		CanonicalIdentifier canonicalIdentifier = resolver.extractIdentifierFromUrl("Patient?_patient?" +
-			"identifier=http://hapifhir.io/fhir/namingsystem/my_id|123456");
-		assertEquals("http://hapifhir.io/fhir/namingsystem/my_id", canonicalIdentifier.getSystemElement().getValueAsString());
-		assertEquals("123456", canonicalIdentifier.getValueElement().getValueAsString());
-
-		canonicalIdentifier = resolver.extractIdentifierFromUrl("Patient?_patient?" +
-			"identifier=http://hapifhir.io/fhir/namingsystem/my_id|123456&identifier=https://www.id.org/identifiers/member|1101331");
-		assertEquals("http://hapifhir.io/fhir/namingsystem/my_id", canonicalIdentifier.getSystemElement().getValueAsString());
-		assertEquals("123456", canonicalIdentifier.getValueElement().getValueAsString());
-
-		canonicalIdentifier = resolver.extractIdentifierFromUrl("Patient?_tag:not=http://hapifhir.io/fhir/namingsystem/mdm-record-status|GOLDEn_rEcorD" +
-			"&identifier=https://www.my.org/identifiers/memBER|123456");
-		assertEquals("https://www.my.org/identifiers/memBER", canonicalIdentifier.getSystemElement().getValueAsString());
-		assertEquals("123456", canonicalIdentifier.getValueElement().getValueAsString());
-
-		canonicalIdentifier = resolver.extractIdentifierFromUrl("Patient?_tag:not=http://hapifhir.io/fhir/namingsystem/mdm-record-status|GOLDEn_rEcorD");
-		assertNull(canonicalIdentifier);
-
+	@ParameterizedTest
+	@MethodSource("getLinkResolutionTestCases")
+	void testLinkResolution(LinkResolutionTestCase theTestCase) {
+		DaoResourceLinkResolver<JpaPid> resolver = new DaoResourceLinkResolver<>();
+		List<CanonicalIdentifier> canonicalIdentifier = resolver.extractIdentifierFromUrl(theTestCase.url);
+		assertEquals(theTestCase.expectedMatches, canonicalIdentifier);
 	}
+
+	static List<LinkResolutionTestCase> getLinkResolutionTestCases() {
+		return List.of(
+
+			// One identifier
+			new LinkResolutionTestCase(
+				"Patient?identifier=http://hapifhir.io/fhir/namingsystem/my_id|123456",
+				List.of(new CanonicalIdentifier("http://hapifhir.io/fhir/namingsystem/my_id", "123456"))
+			),
+
+			// Multiple identifiers
+			new LinkResolutionTestCase(
+				"Patient?_tag:not=http://hapifhir.io/fhir/namingsystem/mdm-record-status|GOLDEn_rEcorD&identifier=https://www.my.org/identifiers/memBER|123456",
+				List.of(new CanonicalIdentifier("https://www.my.org/identifiers/memBER", "123456"))
+			),
+
+			// No identifier
+			new LinkResolutionTestCase(
+				"Patient?name=smith",
+				List.of()
+			),
+
+			// Identifier plus other parameters: Should be treated as no identifiers
+			// since there are other params in there too
+			new LinkResolutionTestCase(
+				"Patient?identifier=http://foo|123&name=smith",
+				List.of()
+			),
+
+			// Identifier with OR values
+			new LinkResolutionTestCase(
+				"Patient?identifier=http://foo|123,http://foo|456",
+				List.of()
+			),
+
+			// Identifier with modifier
+			new LinkResolutionTestCase(
+				"Patient?identifier:not=http://foo|123",
+				List.of()
+			),
+
+			// Identifier with modifier
+			new LinkResolutionTestCase(
+				"Patient?identifier:missing=true",
+				List.of()
+			)
+
+		);
+	}
+
+	private record LinkResolutionTestCase(String url, List<CanonicalIdentifier> expectedMatches){}
 
 }
 


### PR DESCRIPTION
Closes #7114 

This PR fixes several issues with Auto-Create Placeholder Reference Targets:

* When _Auto-Create Placeholder Reference Targets_ is enabled in combination with _Populate Identifier In Auto Created Placeholder Reference Targets_ and _Allow Inline Match URLs_, concurrent requests can create duplicate placeholder resources which match a given conditional URL reference. This is now prevented through the use of a database constraint like it is for other conditional create/update operations.
* When _Auto-Create Placeholder Reference Targets_ is enabled in combination with _Allow Inline Match URLs_, a placeholder reference was incorrectly created if a conditional URL reference could not be resolved, even though the placeholder reference would not actually satisfy the conditional URL. This has been corrected and no placeholder resource will be created (meaning that the operation will now fail unless _Populate Identifier In Auto Created Placeholder Reference Targets_ is also enabled).
* When _Populate Identifier In Auto Created Placeholder Reference Targets_ is used, the system will now copy multiple identifiers into the created placeholder resource if multiple identifiers are present on the conditional URL.