### PR TITLE
Improve IdSubstitutionMap performance

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7156-improve-idsubstitution-performance.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7156-improve-idsubstitution-performance.yaml
@@ -1,0 +1,5 @@
+---
+type: perf
+issue: 7156
+title: "When performing FHIR transaction operations which create a large number of resources,
+  a CPU bottleneck in the transaction processor was resolved."


### PR DESCRIPTION
This PR resolves an O(n^2) bottleneck when invoking FHIR transactions with lots of entries