### PR TITLE
Add resource type to the HFJ_RESOURCE_TYPE primary key to avoid collisions

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7152-add-resource-type-to-primary-key-to-guarantee-uniqueness.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7152-add-resource-type-to-primary-key-to-guarantee-uniqueness.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7152
+jira: SMILE-10226
+title: "Modified resources could potentially be removed from the subscription list of they shared ID and Version with 
+others. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/upgrade.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/upgrade.md
@@ -27,3 +27,6 @@ As of `8.3.12-SNAPSHOT`, HAPI-FHIR snapshots are now published on [Maven Central
 
 * `$export` and `$everything` operations on Patient Compartment (instance or type) will no longer return `List` or `Group` resources, regardless of auth rules.
 
+## Zero-Downtime Upgrades with Subscriptions
+
+The database upgrade includes changes to the `HFJ_RESOURCE_MODIFIED` table. This table holds transitional data about resources that have been modified. Under normal conditions, this table will be empty or nearly so. It is recommended to verify that subscriptions are running smoothly to avoid prolonged table locks while the table structure is updated.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -134,7 +134,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 	}
 
 	protected void init860() {
-		Builder version = forVersion(VersionEnum.V8_6_0);
+		Builder version = forVersion(VersionEnum.V8_4_0);
 		{
 			version.onTable("HFJ_RESOURCE_MODIFIED").dropPrimaryKey("20250729.1");
 			version.onTable("HFJ_RESOURCE_MODIFIED").addPrimaryKey("20250729.2", "RES_ID", "RES_VER", "RESOURCE_TYPE");

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -130,6 +130,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		init780();
 		init820();
 		init840();
+		init860();
+	}
+
+	protected void init860() {
+		Builder version = forVersion(VersionEnum.V8_6_0);
+		{
+			version.onTable("HFJ_RESOURCE_MODIFIED").dropPrimaryKey("20250729.1");
+			version.onTable("HFJ_RESOURCE_MODIFIED").addPrimaryKey("20250729.2", "RES_ID", "RES_VER", "RESOURCE_TYPE");
+		}
 	}
 
 	protected void init840() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
@@ -171,7 +171,8 @@ public class ResourceModifiedMessagePersistenceSvcImpl implements IResourceModif
 		IIdType theMsgId = theMsg.getPayloadId(myFhirContext);
 
 		ResourceModifiedEntity resourceModifiedEntity = new ResourceModifiedEntity();
-		resourceModifiedEntity.setResourceModifiedEntityPK(with(theMsgId.getIdPart(), theMsgId.getVersionIdPart()));
+		resourceModifiedEntity.setResourceModifiedEntityPK(
+				with(theMsgId.getIdPart(), theMsgId.getVersionIdPart(), theMsg.getResourceType(myFhirContext)));
 
 		String partialModifiedMessage = getPayloadLessMessageAsString(theMsg);
 		resourceModifiedEntity.setSummaryResourceModifiedMessage(partialModifiedMessage);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/ResourceModifiedMessagePersistenceSvcImpl.java
@@ -172,11 +172,10 @@ public class ResourceModifiedMessagePersistenceSvcImpl implements IResourceModif
 
 		ResourceModifiedEntity resourceModifiedEntity = new ResourceModifiedEntity();
 		resourceModifiedEntity.setResourceModifiedEntityPK(
-				with(theMsgId.getIdPart(), theMsgId.getVersionIdPart(), theMsg.getResourceType(myFhirContext)));
+				with(theMsgId.getIdPart(), theMsgId.getVersionIdPart(), theMsgId.getResourceType()));
 
 		String partialModifiedMessage = getPayloadLessMessageAsString(theMsg);
 		resourceModifiedEntity.setSummaryResourceModifiedMessage(partialModifiedMessage);
-		resourceModifiedEntity.setResourceType(theMsgId.getResourceType());
 		resourceModifiedEntity.setCreatedTime(new Date());
 
 		return resourceModifiedEntity;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/PersistedResourceModifiedMessageEntityPK.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/PersistedResourceModifiedMessageEntityPK.java
@@ -35,6 +35,9 @@ public class PersistedResourceModifiedMessageEntityPK implements IPersistedResou
 	@Column(name = "RES_VER", length = 8, nullable = false)
 	private String myResourceVersion;
 
+	@Column(name = "RESOURCE_TYPE", length = ResourceTable.RESTYPE_LEN, nullable = false)
+	private String myResourceType;
+
 	public String getResourcePid() {
 		return myResourcePid;
 	}
@@ -53,10 +56,21 @@ public class PersistedResourceModifiedMessageEntityPK implements IPersistedResou
 		return this;
 	}
 
-	public static PersistedResourceModifiedMessageEntityPK with(String theResourcePid, String theResourceVersion) {
+	public String getResourceType() {
+		return myResourceType;
+	}
+
+	public PersistedResourceModifiedMessageEntityPK setResourceType(String theResourceType) {
+		myResourceType = theResourceType;
+		return this;
+	}
+
+	public static PersistedResourceModifiedMessageEntityPK with(
+			String theResourcePid, String theResourceVersion, String theResourceType) {
 		return new PersistedResourceModifiedMessageEntityPK()
 				.setResourcePid(theResourcePid)
-				.setResourceVersion(theResourceVersion);
+				.setResourceVersion(theResourceVersion)
+				.setResourceType(theResourceType);
 	}
 
 	@Override
@@ -64,16 +78,18 @@ public class PersistedResourceModifiedMessageEntityPK implements IPersistedResou
 		if (this == theO) return true;
 		if (theO == null || getClass() != theO.getClass()) return false;
 		PersistedResourceModifiedMessageEntityPK that = (PersistedResourceModifiedMessageEntityPK) theO;
-		return myResourcePid.equals(that.myResourcePid) && myResourceVersion.equals(that.myResourceVersion);
+		return myResourcePid.equals(that.myResourcePid)
+				&& myResourceVersion.equals(that.myResourceVersion)
+				&& myResourceType.equals(that.myResourceType);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(myResourcePid, myResourceVersion);
+		return Objects.hash(myResourcePid, myResourceVersion, myResourceType);
 	}
 
 	@Override
 	public String toString() {
-		return myResourcePid + "/" + myResourceVersion;
+		return myResourceType + "/" + myResourcePid + "/" + myResourceVersion;
 	}
 }

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceModifiedEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceModifiedEntity.java
@@ -53,9 +53,6 @@ public class ResourceModifiedEntity implements IPersistedResourceModifiedMessage
 	@Temporal(TemporalType.TIMESTAMP)
 	private Date myCreatedTime;
 
-	@Column(name = "RESOURCE_TYPE", length = ResourceTable.RESTYPE_LEN, nullable = false)
-	private String myResourceType;
-
 	public PersistedResourceModifiedMessageEntityPK getResourceModifiedEntityPK() {
 		return myResourceModifiedEntityPK;
 	}
@@ -68,11 +65,11 @@ public class ResourceModifiedEntity implements IPersistedResourceModifiedMessage
 
 	@Override
 	public String getResourceType() {
-		return myResourceType;
+		return myResourceModifiedEntityPK.getResourceType();
 	}
 
 	public ResourceModifiedEntity setResourceType(String theResourceType) {
-		myResourceType = theResourceType;
+		myResourceModifiedEntityPK.setResourceType(theResourceType);
 		return this;
 	}
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceModifiedEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceModifiedEntity.java
@@ -65,10 +65,13 @@ public class ResourceModifiedEntity implements IPersistedResourceModifiedMessage
 
 	@Override
 	public String getResourceType() {
-		return myResourceModifiedEntityPK.getResourceType();
+		return myResourceModifiedEntityPK == null ? null : myResourceModifiedEntityPK.getResourceType();
 	}
 
 	public ResourceModifiedEntity setResourceType(String theResourceType) {
+		if (myResourceModifiedEntityPK == null) {
+			myResourceModifiedEntityPK = new PersistedResourceModifiedMessageEntityPK();
+		}
 		myResourceModifiedEntityPK.setResourceType(theResourceType);
 		return this;
 	}

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceModifiedEntity.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceModifiedEntity.java
@@ -68,14 +68,6 @@ public class ResourceModifiedEntity implements IPersistedResourceModifiedMessage
 		return myResourceModifiedEntityPK == null ? null : myResourceModifiedEntityPK.getResourceType();
 	}
 
-	public ResourceModifiedEntity setResourceType(String theResourceType) {
-		if (myResourceModifiedEntityPK == null) {
-			myResourceModifiedEntityPK = new PersistedResourceModifiedMessageEntityPK();
-		}
-		myResourceModifiedEntityPK.setResourceType(theResourceType);
-		return this;
-	}
-
 	@Override
 	public Date getCreatedTime() {
 		return myCreatedTime;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR4Test.java
@@ -234,13 +234,15 @@ public abstract class BaseSubscriptionsR4Test extends BaseResourceProviderR4Test
 			patient.setId(thePatientId);
 		}
 
-		DaoMethodOutcome outcome = myPatientDao.create(patient);
-		patient.setActive(true);
-
+		DaoMethodOutcome outcome;
 		if(Strings.isNullOrEmpty(thePatientId)) {
+			outcome = myPatientDao.create(patient);
 			patient.setId( outcome.getId());
+		} else {
+			myPatientDao.update(patient);
 		}
 
+		patient.setActive(true);
 		return patient;
 	}
 
@@ -255,9 +257,12 @@ public abstract class BaseSubscriptionsR4Test extends BaseResourceProviderR4Test
 			org.setId(theOrgId);
 		}
 
-		DaoMethodOutcome outcome = myOrganizationDao.create(org);
+		DaoMethodOutcome outcome;
 		if(Strings.isNullOrEmpty(theOrgId)) {
+			outcome = myOrganizationDao.create(org);
 			org.setId(outcome.getId());
+		} else {
+			myOrganizationDao.update(org);
 		}
 
 		return org;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/BaseSubscriptionsR4Test.java
@@ -21,6 +21,7 @@ import ca.uhn.fhir.test.utilities.server.TransactionCapturingProviderExtension;
 import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.test.concurrency.PointcutLatch;
 import com.apicatalog.jsonld.StringUtils;
+import com.google.common.base.Strings;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
 import net.ttddyy.dsproxy.QueryCount;
@@ -224,21 +225,40 @@ public abstract class BaseSubscriptionsR4Test extends BaseResourceProviderR4Test
 	}
 
 	protected Patient sendPatient() {
+		return sendPatient(null);
+	}
+
+	protected Patient sendPatient(String thePatientId) {
 		Patient patient = new Patient();
+		if(!Strings.isNullOrEmpty(thePatientId)) {
+			patient.setId(thePatientId);
+		}
+
+		DaoMethodOutcome outcome = myPatientDao.create(patient);
 		patient.setActive(true);
 
-		IIdType id = myPatientDao.create(patient).getId();
-		patient.setId(id);
+		if(Strings.isNullOrEmpty(thePatientId)) {
+			patient.setId( outcome.getId());
+		}
 
 		return patient;
 	}
 
 	protected Organization sendOrganization() {
-		Organization org = new Organization();
-		org.setName("ORG");
+		return sendOrganization(null);
+	}
 
-		IIdType id = myOrganizationDao.create(org).getId();
-		org.setId(id);
+	protected Organization sendOrganization( String theOrgId) {
+		Organization org = new Organization();
+		org.setName("ORG" + (theOrgId == null ? "" : theOrgId));
+		if(!Strings.isNullOrEmpty(theOrgId)) {
+			org.setId(theOrgId);
+		}
+
+		DaoMethodOutcome outcome = myOrganizationDao.create(org);
+		if(Strings.isNullOrEmpty(theOrgId)) {
+			org.setId(outcome.getId());
+		}
 
 		return org;
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/async/AsyncSubscriptionMessageSubmissionIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/async/AsyncSubscriptionMessageSubmissionIT.java
@@ -100,10 +100,10 @@ public class AsyncSubscriptionMessageSubmissionIT extends BaseSubscriptionsR4Tes
 		int numberOfResourcesToCreate = factor * AsyncResourceModifiedSubmitterSvc.MAX_LIMIT;
 
 		ResourceModifiedEntity entity = new ResourceModifiedEntity();
-		entity.setResourceType(resourceType);
 		PersistedResourceModifiedMessageEntityPK rpm = new PersistedResourceModifiedMessageEntityPK();
 		rpm.setResourceVersion("1");
 		entity.setResourceModifiedEntityPK(rpm);
+		entity.setResourceType(resourceType);
 
 		// we reuse the same exact msg content to avoid
 		// the slowdown of serializing it over and over

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/async/AsyncSubscriptionMessageSubmissionIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/async/AsyncSubscriptionMessageSubmissionIT.java
@@ -102,8 +102,8 @@ public class AsyncSubscriptionMessageSubmissionIT extends BaseSubscriptionsR4Tes
 		ResourceModifiedEntity entity = new ResourceModifiedEntity();
 		PersistedResourceModifiedMessageEntityPK rpm = new PersistedResourceModifiedMessageEntityPK();
 		rpm.setResourceVersion("1");
+		rpm.setResourceType(resourceType);
 		entity.setResourceModifiedEntityPK(rpm);
-		entity.setResourceType(resourceType);
 
 		// we reuse the same exact msg content to avoid
 		// the slowdown of serializing it over and over

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
@@ -241,7 +241,7 @@ public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
 
 	@Test
 	public void testMethodDeleteByPK_whenEntitiesExistWithRepeatedId_willDeleteTheCorrectEntityAndReturnTrue(){
-		String commonId = "common_id";
+		String commonId = "common-id";
 
 		mySubscriptionTestUtil.unregisterSubscriptionInterceptor();
 
@@ -265,6 +265,26 @@ public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
 		assertThat(messages).hasSize(1);
 		assertEquals(ResourceType.Organization.name(), messages.stream().toList().get(0).getResourceType());
 
+	}
+
+	@Test
+	public void testMethodPersist_AddEntriesWithSameExternalIdAndVersion_expectSuccess(){
+		mySubscriptionTestUtil.unregisterSubscriptionInterceptor();
+
+		// given
+		String commonId = "common-id";
+		Patient patient = sendPatient(commonId);
+		Organization organization = sendOrganization(commonId);
+
+		ResourceModifiedMessage patientResourceModifiedMessage = new ResourceModifiedMessage(myFhirContext, patient, BaseResourceMessage.OperationTypeEnum.CREATE);
+		ResourceModifiedMessage organizationResourceModifiedMessage = new ResourceModifiedMessage(myFhirContext, organization, BaseResourceMessage.OperationTypeEnum.CREATE);
+
+		// when
+		myResourceModifiedMessagePersistenceSvc.persist(patientResourceModifiedMessage);
+		myResourceModifiedMessagePersistenceSvc.persist(organizationResourceModifiedMessage);
+
+		// then
+		assertEquals(2,  myResourceModifiedMessagePersistenceSvc.getMessagePersistedCount());
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/subscription/message/MessageSubscriptionR4Test.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -244,7 +245,7 @@ public class MessageSubscriptionR4Test extends BaseSubscriptionsR4Test {
 
 		// given
 		TransactionTemplate transactionTemplate = new TransactionTemplate(myTxManager);
-		IPersistedResourceModifiedMessagePK nonExistentResourceWithPk = PersistedResourceModifiedMessageEntityPK.with("one", "one");
+		IPersistedResourceModifiedMessagePK nonExistentResourceWithPk = PersistedResourceModifiedMessageEntityPK.with("one", "one", ResourceType.Patient.toString());
 
 		// when
 		boolean wasDeleted = transactionTemplate.execute(tx -> myResourceModifiedMessagePersistenceSvc.deleteByPK(nonExistentResourceWithPk));


### PR DESCRIPTION
The original issue occurs when more than one resource type uses the same external ID and version. This can happen during POSTs, which can lead to UPSERTS. Since the primary key used to contain only ID and Version, inserting a resource of a different type could overwrite an existing resource that has the same ID and version. Adding the resource type to the primary key enforces the necessary uniqueness.

Closes #7152 
