### PR TITLE
fix links to GitHub repo and HAPI FHIR website

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>hapi-fhir-base</artifactId>
 	<packaging>bundle</packaging>
 
-	<url>http://jamesagnew.github.io/hapi-fhir/</url>
+	<url>https://hapifhir.io/</url>
 
 	<name>HAPI FHIR - Core Library</name>
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
@@ -330,7 +330,7 @@ public class FhirContext {
 	 * avoiding the need to manually add profile declarations for these custom types.
 	 * </p>
 	 * <p>
-	 * See <a href="http://jamesagnew.gihhub.io/hapi-fhir/doc_extensions.html">Profiling and Extensions</a>
+	 * See <a href="https://hapifhir.io/hapi-fhir/docs/model/profiles_and_extensions.html">Profiles and Extensions</a>
 	 * for more information on using custom types.
 	 * </p>
 	 * <p>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IClientExecutable.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IClientExecutable.java
@@ -111,7 +111,7 @@ public interface IClientExecutable<T extends IClientExecutable<?, Y>, Y> {
 	 * is useful for invocations where the response is a Bundle/Parameters containing nested resources,
 	 * and you want to use specific custom structures for those nested resources.
 	 * <p>
-	 * See <a href="https://jamesagnew.github.io/hapi-fhir/doc_extensions.html">Profiles and Extensions</a> for more information on using custom structures
+	 * See <a href="https://hapifhir.io/hapi-fhir/docs/model/profiles_and_extensions.html">Profiles and Extensions</a> for more information on using custom structures
 	 * </p>
 	 */
 	T preferResponseType(Class<? extends IBaseResource> theType);
@@ -122,7 +122,7 @@ public interface IClientExecutable<T extends IClientExecutable<?, Y>, Y> {
 	 * is useful for invocations where the response is a Bundle/Parameters containing nested resources,
 	 * and you want to use specific custom structures for those nested resources.
 	 * <p>
-	 * See <a href="https://jamesagnew.github.io/hapi-fhir/doc_extensions.html">Profiles and Extensions</a> for more information on using custom structures
+	 * See <a href="https://hapifhir.io/hapi-fhir/docs/model/profiles_and_extensions.html">Profiles and Extensions</a> for more information on using custom structures
 	 * </p>
 	 */
 	T preferResponseTypes(List<Class<? extends IBaseResource>> theTypes);

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/contributing/hacking_guide.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/contributing/hacking_guide.md
@@ -18,7 +18,7 @@ The following is a list of key subprojects you might open in your IDE:
     <a class="externalLink" href="https://dev.azure.com/hapifhir/HAPI%20FHIR/_build/latest?definitionId=1&branchName=master"><img src="https://dev.azure.com/hapifhir/HAPI%20FHIR/_apis/build/status/jamesagnew.hapi-fhir?branchName=master" alt="Build Status" class="img-fluid"/></a>
 </p>
 
-The best way to grab our sources is with Git. Grab the repository URL from our [GitHub page](https://github.com/jamesagnew/hapi-fhir). We try our best to ensure that the sources are always left in a buildable state. Check Azure Pipelines CI (see the image/link on the right) to see if the sources currently build.
+The best way to grab our sources is with Git. Grab the repository URL from our [GitHub page](https://github.com/hapifhir/hapi-fhir). We try our best to ensure that the sources are always left in a buildable state. Check Azure Pipelines CI (see the image/link on the right) to see if the sources currently build.
 
 # Building HAPI FHIR
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/getting_started/modules.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/getting_started/modules.md
@@ -115,7 +115,7 @@ The following table shows the modules that make up the HAPI FHIR library.
     <tr>
         <td style="font-weight: bold; white-space: nowrap;">hapi-fhir-client-okhttp</td>
         <td>
-            <a href="https://github.com/jamesagnew/hapi-fhir/tree/master/hapi-fhir-client-okhttp">Sources&nbsp;&rsaquo;</a>
+            <a href="https://github.com/hapifhir/hapi-fhir/tree/master/hapi-fhir-client-okhttp">Sources&nbsp;&rsaquo;</a>
         </td>
         <td>
             This module contains an alternate HTTP implementation based on
@@ -126,7 +126,7 @@ The following table shows the modules that make up the HAPI FHIR library.
         <td style="font-weight: bold; white-space: nowrap;">hapi-fhir-android</td>
         <td>
             <a href="/hapi-fhir/docs/android/">Documentation&nbsp;&rsaquo;</a>
-            <a href="https://github.com/jamesagnew/hapi-fhir/tree/master/hapi-fhir-android/">Sources&nbsp;&rsaquo;</a>
+            <a href="https://github.com/hapifhir/hapi-fhir/tree/master/hapi-fhir-android/">Sources&nbsp;&rsaquo;</a>
         </td>
         <td>
             This module contains the Android HAPI FHIR framework, which is a FHIR
@@ -202,7 +202,7 @@ The following table shows the modules that make up the HAPI FHIR library.
         <td>
             <a href="/hapi-fhir/docs/server_plain/">Documentation&nbsp;&rsaquo;</a><br/>
             <a href="/hapi-fhir/apidocs/hapi-fhir-server/">JavaDoc&nbsp;&rsaquo;</a>
-            <a href="https://github.com/jamesagnew/hapi-fhir/tree/master/hapi-fhir-server/">Sources&nbsp;&rsaquo;</a>
+            <a href="https://github.com/hapifhir/hapi-fhir/tree/master/hapi-fhir-server/">Sources&nbsp;&rsaquo;</a>
         </td>
         <td>
             This module contains the HAPI FHIR Server framework, which can be used to
@@ -214,7 +214,7 @@ The following table shows the modules that make up the HAPI FHIR library.
         <td>
             <a href="/hapi-fhir/docs/server_jpa/">Documentation&nbsp;&rsaquo;</a><br/>
             <a href="/hapi-fhir/apidocs/hapi-fhir-jpaserver-base/">JavaDoc&nbsp;&rsaquo;</a>
-            <a href="https://github.com/jamesagnew/hapi-fhir/tree/master/hapi-fhir-jpaserver-base/">Sources&nbsp;&rsaquo;</a>
+            <a href="https://github.com/hapifhir/hapi-fhir/tree/master/hapi-fhir-jpaserver-base/">Sources&nbsp;&rsaquo;</a>
         </td>
         <td>
             This module contains the HAPI FHIR "JPA Server", which is a complete
@@ -226,7 +226,7 @@ The following table shows the modules that make up the HAPI FHIR library.
         <td style="font-weight: bold; white-space: nowrap;">hapi-fhir-testpage-overlay</td>
         <td>
             <a href="/hapi-fhir/docs/server_plain/web_testpage_overlay.html">Documentation&nbsp;&rsaquo;</a><br/>
-            <a href="https://github.com/jamesagnew/hapi-fhir/tree/master/hapi-fhir-testpage-overlay/">Sources&nbsp;&rsaquo;</a>
+            <a href="https://github.com/hapifhir/hapi-fhir/tree/master/hapi-fhir-testpage-overlay/">Sources&nbsp;&rsaquo;</a>
         </td>
         <td>
             This module contains the web based "testpage overlay", which is the

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/built_in_client_interceptors.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/built_in_client_interceptors.md
@@ -104,9 +104,9 @@ The following example shows how to enable the GZipContentInterceptor.
 The CapturingInterceptor can be used to capture the details of the last request that was sent by the client, as well as the corresponding response that was received. 
 
 * [CapturingInterceptor JavaDoc](/apidocs/hapi-fhir-client/ca/uhn/fhir/rest/client/interceptor/CapturingInterceptor.html)
-* [CapturingInterceptor Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/CapturingInterceptor.java)
+* [CapturingInterceptor Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/CapturingInterceptor.java)
 
 A separate but related interceptor called ThreadLocalCapturingInterceptor also captures request/response pairs but stores these in a Java ThreadLocal so it is suitable for use in multithreaded environments.  
 
 * [ThreadLocalCapturingInterceptor JavaDoc](/apidocs/hapi-fhir-client/ca/uhn/fhir/rest/client/interceptor/ThreadLocalCapturingInterceptor.html)
-* [ThreadLocalCapturingInterceptor Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/ThreadLocalCapturingInterceptor.java)
+* [ThreadLocalCapturingInterceptor Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/ThreadLocalCapturingInterceptor.java)

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/validation/validation_support_modules.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/validation/validation_support_modules.md
@@ -39,13 +39,13 @@ This module supplies the built-in FHIR core structure definitions, including bot
 
 # InMemoryTerminologyServerValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/InMemoryTerminologyServerValidationSupport.java)
 
 This module acts as a simple terminology service that can validate codes against ValueSet and CodeSystem resources purely in-memory (i.e. with no database). This is sufficient in many basic cases, although it is not able to validate CodeSystems with external content (i.e CodeSystems where the `CodeSystem.content` field is `external`, such as the LOINC and SNOMED CT CodeSystems).
 
 # PrePopulatedValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/PrePopulatedValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/PrePopulatedValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/PrePopulatedValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/PrePopulatedValidationSupport.java)
 
 This module contains a series of HashMaps that store loaded conformance resources in memory. Typically this is initialized at startup in order to add custom conformance resources into the chain.
 
@@ -54,20 +54,20 @@ This module contains a series of HashMaps that store loaded conformance resource
 
 # NpmPackageValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/NpmPackageValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/NpmPackageValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/NpmPackageValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/NpmPackageValidationSupport.java)
 
 This module can be used to load FHIR NPM Packages and supply the conformance resources within them to the validator. See [Validating Using Packages](./instance_validator.html#packages) for am example of how to use this module. 
 
 
 # SnapshotGeneratingValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/SnapshotGeneratingValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/SnapshotGeneratingValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/SnapshotGeneratingValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/SnapshotGeneratingValidationSupport.java)
 
 This module generates StructureDefinition snapshots as needed. This should be added to your chain if you are working wiith differential StructureDefinitions that do not include the snapshot view.
 
 # CommonCodeSystemsTerminologyService
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CommonCodeSystemsTerminologyService.java)
 
 This module validates codes in CodeSystems that are not distributed with the FHIR specification because they are difficult to distribute but are commonly used in FHIR resources.
 
@@ -151,7 +151,7 @@ The following table lists vocabulary that is validated by this module:
 
 # RemoteTerminologyServiceValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java)
 
 This module validates codes using a remote FHIR-based terminology server.
 
@@ -164,7 +164,7 @@ This module will invoke the following operations on the remote terminology serve
 
 # UnknownCodeSystemWarningValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.java)
 
 This validation support module may be placed at the end of a ValidationSupportChain in order to configure the validator to generate a warning if a resource being validated contains an unknown code system.
 
@@ -172,7 +172,7 @@ Note that this module must also be activated by calling [setAllowNonExistentCode
 
 # CachingValidationSupport
 
-[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.html) / [Source](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java)
+[JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/CachingValidationSupport.java)
 
 This module is deprecated and no longer provides any functionality. Caching is provided by [ValidationSupportChain](#validationsupportchain).
 

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>hapi-fhir-test-utilities</artifactId>
 	<packaging>jar</packaging>
 	<name>HAPI FHIR Test Utilities</name>
-	<url>http://jamesagnew.github.io/hapi-fhir/</url>
+	<url>https://hapifhir.io/</url>
 
 	<properties>
 		<!-- this is a test jar, so use our test settings -->

--- a/list_releases.sh
+++ b/list_releases.sh
@@ -1,1 +1,1 @@
-curl https://api.github.com/repos/jamesagnew/hapi-fhir/releases
+curl https://api.github.com/repos/hapifhir/hapi-fhir/releases


### PR DESCRIPTION
I suppose that links should go to the "official" HAPI FHIR repo and not @jamesagnew 's mirror?
Hope this PR helps! 