### PR TITLE
Duplicate uploads of binary content for externalized attachments

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/AttachmentUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/AttachmentUtil.java
@@ -27,10 +27,14 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.model.primitive.CodeDt;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import java.util.List;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class AttachmentUtil {
 
@@ -91,6 +95,17 @@ public class AttachmentUtil {
 		} else {
 			entryChild.getMutator().setValue(theAttachment, newPrimitive(theContext, "unsignedInt", theLength));
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Optional<String> getFirstExtension(IBaseHasExtensions theAttachment, String theExtension) {
+		return theAttachment.getExtension().stream()
+				.filter(t -> theExtension.equals(t.getUrl()))
+				.filter(t -> t.getValue() instanceof IPrimitiveType)
+				.map(t -> (IPrimitiveType<String>) t.getValue())
+				.map(t -> t.getValue())
+				.filter(t -> isNotBlank(t))
+				.findFirst();
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/AttachmentUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/AttachmentUtil.java
@@ -27,12 +27,14 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.model.primitive.CodeDt;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -98,8 +100,10 @@ public class AttachmentUtil {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static Optional<String> getFirstExtension(IBaseHasExtensions theAttachment, String theExtension) {
+	public static Optional<String> getFirstExtension(
+			IBaseHasExtensions theAttachment, String theExtension, Predicate<? super IBaseExtension<?, ?>> theFilter) {
 		return theAttachment.getExtension().stream()
+				.filter(theFilter)
 				.filter(t -> theExtension.equals(t.getUrl()))
 				.filter(t -> t.getValue() instanceof IPrimitiveType)
 				.map(t -> (IPrimitiveType<String>) t.getValue())

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -82,6 +82,12 @@ public class HapiExtensions {
 			"http://hapifhir.io/fhir/StructureDefinition/externalized-binary-id";
 
 	/**
+	 * Extension ID for the SHA-256 hash of external binary content
+	 */
+	public static final String EXT_EXTERNALIZED_BINARY_HASH_SHA_256 =
+			"http://hapifhir.io/fhir/StructureDefinition/externalized-binary-hash-sha256";
+
+	/**
 	 * For subscription, deliver a bundle containing a search result instead of just a single resource
 	 */
 	public static final String EXT_SUBSCRIPTION_PAYLOAD_SEARCH_CRITERIA =

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7183-duplicate-uploads-of-binary-content-for-externalized-binary-storage.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_4_0/7183-duplicate-uploads-of-binary-content-for-externalized-binary-storage.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7183
+jira: SMILE-10474
+title: "Previously, updating the binary content of a DocumentReference or Binary resource multiple times with 
+the same data via the $binary-access-write operation or a resource update would cause a new resource version 
+to be created and the binary data to be re-uploaded to external binary storage. This has been fixed."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -374,7 +374,7 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 		runInTransaction(() -> {
 			SearchParameterMap map = SearchParameterMap.newSynchronous();
 			map.add(StructureDefinition.SP_URL, new UriParam("http://hl7.org/fhir/uv/shorthand/CodeSystem/shorthand-code-system"));
-			IBundleProvider result = myCodeSystemDao.search(map);
+			IBundleProvider result = myCodeSystemDao.search(map, mySrd);
 			assertEquals(1, result.sizeOrThrowNpe());
 			IBaseResource resource = result.getResources(0, 1).get(0);
 			assertEquals("CodeSystem/shorthand-code-system/_history/1", resource.getIdElement().toString());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
@@ -410,8 +410,10 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 
 	}
 
-	@Test
-	public void testUpdate_withSameBinaryContent_isNoOp() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testUpdate_withSameBinaryContent_isNoOp(boolean theIsAllowAutoInflateBinaries) {
+		myBinaryStorageInterceptor.setAllowAutoInflateBinaries(theIsAllowAutoInflateBinaries);
 		// Create a resource with a big enough docRef
 		DocumentReference docRef = new DocumentReference();
 		addDocumentAttachmentData(docRef, SOME_BYTES);
@@ -436,13 +438,16 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		validateContentExternalized(outcome);
 
 		// Now read it back
+		myBinaryStorageInterceptor.setAllowAutoInflateBinaries(true);
 		DocumentReference output = myDocumentReferenceDao.read(id.withVersion("1"), mySrd);
 		assertEquals("application/octet-stream", output.getContentFirstRep().getAttachment().getContentType());
 		assertThat(output.getContentFirstRep().getAttachment().getData()).containsExactly(SOME_BYTES);
 	}
 
-	@Test
-	public void testUpdate_withSameBinaryContent_reuseBinaryId() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testUpdate_withSameBinaryContent_reuseBinaryId(boolean theIsAllowAutoInflateBinaries) {
+		myBinaryStorageInterceptor.setAllowAutoInflateBinaries(theIsAllowAutoInflateBinaries);
 		// Create a resource with a big enough docRef
 		DocumentReference docRef = new DocumentReference();
 		addDocumentAttachmentData(docRef, SOME_BYTES);
@@ -472,6 +477,7 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		assertEquals(contentHash, contentHashV2);
 
 		// Now read it back
+		myBinaryStorageInterceptor.setAllowAutoInflateBinaries(true);
 		DocumentReference output = myDocumentReferenceDao.read(id.withVersion("2"), mySrd);
 		assertEquals("application/octet-stream", output.getContentFirstRep().getAttachment().getContentType());
 		assertThat(output.getContentFirstRep().getAttachment().getData()).containsExactly(SOME_BYTES);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/BinaryStorageInterceptorR4Test.java
@@ -562,6 +562,8 @@ public class BinaryStorageInterceptorR4Test extends BaseResourceProviderR4Test {
 		validateContentExternalized(outcome);
 		String binaryId = getExtensionByUrl(docRef, HapiExtensions.EXT_EXTERNALIZED_BINARY_ID);
 		assertThat(binaryId).isNotBlank();
+		String hash = getExtensionByUrl(docRef, HapiExtensions.EXT_EXTERNALIZED_BINARY_HASH_SHA_256);
+		assertThat(hash).isNotBlank();
 
 		// Now update
 		docRef = new DocumentReference();

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/api/IBinaryTarget.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/api/IBinaryTarget.java
@@ -19,13 +19,11 @@
  */
 package ca.uhn.fhir.jpa.binary.api;
 
+import ca.uhn.fhir.util.AttachmentUtil;
 import ca.uhn.fhir.util.HapiExtensions;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
-import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import java.util.Optional;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * Wraps an Attachment datatype or Binary resource, since they both
@@ -45,14 +43,11 @@ public interface IBinaryTarget {
 
 	IBaseHasExtensions getTarget();
 
-	@SuppressWarnings("unchecked")
 	default Optional<String> getAttachmentId() {
-		return getTarget().getExtension().stream()
-				.filter(t -> HapiExtensions.EXT_EXTERNALIZED_BINARY_ID.equals(t.getUrl()))
-				.filter(t -> t.getValue() instanceof IPrimitiveType)
-				.map(t -> (IPrimitiveType<String>) t.getValue())
-				.map(t -> t.getValue())
-				.filter(t -> isNotBlank(t))
-				.findFirst();
+		return AttachmentUtil.getFirstExtension(getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_ID);
+	}
+
+	default Optional<String> getHashExtension() {
+		return AttachmentUtil.getFirstExtension(getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_HASH_SHA_256);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/api/IBinaryTarget.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/api/IBinaryTarget.java
@@ -21,9 +21,11 @@ package ca.uhn.fhir.jpa.binary.api;
 
 import ca.uhn.fhir.util.AttachmentUtil;
 import ca.uhn.fhir.util.HapiExtensions;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Wraps an Attachment datatype or Binary resource, since they both
@@ -44,10 +46,20 @@ public interface IBinaryTarget {
 	IBaseHasExtensions getTarget();
 
 	default Optional<String> getAttachmentId() {
-		return AttachmentUtil.getFirstExtension(getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_ID);
+		return AttachmentUtil.getFirstExtension(getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_ID, e -> true);
+	}
+
+	default Optional<String> getAttachmentIdFiltered(Predicate<? super IBaseExtension<?, ?>> theFilter) {
+		return AttachmentUtil.getFirstExtension(getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_ID, theFilter);
 	}
 
 	default Optional<String> getHashExtension() {
-		return AttachmentUtil.getFirstExtension(getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_HASH_SHA_256);
+		return AttachmentUtil.getFirstExtension(
+				getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_HASH_SHA_256, e -> true);
+	}
+
+	default Optional<String> getHashExtensionFiltered(Predicate<? super IBaseExtension<?, ?>> theFilter) {
+		return AttachmentUtil.getFirstExtension(
+				getTarget(), HapiExtensions.EXT_EXTERNALIZED_BINARY_HASH_SHA_256, theFilter);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
@@ -423,7 +423,7 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 	public void preShow(IPreResourceShowDetails theDetails, RequestDetails theRequestDetails) throws IOException {
 		boolean isAllowAutoInflateBinaries = isAllowAutoInflateBinaries();
 		// Override isAllowAutoInflateBinaries setting if AUTO_INFLATE_BINARY_CONTENT flag is present in userData
-		if (theRequestDetails.getUserData().containsKey(AUTO_INFLATE_BINARY_CONTENT_KEY)) {
+		if (theRequestDetails != null && theRequestDetails.getUserData().containsKey(AUTO_INFLATE_BINARY_CONTENT_KEY)) {
 			isAllowAutoInflateBinaries =
 					Boolean.TRUE.equals(theRequestDetails.getUserData().get(AUTO_INFLATE_BINARY_CONTENT_KEY));
 		}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
@@ -422,9 +422,10 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 	@Hook(Pointcut.STORAGE_PRESHOW_RESOURCES)
 	public void preShow(IPreResourceShowDetails theDetails, RequestDetails theRequestDetails) throws IOException {
 		boolean isAllowAutoInflateBinaries = isAllowAutoInflateBinaries();
+		// Override isAllowAutoInflateBinaries setting if AUTO_INFLATE_BINARY_CONTENT flag is present in userData
 		if (theRequestDetails.getUserData().containsKey(AUTO_INFLATE_BINARY_CONTENT_KEY)) {
 			isAllowAutoInflateBinaries =
-					(Boolean) theRequestDetails.getUserData().get(AUTO_INFLATE_BINARY_CONTENT_KEY);
+					Boolean.TRUE.equals(theRequestDetails.getUserData().get(AUTO_INFLATE_BINARY_CONTENT_KEY));
 		}
 		if (!isAllowAutoInflateBinaries) {
 			return;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/interceptor/BinaryStorageInterceptor.java
@@ -47,6 +47,7 @@ import jakarta.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -60,13 +61,16 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static ca.uhn.fhir.util.HapiExtensions.EXT_EXTERNALIZED_BINARY_HASH_SHA_256;
 import static ca.uhn.fhir.util.HapiExtensions.EXT_EXTERNALIZED_BINARY_ID;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -74,6 +78,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(BinaryStorageInterceptor.class);
+	public static final String AUTO_INFLATE_BINARY_CONTENT_KEY = "AUTO_INFLATE_BINARY_CONTENT";
 
 	@Autowired
 	private IBinaryStorageSvc myBinaryStorageSvc;
@@ -145,7 +150,7 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 			IBaseResource theResource,
 			Pointcut thePointcut)
 			throws IOException {
-		extractLargeBinaries(theRequestDetails, theTransactionDetails, theResource, thePointcut);
+		extractLargeBinaries(theRequestDetails, theTransactionDetails, theResource, null, thePointcut);
 	}
 
 	@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
@@ -156,64 +161,76 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 			IBaseResource theResource,
 			Pointcut thePointcut)
 			throws IOException {
-		blockIllegalExternalBinaryIds(thePreviousResource, theResource);
-		extractLargeBinaries(theRequestDetails, theTransactionDetails, theResource, thePointcut);
+		blockIllegalExternalExtensions(thePreviousResource, theResource);
+		extractLargeBinaries(theRequestDetails, theTransactionDetails, theResource, thePreviousResource, thePointcut);
 	}
 
 	/**
-	 * Don't allow clients to submit resources with binary storage attachments declared unless the ID was already in the
-	 * resource. In other words, only HAPI itself may add a binary storage ID extension to a resource unless that
-	 * extension was already present.
+	 * Prevents clients from submitting resources with binary storage ID or binary storage hash extensions,
+	 * unless those extensions were already present in the existing resource. In other words, only HAPI itself
+	 * may add these extensions to a resource.
 	 */
-	private void blockIllegalExternalBinaryIds(IBaseResource thePreviousResource, IBaseResource theResource) {
+	private void blockIllegalExternalExtensions(IBaseResource thePreviousResource, IBaseResource theResource) {
 		Set<String> existingBinaryIds = new HashSet<>();
+		Set<String> existingHashes = new HashSet<>();
 		if (thePreviousResource != null) {
-			List<T> base64fields =
-					myCtx.newTerser().getAllPopulatedChildElementsOfType(thePreviousResource, myBinaryType);
-			for (IPrimitiveType<byte[]> nextBase64 : base64fields) {
-				if (nextBase64 instanceof IBaseHasExtensions) {
-					((IBaseHasExtensions) nextBase64)
-							.getExtension().stream()
-									.filter(t -> t.getUserData(JpaConstants.EXTENSION_EXT_SYSTEMDEFINED) == null)
-									.filter(t -> EXT_EXTERNALIZED_BINARY_ID.equals(t.getUrl()))
-									.map(t -> (IPrimitiveType<?>) t.getValue())
-									.map(IPrimitiveType::getValueAsString)
-									.filter(StringUtils::isNotBlank)
-									.forEach(existingBinaryIds::add);
-				}
-			}
+			myCtx.newTerser().getAllPopulatedChildElementsOfType(thePreviousResource, myBinaryType).stream()
+					.filter(IBaseHasExtensions.class::isInstance)
+					.map(IBaseHasExtensions.class::cast)
+					.flatMap(base -> base.getExtension().stream())
+					.filter(ext -> ext.getUserData(JpaConstants.EXTENSION_EXT_SYSTEMDEFINED) == null)
+					.forEach(ext -> {
+						if (EXT_EXTERNALIZED_BINARY_ID.equals(ext.getUrl())) {
+							extractExtensionValue(ext).ifPresent(existingBinaryIds::add);
+						} else if (EXT_EXTERNALIZED_BINARY_HASH_SHA_256.equals(ext.getUrl())) {
+							extractExtensionValue(ext).ifPresent(existingHashes::add);
+						}
+					});
 		}
 
-		List<T> base64fields = myCtx.newTerser().getAllPopulatedChildElementsOfType(theResource, myBinaryType);
-		for (IPrimitiveType<byte[]> nextBase64 : base64fields) {
-			if (nextBase64 instanceof IBaseHasExtensions) {
-				Optional<String> hasExternalizedBinaryReference = ((IBaseHasExtensions) nextBase64)
-						.getExtension().stream()
-								.filter(t -> t.getUserData(JpaConstants.EXTENSION_EXT_SYSTEMDEFINED) == null)
-								.filter(t -> t.getUrl().equals(EXT_EXTERNALIZED_BINARY_ID))
-								.map(t -> (IPrimitiveType<?>) t.getValue())
-								.map(IPrimitiveType::getValueAsString)
-								.filter(StringUtils::isNotBlank)
-								.filter(t -> !existingBinaryIds.contains(t))
-								.findFirst();
+		myCtx.newTerser().getAllPopulatedChildElementsOfType(theResource, myBinaryType).stream()
+				.filter(IBaseHasExtensions.class::isInstance)
+				.map(IBaseHasExtensions.class::cast)
+				.flatMap(base -> base.getExtension().stream())
+				.filter(ext -> ext.getUserData(JpaConstants.EXTENSION_EXT_SYSTEMDEFINED) == null)
+				.forEach(ext -> {
+					Optional<String> extensionValue = extractExtensionValue(ext);
+					if (EXT_EXTERNALIZED_BINARY_ID.equals(ext.getUrl())) {
+						extensionValue
+								.filter(v -> !existingBinaryIds.contains(v))
+								.ifPresent(v -> throwIllegalExtension(EXT_EXTERNALIZED_BINARY_ID, v));
+					} else if (EXT_EXTERNALIZED_BINARY_HASH_SHA_256.equals(ext.getUrl())) {
+						extensionValue
+								.filter(v -> !existingHashes.contains(v))
+								.ifPresent(v -> throwIllegalExtension(EXT_EXTERNALIZED_BINARY_HASH_SHA_256, v));
+					}
+				});
+	}
 
-				if (hasExternalizedBinaryReference.isPresent()) {
-					String msg = myCtx.getLocalizer()
-							.getMessage(
-									BinaryStorageInterceptor.class,
-									"externalizedBinaryStorageExtensionFoundInRequestBody",
-									EXT_EXTERNALIZED_BINARY_ID,
-									hasExternalizedBinaryReference.get());
-					throw new InvalidRequestException(Msg.code(1329) + msg);
-				}
-			}
+	@SuppressWarnings("unchecked")
+	private Optional<String> extractExtensionValue(IBaseExtension<?, ?> theExtension) {
+		if (theExtension.getValue() instanceof IPrimitiveType) {
+			return Optional.ofNullable(((IPrimitiveType<String>) theExtension.getValue()).getValueAsString())
+					.filter(StringUtils::isNotBlank);
 		}
+		return Optional.empty();
+	}
+
+	private void throwIllegalExtension(String theExtensionUrl, String theValue) {
+		String msg = myCtx.getLocalizer()
+				.getMessage(
+						BinaryStorageInterceptor.class,
+						"externalizedBinaryStorageExtensionFoundInRequestBody",
+						theExtensionUrl,
+						theValue);
+		throw new InvalidRequestException(Msg.code(1329) + msg);
 	}
 
 	private void extractLargeBinaries(
 			RequestDetails theRequestDetails,
 			TransactionDetails theTransactionDetails,
 			IBaseResource theResource,
+			IBaseResource thePreviousResource,
 			Pointcut thePointcut)
 			throws IOException {
 
@@ -223,6 +240,7 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 			resourceId = new IdType(resourceType + "/" + resourceId.getIdPart());
 		}
 
+		Map<String, String> existingHashToAttachmentId = buildHashToAttachmentIdMap(thePreviousResource);
 		List<IBinaryTarget> attachments = recursivelyScanResourceForBinaryData(theResource);
 		for (IBinaryTarget nextTarget : attachments) {
 			byte[] data = nextTarget.getData();
@@ -233,13 +251,16 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 				boolean shouldStoreBlob =
 						myBinaryStorageSvc.shouldStoreBinaryContent(nextPayloadLength, resourceId, nextContentType);
 				if (shouldStoreBlob) {
-
+					String binaryContentHash = myBinaryAccessProvider.getBinaryContentHash(data);
 					String newBinaryContentId;
 					if (thePointcut == Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED) {
-						ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-						StoredDetails storedDetails = myBinaryStorageSvc.storeBinaryContent(
-								resourceId, null, nextContentType, inputStream, theRequestDetails);
-						newBinaryContentId = storedDetails.getBinaryContentId();
+						newBinaryContentId = storeBinaryContentIfRequired(
+								theRequestDetails,
+								existingHashToAttachmentId,
+								binaryContentHash,
+								data,
+								resourceId,
+								nextContentType);
 					} else {
 						assert thePointcut == Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED : thePointcut.name();
 						newBinaryContentId = myBinaryStorageSvc.newBinaryContentId();
@@ -264,8 +285,57 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 					}
 
 					myBinaryAccessProvider.replaceDataWithExtension(nextTarget, newBinaryContentId);
+					myBinaryAccessProvider.addHashExtension(nextTarget, binaryContentHash);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Builds a map of SHA-256 hashes to corresponding attachment IDs from the given FHIR resource.
+	 * @return A {@link Map} with keys as SHA-256 binary content hashes and values as attachment IDs.
+	 */
+	private Map<String, String> buildHashToAttachmentIdMap(IBaseResource thePreviousResource) {
+		Map<String, String> hashToAttachmentIdMap = new HashMap<>();
+
+		if (thePreviousResource == null) {
+			return hashToAttachmentIdMap;
+		}
+
+		List<IBinaryTarget> previousAttachments = recursivelyScanResourceForBinaryData(thePreviousResource);
+		for (IBinaryTarget attachment : previousAttachments) {
+			Optional<String> hashOpt = attachment.getHashExtension();
+			Optional<String> idOpt = attachment.getAttachmentId();
+
+			if (hashOpt.isPresent() && idOpt.isPresent()) {
+				hashToAttachmentIdMap.put(hashOpt.get(), idOpt.get());
+			}
+		}
+		return hashToAttachmentIdMap;
+	}
+
+	/**
+	 * This method checks if the given binary content (based on its SHA-256 hash) is already stored in previous
+	 * resource version. If it is, it reuses the existing attachment ID to avoid saving the same content again.
+	 * If it's not found, it stores the new content and returns the newly generated attachment ID.
+	 */
+	private String storeBinaryContentIfRequired(
+			RequestDetails theRequestDetails,
+			Map<String, String> existingHashToAttachmentId,
+			String binaryContentHash,
+			byte[] data,
+			IIdType resourceId,
+			String nextContentType)
+			throws IOException {
+		if (existingHashToAttachmentId.get(binaryContentHash) != null) {
+			// input binary content is the same as existing binary content, reuse existing binaryId
+			return existingHashToAttachmentId.get(binaryContentHash);
+		} else {
+			// there is no existing binary content or content is different, store new content in binary storage
+			ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+			StoredDetails storedDetails = myBinaryStorageSvc.storeBinaryContent(
+					resourceId, null, nextContentType, inputStream, theRequestDetails);
+			return storedDetails.getBinaryContentId();
 		}
 	}
 
@@ -350,8 +420,13 @@ public class BinaryStorageInterceptor<T extends IPrimitiveType<byte[]>> {
 	}
 
 	@Hook(Pointcut.STORAGE_PRESHOW_RESOURCES)
-	public void preShow(IPreResourceShowDetails theDetails) throws IOException {
-		if (!isAllowAutoInflateBinaries()) {
+	public void preShow(IPreResourceShowDetails theDetails, RequestDetails theRequestDetails) throws IOException {
+		boolean isAllowAutoInflateBinaries = isAllowAutoInflateBinaries();
+		if (theRequestDetails.getUserData().containsKey(AUTO_INFLATE_BINARY_CONTENT_KEY)) {
+			isAllowAutoInflateBinaries =
+					(Boolean) theRequestDetails.getUserData().get(AUTO_INFLATE_BINARY_CONTENT_KEY);
+		}
+		if (!isAllowAutoInflateBinaries) {
 			return;
 		}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/provider/BinaryAccessProvider.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/binary/provider/BinaryAccessProvider.java
@@ -194,9 +194,11 @@ public class BinaryAccessProvider {
 		String path = validateResourceTypeAndPath(theResourceId, thePath);
 		IFhirResourceDao dao = getDaoForRequest(theResourceId);
 		// disable auto-inflation temporarily as binary content will be replaced anyway
-		theRequestDetails.getUserData().put(AUTO_INFLATE_BINARY_CONTENT_KEY, Boolean.FALSE);
+		Optional.ofNullable(theRequestDetails)
+				.ifPresent(rd -> rd.getUserData().put(AUTO_INFLATE_BINARY_CONTENT_KEY, Boolean.FALSE));
 		IBaseResource resource = dao.read(theResourceId, theRequestDetails, false);
-		theRequestDetails.getUserData().remove(AUTO_INFLATE_BINARY_CONTENT_KEY);
+		Optional.ofNullable(theRequestDetails)
+				.ifPresent(rd -> theRequestDetails.getUserData().remove(AUTO_INFLATE_BINARY_CONTENT_KEY));
 
 		IBinaryTarget target = findAttachmentForRequest(resource, path, theRequestDetails);
 


### PR DESCRIPTION
- Added `http://hapifhir.io/fhir/StructureDefinition/externalized-binary-hash-sha256` extension to attachment.data for DocumentReference and Binary resources. Extension is populated upon updates.
- Added logic to BinaryStorageInterceptor, BinaryAccessProvider#binaryAccessWrite that allows to skip re-uploading of binary content if sha256 hash of uploaded and current binary are the same.
- Added tests to BinaryStorageInterceptorR4Test, BinaryAccessProviderR4Test
- Added changelog

New Extension example:
```json
{
  "attachment": {
    "contentType": "image/png",
    "_data": {
      "extension": [
        {
          "url": "http://hapifhir.io/fhir/StructureDefinition/externalized-binary-id",
          "valueString": "lD19CJaQHcSotA1xvFkatXwEa7f3AV6fzfxBPXkNunjaykUejwublRb8NvERMGl2I1yFFE4XJyBeS2Z8IuYj32KbOJdQj5WyEUJu"
        },
        {
          "url": "http://hapifhir.io/fhir/StructureDefinition/externalized-binary-hash-sha256",
          "valueString": "eed596de0c2c2285799123e7e0e1922e8bcd96e874eb6ee9e31330baa6c6a5ac"
        }
      ]
    },
    "size": 89471
  }
}
```
