### PR TITLE
made unknown code system error severity config work

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -890,8 +890,11 @@ public class JpaConfig {
 
 	@Bean
 	public UnknownCodeSystemWarningValidationSupport unknownCodeSystemWarningValidationSupport(
-			FhirContext theFhirContext) {
-		return new UnknownCodeSystemWarningValidationSupport(theFhirContext);
+			FhirContext theFhirContext, JpaStorageSettings theStorageSettings) {
+		UnknownCodeSystemWarningValidationSupport support =
+				new UnknownCodeSystemWarningValidationSupport(theFhirContext);
+		support.setNonExistentCodeSystemSeverity(theStorageSettings.getIssueSeverityForUnknownCodeSystem());
+		return support;
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/ValidationSupportConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/ValidationSupportConfig.java
@@ -60,6 +60,7 @@ public class ValidationSupportConfig {
 		InMemoryTerminologyServerValidationSupport retVal =
 				new InMemoryTerminologyServerValidationSupport(theFhirContext);
 		retVal.setIssueSeverityForCodeDisplayMismatch(theStorageSettings.getIssueSeverityForCodeDisplayMismatch());
+		retVal.setIssueSeverityForUnknownCodeSystem(theStorageSettings.getIssueSeverityForUnknownCodeSystem());
 		return retVal;
 	}
 

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3CodeSystemTest.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3CodeSystemTest.java
@@ -368,7 +368,7 @@ public class ResourceProviderDstu3CodeSystemTest extends BaseResourceProviderDst
 			.map(t -> ((IPrimitiveType<String>) t.getValue()).getValue())
 			.findFirst()
 			.orElseThrow(IllegalArgumentException::new);
-		assertThat(message).contains("Terminology service was unable to provide validation for https://url#1");
+		assertThat(message).contains("CodeSystem is unknown and can't be validated: https://url for 'https://url#1'");
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
@@ -725,11 +725,11 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 			fail(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(e.getOperationOutcome()));
 		}
 		myCaptureQueriesListener.logSelectQueriesForCurrentThread();
-		assertEquals(11, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+		assertEquals(12, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getDeleteQueriesForCurrentThread().size());
-		assertEquals(9, myCaptureQueriesListener.countCommits());
+		assertEquals(10, myCaptureQueriesListener.countCommits());
 
 		// Validate again (should rely only on caches)
 		myCaptureQueriesListener.clear();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
@@ -309,12 +309,13 @@ public class RemoteTerminologyServiceJpaR4Test extends BaseJpaR4Test {
 			"None of the codings provided are in the value set 'IdentifierType'");
 
 		// Verify 1
-		Assertions.assertEquals(2, myCaptureQueriesListener.countGetConnections());
+		Assertions.assertEquals(3, myCaptureQueriesListener.countGetConnections());
 		assertThat(ourValueSetProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
 			"http://hl7.org/fhir/ValueSet/identifier-type",
 			"http://hl7.org/fhir/ValueSet/identifier-type"
 		);
 		assertThat(ourCodeSystemProvider.mySearchUrls).asList().containsExactlyInAnyOrder(
+			"http://terminology.hl7.org/CodeSystem/v2-0203",
 			"http://terminology.hl7.org/CodeSystem/v2-0203",
 			"http://terminology.hl7.org/CodeSystem/v2-0203"
 		);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/validation/performance/ValidationCanonicalizationTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/validation/performance/ValidationCanonicalizationTest.java
@@ -148,22 +148,27 @@ public class ValidationCanonicalizationTest extends BaseResourceProviderR4Test {
 
 		private void assertHasInvalidCodeError(OperationOutcome theOperationOutcome) {
 			List<OperationOutcomeIssueComponent> issues = theOperationOutcome.getIssue();
-			assertEquals(3, issues.size());
+			assertEquals(4, issues.size());
 
-			OperationOutcomeIssueComponent issue1 = issues.get(0);
+			OperationOutcomeIssueComponent issue0 = issues.get(0);
+			assertEquals(IssueSeverity.ERROR, issue0.getSeverity());
+			String expectedMessage0 = "CodeSystem is unknown and can't be validated: http://acme.org/invalid for 'http://acme.org/invalid#invalid'";
+			assertEquals(expectedMessage0, issue0.getDiagnostics());
+
+			OperationOutcomeIssueComponent issue1 = issues.get(1);
 			assertEquals(IssueSeverity.ERROR, issue1.getSeverity());
 			assertEquals("Parameters.parameter[0].resource/*Procedure/null*/.code", issue1.getLocation().get(0).getValue());
 			Map<String, String> formatValues = Map.of("conceptNumber", String.valueOf(NUM_CONCEPTS));
 			String expectedMessage1 = "None of the codings provided are in the value set 'Value Set Combined' (http://acme.org/ValueSet/valueset-combined|1), and a coding from this value set is required) (codes = http://acme.org/CodeSystem/codesystem-1#codesystem-1-concept-${conceptNumber}, http://acme.org/CodeSystem/codesystem-2#codesystem-2-concept-${conceptNumber}, http://acme.org/invalid#invalid)";
 			assertEquals(formatMessage(expectedMessage1, formatValues), issue1.getDiagnostics());
 
-			OperationOutcomeIssueComponent issue2 = issues.get(1);
+			OperationOutcomeIssueComponent issue2 = issues.get(2);
 			assertEquals(IssueSeverity.INFORMATION, issue2.getSeverity());
 			assertEquals("Parameters.parameter[0].resource/*Procedure/null*/.code.coding[2]", issue2.getLocation().get(0).getValue());
 			String expectedMessage2 = "This element does not match any known slice defined in the profile http://example.org/fhir/StructureDefinition/TestProcedure|1.0.0 (this may not be a problem, but you should check that it's not intended to match a slice) - Does not match slice 'slice1' (discriminator: ($this memberOf 'http://acme.org/ValueSet/valueset-1'))";
 			assertEquals(expectedMessage2, issue2.getDiagnostics());
 
-			OperationOutcomeIssueComponent issue3 = issues.get(2);
+			OperationOutcomeIssueComponent issue3 = issues.get(3);
 			assertEquals(IssueSeverity.INFORMATION, issue3.getSeverity());
 			assertEquals("Parameters.parameter[0].resource/*Procedure/null*/.code.coding[2]", issue3.getLocation().get(0).getValue());
 			String expectedMessage3 = "This element does not match any known slice defined in the profile http://example.org/fhir/StructureDefinition/TestProcedure|1.0.0 (this may not be a problem, but you should check that it's not intended to match a slice) - Does not match slice 'slice2' (discriminator: ($this memberOf 'http://acme.org/ValueSet/valueset-2'))";

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/ValidateCodeWithRemoteTerminologyR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/ValidateCodeWithRemoteTerminologyR4Test.java
@@ -140,8 +140,7 @@ public class ValidateCodeWithRemoteTerminologyR4Test extends BaseResourceProvide
 		ourLog.info(resp);
 
 		assertFalse(((BooleanType) respParam.getParameterValue("result")).booleanValue());
-		assertThat(respParam.getParameterValue("message").toString()).isEqualTo("Terminology service was unable to provide validation for " + INVALID_CODE_SYSTEM_URI +
-			"#P");
+		assertThat(respParam.getParameterValue("message").toString()).isEqualTo("CodeSystem is unknown and can't be validated: %s for '%s%s'", INVALID_CODE_SYSTEM_URI, INVALID_CODE_SYSTEM_URI, "#P");
 	}
 
 	@Test
@@ -216,6 +215,7 @@ public class ValidateCodeWithRemoteTerminologyR4Test extends BaseResourceProvide
 	@Test
 	public void validateCodeOperationOnValueSet_byCodingAndUrlWhereValueSetIsUnknown_returnsFalse() {
 		myValueSetProvider.setShouldThrowExceptionForResourceNotFound(false);
+		myCodeSystemProvider.setShouldThrowExceptionForResourceNotFound(false);
 
 		Parameters respParam = myClient
 			.operation()

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
@@ -364,6 +364,13 @@ public class JpaStorageSettings extends StorageSettings {
 			IValidationSupport.IssueSeverity.WARNING;
 
 	/**
+	 * @since 8.6.0
+	 */
+	@Nonnull
+	private IValidationSupport.IssueSeverity myIssueSeverityForUnknownCodeSystem =
+			IValidationSupport.IssueSeverity.ERROR;
+
+	/**
 	 * This setting allows preventing a conditional update to invalidate the match criteria.
 	 * <p/>
 	 * By default, this is disabled unless explicitly enabled.
@@ -2613,6 +2620,30 @@ public class JpaStorageSettings extends StorageSettings {
 		Validate.notNull(
 				theIssueSeverityForCodeDisplayMismatch, "theIssueSeverityForCodeDisplayMismatch must not be null");
 		myIssueSeverityForCodeDisplayMismatch = theIssueSeverityForCodeDisplayMismatch;
+	}
+
+	/**
+	 * This setting controls the validation issue severity to report when a code validation
+	 * encounters an unknown CodeSystem. Defaults to {@link IValidationSupport.IssueSeverity#ERROR}.
+	 *
+	 * @since 8.6.0
+	 */
+	@Nonnull
+	public IValidationSupport.IssueSeverity getIssueSeverityForUnknownCodeSystem() {
+		return myIssueSeverityForUnknownCodeSystem;
+	}
+
+	/**
+	 * This setting controls the validation issue severity to report when a code validation
+	 * encounters an unknown CodeSystem. Defaults to {@link IValidationSupport.IssueSeverity#ERROR}.
+	 *
+	 * @param theIssueSeverityForUnknownCodeSystem The severity. Must not be {@literal null}.
+	 * @since 8.6.0
+	 */
+	public void setIssueSeverityForUnknownCodeSystem(
+			@Nonnull IValidationSupport.IssueSeverity theIssueSeverityForUnknownCodeSystem) {
+		Validate.notNull(theIssueSeverityForUnknownCodeSystem, "theIssueSeverityForUnknownCodeSystem must not be null");
+		myIssueSeverityForUnknownCodeSystem = theIssueSeverityForUnknownCodeSystem;
 	}
 
 	/**

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 
 /**
  * This validation support module may be placed at the end of a {@link ValidationSupportChain}
- * in order to configure the validator to generate a warning if a resource being validated
+ * in order to configure the validator to generate a warning or an error if a resource being validated
  * contains an unknown code system.
  *
  * Note that this module must also be activated by calling {@link #setAllowNonExistentCodeSystem(boolean)}
@@ -52,7 +52,6 @@ public class UnknownCodeSystemWarningValidationSupport extends BaseValidationSup
 	@Override
 	public LookupCodeResult lookupCode(
 			ValidationSupportContext theValidationSupportContext, @Nonnull LookupCodeRequest theLookupCodeRequest) {
-		// filters out error/fatal
 		if (canValidateCodeSystem(theValidationSupportContext, theLookupCodeRequest.getSystem())) {
 			return new LookupCodeResult().setFound(true);
 		}
@@ -68,7 +67,6 @@ public class UnknownCodeSystemWarningValidationSupport extends BaseValidationSup
 			String theCode,
 			String theDisplay,
 			String theValueSetUrl) {
-		// filters out error/fatal
 		if (!canValidateCodeSystem(theValidationSupportContext, theCodeSystem)) {
 			return null;
 		}
@@ -80,19 +78,11 @@ public class UnknownCodeSystemWarningValidationSupport extends BaseValidationSup
 				+ "#" + theCode + "'";
 		result.setMessage(theMessage);
 
-		// For information level, we just strip out the severity+message entirely
-		// so that nothing appears in the validation result
-		if (myNonExistentCodeSystemSeverity == IssueSeverity.INFORMATION) {
-			result.setCode(theCode);
-			result.setSeverity(null);
-			result.setMessage(null);
-		} else {
-			result.addIssue(new CodeValidationIssue(
-					theMessage,
-					myNonExistentCodeSystemSeverity,
-					CodeValidationIssueCode.NOT_FOUND,
-					CodeValidationIssueCoding.NOT_FOUND));
-		}
+		result.addIssue(new CodeValidationIssue(
+				theMessage,
+				myNonExistentCodeSystemSeverity,
+				CodeValidationIssueCode.NOT_FOUND,
+				CodeValidationIssueCoding.NOT_FOUND));
 
 		return result;
 	}
@@ -118,35 +108,9 @@ public class UnknownCodeSystemWarningValidationSupport extends BaseValidationSup
 	}
 
 	/**
-	 * Returns true if non existent code systems will still validate.
-	 * False if they will throw errors.
-	 * @return
+	 * If a validation support can fetch the code system, returns false. Otherwise, returns true.
 	 */
-	private boolean allowNonExistentCodeSystems() {
-		switch (myNonExistentCodeSystemSeverity) {
-			case ERROR:
-			case FATAL:
-				return false;
-			case WARNING:
-			case INFORMATION:
-				return true;
-			default:
-				ourLog.info("Unknown issue severity " + myNonExistentCodeSystemSeverity.name()
-						+ ". Treating as INFO/WARNING");
-				return true;
-		}
-	}
-
-	/**
-	 * Determines if the code system can (and should) be validated.
-	 * @param theValidationSupportContext
-	 * @param theCodeSystem
-	 * @return
-	 */
-	private boolean canValidateCodeSystem(ValidationSupportContext theValidationSupportContext, String theCodeSystem) {
-		if (!allowNonExistentCodeSystems()) {
-			return false;
-		}
+	public boolean canValidateCodeSystem(ValidationSupportContext theValidationSupportContext, String theCodeSystem) {
 		if (theCodeSystem == null) {
 			return false;
 		}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChain.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChain.java
@@ -1241,6 +1241,35 @@ public class ValidationSupportChain implements IValidationSupport {
 		}
 	}
 
+	static class CanGenerateValidationResultForCodeSystemKey extends BaseKey<Boolean> {
+
+		private final String myCodeSystemUrl;
+		private final IValidationSupport myValidationSupport;
+		private final int myHashCode;
+
+		private CanGenerateValidationResultForCodeSystemKey(
+				IValidationSupport theValidationSupport, String theCodeSystemUrl) {
+			myValidationSupport = theValidationSupport;
+			myCodeSystemUrl = theCodeSystemUrl;
+			myHashCode =
+					Objects.hash("CanGenerateValidationResultForCodeSystemKey", theValidationSupport, myCodeSystemUrl);
+		}
+
+		@Override
+		public boolean equals(Object theO) {
+			if (this == theO) return true;
+			if (!(theO instanceof CanGenerateValidationResultForCodeSystemKey)) return false;
+			CanGenerateValidationResultForCodeSystemKey that = (CanGenerateValidationResultForCodeSystemKey) theO;
+			return myValidationSupport == that.myValidationSupport
+					&& Objects.equals(myCodeSystemUrl, that.myCodeSystemUrl);
+		}
+
+		@Override
+		public int hashCode() {
+			return myHashCode;
+		}
+	}
+
 	static class LookupCodeKey extends BaseKey<LookupCodeResult> {
 
 		private final LookupCodeRequest myRequest;

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChainTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChainTest.java
@@ -185,25 +185,25 @@ public class ValidationSupportChainTest extends BaseTest {
 		prepareMock(myValidationSupport0, myValidationSupport1, myValidationSupport2);
 		ValidationSupportChain chain = new ValidationSupportChain(newCacheConfiguration(theUseCache), myValidationSupport0, myValidationSupport1, myValidationSupport2);
 
-		when(myValidationSupport0.isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(false);
-		when(myValidationSupport1.isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(true);
+		when(myValidationSupport0.canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(false);
+		when(myValidationSupport1.canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(true);
 		when(myValidationSupport1.validateCode(any(), any(), any(), any(), any(), any())).thenAnswer(t -> new IValidationSupport.CodeValidationResult());
 
 		// Test
 		IValidationSupport.CodeValidationResult result = chain.validateCode(newValidationCtx(chain), new ConceptValidationOptions(), CODE_SYSTEM_URL_0, CODE_0, DISPLAY_0, null);
 
 		// Verify
-		verify(myValidationSupport0, times(1)).isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0));
-		verify(myValidationSupport1, times(1)).isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0));
-		verify(myValidationSupport2, never()).isCodeSystemSupported(any(), any());
+		verify(myValidationSupport0, times(1)).canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0));
+		verify(myValidationSupport1, times(1)).canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0));
+		verify(myValidationSupport2, never()).canGenerateValidationResultForCodeSystem(any(), any());
 		verify(myValidationSupport0, never()).validateCode(any(), any(), any(), any(), any(), any());
 		verify(myValidationSupport1, times(1)).validateCode(any(), any(), any(), any(), any(), any());
 		verify(myValidationSupport2, never()).validateCode(any(), any(), any(), any(), any(), any());
 
 		// Setup for second execution (should use cache this time)
 		prepareMock(myValidationSupport0, myValidationSupport1, myValidationSupport2);
-		when(myValidationSupport0.isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(false);
-		when(myValidationSupport1.isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(true);
+		when(myValidationSupport0.canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(false);
+		when(myValidationSupport1.canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0))).thenReturn(true);
 		when(myValidationSupport1.validateCode(any(), any(), any(), any(), any(), any())).thenAnswer(t -> new IValidationSupport.CodeValidationResult());
 
 		// Test again (should use cache)
@@ -215,9 +215,9 @@ public class ValidationSupportChainTest extends BaseTest {
 			verifyNoInteractions(myValidationSupport0, myValidationSupport1, myValidationSupport2);
 		} else {
 			assertNotSame(result, result2);
-			verify(myValidationSupport0, times(1)).isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0));
-			verify(myValidationSupport1, times(1)).isCodeSystemSupported(any(), eq(CODE_SYSTEM_URL_0));
-			verify(myValidationSupport2, never()).isCodeSystemSupported(any(), any());
+			verify(myValidationSupport0, times(1)).canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0));
+			verify(myValidationSupport1, times(1)).canGenerateValidationResultForCodeSystem(any(), eq(CODE_SYSTEM_URL_0));
+			verify(myValidationSupport2, never()).canGenerateValidationResultForCodeSystem(any(), any());
 			verify(myValidationSupport0, never()).validateCode(any(), any(), any(), any(), any(), any());
 			verify(myValidationSupport1, times(1)).validateCode(any(), any(), any(), any(), any(), any());
 			verify(myValidationSupport2, never()).validateCode(any(), any(), any(), any(), any(), any());

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/QuestionnaireResponseValidatorDstu3Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/QuestionnaireResponseValidatorDstu3Test.java
@@ -220,8 +220,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		q.addItem().setLinkId("link0").setRequired(false).setType(QuestionnaireItemType.CHOICE).setOptions(new Reference("http://somevalueset"));
 		when(myValSupport.fetchResource(eq(Questionnaire.class), eq(QUESTIONNAIRE_URL))).thenReturn(q);
 
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system"))).thenReturn(true);
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
 		when(myValSupport.validateCodeInValueSet(any(), any(), eq("http://codesystems.com/system"), eq("code0"), any(), nullable(ValueSet.class)))
 			.thenReturn(new IValidationSupport.CodeValidationResult().setCode("code0"));
 		when(myValSupport.validateCodeInValueSet(any(), any(), eq("http://codesystems.com/system"), eq("code1"), any(), nullable(ValueSet.class)))
@@ -1030,8 +1030,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		item.setLinkId("link0").setRequired(true).setType(QuestionnaireItemType.OPENCHOICE).setOptions(new Reference("http://somevalueset"));
 		when(myValSupport.fetchResource(eq(Questionnaire.class), eq(questionnaireRef))).thenReturn(q);
 
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system"))).thenReturn(true);
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
 		when(myValSupport.validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code0"), any(), nullable(String.class)))
 			.thenReturn(new IValidationSupport.CodeValidationResult().setCode("code0"));
 		when(myValSupport.validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code1"), any(), nullable(String.class)))

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/QuestionnaireResponseValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/QuestionnaireResponseValidatorR4Test.java
@@ -215,8 +215,8 @@ public class QuestionnaireResponseValidatorR4Test {
 		q.addItem().setLinkId("link0").setRequired(false).setType(QuestionnaireItemType.CHOICE).setAnswerValueSet("http://somevalueset");
 		when(myValSupport.fetchResource(eq(Questionnaire.class), eq("http://example.com/Questionnaire/q1"))).thenReturn(q);
 
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system"))).thenReturn(true);
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
 		when(myValSupport.validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code0"), any(), nullable(String.class)))
 			.thenReturn(new IValidationSupport.CodeValidationResult().setCode("code0"));
 		when(myValSupport.validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code1"), any(), nullable(String.class)))

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/QuestionnaireResponseValidatorR5Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/QuestionnaireResponseValidatorR5Test.java
@@ -215,8 +215,8 @@ public class QuestionnaireResponseValidatorR5Test  {
 		q.addItem().setLinkId("link0").setRequired(false).setType(QuestionnaireItemType.CODING).setAnswerValueSet("http://somevalueset");
 		when(myValSupport.fetchResource(eq(Questionnaire.class), eq("http://example.com/Questionnaire/q1"))).thenReturn(q);
 
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system"))).thenReturn(true);
-		when(myValSupport.isCodeSystemSupported(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system"))).thenReturn(true);
+		when(myValSupport.canGenerateValidationResultForCodeSystem(any(), eq("http://codesystems.com/system2"))).thenReturn(true);
 		when(myValSupport.validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code0"), any(), nullable(String.class)))
 			.thenReturn(new IValidationSupport.CodeValidationResult().setCode("code0"));
 		when(myValSupport.validateCode(any(), any(), eq("http://codesystems.com/system"), eq("code1"), any(), nullable(String.class)))


### PR DESCRIPTION
#closes #7196


### Description

This PR addresses a bug where validating a resource with an unknown **CodeSystem** fails to produce any validation issues, even when the **UnknownCodeSystem** issue severity is set to **ERROR**.

---

### Root Cause

The main issue was that none of **ValidationSupport** classes were returning a validation result for unknown code systems. The **UnknownCodeSystemWarningValidationSupport** class, whose purpose is to generate these issues, was skipping the creation of an issue if the severity was set to **ERROR**, but would correctly produce an issue if the severity was set to **WARNING**.

It appears this feature may have never worked as intended. The existing validation tests were also not expecting any **ERROR** level issues and were, in fact, incorrectly asserting that no issues would be produced when the severity was set to **ERROR**.

---

### Changes in this PR

This PR makes two key improvements: it corrects the behavior of UnknownCodeSystemWarningValidationSupport to properly handle error cases, and it refines the ValidationSupport interface to align with the unique role of UnknownCodeSystemWarningValidationSupport.

**1. The `UnknownCodeSystemWarningValidationSupport` class now produces a validation issue with the configured severity if there's an unknown code system**
* The class will no longer skip generating an issue when the severity is set to **ERROR**.
* This also changes the behavior for the **INFORMATION** severity setting. Instead of attempting to suppress validation issues (the previous behavior), it will now correctly generate **INFORMATION** level issues as configured. If the goal is to suppress issues, a mechanism like [ValidationMessageSuppressingInterceptor.java](https://github.com/hapifhir/hapi-fhir/blob/e7180f29855f3751f69d076c7d9b8514cc007864/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/validation/ValidationMessageSuppressingInterceptor.java#L36-L36) would be a more appropriate approach, or at least we can introduce a separate config or a config value for suppressing the issues.

**2. A new method, `canGenerateValidationResultForCodeSystem`, has been added to the `ValidationSupport` interface.**
* The `UnknownCodeSystemWarningValidationSupport` class is not a true **ValidationSupport** class as it cannot actually validate a code system. However, to ensure it was called at the end of the validation chain, it was "abusing" the **`ValidationSupport`** interface by returning `true` for **`isSupportedCodeSystem`**, which would mislead the core validator.
* This had the unintended effect of causing the core library to follow a different code path for the same resource when validated through the CLI versus HAPI-FHIR because core validator also calls  isSupportedCodeSystem itself in several places through `context.supportsSystem`, see for example [src1](https://github.com/hapifhir/org.hl7.fhir.core/blob/644d3d097ed6655e11549ccf5ef2be58564aa72b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java#L1180-L1180), [src2](https://github.com/hapifhir/org.hl7.fhir.core/blob/644d3d097ed6655e11549ccf5ef2be58564aa72b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java#L1699-L1699)

* To improve this discrepancy, the new **`canGenerateValidationResultForCodeSystem`** method is now called in the validation chain. **`UnknownCodeSystemWarningValidationSupport`** will return `true` for this new method (since it can generate a result) but will now correctly return `false` for **`isSupportedCodeSystem`**. This ensures the core validator is not misled while still allowing the **`UnknownCodeSystemWarningValidationSupport`** to be properly invoked. For all the other existing ValidationSupport classes **`canGenerateValidationResultForCodeSystem`** behaves the same as **`isSupportedCodeSystem`**.

---


### Outstanding Issue

Even though this PR attempts to fix the issue on the HAPI-FHIR side, this is not enough to generate error level issues in all cases. There is still an outstanding question for the core validator. The core validator has its own logic ([src](https://github.com/hapifhir/org.hl7.fhir.core/blob/6.4.0/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java#L1722)) for determining the severity of an issue for an unknown CodeSystem, which is based on the binding strength. It will ignore the error severity set by HAPI-FHIR. It produces errors only when binding strength is REQUIRED. For any other binding strength, it  assigns a warning severity be default. See the issue on the core validator: https://github.com/hapifhir/org.hl7.fhir.core/issues/2129. So currently we are able to produce an error level issue only for a REQUIRED binding.

---

### Future Work

I believe a better long-term solution would be to move the logic of **`UnknownCodeSystemWarningValidationSupport`** somewhere eles, maybe into the validation chain or to the wrapper, rather than trying to make it conform to the **`ValidationSupport`** interface. However, since this would require a larger refactoring, I am leaving that for a future PR.

  