### PR TITLE
[7206] fix unit tests to ensure search by resource meta.source works …

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7206-fix-unit-test-for-mongodb-resource-meta-source.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7206-fix-unit-test-for-mongodb-resource-meta-source.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 7206
+title: "Update the unit tests to ensure search by resource `meta.source` works correctly with MongoDB repositories."

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/search/BaseSourceSearchParameterTestCases.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/search/BaseSourceSearchParameterTestCases.java
@@ -102,6 +102,7 @@ public abstract class BaseSourceSearchParameterTestCases implements ITestDataBui
 				pt2id);
 	}
 
+	@EnabledIf("isRequestIdSupported")
 	@Test
 	public void testSearchSource_whenSameSourceForMultipleResourceTypes_willMatchSearchResourceTypeOnly() {
 		String sourceUrn = "http://host/0";
@@ -111,11 +112,12 @@ public abstract class BaseSourceSearchParameterTestCases implements ITestDataBui
 		IIdType ob0id = createObservation(withSource(sourceUrn), withStatus("final"));
 
 		myTestDaoSearch.assertSearchFinds(
-				"search source URI for Patient finds", "Patient?_source=http://host/0", pt0id);
+				"search source URI for Patient finds", "Patient?_source=http://host/0#a_request_id", pt0id);
 		myTestDaoSearch.assertSearchNotFound(
 				"search source URI for Patient - Observation not found", "Patient?_source=http://host/0", ob0id);
 	}
 
+	@EnabledIf("isRequestIdSupported")
 	@Test
 	public void testSearchSource_withOrJoinedParameter_returnsUnionResultBundle() {
 		myTestDataBuilder.setRequestId("a_request_id");
@@ -125,7 +127,10 @@ public abstract class BaseSourceSearchParameterTestCases implements ITestDataBui
 		createPatient(withSource("http://host/2"), withActiveTrue());
 
 		myTestDaoSearch.assertSearchFinds(
-				"search source URI with union", "Patient?_source=http://host/0,http://host/1", pt0id, pt1id);
+				"search source URI with union",
+				"Patient?_source=http://host/0#a_request_id,http://host/1#a_request_id",
+				pt0id,
+				pt1id);
 	}
 
 	@EnabledIf("isRequestIdSupported")


### PR DESCRIPTION
We are fixing the issue that MongoDB newly created resource `meta.source` doesn't contain request id. 
With the fix, the unit tests need to be updated to ensure search by resource meta.source works correctly with MongoDB repository.

Closes #7206 