### PR TITLE
Rename MdmSettings.myMdmMode setter such that it aligns with getter/setter naming conventions

### DIFF
--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/config/MdmSettings.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/config/MdmSettings.java
@@ -174,7 +174,7 @@ public class MdmSettings implements IMdmSettings {
 		myShouldAutoDeleteGoldenResources = theShouldAutoExpunge;
 	}
 
-	public void setMdmMode(MdmModeEnum theMdmMode) {
+	public void setMode(MdmModeEnum theMdmMode) {
 		myMdmMode = theMdmMode;
 	}
 


### PR DESCRIPTION
This fixes https://github.com/hapifhir/hapi-fhir/issues/7229