### PR TITLE
Improve efficiency of correctCurrentVersion $reindex

### DIFF
--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/BaseJpaR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/BaseJpaR5Test.java
@@ -45,6 +45,7 @@ import ca.uhn.fhir.jpa.dao.data.ITermConceptParentChildLinkDao;
 import ca.uhn.fhir.jpa.dao.data.ITermValueSetConceptDao;
 import ca.uhn.fhir.jpa.dao.data.ITermValueSetConceptDesignationDao;
 import ca.uhn.fhir.jpa.dao.data.ITermValueSetDao;
+import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.entity.TermValueSet;
 import ca.uhn.fhir.jpa.entity.TermValueSetConcept;
 import ca.uhn.fhir.jpa.interceptor.PerformanceTracingLoggingInterceptor;
@@ -147,6 +148,8 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {TestR5Config.class, TestDaoSearch.Config.class})
 public abstract class BaseJpaR5Test extends BaseJpaTest implements ITestDataBuilder {
+	@Autowired
+	protected IHapiTransactionService myTxService;
 	@Autowired
 	protected IJobCoordinator myJobCoordinator;
 	@Autowired

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/bulkpatch/BaseBulkModifyResourcesStepR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/bulkpatch/BaseBulkModifyResourcesStepR5Test.java
@@ -1,0 +1,150 @@
+package ca.uhn.fhir.jpa.dao.r5.bulkpatch;
+
+import ca.uhn.fhir.batch2.api.IJobDataSink;
+import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
+import ca.uhn.fhir.batch2.api.RunOutcome;
+import ca.uhn.fhir.batch2.api.StepExecutionDetails;
+import ca.uhn.fhir.batch2.jobs.bulkmodify.framework.api.ResourceModificationRequest;
+import ca.uhn.fhir.batch2.jobs.bulkmodify.framework.api.ResourceModificationResponse;
+import ca.uhn.fhir.batch2.jobs.bulkmodify.framework.base.BaseBulkModifyResourcesStep;
+import ca.uhn.fhir.batch2.jobs.bulkmodify.framework.common.BulkModifyResourcesChunkOutcomeJson;
+import ca.uhn.fhir.batch2.jobs.bulkmodify.patch.BulkPatchJobParameters;
+import ca.uhn.fhir.batch2.jobs.chunk.TypedPidAndVersionJson;
+import ca.uhn.fhir.batch2.jobs.chunk.TypedPidAndVersionListWorkChunkJson;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.WorkChunk;
+import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
+import ca.uhn.fhir.jpa.dao.r5.BaseJpaR5Test;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r5.model.Patient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class BaseBulkModifyResourcesStepR5Test extends BaseJpaR5Test {
+
+	@Mock
+	private IMockStep myMockStep;
+	@Mock
+	private IJobDataSink<BulkModifyResourcesChunkOutcomeJson> mySink;
+
+	private MyBulkModifyResourcesStep myStep;
+
+	@Autowired
+	private IIdHelperService<IResourcePersistentId<?>> myIdHelper;
+
+	@BeforeEach
+	public void before() {
+		myStep = new MyBulkModifyResourcesStep();
+		myStep.setSystemDaoForUnitTest(mySystemDao);
+		myStep.setDaoRegistryForUnitTest(myDaoRegistry);
+		myStep.setTransactionServiceForUnitTest(myTxService);
+		myStep.setFhirContextForUnitTest(myFhirCtx);
+		myStep.setIdHelperServiceForUnitTest(myIdHelper);
+		myStep.setMockStep(myMockStep);
+	}
+
+	@Test
+	public void testDeleteResource() {
+		createPatient(withId("P1"), withFamily("Family1"));
+		createPatient(withId("P2"), withFamily("Family2"));
+		TypedPidAndVersionListWorkChunkJson data = createWorkChunkForAllResources();
+		StepExecutionDetails<BulkPatchJobParameters, TypedPidAndVersionListWorkChunkJson> stepExecutionDetails = new StepExecutionDetails<>(new BulkPatchJobParameters(), data, new JobInstance(), new WorkChunk());
+
+		when(myMockStep.modifyResource(any(), any(), any())).thenAnswer(t->{
+			ResourceModificationRequest request = t.getArgument(2, ResourceModificationRequest.class);
+			Patient patient = (Patient) request.getResource();
+			if ("P1".equals(patient.getIdElement().getIdPart())) {
+				return ResourceModificationResponse.noChange();
+			}
+			if ("P2".equals(patient.getIdElement().getIdPart())) {
+				return ResourceModificationResponse.delete();
+			}
+			throw new IllegalStateException();
+		});
+
+		// Test
+		RunOutcome outcome = myStep.run(stepExecutionDetails, mySink);
+		assertEquals(0, outcome.getRecordsProcessed());
+
+		// Verify
+		assertNotGone("Patient/P1");
+		assertGone("Patient/P2");
+	}
+
+	@Test
+	public void testDeleteResource_RewriteHistoryIsBlocked() {
+		createPatient(withId("P1"), withFamily("Family1"));
+		TypedPidAndVersionListWorkChunkJson data = createWorkChunkForAllResources();
+		StepExecutionDetails<BulkPatchJobParameters, TypedPidAndVersionListWorkChunkJson> stepExecutionDetails = new StepExecutionDetails<>(new BulkPatchJobParameters(), data, new JobInstance(), new WorkChunk());
+
+		when(myMockStep.isRewriteHistory(any(), any())).thenReturn(true);
+		when(myMockStep.modifyResource(any(), any(), any())).thenReturn(ResourceModificationResponse.delete());
+
+		// Test & Verify
+		assertThatThrownBy(()->myStep.run(stepExecutionDetails, mySink))
+			.isInstanceOf(JobExecutionFailedException.class)
+			.hasMessageContaining("Can't store deleted resources as history rewrites");
+	}
+
+	@Nonnull
+	private TypedPidAndVersionListWorkChunkJson createWorkChunkForAllResources() {
+		TypedPidAndVersionListWorkChunkJson data = new TypedPidAndVersionListWorkChunkJson();
+		runInTransaction(()->{
+			for (ResourceTable next : myResourceTableDao.findAll()) {
+				data.addTypedPidWithNullPartitionForUnitTest(next.getResourceType(), next.getId().getId(), next.getVersion());
+			}
+		});
+		return data;
+	}
+
+
+	public static class MyBulkModifyResourcesStep extends BaseBulkModifyResourcesStep<BulkPatchJobParameters, Object> {
+
+		private IMockStep myMockStep;
+
+		@Override
+		public boolean isRewriteHistory(Object theState, IBaseResource theResource) {
+			return myMockStep.isRewriteHistory(theState, theResource);
+		}
+
+		@Nullable
+		@Override
+		protected Object preModifyResources(BulkPatchJobParameters theJobParameters, List<TypedPidAndVersionJson> thePids) {
+			return myMockStep.preModifyResources(theJobParameters, thePids);
+		}
+
+		@Override
+		protected ResourceModificationResponse modifyResource(BulkPatchJobParameters theJobParameters, Object theModificationContext, @Nonnull ResourceModificationRequest theModificationRequest) {
+			return myMockStep.modifyResource(theJobParameters, theModificationContext, theModificationRequest);
+		}
+
+		public void setMockStep(IMockStep theMockStep) {
+			assert myMockStep == null;
+			myMockStep = theMockStep;
+		}
+	}
+
+
+	interface IMockStep {
+
+		Object preModifyResources(BulkPatchJobParameters theJobParameters, List<TypedPidAndVersionJson> thePids);
+
+		ResourceModificationResponse modifyResource(BulkPatchJobParameters theJobParameters, Object theModificationContext, @Nonnull ResourceModificationRequest theModificationRequest);
+
+		boolean isRewriteHistory(Object theState, IBaseResource theResource);
+	}
+
+}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/TestDefinitions.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/TestDefinitions.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.batch2.jobs.chunk.TypedPidJson;
 import ca.uhn.fhir.batch2.jobs.expunge.DeleteExpungeJobParameters;
 import ca.uhn.fhir.batch2.jobs.expunge.DeleteExpungeStep;
 import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.ValueSetExpansionOptions;
 import ca.uhn.fhir.interceptor.executor.InterceptorService;
@@ -217,8 +218,7 @@ abstract class TestDefinitions implements ITestDataBuilder {
 		);
 		ResourceIdListWorkChunkJson workChunk = new ResourceIdListWorkChunkJson(typedPids, RequestPartitionId.fromPartitionId(PARTITION_1));
 		JobInstance jobInstance = new JobInstance();
-		String workChunkId = "AA";
-		StepExecutionDetails<DeleteExpungeJobParameters, ResourceIdListWorkChunkJson> executionDetails = new StepExecutionDetails<>(params, workChunk, jobInstance, workChunkId);
+		StepExecutionDetails<DeleteExpungeJobParameters, ResourceIdListWorkChunkJson> executionDetails = new StepExecutionDetails<>(params, workChunk, jobInstance, new WorkChunk());
 		myDeleteExpungeStep.run(executionDetails, myVoidSink);
 
 		// Verify

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -1072,6 +1072,13 @@ public abstract class BaseJpaTest extends BaseTest {
 	/**
 	 * Asserts that the resource with {@literal theId} is deleted
 	 */
+	protected void assertGone(String theId) {
+		assertGone(myFhirContext.getVersion().newIdType(theId));
+	}
+
+	/**
+	 * Asserts that the resource with {@literal theId} is deleted
+	 */
 	protected void assertGone(IIdType theId) {
 		IFhirResourceDao dao = myDaoRegistry.getResourceDao(theId.getResourceType());
 		IBaseResource result = dao.read(theId, newSrd(), true);
@@ -1097,6 +1104,16 @@ public abstract class BaseJpaTest extends BaseTest {
 	 */
 	protected void assertExists(IIdType theId) {
 		assertNotGone(theId);
+	}
+
+	/**
+	 * Asserts that the resource with {@literal theId} exists and is not deleted.
+	 * Note that {@link #assertExists(IIdType)} and {@link #assertNotGone(IIdType)}
+	 * are synonyms but both exist for better readability in different kinds
+	 * of tests.
+	 */
+	protected void assertNotGone(String theId) {
+		assertNotGone(myFhirContext.getVersion().newIdType(theId));
 	}
 
 	/**

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/api/ResourceModificationResponse.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/api/ResourceModificationResponse.java
@@ -28,19 +28,27 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
  * Implementations of bulk modification jobs will subclass {@link ca.uhn.fhir.batch2.jobs.bulkmodify.framework.base.BaseBulkModifyResourcesStep}
  * and will return this object for each resource candidate to be modified.
  *
- * @since 8.6.0
  * @see ResourceModificationRequest
+ * @since 8.6.0
  */
+@SuppressWarnings("ClassCanBeRecord")
 public class ResourceModificationResponse {
 
 	@Nullable
 	private final IBaseResource myResource;
 
+	private final boolean myDeleted;
+
 	/**
 	 * Use static factory methods to instantiate this class
 	 */
-	private ResourceModificationResponse(@Nullable IBaseResource theResource) {
+	private ResourceModificationResponse(@Nullable IBaseResource theResource, boolean theDeleted) {
 		myResource = theResource;
+		myDeleted = theDeleted;
+	}
+
+	public boolean isDeleted() {
+		return myDeleted;
 	}
 
 	@Nullable
@@ -48,12 +56,25 @@ public class ResourceModificationResponse {
 		return myResource;
 	}
 
+	/**
+	 * Update the current resource contents with the given resource.
+	 */
 	public static ResourceModificationResponse updateResource(@Nonnull IBaseResource theResource) {
 		Validate.notNull(theResource, "theResource must not be null");
-		return new ResourceModificationResponse(theResource);
+		return new ResourceModificationResponse(theResource, false);
 	}
 
+	/**
+	 * This response indicates that the resource should not be modified.
+	 */
 	public static ResourceModificationResponse noChange() {
-		return new ResourceModificationResponse(null);
+		return new ResourceModificationResponse(null, false);
+	}
+
+	/**
+	 * This response indicates that the resource should be deleted.
+	 */
+	public static ResourceModificationResponse delete() {
+		return new ResourceModificationResponse(null, true);
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyJobParameters.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyJobParameters.java
@@ -20,8 +20,22 @@
 package ca.uhn.fhir.batch2.jobs.bulkmodify.framework.base;
 
 import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrlJobParameters;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Base class for bulk modification job parameters objects
  */
-public abstract class BaseBulkModifyJobParameters extends PartitionedUrlJobParameters {}
+public abstract class BaseBulkModifyJobParameters extends PartitionedUrlJobParameters {
+
+	@JsonProperty("dryRun")
+	private boolean myDryRun;
+
+	public void setDryRun(boolean theDryRun) {
+		myDryRun = theDryRun;
+	}
+
+	public boolean isDryRun() {
+		return myDryRun;
+	}
+
+}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyJobParameters.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyJobParameters.java
@@ -37,5 +37,4 @@ public abstract class BaseBulkModifyJobParameters extends PartitionedUrlJobParam
 	public boolean isDryRun() {
 		return myDryRun;
 	}
-
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyResourcesStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyResourcesStep.java
@@ -48,7 +48,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
-import com.google.common.collect.SetMultimap;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import jakarta.annotation.Nonnull;
@@ -67,7 +66,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -163,9 +161,9 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 		try {
 
 			myTransactionService
-				.withSystemRequestOnPartition(theRequestPartitionId)
-				.withTransactionDetails(transactionDetails)
-				.execute(() -> processPidsInTransaction(jobParameters, theState, thePids, transactionDetails));
+					.withSystemRequestOnPartition(theRequestPartitionId)
+					.withTransactionDetails(transactionDetails)
+					.execute(() -> processPidsInTransaction(jobParameters, theState, thePids, transactionDetails));
 
 			// Storage transaction succeeded
 			theState.movePendingToSaved();
@@ -362,7 +360,8 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			SystemRequestDetails requestDetails = createRequestDetails(theModificationContext, pidAndResource);
 			if (requestDetails.isRewriteHistory()) {
 				// FIXME: new code
-				throw new JobExecutionFailedException(Msg.code(0) + "Can't store deleted resources as history rewrites");
+				throw new JobExecutionFailedException(
+						Msg.code(0) + "Can't store deleted resources as history rewrites");
 			}
 
 			IIdType resourceId = pidAndResource.resource().getIdElement();
@@ -488,7 +487,7 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			return switch (this) {
 				case CHANGED_UNSAVED -> CHANGED_PENDING;
 				case DELETED_UNSAVED -> DELETED_PENDING;
-				// FIXME: new code
+					// FIXME: new code
 				default -> throw new IllegalStateException(Msg.code(0) + "Can't convert " + this + " to pending");
 			};
 		}
@@ -497,7 +496,7 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			return switch (this) {
 				case CHANGED_PENDING -> CHANGED_SAVED;
 				case DELETED_PENDING -> DELETED_SAVED;
-				// FIXME: new code
+					// FIXME: new code
 				default -> throw new IllegalStateException(Msg.code(0) + "Can't convert " + this + " to saved");
 			};
 		}
@@ -509,8 +508,9 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 
 	private static class State {
 
-//		private final List<TypedPidAndVersionJson> myPidsToModify = new ArrayList<>();
-		private ListMultimap<StateEnum, PidAndResource> myStateMap = MultimapBuilder.enumKeys(StateEnum.class).arrayListValues().build();
+		//		private final List<TypedPidAndVersionJson> myPidsToModify = new ArrayList<>();
+		private ListMultimap<StateEnum, PidAndResource> myStateMap =
+				MultimapBuilder.enumKeys(StateEnum.class).arrayListValues().build();
 		private final Map<PidAndResource, String> myFailures = new HashMap<>();
 		private int myRetryCount;
 		private int myRetriedResourceCount;
@@ -569,7 +569,6 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			}
 		}
 
-
 		public void movePendingBackToModificationList() {
 			for (StateEnum state : StateEnum.pendingStates()) {
 				List<PidAndResource> pidsAndResources = getResourcesInStateAndClear(state);
@@ -603,7 +602,6 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 		public void setJobFailure(JobExecutionFailedException theJobFailure) {
 			myJobFailure = theJobFailure;
 		}
-
 	}
 
 	private record PidAndResource(TypedPidAndVersionJson pid, IBaseResource resource) {}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyResourcesStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyResourcesStep.java
@@ -44,8 +44,11 @@ import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.SetMultimap;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import jakarta.annotation.Nonnull;
@@ -62,6 +65,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,8 +78,8 @@ import java.util.Set;
  * Several other methods are provided which can also be overridden.
  *
  * @param <PT> The job parameters type
- * @param <C> A context object which will be passed between methods for a single chunk of resources. The format of the
- *           context object is up to the subclass, the framework doesn't look at it.
+ * @param <C>  A context object which will be passed between methods for a single chunk of resources. The format of the
+ *             context object is up to the subclass, the framework doesn't look at it.
  * @since 8.6.0
  */
 public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobParameters, C>
@@ -159,13 +163,15 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 		try {
 
 			myTransactionService
-					.withSystemRequestOnPartition(theRequestPartitionId)
-					.withTransactionDetails(transactionDetails)
-					.execute(() -> processPidsInTransaction(jobParameters, theState, thePids, transactionDetails));
+				.withSystemRequestOnPartition(theRequestPartitionId)
+				.withTransactionDetails(transactionDetails)
+				.execute(() -> processPidsInTransaction(jobParameters, theState, thePids, transactionDetails));
 
 			// Storage transaction succeeded
 			theState.movePendingToSaved();
 
+		} catch (JobExecutionFailedException e) {
+			throw e;
 		} catch (Exception e) {
 
 			ourLog.warn("Failure occurred during bulk modification, will retry. Failure: {}", e.toString());
@@ -208,10 +214,10 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 
 	private void processPidsInIndividualTransactions(
 			PT theJobParameters, State theState, RequestPartitionId theRequestPartitionId, boolean theFinalRetry) {
-		List<TypedPidAndVersionJson> pids = theState.getPidsToModifyAndClear();
+		List<PidAndResource> pids = theState.getPidsToModifyAndClear();
 
-		for (TypedPidAndVersionJson nextPid : pids) {
-			processPids(theJobParameters, theState, List.of(nextPid), theRequestPartitionId, theFinalRetry);
+		for (PidAndResource nextPid : pids) {
+			processPids(theJobParameters, theState, List.of(nextPid.pid()), theRequestPartitionId, theFinalRetry);
 		}
 	}
 
@@ -286,9 +292,14 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 						+ resource.getIdElement() + "]");
 			}
 
+			if (modificationResponse.isDeleted()) {
+				theState.addResource(StateEnum.DELETED_UNSAVED, new PidAndResource(pid, resource));
+				continue;
+			}
+
 			IBaseResource updatedResource = modificationResponse.getResource();
 			if (updatedResource == null) {
-				theState.addUnchangedResource(new PidAndResource(pid, resource));
+				theState.addResource(StateEnum.UNCHANGED, new PidAndResource(pid, resource));
 				continue;
 			}
 
@@ -309,9 +320,9 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			HashingWriter postModificationHash = hashResource(resource);
 
 			if (preModificationHash.matches(postModificationHash)) {
-				theState.addUnchangedResource(new PidAndResource(pid, updatedResource));
+				theState.addResource(StateEnum.UNCHANGED, new PidAndResource(pid, updatedResource));
 			} else {
-				theState.addChangedUnsavedResource(new PidAndResource(pid, updatedResource));
+				theState.addResource(StateEnum.CHANGED_UNSAVED, new PidAndResource(pid, updatedResource));
 			}
 		}
 
@@ -330,11 +341,11 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			C theModificationContext, State theState, TransactionDetails theTransactionDetails) {
 		assert TransactionSynchronizationManager.isActualTransactionActive();
 
-		for (PidAndResource pidAndResource : theState.getChangedUnsavedResourcesAndMoveToPending()) {
+		// Changed resources
+		for (PidAndResource pidAndResource : theState.getResourcesInStateAndMoveToPending(StateEnum.CHANGED_UNSAVED)) {
 			IFhirResourceDao<IBaseResource> dao = myDaoRegistry.getResourceDao(pidAndResource.resource());
 
-			SystemRequestDetails requestDetails = new SystemRequestDetails();
-			requestDetails.setRewriteHistory(isRewriteHistory(theModificationContext, pidAndResource.resource()));
+			SystemRequestDetails requestDetails = createRequestDetails(theModificationContext, pidAndResource);
 
 			DaoMethodOutcome outcome =
 					dao.update(pidAndResource.resource(), null, true, false, requestDetails, theTransactionDetails);
@@ -343,6 +354,32 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 					pidAndResource.pid,
 					outcome.getId().getVersionIdPart());
 		}
+
+		// Deleted resources
+		for (PidAndResource pidAndResource : theState.getResourcesInStateAndMoveToPending(StateEnum.DELETED_UNSAVED)) {
+			IFhirResourceDao<IBaseResource> dao = myDaoRegistry.getResourceDao(pidAndResource.resource());
+
+			SystemRequestDetails requestDetails = createRequestDetails(theModificationContext, pidAndResource);
+			if (requestDetails.isRewriteHistory()) {
+				// FIXME: new code
+				throw new JobExecutionFailedException(Msg.code(0) + "Can't store deleted resources as history rewrites");
+			}
+
+			IIdType resourceId = pidAndResource.resource().getIdElement();
+			DaoMethodOutcome outcome = dao.delete(resourceId, requestDetails);
+
+			ourLog.debug(
+					"Deletion for PID[{}] resulted in version: {}",
+					pidAndResource.pid,
+					outcome.getId().getVersionIdPart());
+		}
+	}
+
+	@Nonnull
+	private SystemRequestDetails createRequestDetails(C theModificationContext, PidAndResource pidAndResource) {
+		SystemRequestDetails requestDetails = new SystemRequestDetails();
+		requestDetails.setRewriteHistory(isRewriteHistory(theModificationContext, pidAndResource.resource()));
+		return requestDetails;
 	}
 
 	/**
@@ -377,6 +414,35 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 	protected abstract ResourceModificationResponse modifyResource(
 			PT theJobParameters, C theModificationContext, @Nonnull ResourceModificationRequest theModificationRequest);
 
+	@VisibleForTesting
+	public void setTransactionServiceForUnitTest(IHapiTransactionService theTransactionService) {
+		assert theTransactionService != null;
+		myTransactionService = theTransactionService;
+	}
+
+	@VisibleForTesting
+	public void setDaoRegistryForUnitTest(DaoRegistry theDaoRegistry) {
+		assert theDaoRegistry != null;
+		myDaoRegistry = theDaoRegistry;
+	}
+
+	@VisibleForTesting
+	public void setSystemDaoForUnitTest(IFhirSystemDao theSystemDao) {
+		assert theSystemDao != null;
+		mySystemDao = theSystemDao;
+	}
+
+	@VisibleForTesting
+	public void setIdHelperServiceForUnitTest(IIdHelperService<IResourcePersistentId<?>> theIdHelperService) {
+		assert theIdHelperService != null;
+		myIdHelperService = theIdHelperService;
+	}
+
+	@VisibleForTesting
+	public void setFhirContextForUnitTest(FhirContext theFhirContext) {
+		myFhirContext = theFhirContext;
+	}
+
 	@Nonnull
 	private static BulkModifyResourcesChunkOutcomeJson generateOutcome(State theState) {
 		BulkModifyResourcesChunkOutcomeJson outcome = new BulkModifyResourcesChunkOutcomeJson();
@@ -384,10 +450,13 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 		outcome.setChunkRetryCount(theState.getRetryCount());
 		outcome.setResourceRetryCount(theState.getRetriedResourceCount());
 
-		for (PidAndResource next : theState.getChangedSavedResources()) {
+		for (PidAndResource next : theState.getResourcesInState(StateEnum.CHANGED_SAVED)) {
 			outcome.addChangedId(next.resource().getIdElement());
 		}
-		for (PidAndResource next : theState.getUnchangedResources()) {
+		for (PidAndResource next : theState.getResourcesInState(StateEnum.DELETED_SAVED)) {
+			outcome.addDeletedId(next.resource().getIdElement());
+		}
+		for (PidAndResource next : theState.getResourcesInState(StateEnum.UNCHANGED)) {
 			outcome.addUnchangedId(next.resource().getIdElement());
 		}
 		for (Map.Entry<PidAndResource, String> next : theState.getFailures().entrySet()) {
@@ -396,13 +465,52 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 		return outcome;
 	}
 
+	private enum StateEnum {
+
+		/** Resource has not yet been fetched or modified, only the PID is present */
+		INITIAL,
+		/** Resource was not modified and doesn't need to be written to the DB */
+		UNCHANGED,
+		/** Resource was modified and needs to be written to the DB */
+		CHANGED_UNSAVED,
+		/** Resource was modified and written to the DB, transaction is not yet committed */
+		CHANGED_PENDING,
+		/** Resource was modified and successfully written to the DB */
+		CHANGED_SAVED,
+		/** Resource was deleted and needs to be written to the DB */
+		DELETED_UNSAVED,
+		/** Resource was deleted and written to the DB, transaction is not yet committed */
+		DELETED_PENDING,
+		/** Resource was deleted and successfully written to the DB */
+		DELETED_SAVED;
+
+		public StateEnum toPending() {
+			return switch (this) {
+				case CHANGED_UNSAVED -> CHANGED_PENDING;
+				case DELETED_UNSAVED -> DELETED_PENDING;
+				// FIXME: new code
+				default -> throw new IllegalStateException(Msg.code(0) + "Can't convert " + this + " to pending");
+			};
+		}
+
+		public StateEnum toSaved() {
+			return switch (this) {
+				case CHANGED_PENDING -> CHANGED_SAVED;
+				case DELETED_PENDING -> DELETED_SAVED;
+				// FIXME: new code
+				default -> throw new IllegalStateException(Msg.code(0) + "Can't convert " + this + " to saved");
+			};
+		}
+
+		public static Set<StateEnum> pendingStates() {
+			return EnumSet.of(CHANGED_PENDING, DELETED_PENDING);
+		}
+	}
+
 	private static class State {
 
-		private final List<TypedPidAndVersionJson> myPidsToModify = new ArrayList<>();
-		private final Set<PidAndResource> myUnchangedResources = new HashSet<>();
-		private final Set<PidAndResource> myChangedUnsavedResources = new HashSet<>();
-		private final Set<PidAndResource> myChangedSavedResources = new HashSet<>();
-		private final List<PidAndResource> myPendingSavedResources = new ArrayList<>();
+//		private final List<TypedPidAndVersionJson> myPidsToModify = new ArrayList<>();
+		private ListMultimap<StateEnum, PidAndResource> myStateMap = MultimapBuilder.enumKeys(StateEnum.class).arrayListValues().build();
 		private final Map<PidAndResource, String> myFailures = new HashMap<>();
 		private int myRetryCount;
 		private int myRetriedResourceCount;
@@ -425,26 +533,24 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			myRetriedResourceCount += theIncrement;
 		}
 
-		public Collection<PidAndResource> getUnchangedResources() {
-			return myUnchangedResources;
+		public List<PidAndResource> getResourcesInState(StateEnum theState) {
+			return List.copyOf(myStateMap.get(theState));
 		}
 
-		public Collection<PidAndResource> getChangedUnsavedResourcesAndMoveToPending() {
-			List<PidAndResource> retVal = List.copyOf(myChangedUnsavedResources);
-			myChangedUnsavedResources.clear();
-			myPendingSavedResources.addAll(retVal);
+		public List<PidAndResource> getResourcesInStateAndClear(StateEnum theState) {
+			return List.copyOf(myStateMap.removeAll(theState));
+		}
+
+		public List<PidAndResource> getResourcesInStateAndMoveToPending(StateEnum theState) {
+			List<PidAndResource> retVal = myStateMap.removeAll(theState);
+			StateEnum nextState = theState.toPending();
+			myStateMap.putAll(nextState, retVal);
 			return retVal;
 		}
 
-		public Collection<PidAndResource> getChangedSavedResources() {
-			return myChangedSavedResources;
-		}
-
-		public void addChangedSavedResources(Collection<PidAndResource> theResources) {
-			int previousSize = myChangedSavedResources.size();
-			myChangedSavedResources.addAll(theResources);
-			Validate.isTrue(
-					myChangedSavedResources.size() == previousSize + theResources.size(), "Added duplicate resources");
+		public void addResource(StateEnum theState, PidAndResource theResource) {
+			assert !myStateMap.containsEntry(theState, theResource);
+			myStateMap.put(theState, theResource);
 		}
 
 		public void addFailure(PidAndResource theResource, String theMessage) {
@@ -456,55 +562,48 @@ public abstract class BaseBulkModifyResourcesStep<PT extends BaseBulkModifyJobPa
 			return myFailures;
 		}
 
-		public void addUnchangedResource(PidAndResource theResource) {
-			boolean added = myUnchangedResources.add(theResource);
-			Validate.isTrue(added, "%s is already present", theResource);
-		}
-
-		public void addChangedUnsavedResource(PidAndResource theResource) {
-			boolean added = myChangedUnsavedResources.add(theResource);
-			Validate.isTrue(added, "%s is already present", theResource);
-		}
-
 		public void movePendingToSaved() {
-			addChangedSavedResources(myPendingSavedResources);
-			myPendingSavedResources.clear();
+			for (StateEnum state : StateEnum.pendingStates()) {
+				List<PidAndResource> pidsAndResources = getResourcesInStateAndClear(state);
+				myStateMap.putAll(state.toSaved(), pidsAndResources);
+			}
 		}
+
 
 		public void movePendingBackToModificationList() {
-			List<TypedPidAndVersionJson> pids =
-					myPendingSavedResources.stream().map(PidAndResource::pid).toList();
-			myPendingSavedResources.clear();
-
-			myPidsToModify.addAll(pids);
-		}
-
-		public List<TypedPidAndVersionJson> getPidsToModifyAndClear() {
-			List<TypedPidAndVersionJson> retVal = List.copyOf(myPidsToModify);
-			myPidsToModify.clear();
-			return retVal;
-		}
-
-		public boolean hasPidsToModify() {
-			return !myPidsToModify.isEmpty();
+			for (StateEnum state : StateEnum.pendingStates()) {
+				List<PidAndResource> pidsAndResources = getResourcesInStateAndClear(state);
+				pidsAndResources.forEach(r -> addResource(StateEnum.INITIAL, r));
+			}
 		}
 
 		public void movePendingToFailed(String theMessage) {
-			myPendingSavedResources.forEach(r -> addFailure(r, theMessage));
-			myPendingSavedResources.clear();
+			for (StateEnum state : StateEnum.pendingStates()) {
+				List<PidAndResource> pidsAndResources = getResourcesInStateAndClear(state);
+				pidsAndResources.forEach(r -> addFailure(r, theMessage));
+			}
+		}
+
+		public List<PidAndResource> getPidsToModifyAndClear() {
+			return getResourcesInStateAndClear(StateEnum.INITIAL);
+		}
+
+		public boolean hasPidsToModify() {
+			return !myStateMap.get(StateEnum.INITIAL).isEmpty();
 		}
 
 		public int countPidsToModify() {
-			return myPidsToModify.size();
+			return myStateMap.get(StateEnum.INITIAL).size();
+		}
+
+		public JobExecutionFailedException getJobFailure() {
+			return myJobFailure;
 		}
 
 		public void setJobFailure(JobExecutionFailedException theJobFailure) {
 			myJobFailure = theJobFailure;
 		}
 
-		public JobExecutionFailedException getJobFailure() {
-			return myJobFailure;
-		}
 	}
 
 	private record PidAndResource(TypedPidAndVersionJson pid, IBaseResource resource) {}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/common/BulkModifyResourcesChunkOutcomeJson.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/common/BulkModifyResourcesChunkOutcomeJson.java
@@ -33,6 +33,9 @@ public class BulkModifyResourcesChunkOutcomeJson implements IModelJson {
 	@JsonProperty("changedIds")
 	private List<String> myChangedIds;
 
+	@JsonProperty("deletedIds")
+	private List<String> myDeletedIds;
+
 	@JsonProperty("unchangedIds")
 	private List<String> myUnchangedIds;
 
@@ -49,11 +52,22 @@ public class BulkModifyResourcesChunkOutcomeJson implements IModelJson {
 		getChangedIds().add(theIdElement.toUnqualified().getValue());
 	}
 
+	public void addDeletedId(IIdType theIdElement) {
+		getDeletedIds().add(theIdElement.toUnqualified().getValue());
+	}
+
 	public List<String> getChangedIds() {
 		if (myChangedIds == null) {
 			myChangedIds = new ArrayList<>();
 		}
 		return myChangedIds;
+	}
+
+	public List<String> getDeletedIds() {
+		if (myDeletedIds == null) {
+			myDeletedIds = new ArrayList<>();
+		}
+		return myDeletedIds;
 	}
 
 	public void addUnchangedId(IIdType theIdElement) {

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/reindex/ReindexJobParameters.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/reindex/ReindexJobParameters.java
@@ -67,9 +67,10 @@ public class ReindexJobParameters extends PartitionedUrlJobParameters {
 		return getIfNull(myCorrectCurrentVersion, ReindexParameters.CORRECT_CURRENT_VERSION_DEFAULT);
 	}
 
-	public void setCorrectCurrentVersion(
+	public ReindexJobParameters setCorrectCurrentVersion(
 			@Nullable ReindexParameters.CorrectCurrentVersionModeEnum theCorrectCurrentVersion) {
 		myCorrectCurrentVersion = theCorrectCurrentVersion;
+		return this;
 	}
 
 	public boolean getOptimisticLock() {

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/StepExecutionDetails.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/StepExecutionDetails.java
@@ -46,28 +46,12 @@ public class StepExecutionDetails<PT extends IModelJson, IT extends IModelJson> 
 		return new StepExecutionDetails<>(theParameters, theIntermediateParams, theInstance, reductionChunk);
 	}
 
-	/**
-	 * Deprecated in 7.3
-	 */
-	@Deprecated
-	public StepExecutionDetails(
-			@Nonnull PT theParameters, @Nullable IT theData, @Nonnull JobInstance theInstance, String theChunkId) {
-		this(
-				theParameters,
-				theData,
-				theInstance,
-				new WorkChunk()
-						.setId(theChunkId)
-						.setInstanceId(theInstance.getInstanceId())
-						.setData(theData));
-	}
-
 	public StepExecutionDetails(
 			@Nonnull PT theParameters,
 			@Nullable IT theData,
 			@Nonnull JobInstance theInstance,
 			@Nonnull WorkChunk theChunk) {
-		Validate.notNull(theParameters);
+		Validate.notNull(theParameters, "theParameters must not be null");
 		myParameters = theParameters;
 		myData = theData;
 		// Make a copy so the step worker can't change the one passed in
@@ -85,7 +69,7 @@ public class StepExecutionDetails<PT extends IModelJson, IT extends IModelJson> 
 	 */
 	@Nonnull
 	public IT getData() {
-		Validate.notNull(myData);
+		Validate.notNull(myData, "Data is currently null");
 		return myData;
 	}
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/parameters/PartitionedUrlJobParameters.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/parameters/PartitionedUrlJobParameters.java
@@ -45,6 +45,17 @@ public class PartitionedUrlJobParameters implements IModelJson {
 	@JsonProperty("partitionedUrl")
 	private List<PartitionedUrl> myPartitionedUrls;
 
+	@JsonProperty("limitResourceCount")
+	private Integer myLimitResourceCount;
+
+	public void setLimitResourceCount(Integer theLimitResourceCount) {
+		myLimitResourceCount = theLimitResourceCount;
+	}
+
+	public Integer getLimitResourceCount() {
+		return myLimitResourceCount;
+	}
+
 	public void setRequestPartitionId(@Nullable RequestPartitionId theRequestPartitionId) {
 		myRequestPartitionId = theRequestPartitionId;
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static ca.uhn.fhir.util.StreamUtil.partition;
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 
 public class ResourceIdListStep<PT extends PartitionedUrlJobParameters>

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStep.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 
 import static ca.uhn.fhir.util.StreamUtil.partition;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 
 public class ResourceIdListStep<PT extends PartitionedUrlJobParameters>
 		implements IJobStepWorker<PT, ChunkRangeJson, ResourceIdListWorkChunkJson> {
@@ -64,7 +65,8 @@ public class ResourceIdListStep<PT extends PartitionedUrlJobParameters>
 
 		Date start = data.getStart();
 		Date end = data.getEnd();
-		Integer batchSize = theStepExecutionDetails.getParameters().getBatchSize();
+		PT parameters = theStepExecutionDetails.getParameters();
+		Integer batchSize = parameters.getBatchSize();
 
 		ourLog.trace(
 				"Beginning to submit chunks in range {} to {} for url {} and partitionId {}",
@@ -73,7 +75,7 @@ public class ResourceIdListStep<PT extends PartitionedUrlJobParameters>
 				data.getUrl(),
 				data.getPartitionId());
 
-		int chunkSize = Math.min(defaultIfNull(batchSize, MAX_BATCH_OF_IDS), MAX_BATCH_OF_IDS);
+		int chunkSize = Math.min(getIfNull(batchSize, MAX_BATCH_OF_IDS), MAX_BATCH_OF_IDS);
 
 		final IResourcePidStream searchResult =
 				myIdChunkProducer.fetchResourceIdStream(theStepExecutionDetails.getData());
@@ -83,6 +85,11 @@ public class ResourceIdListStep<PT extends PartitionedUrlJobParameters>
 			AtomicInteger chunkCount = new AtomicInteger();
 
 			Stream<TypedPidJson> jsonStream = typedResourcePidStream.map(TypedPidJson::new);
+
+			Integer limitResourceCount = parameters.getLimitResourceCount();
+			if (limitResourceCount != null) {
+				jsonStream = jsonStream.limit(limitResourceCount);
+			}
 
 			// chunk by size maxBatchId and submit the batches
 			partition(jsonStream, chunkSize).forEach(idBatch -> {

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/jobs/step/ResourceIdListStepTest.java
@@ -5,17 +5,18 @@ import ca.uhn.fhir.batch2.api.RunOutcome;
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.jobs.chunk.ChunkRangeJson;
 import ca.uhn.fhir.batch2.jobs.chunk.ResourceIdListWorkChunkJson;
+import ca.uhn.fhir.batch2.jobs.chunk.TypedPidJson;
 import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrlJobParameters;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.pid.HomogeneousResourcePidList;
 import ca.uhn.fhir.jpa.api.pid.IResourcePidStream;
 import ca.uhn.fhir.jpa.api.pid.ListWrappingPidStream;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
-import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -27,9 +28,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,8 +46,6 @@ class ResourceIdListStepTest {
 	private IJobDataSink<ResourceIdListWorkChunkJson> myDataSink;
 	@Mock
 	private ChunkRangeJson myData;
-	@Mock
-	private PartitionedUrlJobParameters myParameters;
 
 	@Captor
 	private ArgumentCaptor<ResourceIdListWorkChunkJson> myDataCaptor;
@@ -60,14 +60,17 @@ class ResourceIdListStepTest {
 	@ParameterizedTest
 	@ValueSource(ints = {0, 1, 100, 500, 501, 2345, 10500})
 	void testResourceIdListBatchSizeLimit(int theListSize) {
-		List<IResourcePersistentId<JpaPid>> idList = generateIdList(theListSize);
+		List<JpaPid> idList = generateIdList(theListSize);
 		RequestPartitionId partitionId = RequestPartitionId.fromPartitionId(1);
 
+		PartitionedUrlJobParameters parameters = new PartitionedUrlJobParameters();
+
 		when(myStepExecutionDetails.getData()).thenReturn(myData);
-		when(myParameters.getBatchSize()).thenReturn(500);
-		when(myStepExecutionDetails.getParameters()).thenReturn(myParameters);
-		IResourcePidStream resourcePidStream = new ListWrappingPidStream(
-			new HomogeneousResourcePidList("Patient", idList, null, partitionId));
+		parameters.setBatchSize(500);
+
+		when(myStepExecutionDetails.getParameters()).thenReturn(parameters);
+		IResourcePidStream resourcePidStream = new ListWrappingPidStream<>(
+			new HomogeneousResourcePidList<>("Patient", idList, null, partitionId));
 		if (theListSize > 0) {
 			// Ensure none of the work chunks exceed MAX_BATCH_OF_IDS in size:
 			doAnswer(i -> {
@@ -103,12 +106,58 @@ class ResourceIdListStepTest {
 		}
 	}
 
-	private List<IResourcePersistentId<JpaPid>> generateIdList(int theListSize) {
-		List<IResourcePersistentId<JpaPid>> idList = new ArrayList<>();
+	@ParameterizedTest
+	@CsvSource(textBlock =
+		//  limitResourceCount, availableIds, batchSize
+		"""
+			100,                222,          500
+			100,                222,          50
+			100,                20,           500
+			""")
+	void testLimitResourceCount(int theLimitResourceCount, int theAvailableIds, int theBatchSize) {
+		// Setup
+		List<JpaPid> idList = generateIdList(theAvailableIds);
+		RequestPartitionId partitionId = RequestPartitionId.fromPartitionId(1);
+
+		when(myStepExecutionDetails.getData()).thenReturn(myData);
+
+		PartitionedUrlJobParameters parameters = new PartitionedUrlJobParameters();
+		parameters.setBatchSize(theBatchSize);
+		parameters.setLimitResourceCount(theLimitResourceCount);
+		when(myStepExecutionDetails.getParameters()).thenReturn(parameters);
+		IResourcePidStream resourcePidStream = new ListWrappingPidStream<>(
+			new HomogeneousResourcePidList<>("Patient", idList, null, partitionId));
+
+		when(myIdChunkProducer.fetchResourceIdStream(any())).thenReturn(resourcePidStream);
+
+		// Test
+		final RunOutcome run = myResourceIdListStep.run(myStepExecutionDetails, myDataSink);
+		assertNotNull(run);
+
+		// Verify
+		verify(myDataSink, atLeast(1)).accept(myDataCaptor.capture());
+		List<TypedPidJson> expectedPids = idList
+			.subList(0, Math.min(theLimitResourceCount, theAvailableIds))
+			.stream()
+			.map(t -> new TypedPidJson("Patient", 1, t.getId().toString()))
+			.toList();
+		List<ResourceIdListWorkChunkJson> allChunks = myDataCaptor.getAllValues();
+		for (var chunk : allChunks) {
+			assertThat(chunk.getTypedPids()).asList().hasSizeBetween(0, theBatchSize);
+		}
+		List<TypedPidJson> actualPids = allChunks
+			.stream()
+			.flatMap(t -> t.getTypedPids().stream())
+			.toList();
+		assertThat(actualPids).containsExactlyElementsOf(expectedPids);
+
+	}
+
+	private List<JpaPid> generateIdList(int theListSize) {
+		List<JpaPid> idList = new ArrayList<>();
 		for (long id = 0; id < theListSize; id++) {
-			IResourcePersistentId<JpaPid> theId = mock(IResourcePersistentId.class);
-			when(theId.getId()).thenReturn(JpaPid.fromId((id + 1)));
-			idList.add(theId);
+			JpaPid pid = JpaPid.fromId(id + 1, 1);
+			idList.add(pid);
 		}
 		return idList;
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/pid/HomogeneousResourcePidList.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/pid/HomogeneousResourcePidList.java
@@ -29,7 +29,7 @@ import java.util.Date;
 /**
  * A resource pid list where all pids have the same resource type
  */
-public class HomogeneousResourcePidList<T extends IResourcePersistentId<T>> extends BaseResourcePidList<T> {
+public class HomogeneousResourcePidList<T extends IResourcePersistentId<?>> extends BaseResourcePidList<T> {
 	@Nonnull
 	final String myResourceType;
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/pid/ListWrappingPidStream.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/api/pid/ListWrappingPidStream.java
@@ -20,14 +20,15 @@
 package ca.uhn.fhir.jpa.api.pid;
 
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-public class ListWrappingPidStream implements IResourcePidStream {
-	private final IResourcePidList myList;
+public class ListWrappingPidStream<P extends IResourcePersistentId<?>> implements IResourcePidStream {
+	private final IResourcePidList<P> myList;
 
-	public ListWrappingPidStream(IResourcePidList theList) {
+	public ListWrappingPidStream(IResourcePidList<P> theList) {
 		myList = theList;
 	}
 


### PR DESCRIPTION
Change #7216 introduced a new option on `$reindex` which corrects the current version of resources when the entry in `HFJ_RESOURCE` points to an unknown version. This PR corrects some redundant queries uncovered during testing on hapi.fhir.org which makes this new option more efficient. Also adds a few more test assertions.

No changelog as this only improves a feature added in the same release as #7216.