### PR TITLE
fix(7248): IdHelperService.resolveResourceIdentities fails with PreconditionFailedException on duplicate id inputs

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/IdHelperService.java
@@ -201,16 +201,19 @@ public class IdHelperService implements IIdHelperService<JpaPid> {
 			return new HashMap<>();
 		}
 
-		Collection<IIdType> ids = new ArrayList<>(theIds);
+		Collection<IIdType> ids = new ArrayList<>(theIds.size());
 		for (IIdType id : theIds) {
 			if (!id.hasIdPart()) {
 				throw new InvalidRequestException(Msg.code(1101) + "Parameter value missing in request");
+			}
+			if (ids.stream().noneMatch(seen -> seen.getValueAsString().equals(id.getValueAsString()))) {
+				ids.add(id);
 			}
 		}
 
 		RequestPartitionId requestPartitionId = replaceDefault(theRequestPartitionId);
 		ListMultimap<IIdType, IResourceLookup<JpaPid>> idToLookup =
-				MultimapBuilder.hashKeys(theIds.size()).arrayListValues(1).build();
+				MultimapBuilder.hashKeys(ids.size()).arrayListValues(1).build();
 
 		// Do we have any FHIR ID lookups cached for any of the IDs
 		if (theMode.isUseCache(myStorageSettings.isDeleteEnabled()) && !ids.isEmpty()) {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/index/IdHelperServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/index/IdHelperServiceTest.java
@@ -7,8 +7,10 @@ import ca.uhn.fhir.jpa.api.svc.ResolveIdentityMode;
 import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.cross.IResourceLookup;
+import ca.uhn.fhir.jpa.model.cross.JpaResourceLookup;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
+import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -18,10 +20,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.hibernate.sql.results.internal.TupleImpl;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Patient;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,48 +62,205 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(MockitoExtension.class)
 public class IdHelperServiceTest {
 
-    @InjectMocks
-    private final IdHelperService myHelperSvc = new IdHelperService();
+	@InjectMocks
+	private final IdHelperService myHelperSvc = new IdHelperService();
 
-    @Mock
-    protected IResourceTableDao myResourceTableDao;
+	@Mock
+	protected IResourceTableDao myResourceTableDao;
 
-    @Mock
-    private JpaStorageSettings myStorageSettings;
+	@Mock
+	private JpaStorageSettings myStorageSettings;
 
-    @Spy
-    private FhirContext myFhirCtx = FhirContext.forR4Cached();
+	@Spy
+	private FhirContext myFhirCtx = FhirContext.forR4Cached();
 
-    @Mock
-    private MemoryCacheService myMemoryCacheService;
+	@Spy
+	private MemoryCacheService myMemoryCacheService = new MemoryCacheService(new JpaStorageSettings());
 
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private EntityManager myEntityManager;
+	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	private EntityManager myEntityManager;
 
-    @Mock
-    private PartitionSettings myPartitionSettings;
+	@Mock
+	private PartitionSettings myPartitionSettings;
 
 	@Mock
 	private TypedQuery myTypedQuery;
 
 	@BeforeEach
-    void setUp() {
-        myHelperSvc.setDontCheckActiveTransactionForUnitTest(true);
+	void setUp() {
+		myHelperSvc.setDontCheckActiveTransactionForUnitTest(true);
 
 		// lenient because some tests require this setup, and others do not
 		lenient().doReturn(true).when(myStorageSettings).isDeleteEnabled();
-    }
-
+	}
 
 	@Test
-	public void testResolveResourceIdentity_defaultFunctionality(){
+	public void testResolveResourceIdentities_usingCache_defaultFunctionality() {
+		// ARRANGE
+		RequestPartitionId partitionId = RequestPartitionId.allPartitions();
+		String resourceType = "Patient";
+		String resourceForcedId = "AAA";
+		JpaPid resourcePid = JpaPid.fromId(1L);
+		var cacheHit = new JpaResourceLookup(resourceType, resourceForcedId, resourcePid, null, resourcePid.getPartitionablePartitionId());
+		var cacheKey = new MemoryCacheService.ForcedIdCacheKey(resourceType, resourceForcedId, RequestPartitionId.allPartitions());
+		myMemoryCacheService.invalidateCaches(MemoryCacheService.CacheEnum.RESOURCE_LOOKUP_BY_FORCED_ID);
+		myMemoryCacheService.put(MemoryCacheService.CacheEnum.RESOURCE_LOOKUP_BY_FORCED_ID, cacheKey, List.of(cacheHit));
+
+		// ACT
+		Map<IIdType, IResourceLookup<JpaPid>> result = myHelperSvc.resolveResourceIdentities(
+			partitionId,
+			List.of(new IdDt(resourceType, resourceForcedId)),
+			ResolveIdentityMode.includeDeleted().cacheOk() // use cache
+		);
+
+		// ASSERT
+		assertEquals(1, result.size());
+		final IResourceLookup<JpaPid> jpaPidIResourceLookup = result.values().iterator().next();
+		assertEquals(resourceForcedId, jpaPidIResourceLookup.getFhirId());
+		assertEquals(resourceType, jpaPidIResourceLookup.getResourceType());
+		assertEquals(resourcePid, jpaPidIResourceLookup.getPersistentId());
+		assertNull(jpaPidIResourceLookup.getDeleted());
+	}
+
+	@Test
+	public void testResolveResourceIdentities_withDuplicateIds_usingCache_returnsSingleResult() {
+		// ARRANGE
+		RequestPartitionId partitionId = RequestPartitionId.allPartitions();
+		String resourceType = "Patient";
+		String resourceForcedId = "AAA";
+		JpaPid resourcePid = JpaPid.fromId(1L);
+		var cacheHit = new JpaResourceLookup(resourceType, resourceForcedId, resourcePid, null, resourcePid.getPartitionablePartitionId());
+		var cacheKey = new MemoryCacheService.ForcedIdCacheKey(resourceType, resourceForcedId, RequestPartitionId.allPartitions());
+		myMemoryCacheService.invalidateCaches(MemoryCacheService.CacheEnum.RESOURCE_LOOKUP_BY_FORCED_ID);
+		myMemoryCacheService.put(MemoryCacheService.CacheEnum.RESOURCE_LOOKUP_BY_FORCED_ID, cacheKey, List.of(cacheHit));
+		Collection<IIdType> idsToResolve = List.of(
+			new IdDt(resourceType, resourceForcedId),
+			new IdDt(resourceType, resourceForcedId)
+		);
+
+		// ACT
+		Map<IIdType, IResourceLookup<JpaPid>> result = myHelperSvc.resolveResourceIdentities(
+			partitionId,
+			idsToResolve, // contains duplicates
+			ResolveIdentityMode.includeDeleted().cacheOk() // use cache
+		);
+
+		// ASSERT
+		assertEquals(1, result.size());
+		final IResourceLookup<JpaPid> jpaPidIResourceLookup = result.values().iterator().next();
+		assertEquals(resourceForcedId, jpaPidIResourceLookup.getFhirId());
+		assertEquals(resourceType, jpaPidIResourceLookup.getResourceType());
+		assertEquals(resourcePid, jpaPidIResourceLookup.getPersistentId());
+		assertNull(jpaPidIResourceLookup.getDeleted());
+	}
+
+	@Test
+	public void testResolveResourceIdentities_usingDb_defaultFunctionality() {
+		// ARRANGE
+		lenient().doReturn(JpaStorageSettings.ClientIdStrategyEnum.ALPHANUMERIC).when(myStorageSettings).getResourceClientIdStrategy();
+		RequestPartitionId partitionId = RequestPartitionId.fromPartitionIdAndName(1, "partition");
+		String resourceType = "Patient";
+		String resourceForcedId = "AAA";
+		Object[] tuple = new Object[]{
+			JpaPid.fromId(1L),
+			"Patient",
+			"AAA",
+			new Date(),
+			null
+		};
+		when(myEntityManager.createQuery(any(CriteriaQuery.class))).thenReturn(myTypedQuery);
+		when(myTypedQuery.getResultList()).thenReturn(List.of(
+			new TupleImpl(null, tuple)
+		));
+
+		// ACT
+		Map<IIdType, IResourceLookup<JpaPid>> result = myHelperSvc.resolveResourceIdentities(
+			partitionId,
+			List.of(new IdDt(resourceType, resourceForcedId)),
+			ResolveIdentityMode.includeDeleted().noCacheUnlessDeletesDisabled() // do not use cache
+		);
+
+		// ASSERT
+		assertEquals(1, result.size());
+		final IResourceLookup<JpaPid> jpaPidIResourceLookup = result.values().iterator().next();
+		assertEquals(tuple[0], jpaPidIResourceLookup.getPersistentId());
+		assertEquals(tuple[1], jpaPidIResourceLookup.getResourceType());
+		assertEquals(tuple[3], jpaPidIResourceLookup.getDeleted());
+	}
+
+	@Test
+	public void testResolveResourceIdentities_withDuplicateIds_usingDb_returnsSingleResult() {
+		// ARRANGE
+		lenient().doReturn(JpaStorageSettings.ClientIdStrategyEnum.ALPHANUMERIC).when(myStorageSettings).getResourceClientIdStrategy();
+		RequestPartitionId partitionId = RequestPartitionId.fromPartitionIdAndName(1, "partition");
+		String type1 = "Patient";
+		String resource1ForcedId = "AAA";
+		Object[] res1 = new Object[]{
+			JpaPid.fromId(1L),
+			type1,
+			resource1ForcedId,
+			new Date(),
+			null
+		};
+
+		String type2 = "Practitioner";
+		String resource2ForcedId = "BBB";
+		Object[] res2 = new Object[]{
+			JpaPid.fromId(2L),
+			type2,
+			resource2ForcedId,
+			new Date(),
+			null
+		};
+
+		when(myEntityManager.createQuery(any(CriteriaQuery.class))).thenReturn(myTypedQuery);
+		when(myTypedQuery.getResultList()).thenReturn(List.of(
+			new TupleImpl(null, res1),
+			new TupleImpl(null, res2)
+		));
+		Collection<IIdType> idsToResolve = List.of(
+			new IdDt(type1, resource1ForcedId),
+			new IdDt(type2, resource2ForcedId),
+			new IdDt(type1, resource1ForcedId)
+		);
+
+		// ACT
+		Map<IIdType, IResourceLookup<JpaPid>> result = myHelperSvc.resolveResourceIdentities(
+			partitionId,
+			idsToResolve, // contains duplicates
+			ResolveIdentityMode.includeDeleted().noCacheUnlessDeletesDisabled()
+		);
+
+		// ASSERT
+		assertEquals(2, result.size());
+		assertThat(result.keySet()).extracting(IIdType::getValue).containsExactlyInAnyOrder("Patient/AAA", "Practitioner/BBB");
+		final List<Map.Entry<IIdType, IResourceLookup<JpaPid>>> entries = result.entrySet().stream().toList();
+		entries.forEach(entry -> {
+			IIdType id = entry.getKey();
+			IResourceLookup<JpaPid> resolved = entry.getValue();
+			if (id.getValue().equals("Patient/AAA")) {
+				assertEquals(res1[0], resolved.getPersistentId());
+				assertEquals(res1[1], resolved.getResourceType());
+				assertEquals(res1[3], resolved.getDeleted());
+			} else if (id.getValue().equals("Practitioner/BBB")) {
+				assertEquals(res2[0], resolved.getPersistentId());
+				assertEquals(res2[1], resolved.getResourceType());
+				assertEquals(res2[3], resolved.getDeleted());
+			} else {
+				Assertions.fail("Unexpected ID: " + id.getValue());
+			}
+		});
+	}
+
+	@Test
+	public void testResolveResourceIdentity_defaultFunctionality() {
 		lenient().doReturn(JpaStorageSettings.ClientIdStrategyEnum.ALPHANUMERIC).when(myStorageSettings).getResourceClientIdStrategy();
 
 		RequestPartitionId partitionId = RequestPartitionId.fromPartitionIdAndName(1, "partition");
 		String resourceType = "Patient";
 		String resourceForcedId = "AAA";
 
-		Object[] tuple = new Object[] {
+		Object[] tuple = new Object[]{
 			JpaPid.fromId(1L),
 			"Patient",
 			"AAA",
@@ -118,11 +280,11 @@ public class IdHelperServiceTest {
 	}
 
 	@Test
-	public void testResolveResourceIdentity_withPersistentIdOfResourceWithForcedIdAndDefaultClientIdStrategy_returnsNotFound(){
+	public void testResolveResourceIdentity_withPersistentIdOfResourceWithForcedIdAndDefaultClientIdStrategy_returnsNotFound() {
 		RequestPartitionId partitionId = RequestPartitionId.fromPartitionIdAndName(1, "partition");
 		String resourceType = "Patient";
 
-		Object[] tuple = new Object[] {
+		Object[] tuple = new Object[]{
 			JpaPid.fromId(1L),
 			"Patient",
 			"AAA",


### PR DESCRIPTION
closes https://github.com/hapifhir/hapi-fhir/issues/7248