### PR TITLE
[7258] add support of application/ndjson for bulk export output format

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjosn-support-for-bulk-export-output-format.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjosn-support-for-bulk-export-output-format.yaml
@@ -1,5 +1,0 @@
----
-type: add
-issue: 7258
-jira: SMILE-11001
-title: "Add support of `application/ndjson` as a Bulk Export output format."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjosn-support-for-bulk-export-output-format.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjosn-support-for-bulk-export-output-format.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 7258
+jira: SMILE-11001
+title: "Add support of `application/ndjson` as a Bulk Export output format."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjson-support-for-bulk-export-output-format.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjson-support-for-bulk-export-output-format.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 7258
+jira: SMILE-11001
+title: "Add support for `application/ndjson` as a Bulk Export output format to conform to the FHIR specification"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjson-support-for-bulk-export-output-format.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7258-add-ndjson-support-for-bulk-export-output-format.yaml
@@ -2,4 +2,4 @@
 type: add
 issue: 7258
 jira: SMILE-11001
-title: "Add support for `application/ndjson` as a Bulk Export output format to conform to the FHIR specification"
+title: "Allow `application/ndjson` in addition to `application/fhir+ndjson` as a Bulk Export output format to conform to the FHIR specification"

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobParametersValidator.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobParametersValidator.java
@@ -73,7 +73,7 @@ public class BulkExportJobParametersValidator implements IJobParametersValidator
 		// validate the output format
 		if (!isSupportedOutputFormat(theParameters.getOutputFormat())) {
 			errorMsgs.add("The allowed formats for Bulk Export are currently %s and %s"
-				.formatted(Constants.CT_FHIR_NDJSON, Constants.CT_APP_NDJSON));
+					.formatted(Constants.CT_FHIR_NDJSON, Constants.CT_APP_NDJSON));
 		}
 		// validate the exportId
 		if (!StringUtils.isBlank(theParameters.getExportIdentifier())) {
@@ -131,7 +131,7 @@ public class BulkExportJobParametersValidator implements IJobParametersValidator
 	}
 
 	private boolean isSupportedOutputFormat(String theOutputFormat) {
-		return Constants.CT_FHIR_NDJSON.equalsIgnoreCase(theOutputFormat) ||
-			Constants.CT_APP_NDJSON.equalsIgnoreCase(theOutputFormat);
+		return Constants.CT_FHIR_NDJSON.equalsIgnoreCase(theOutputFormat)
+				|| Constants.CT_APP_NDJSON.equalsIgnoreCase(theOutputFormat);
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobParametersValidator.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobParametersValidator.java
@@ -71,8 +71,9 @@ public class BulkExportJobParametersValidator implements IJobParametersValidator
 		}
 
 		// validate the output format
-		if (!Constants.CT_FHIR_NDJSON.equalsIgnoreCase(theParameters.getOutputFormat())) {
-			errorMsgs.add("The only allowed format for Bulk Export is currently " + Constants.CT_FHIR_NDJSON);
+		if (!isSupportedOutputFormat(theParameters.getOutputFormat())) {
+			errorMsgs.add("The allowed formats for Bulk Export are currently %s and %s"
+				.formatted(Constants.CT_FHIR_NDJSON, Constants.CT_APP_NDJSON));
 		}
 		// validate the exportId
 		if (!StringUtils.isBlank(theParameters.getExportIdentifier())) {
@@ -127,5 +128,10 @@ public class BulkExportJobParametersValidator implements IJobParametersValidator
 		}
 
 		return errorMsgs;
+	}
+
+	private boolean isSupportedOutputFormat(String theOutputFormat) {
+		return Constants.CT_FHIR_NDJSON.equalsIgnoreCase(theOutputFormat) ||
+			Constants.CT_APP_NDJSON.equalsIgnoreCase(theOutputFormat);
 	}
 }


### PR DESCRIPTION
Add support for application/ndjson as _outputFormat for bulk export to conform to the FHIR specification.

Closes #7258 