### PR TITLE
7261: Return 404 when querying the status of a cancelled bulk export

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7261-return-correct-http-code-when-querying-cancelled-job-status.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7261-return-correct-http-code-when-querying-cancelled-job-status.yaml
@@ -1,5 +1,6 @@
 ---
 type: fix
 issue: 7261
+jira: SMILE-11023
 title: "Querying the status of a cancelled bulk export job was returning a 
     HTTP 202 instead of a HTTP 404. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7261-return-correct-http-code-when-querying-cancelled-job-status.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7261-return-correct-http-code-when-querying-cancelled-job-status.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 7261
+title: "Querying the status of a cancelled bulk export job was returning a 
+    HTTP 202 instead of a HTTP 404. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7261-return-correct-http-code-when-querying-cancelled-job-status.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7261-return-correct-http-code-when-querying-cancelled-job-status.yaml
@@ -3,4 +3,5 @@ type: fix
 issue: 7261
 jira: SMILE-11023
 title: "Querying the status of a cancelled bulk export job was returning a 
-    HTTP 202 instead of a HTTP 404. This has been fixed."
+    HTTP 202 instead of a HTTP 404 as required by the spec 
+    (https://hl7.org/fhir/uv/bulkdata/STU2/export.html#bulk-data-delete-request). This has been fixed."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
@@ -1093,6 +1093,38 @@ public class BulkDataExportProviderR4Test {
 		}
 	}
 
+	@Test
+	public void testGetForOperationPollStatus_CANCELLED_ShouldReturnError() throws IOException {
+		// setup
+		JobInstance info = new JobInstance();
+		info.setInstanceId(A_JOB_ID);
+		info.setStatus(StatusEnum.CANCELLED);
+		info.setEndTime(InstantType.now().getValue());
+
+		BulkExportJobParameters parameters = new BulkExportJobParameters();
+		info.setParameters(parameters);
+
+		// when
+		when(myJobCoordinator.getInstance(eq(A_JOB_ID)))
+			.thenReturn(info);
+
+		// call
+		String url = myServer.getBaseUrl() + "/" + ProviderConstants.OPERATION_EXPORT_POLL_STATUS + "?" +
+			JpaConstants.PARAM_EXPORT_POLL_STATUS_JOB_ID + "=" + A_JOB_ID;
+		HttpDelete delete = new HttpDelete(url);
+		try (CloseableHttpResponse response = myClient.execute(delete)) {
+			ourLog.info("Response: {}", response.toString());
+
+			assertEquals(404, response.getStatusLine().getStatusCode());
+			assertEquals("Not Found", response.getStatusLine().getReasonPhrase());
+
+			String responseContent = IOUtils.toString(response.getEntity().getContent(), Charsets.UTF_8);
+			// content would be blank, since the job is cancelled
+			ourLog.info("Response content: {}", responseContent);
+			assertThat(responseContent).contains("was cancelled.  No status to report.");
+		}
+	}
+
 	@ParameterizedTest
 	@ValueSource(strings = {
 		"$export",

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
@@ -1119,7 +1119,6 @@ public class BulkDataExportProviderR4Test {
 			assertEquals("Not Found", response.getStatusLine().getReasonPhrase());
 
 			String responseContent = IOUtils.toString(response.getEntity().getContent(), Charsets.UTF_8);
-			// content would be blank, since the job is cancelled
 			ourLog.info("Response content: {}", responseContent);
 			assertThat(responseContent).contains("was cancelled.  No status to report.");
 		}

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -479,7 +479,6 @@ public class BulkDataExportProvider {
 			case FINALIZE:
 			case QUEUED:
 			case IN_PROGRESS:
-			case CANCELLED:
 				//noinspection deprecation - we need to support old jobs after upgrade.
 			case ERRORED:
 				if (theRequestDetails.getRequestType() == RequestTypeEnum.DELETE) {
@@ -492,6 +491,22 @@ public class BulkDataExportProvider {
 							"Build in progress - Status set to " + info.getStatus() + " at " + dateString);
 					response.addHeader(Constants.HEADER_RETRY_AFTER, "120");
 				}
+				break;
+			case CANCELLED:
+				response.setStatus(Constants.STATUS_HTTP_404_NOT_FOUND);
+				IBaseOperationOutcome outcome = OperationOutcomeUtil.newInstance(myFhirContext);
+				OperationOutcomeUtil.addIssue(
+						myFhirContext,
+						outcome,
+						"error",
+						"Job instance <" + theJobId.getValueAsString() + "> was cancelled.  No status to report.",
+						null,
+						null);
+				myFhirContext
+						.newJsonParser()
+						.setPrettyPrint(true)
+						.encodeResourceToWriter(outcome, response.getWriter());
+				response.getWriter().close();
 				break;
 		}
 	}


### PR DESCRIPTION
Make sure we return a HTTP 404 when a user queries the status of a cancelled bulk export

Fixes #7261 
Fixes Smile [#7880](https://gitlab.com/simpatico.ai/cdr/-/issues/7880)
