### PR TITLE
Fix issue that not logical operator does not work in FHIR filter

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/predicate/SearchFilterParser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/predicate/SearchFilterParser.java
@@ -598,7 +598,7 @@ public class SearchFilterParser {
 				return CODES_LogicalOperation.get(getOperation().ordinal()) + " " + FFilter1.toString();
 			} else {
 				return FFilter1.toString() + " "
-					+ CODES_LogicalOperation.get(getOperation().ordinal()) + " " + FFilter2.toString();
+						+ CODES_LogicalOperation.get(getOperation().ordinal()) + " " + FFilter2.toString();
 			}
 		}
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/predicate/SearchFilterParser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/predicate/SearchFilterParser.java
@@ -237,14 +237,14 @@ public class SearchFilterParser {
 	}
 
 	private BaseFilter parseLogical(BaseFilter filter) throws FilterSyntaxException {
-
 		BaseFilter result = null;
-		String s;
 		FilterLogical logical;
 		if (filter == null) {
-			s = "not";
+			logical = new FilterLogical();
+			logical.setOperation(FilterLogicalOperation.not);
+			logical.setFilter1(parseOpen());
 		} else {
-			s = consumeName();
+			String s = consumeName();
 			if ((!s.equals("or")) && (!s.equals("and")) && (!s.equals("not"))) {
 				throw new FilterSyntaxException(Msg.code(1059) + String.format("Unexpected Name %s at %d", s, cursor));
 			}
@@ -260,8 +260,8 @@ public class SearchFilterParser {
 			}
 
 			logical.setFilter2(parseOpen());
-			result = logical;
 		}
+		result = logical;
 		return result;
 	}
 
@@ -594,8 +594,12 @@ public class SearchFilterParser {
 
 		@Override
 		public String toString() {
-			return FFilter1.toString() + " "
+			if ("not".equals(CODES_LogicalOperation.get(getOperation().ordinal()))) {
+				return CODES_LogicalOperation.get(getOperation().ordinal()) + " " + FFilter1.toString();
+			} else {
+				return FFilter1.toString() + " "
 					+ CODES_LogicalOperation.get(getOperation().ordinal()) + " " + FFilter2.toString();
+			}
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -963,13 +963,14 @@ public class QueryStack {
 					theRequestPartitionId);
 
 			// Right side
-			Condition yPredicate = ((SearchFilterParser.FilterLogical) theFilter).getOperation() == SearchFilterParser.FilterLogicalOperation.not ?
-				null :
-				createPredicateFilter(
-					theQueryStack3,
-					((SearchFilterParser.FilterLogical) theFilter).getFilter2(),
-					theResourceName,
-					theRequestPartitionId);
+			Condition yPredicate = ((SearchFilterParser.FilterLogical) theFilter).getOperation()
+							== SearchFilterParser.FilterLogicalOperation.not
+					? null
+					: createPredicateFilter(
+							theQueryStack3,
+							((SearchFilterParser.FilterLogical) theFilter).getFilter2(),
+							theResourceName,
+							theRequestPartitionId);
 
 			if (((SearchFilterParser.FilterLogical) theFilter).getOperation()
 					== SearchFilterParser.FilterLogicalOperation.and) {
@@ -977,8 +978,8 @@ public class QueryStack {
 			} else if (((SearchFilterParser.FilterLogical) theFilter).getOperation()
 					== SearchFilterParser.FilterLogicalOperation.or) {
 				return ComboCondition.or(xPredicate, yPredicate);
-			}  else if (((SearchFilterParser.FilterLogical) theFilter).getOperation()
-				== SearchFilterParser.FilterLogicalOperation.not) {
+			} else if (((SearchFilterParser.FilterLogical) theFilter).getOperation()
+					== SearchFilterParser.FilterLogicalOperation.not) {
 				return new NotCondition(xPredicate);
 			} else {
 				// Shouldn't happen

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -98,6 +98,7 @@ import com.healthmarketscience.sqlbuilder.ComboCondition;
 import com.healthmarketscience.sqlbuilder.Condition;
 import com.healthmarketscience.sqlbuilder.Expression;
 import com.healthmarketscience.sqlbuilder.InCondition;
+import com.healthmarketscience.sqlbuilder.NotCondition;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
 import com.healthmarketscience.sqlbuilder.SetOperationQuery;
 import com.healthmarketscience.sqlbuilder.Subquery;
@@ -962,7 +963,9 @@ public class QueryStack {
 					theRequestPartitionId);
 
 			// Right side
-			Condition yPredicate = createPredicateFilter(
+			Condition yPredicate = ((SearchFilterParser.FilterLogical) theFilter).getOperation() == SearchFilterParser.FilterLogicalOperation.not ?
+				null :
+				createPredicateFilter(
 					theQueryStack3,
 					((SearchFilterParser.FilterLogical) theFilter).getFilter2(),
 					theResourceName,
@@ -974,6 +977,9 @@ public class QueryStack {
 			} else if (((SearchFilterParser.FilterLogical) theFilter).getOperation()
 					== SearchFilterParser.FilterLogicalOperation.or) {
 				return ComboCondition.or(xPredicate, yPredicate);
+			}  else if (((SearchFilterParser.FilterLogical) theFilter).getOperation()
+				== SearchFilterParser.FilterLogicalOperation.not) {
+				return new NotCondition(xPredicate);
 			} else {
 				// Shouldn't happen
 				throw new InvalidRequestException(Msg.code(1205) + "Don't know how to handle operation "

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/SearchFilterSyntaxTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/SearchFilterSyntaxTest.java
@@ -27,6 +27,11 @@ public class SearchFilterSyntaxTest {
 	}
 
 	@Test
+	public void testTokenNot() throws SearchFilterParser.FilterSyntaxException {
+		testParse("not name eq loinc|1234");
+	}
+
+	@Test
 	public void testUrl() throws SearchFilterParser.FilterSyntaxException {
 		testParse("name in http://loinc.org/vs/LP234");
 	}
@@ -54,6 +59,11 @@ public class SearchFilterSyntaxTest {
 	@Test
 	public void testFilter2() throws SearchFilterParser.FilterSyntaxException {
 		testParse("related[type eq comp and this lt that].target pr false");
+	}
+
+	@Test
+	public void testFilter2WithNot() throws SearchFilterParser.FilterSyntaxException {
+		testParse("related[type eq comp and not this lt that].target pr false");
 	}
 
 	@Test


### PR DESCRIPTION
NOT logical operator does not work in FHIR filter. Based on the FHIR filter specification it should be supported.

This also closes https://github.com/hapifhir/hapi-fhir/issues/5026.