### PR TITLE
Declare mandatory commons-collections4 as such (#6307)

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -92,6 +92,10 @@
 			<artifactId>commons-codec</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>


### PR DESCRIPTION
it was previously coming from a transitive dependency (jena-core) which is optional but this is used directly and so better to declare it directly

https://github.com/hapifhir/hapi-fhir/blob/fb93c3d601272a146904e438c11af93f32e70f1e/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/CollectionUtil.java#L24C8-L24C55