### PR TITLE
fixed $translate operation caching

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/support/IValidationSupport.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/support/IValidationSupport.java
@@ -1395,7 +1395,7 @@ public interface IValidationSupport {
 			TranslateCodeRequest that = (TranslateCodeRequest) theO;
 
 			return new EqualsBuilder()
-					.append(myCodings, that.myCodings)
+					.append(CodingEqualsAdapter.fromList(myCodings), CodingEqualsAdapter.fromList(that.myCodings))
 					.append(myTargetSystemUrl, that.myTargetSystemUrl)
 					.append(myConceptMapUrl, that.myConceptMapUrl)
 					.append(myConceptMapVersion, that.myConceptMapVersion)
@@ -1409,7 +1409,7 @@ public interface IValidationSupport {
 		@Override
 		public int hashCode() {
 			return new HashCodeBuilder(17, 37)
-					.append(myCodings)
+					.append(CodingEqualsAdapter.fromList(myCodings))
 					.append(myTargetSystemUrl)
 					.append(myConceptMapUrl)
 					.append(myConceptMapVersion)
@@ -1460,6 +1460,58 @@ public interface IValidationSupport {
 					.append("targetValueSetUrl", myTargetValueSetUrl)
 					.append("reverse", myReverse)
 					.toString();
+		}
+
+		/**
+		 * Adapter class that provides semantic equality comparison for {@link IBaseCoding} instances in the context
+		 * of TranslateCodeRequests.
+		 * <p>
+		 * This adapter is used to compare codings based on their semantic content (system, code, and version)
+		 * rather than object identity. This is essential for proper cache key comparison.
+		 * </p>
+		 * <p>
+		 * The display value is intentionally excluded from equality comparison as it is not semantically
+		 * significant for code translation operations.
+		 * </p>
+		 */
+		private static class CodingEqualsAdapter {
+			private final IBaseCoding myCoding;
+
+			CodingEqualsAdapter(IBaseCoding theCoding) {
+				myCoding = theCoding;
+			}
+
+			@Override
+			public int hashCode() {
+				return new HashCodeBuilder(17, 37)
+						.append(myCoding.getSystem())
+						.append(myCoding.getCode())
+						.append(myCoding.getVersion())
+						.toHashCode();
+			}
+
+			@Override
+			public boolean equals(Object theO) {
+
+				if (this == theO) {
+					return true;
+				}
+
+				if (theO == null || getClass() != theO.getClass()) {
+					return false;
+				}
+
+				CodingEqualsAdapter that = (CodingEqualsAdapter) theO;
+				return new EqualsBuilder()
+						.append(myCoding.getSystem(), that.myCoding.getSystem())
+						.append(myCoding.getCode(), that.myCoding.getCode())
+						.append(myCoding.getVersion(), that.myCoding.getVersion())
+						.isEquals();
+			}
+
+			static List<CodingEqualsAdapter> fromList(List<IBaseCoding> theList) {
+				return theList.stream().map(CodingEqualsAdapter::new).toList();
+			}
 		}
 	}
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7371-fix-translate-code-request-cache-key-equality.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_6_0/7371-fix-translate-code-request-cache-key-equality.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 7371
+title: "Fixed an issue where ConceptMap $translate operation caching was not working properly,
+  causing unnecessary cache misses for semantically identical requests."

--- a/hapi-fhir-validation/src/test/java/ca/uhn/fhir/context/support/TranslateCodeRequestTest.java
+++ b/hapi-fhir-validation/src/test/java/ca/uhn/fhir/context/support/TranslateCodeRequestTest.java
@@ -1,0 +1,189 @@
+package ca.uhn.fhir.context.support;
+
+import org.hl7.fhir.r4.model.Coding;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Tests for {@link ca.uhn.fhir.context.support.IValidationSupport.TranslateCodeRequest}
+ * which is used as a cacheKey for $translate operations.
+ */
+class TranslateCodeRequestTest {
+
+	@Test
+	void testEqualsAndHashCodeWithNoVersion() {
+		// Two requests with identical codings (but different instances)
+		Coding coding1 = new Coding("http://loinc.org", "1234-5", "Test Display");
+		Coding coding2 = new Coding("http://loinc.org", "1234-5", "Test Display");
+
+		IValidationSupport.TranslateCodeRequest request1 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.singletonList(coding1), "http://target.system");
+		IValidationSupport.TranslateCodeRequest request2 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.singletonList(coding2), "http://target.system");
+
+		assertEquals(request1, request2);
+		assertEquals(request1.hashCode(), request2.hashCode());
+	}
+
+	@Test
+	void testEqualsAndHashCodeWithVersion() {
+		Coding coding1 = codingWithVersion("http://loinc.org", "1234-5", null, "v1");
+		Coding coding2 = codingWithVersion("http://loinc.org", "1234-5", null, "v1");
+
+		IValidationSupport.TranslateCodeRequest request1 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.singletonList(coding1), "http://target.system");
+		IValidationSupport.TranslateCodeRequest request2 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.singletonList(coding2), "http://target.system");
+
+		assertEquals(request1, request2);
+		assertEquals(request1.hashCode(), request2.hashCode());
+	}
+
+	@Test
+	void testEqualsAndHashCodeWithMultipleCodings() {
+		Coding coding1a = new Coding("http://loinc.org", "1234-5", null);
+		Coding coding1b = new Coding("http://snomed.info/sct", "9999-0", null);
+		Coding coding2a = new Coding("http://loinc.org", "1234-5", null);
+		Coding coding2b = new Coding("http://snomed.info/sct", "9999-0", null);
+
+		IValidationSupport.TranslateCodeRequest request1 =
+			new IValidationSupport.TranslateCodeRequest(
+				Arrays.asList(coding1a, coding1b), "http://target.system");
+		IValidationSupport.TranslateCodeRequest request2 =
+			new IValidationSupport.TranslateCodeRequest(
+				Arrays.asList(coding2a, coding2b), "http://target.system");
+
+		assertEquals(request1, request2);
+		assertEquals(request1.hashCode(), request2.hashCode());
+	}
+
+	@Test
+	void testEqualsAndHashCodeWithoutCodings() {
+		IValidationSupport.TranslateCodeRequest request1 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.emptyList(), "http://target.system");
+		IValidationSupport.TranslateCodeRequest request2 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.emptyList(), "http://target.system");
+
+		assertEquals(request1, request2);
+		assertEquals(request1.hashCode(), request2.hashCode());
+	}
+
+	@Test
+	void testEqualsAndHashCodeIgnoresDisplay() {
+		Coding coding1 = new Coding("http://loinc.org", "1234-5", "Display Text 1");
+		Coding coding2 = new Coding("http://loinc.org", "1234-5", "Display Text 2");
+
+		IValidationSupport.TranslateCodeRequest request1 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.singletonList(coding1), "http://target.system");
+		IValidationSupport.TranslateCodeRequest request2 =
+			new IValidationSupport.TranslateCodeRequest(
+				Collections.singletonList(coding2), "http://target.system");
+
+		assertEquals(request1, request2);
+		assertEquals(request1.hashCode(), request2.hashCode());
+	}
+
+	static Stream<Object[]> differenceTestCases() {
+		return Stream.of(
+			new Object[]{
+				"different code",
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "1234-5", null)),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "9999-9", null)),
+					"http://target.system")
+			},
+			new Object[]{
+				"different system",
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "1234-5", null)),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://snomed.info/sct", "1234-5", null)),
+					"http://target.system")
+			},
+			new Object[]{
+				"different version",
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(codingWithVersion("http://loinc.org", "1234-5", null, "v1")),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(codingWithVersion("http://loinc.org", "1234-5", null, "v2")),
+					"http://target.system")
+			},
+			new Object[]{
+				"different target system",
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "1234-5", null)),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "1234-5", null)),
+					"http://different.target.system")
+			},
+			new Object[]{
+				"different number of codings",
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "1234-5", null)),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Arrays.asList(
+						new Coding("http://loinc.org", "1234-5", null),
+						new Coding("http://loinc.org", "6789-0", null)),
+					"http://target.system")
+			},
+			new Object[]{
+				"different coding order",
+				new IValidationSupport.TranslateCodeRequest(
+					Arrays.asList(
+						new Coding("http://loinc.org", "1234-5", null),
+						new Coding("http://snomed.info/sct", "9999-0", null)),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Arrays.asList(
+						new Coding("http://snomed.info/sct", "9999-0", null),
+						new Coding("http://loinc.org", "1234-5", null)),
+					"http://target.system")
+			},
+			new Object[]{
+				"one with coding one without",
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.singletonList(new Coding("http://loinc.org", "1234-5", null)),
+					"http://target.system"),
+				new IValidationSupport.TranslateCodeRequest(
+					Collections.emptyList(),
+					"http://target.system")
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("differenceTestCases")
+	void testNotEqualRequests(String theMessage,
+											IValidationSupport.TranslateCodeRequest theValue,
+											IValidationSupport.TranslateCodeRequest theComparisonValue) {
+		assertNotEquals(theValue, theComparisonValue);
+		assertNotEquals(theValue.hashCode(), theComparisonValue.hashCode(), theMessage);
+	}
+
+	private static Coding codingWithVersion(String theSystem, String theCode, String theDisplay, String theVersion) {
+		Coding coding = new Coding(theSystem, theCode, theDisplay);
+		coding.setVersion(theVersion);
+		return coding;
+	}
+}


### PR DESCRIPTION

closes #7371

## Problem

The ConceptMap `$translate` operation caching was not working properly due to an issue with the cache key comparison. The `TranslateCodeRequest` class was using default object equality for `IBaseCoding` instances, which meant that two semantically identical codings (same system, code, and version) but different object instances were treated as different cache keys. This resulted in unnecessary cache misses.

## Solution
Implemented a `CodingEqualsAdapter` inner class in `TranslateCodeRequest` class. THis provides semantic equality comparison for `IBaseCoding` instances. The adapter compares codings based on their semantic content:
- System
- Code
- Version

The display value is intentionally excluded from the comparison as it is not semantically significant for code translation operations.