### PR TITLE
7384 mdm expansion search impacts the search operation with conditional references

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/ReferenceParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/ReferenceParam.java
@@ -128,12 +128,12 @@ public class ReferenceParam extends BaseParam /*implements IQueryParameterType*/
 
 	@Override
 	void doSetValueAsQueryToken(FhirContext theContext, String theParamName, String theQualifier, String theValue) {
-		if (Constants.PARAMQUALIFIER_MDM.equals(theQualifier)) {
+		String q = theQualifier;
+		if (q != null && q.endsWith(Constants.PARAMQUALIFIER_MDM)) {
 			myMdmExpand = true;
-			theQualifier = "";
+			q = q.substring(0, q.length() - Constants.PARAMQUALIFIER_MDM.length());
 		}
 
-		String q = theQualifier;
 		if (isNotBlank(q)) {
 			if (q.startsWith(":")) {
 				int nextIdx = q.indexOf('.');

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/ReferenceParamTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/ReferenceParamTest.java
@@ -1,8 +1,10 @@
 package ca.uhn.fhir.rest.param;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReferenceParamTest {
@@ -34,4 +36,13 @@ class ReferenceParamTest {
 		}
 	}
 
+	@Test
+	void testChainedParamWithMdmExpand() {
+		ReferenceParam param = new ReferenceParam();
+		param.setValueAsQueryToken(null, "patient", ".name:mdm", "Smith");
+
+		assertThat(param.isMdmExpand()).isTrue();
+		assertThat(param.getChain()).isEqualTo("name");
+		assertThat(param.getValue()).isEqualTo("Smith");
+	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7384-fix-chained-reference-search-error-on-mdm-expansion.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7384-fix-chained-reference-search-error-on-mdm-expansion.yaml
@@ -2,7 +2,6 @@
 type: fix
 issue: 7384
 jira: SMILE-11171
-title: "Fixed chained-reference search on MDM expansion to ensure a 400 Bad Request is returned with the correct 
-message when an invalid search parameter is used."
-
-
+title: "Previously, chained reference searches by users with `FHIR_AUTO_MDM` could cause a 500 resource not known error. 
+This fix runs those searches without MDM expansion so they return correct results. If a chained search explicitly 
+includes the `:mdm` modifier, the request is invalid and the server now returns a 400 Bad Request."

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/MdmSearchExpandingInterceptorIT.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/interceptor/MdmSearchExpandingInterceptorIT.java
@@ -29,7 +29,6 @@ import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -41,12 +40,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.slf4j.LoggerFactory.getLogger;
 
 @ContextConfiguration(classes = {MdmHelperConfig.class})
 public class MdmSearchExpandingInterceptorIT extends BaseMdmR4Test {
-
-	private static final Logger ourLog = getLogger(MdmSearchExpandingInterceptorIT.class);
 
 	@RegisterExtension
 	@Autowired

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/MdmSearchExpansionSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/MdmSearchExpansionSvc.java
@@ -149,11 +149,11 @@ public class MdmSearchExpansionSvc {
 		List<IQueryParameterType> toAdd = new ArrayList<>();
 		for (IQueryParameterType iQueryParameterType : orList) {
 			if (iQueryParameterType instanceof ReferenceParam refParam) {
-				if (refParam.hasChain()) {
-					throw new InvalidRequestException(
-							Msg.code(2822) + "MDM Expansion can not be applied to chained reference search.");
-				}
 				if (theParamTester.shouldExpand(theParamName, refParam)) {
+					if (refParam.hasChain()) {
+						throw new InvalidRequestException(
+								Msg.code(2822) + "MDM Expansion can not be applied to chained reference search.");
+					}
 					ourLog.debug("Found a reference parameter to expand: {}", refParam);
 					// First, attempt to expand as a source resource.
 					IIdType sourceId = newId(refParam.getValue());


### PR DESCRIPTION
### Problem Statement 
Search operation with chained referencing is not working after enabling MDM expansion search.

### Description
When MDM expansion search is enabled, search operations with chained reference are failing.
Example: http://localhost:8000/AllergyIntolerance?patient.identifier=https://test.com/fhir/NamingSystem/hw-1222%7Cpaaaid1102101

This worked fine before enabling the MDM expansion search. but doesn't work after enabling it. Below is the error message
```
{
    "resourceType": "OperationOutcome",
    "issue": [
        {
            "severity": "error",
            "code": "processing",
            "diagnostics": "HAPI-2001: Resource NamingSystem/hw-1222|paaaid1102101 is not known"
        }
    ]
}
```
### Cause
It is noticed that the existing MDM expansion on chained or conditional reference search behaved differently for the user with FHIR_AUTO_MDM permission and the user without this permission.

* When the user (e.g. admin) has FHIR_AUTO_MDM, conditional reference search failed with 404 resource not known error as described in the ticket due to search param parsing error.
* When the user does not have FHIR_AUTO_MDM, conditional reference search would succeed with 200 response. However, the search did not perform MDM-expansion at all.

### Fix
A 400 bad request error will be thrown if MDM expansion is attempted on a chain.

Closes #7384 
