### PR TITLE
Refactor parameter handling in GenericClient to prevent qualifier buildup, when there are multiple IQueryParameterType.

### DIFF
--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/GenericClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/GenericClient.java
@@ -769,10 +769,11 @@ public class GenericClient extends BaseClient implements IGenericClient {
 				for (IQueryParameterType nextValue : nextValues) {
 					String value = nextValue.getValueAsQueryToken(myContext);
 					String qualifier = nextValue.getQueryParameterQualifier();
+					String parameterName = nextKey;
 					if (isNotBlank(qualifier)) {
-						nextKey = nextKey + qualifier;
+						parameterName += qualifier;
 					}
-					addParam(myParams, nextKey, value);
+					addParam(myParams, parameterName, value);
 				}
 			}
 			return (QUERY) this;


### PR DESCRIPTION
See https://github.com/hapifhir/hapi-fhir/issues/7410