### PR TITLE
Fix: Clear cached payload in ResourceDeliveryMessage.setPayload()

### DIFF
--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceDeliveryMessage.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/subscription/model/ResourceDeliveryMessage.java
@@ -104,6 +104,7 @@ public class ResourceDeliveryMessage extends BaseResourceMessage implements IRes
 		 *  - If use a serializing queue, we aren't behaving differently (and therefore possibly missing things
 		 *    in tests)
 		 */
+		myPayloadDecoded = null;
 		myPayloadString = theEncoding.newParser(theCtx).encodeResourceToString(thePayload);
 		myPayloadId = thePayload.getIdElement().toUnqualifiedVersionless().getValue();
 	}


### PR DESCRIPTION
`ResourceDeliveryMessage.setPayload()` updates the serialized payload string (`myPayloadString`) but does not clear the cached parsed resource (`myPayloadDecoded`).

This causes `getPayload()` to return stale data if it was called before `setPayload()`, because `getPayload()` returns the cached value when available instead of re-parsing the updated string.

This issue was encountered when trying to intercept subscription delivery and change the content of the payload. Example for illustration:

```(java)
ResourceDeliveryMessage message = new ResourceDeliveryMessage();
message.setPayload(ctx, originalResource, EncodingEnum.JSON);
// myPayloadString = "{original}", myPayloadDecoded = null

IBaseResource payload1 = message.getPayload(ctx);
// myPayloadDecoded is now cached with originalResource

message.setPayload(ctx, newResource, EncodingEnum.JSON);
// myPayloadString = "{new}", but myPayloadDecoded still holds originalResource!

IBaseResource payload2 = message.getPayload(ctx);
// Returns originalResource (stale!) instead of newResource
```

Let me know if the above flow is not the intended use of the API.