### PR TITLE
$expunge operation does not delete externally stored resources 

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7483-add-expunge-for-externally-stored-resources.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7483-add-expunge-for-externally-stored-resources.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 7483
+title: "Added support for removing externally stored resources from storage providers during instance-level and type-level `$expunge` operations."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeService.java
@@ -42,12 +42,16 @@ import ca.uhn.fhir.jpa.dao.data.IResourceLinkDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceTagDao;
 import ca.uhn.fhir.jpa.dao.data.ISearchParamPresentDao;
+import ca.uhn.fhir.jpa.esr.ExternallyStoredResourceServiceRegistry;
+import ca.uhn.fhir.jpa.esr.IExternallyStoredResourceService;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.jpa.model.entity.ResourceEncodingEnum;
 import ca.uhn.fhir.jpa.model.entity.ResourceHistoryProvenanceEntity;
 import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTable;
 import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTablePk;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
+import ca.uhn.fhir.jpa.util.ResourceParserUtil.EsrResourceDetails;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
@@ -73,6 +77,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static ca.uhn.fhir.jpa.util.ResourceParserUtil.getEsrResourceDetails;
+import static ca.uhn.fhir.jpa.util.ResourceParserUtil.getResourceText;
 
 @Service
 public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid, ResourceHistoryTablePk> {
@@ -140,6 +147,9 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 
 	@Autowired
 	private IJpaStorageResourceParser myJpaStorageResourceParser;
+
+	@Autowired
+	private ExternallyStoredResourceServiceRegistry myExternallyStoredResourceServiceRegistry;
 
 	@Override
 	@Transactional
@@ -235,6 +245,8 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 
 		callHooks(theRequestDetails, theRemainingCount, version, id);
 
+		expungeExternallyStoredResource(version);
+
 		if (myStorageSettings.isAccessMetaSourceInformationFromProvenanceTable()) {
 			Optional<ResourceHistoryProvenanceEntity> provenanceOpt =
 					myResourceHistoryProvenanceTableDao.findById(theNextVersionId.asIdAndPartitionId());
@@ -245,6 +257,19 @@ public class JpaResourceExpungeService implements IResourceExpungeService<JpaPid
 		myResourceHistoryTableDao.deleteByPid(version.getId());
 
 		theRemainingCount.decrementAndGet();
+	}
+
+	private void expungeExternallyStoredResource(ResourceHistoryTable theResourceHistoryEntity) {
+		if (theResourceHistoryEntity.getEncoding() == ResourceEncodingEnum.ESR) {
+			byte[] resourceBytes = theResourceHistoryEntity.getResource();
+			String resourceText = theResourceHistoryEntity.getResourceTextVc();
+			ResourceEncodingEnum resourceEncoding = theResourceHistoryEntity.getEncoding();
+			String decodedText = getResourceText(resourceBytes, resourceText, resourceEncoding);
+			EsrResourceDetails esrResourceDetails = getEsrResourceDetails(decodedText);
+			IExternallyStoredResourceService provider =
+					myExternallyStoredResourceServiceRegistry.getProvider(esrResourceDetails.providerId());
+			provider.deleteResource(esrResourceDetails.address());
+		}
 	}
 
 	private void callHooks(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/esr/IExternallyStoredResourceService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/esr/IExternallyStoredResourceService.java
@@ -59,4 +59,16 @@ public interface IExternallyStoredResourceService {
 		}
 		return result;
 	}
+
+	/**
+	 * Deletes the resource at the given address from external storage.
+	 * Implementations should override this method to support externally stored resource
+	 * removal during the $expunge operation.
+	 *
+	 * @param theAddress The address string is a format that is entirely up to the individual provider. HAPI FHIR
+	 *                   doesn't try to understand it. This should be the same address format used in {@link #fetchResource(String)}.
+	 */
+	default void deleteResource(String theAddress) {
+		// no-op
+	}
 }

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/JpaResourceExpungeServiceTest.java
@@ -1,33 +1,41 @@
 package ca.uhn.fhir.jpa.dao.expunge;
 
+import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTableDao;
+import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTagDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceTableDao;
+import ca.uhn.fhir.jpa.esr.ExternallyStoredResourceServiceRegistry;
+import ca.uhn.fhir.jpa.esr.IExternallyStoredResourceService;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.jpa.model.entity.ResourceEncodingEnum;
+import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTable;
+import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTablePk;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ch.qos.logback.classic.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class JpaResourceExpungeServiceTest {
-	private static final Logger ourLog = (Logger) LoggerFactory.getLogger(JpaResourceExpungeService.class);
 
 	@InjectMocks
 	@Spy
@@ -43,17 +51,75 @@ public class JpaResourceExpungeServiceTest {
 	private RequestDetails myRequestDetails;
 
 	@Mock
-	private ResourceTable resourceTable;
+	private ResourceTable myResourceTable;
+
+	@Mock
+	private ExternallyStoredResourceServiceRegistry myExternallyStoredResourceServiceRegistry;
+
+	@Mock
+	private IExternallyStoredResourceService myExternalStorageProvider;
+
+	@Mock
+	private IInterceptorBroadcaster myInterceptorBroadcaster;
 
 	@Mock
 	private JpaStorageSettings myStorageSettings;
 
+	@Mock
+	private IResourceHistoryTagDao myResourceHistoryTagDao;
+
 	@Test
 	public void testExpungeDoesNotDeleteAllSearchParams() {
-		when(myResourceTableDao.findById(any(JpaPid.class))).thenReturn(Optional.of(resourceTable));
-		when(resourceTable.getIdDt()).thenReturn(new IdDt());
-		when(resourceTable.getId()).thenReturn(new JpaPid());
+		when(myResourceTableDao.findById(any(JpaPid.class))).thenReturn(Optional.of(myResourceTable));
+		when(myResourceTable.getIdDt()).thenReturn(new IdDt());
+		when(myResourceTable.getId()).thenReturn(new JpaPid());
 		myService.expungeCurrentVersionOfResource(myRequestDetails, JpaPid.fromId(1L), new AtomicInteger(1));
 		verify(myService, never()).deleteAllSearchParams(any());
+	}
+
+	@Test
+	void testExpungeHistoricalVersions_withEsrResource_expungesEsrTagAndHistoryEntity() {
+		// setup
+		ResourceHistoryTablePk historyPk = new ResourceHistoryTablePk();
+		ResourceHistoryTable historyVersion = new ResourceHistoryTable();
+		historyVersion.setResourceTable(myResourceTable);
+		historyVersion.setVersion(1L);
+		historyVersion.setEncoding(ResourceEncodingEnum.ESR);
+		historyVersion.setResourceTextVc("esr-provider:address");
+
+		when(myResourceHistoryTableDao.findById(historyPk)).thenReturn(Optional.of(historyVersion));
+		when(myExternallyStoredResourceServiceRegistry.getProvider("esr-provider"))
+			.thenReturn(myExternalStorageProvider);
+
+		// execute
+		myService.expungeHistoricalVersions(myRequestDetails, List.of(historyPk), new AtomicInteger(10));
+
+		// verify
+		verify(myExternallyStoredResourceServiceRegistry, times(1)).getProvider("esr-provider");
+		verify(myExternalStorageProvider, times(1)).deleteResource("address");
+		verify(myResourceHistoryTagDao, times(1)).deleteByPid(historyPk);
+		verify(myResourceHistoryTableDao, times(1)).deleteByPid(historyPk);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = ResourceEncodingEnum.class, names = {"JSON", "JSONC", "DEL"})
+	void testExpungeHistoricalVersions_withNonEsrResource_expungesTagAndHistoryEntity(ResourceEncodingEnum theEncoding) {
+		// setup
+		ResourceHistoryTablePk historyPk = new ResourceHistoryTablePk();
+		ResourceHistoryTable historyVersion = new ResourceHistoryTable();
+		historyVersion.setResourceTable(myResourceTable);
+		historyVersion.setVersion(1L);
+		historyVersion.setEncoding(theEncoding);
+
+		when(myResourceHistoryTableDao.findById(historyPk)).thenReturn(Optional.of(historyVersion));
+
+		// execute
+		myService.expungeHistoricalVersions(myRequestDetails, List.of(historyPk), new AtomicInteger(10));
+
+		// verify
+		verify(myExternallyStoredResourceServiceRegistry, never()).getProvider(any());
+		verify(myExternalStorageProvider, never()).deleteResource(any());
+		verify(myResourceHistoryTagDao, times(1)).deleteByPid(historyPk);
+		verify(myResourceHistoryTableDao, times(1)).deleteByPid(historyPk);
 	}
 }


### PR DESCRIPTION
- Added support for removing externally stored resources from storage providers during instance-level and type-level `$expunge` operations.
- unit tests
- changelog