### PR TITLE
  Transform relative URLs in search parameter documentation to absolu…

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ServerCapabilityStatementProvider.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.rest.server.provider;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.context.support.IValidationSupport;
@@ -76,6 +77,8 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
@@ -428,7 +431,9 @@ public class ServerCapabilityStatementProvider implements IServerConformanceProv
 					terser.addElement(searchParam, "name", next.getName());
 					terser.addElement(searchParam, "type", next.getParamType().getCode());
 					if (isNotBlank(next.getDescription())) {
-						terser.addElement(searchParam, "documentation", next.getDescription());
+						String documentation = transformRelativeUrls(
+								next.getDescription(), myContext.getVersion().getVersion());
+						terser.addElement(searchParam, "documentation", documentation);
 					}
 
 					String spUri = next.getUri();
@@ -927,5 +932,57 @@ public class ServerCapabilityStatementProvider implements IServerConformanceProv
 
 	public void setRestResourceRevIncludesEnabled(boolean theRestResourceRevIncludesEnabled) {
 		myRestResourceRevIncludesEnabled = theRestResourceRevIncludesEnabled;
+	}
+
+	/**
+	 * Pattern to match relative markdown links like [text](resourcename.html) or [text](resourcename.html#fragment)
+	 * These are links that don't start with http://, https://, or /
+	 */
+	private static final Pattern RELATIVE_LINK_PATTERN =
+			Pattern.compile("\\]\\(([a-z][a-z0-9-]*\\.html(?:#[^)]*)?)\\)");
+
+	/**
+	 * Returns the HL7 FHIR specification base URL for the given FHIR version.
+	 *
+	 * @param theFhirVersion the FHIR version
+	 * @return the base URL for the HL7 FHIR specification (e.g., "https://hl7.org/fhir/R4/")
+	 */
+	public static String getHl7BaseUrl(FhirVersionEnum theFhirVersion) {
+		switch (theFhirVersion) {
+			case DSTU2:
+			case DSTU2_HL7ORG:
+				return "https://hl7.org/fhir/DSTU2/";
+			case DSTU2_1:
+				return "https://hl7.org/fhir/2016May/";
+			case DSTU3:
+				return "https://hl7.org/fhir/STU3/";
+			case R4:
+				return "https://hl7.org/fhir/R4/";
+			case R4B:
+				return "https://hl7.org/fhir/R4B/";
+			case R5:
+				return "https://hl7.org/fhir/R5/";
+			default:
+				return "https://hl7.org/fhir/";
+		}
+	}
+
+	/**
+	 * Transforms relative markdown links in a description to absolute HL7 FHIR specification URLs.
+	 * <p>
+	 * For example, transforms:
+	 * <code>[CarePlan](careplan.html)</code> to <code>[CarePlan](https://hl7.org/fhir/R4/careplan.html)</code>
+	 *
+	 * @param theDescription the description text that may contain relative markdown links
+	 * @param theFhirVersion the FHIR version to use for constructing the absolute URL
+	 * @return the description with relative links converted to absolute HL7 FHIR specification URLs
+	 */
+	public static String transformRelativeUrls(String theDescription, FhirVersionEnum theFhirVersion) {
+		if (theDescription == null) {
+			return null;
+		}
+		String baseUrl = getHl7BaseUrl(theFhirVersion);
+		Matcher matcher = RELATIVE_LINK_PATTERN.matcher(theDescription);
+		return matcher.replaceAll("](" + baseUrl + "$1)");
 	}
 }

--- a/hapi-fhir-validation/src/test/java/ca/uhn/fhir/rest/server/ServerCapabilityStatementProviderR4Test.java
+++ b/hapi-fhir-validation/src/test/java/ca/uhn/fhir/rest/server/ServerCapabilityStatementProviderR4Test.java
@@ -1,6 +1,7 @@
 package ca.uhn.fhir.rest.server;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.fhirpath.BaseValidationTestWithInlineMocks;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.model.api.Include;
@@ -1389,6 +1390,74 @@ public class ServerCapabilityStatementProviderR4Test extends BaseValidationTestW
 		assertThat(warningsAndErrors).as(outcome).isEmpty();
 
 		return myCtx.newXmlParser().setPrettyPrint(false).encodeResourceToString(theResource);
+	}
+
+	@Test
+	void testGetHl7BaseUrl() {
+		assertThat(ServerCapabilityStatementProvider.getHl7BaseUrl(FhirVersionEnum.DSTU2))
+			.isEqualTo("https://hl7.org/fhir/DSTU2/");
+		assertThat(ServerCapabilityStatementProvider.getHl7BaseUrl(FhirVersionEnum.DSTU2_HL7ORG))
+			.isEqualTo("https://hl7.org/fhir/DSTU2/");
+		assertThat(ServerCapabilityStatementProvider.getHl7BaseUrl(FhirVersionEnum.DSTU3))
+			.isEqualTo("https://hl7.org/fhir/STU3/");
+		assertThat(ServerCapabilityStatementProvider.getHl7BaseUrl(FhirVersionEnum.R4))
+			.isEqualTo("https://hl7.org/fhir/R4/");
+		assertThat(ServerCapabilityStatementProvider.getHl7BaseUrl(FhirVersionEnum.R4B))
+			.isEqualTo("https://hl7.org/fhir/R4B/");
+		assertThat(ServerCapabilityStatementProvider.getHl7BaseUrl(FhirVersionEnum.R5))
+			.isEqualTo("https://hl7.org/fhir/R5/");
+	}
+
+	@Test
+	void testTransformRelativeUrls() {
+		// Test simple link
+		String input = "Date first version recorded\r\n* [CarePlan](careplan.html): Time period plan covers";
+		String expected = "Date first version recorded\r\n* [CarePlan](https://hl7.org/fhir/R4/careplan.html): Time period plan covers";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R4))
+			.isEqualTo(expected);
+
+		// Test multiple links
+		input = "* [AllergyIntolerance](allergyintolerance.html): Date recorded\r\n* [CarePlan](careplan.html): Time period";
+		expected = "* [AllergyIntolerance](https://hl7.org/fhir/R4/allergyintolerance.html): Date recorded\r\n* [CarePlan](https://hl7.org/fhir/R4/careplan.html): Time period";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R4))
+			.isEqualTo(expected);
+
+		// Test link with fragment
+		input = "[Patient](patient.html#search): Patient resource";
+		expected = "[Patient](https://hl7.org/fhir/R4/patient.html#search): Patient resource";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R4))
+			.isEqualTo(expected);
+
+		// Test that absolute links are not modified
+		input = "[FHIR](https://hl7.org/fhir/): The FHIR spec";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R4))
+			.isEqualTo(input);
+
+		// Test null input
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(null, FhirVersionEnum.R4))
+			.isNull();
+
+		// Test different FHIR versions
+		input = "[Patient](patient.html): Patient resource";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.DSTU3))
+			.isEqualTo("[Patient](https://hl7.org/fhir/STU3/patient.html): Patient resource");
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R5))
+			.isEqualTo("[Patient](https://hl7.org/fhir/R5/patient.html): Patient resource");
+	}
+
+	@Test
+	void testTransformRelativeUrls_resourceWithHyphen() {
+		// Test resource names with hyphens (like family-member-history)
+		String input = "[FamilyMemberHistory](familymemberhistory.html): When history was recorded";
+		String expected = "[FamilyMemberHistory](https://hl7.org/fhir/R4/familymemberhistory.html): When history was recorded";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R4))
+			.isEqualTo(expected);
+
+		// Test resource names with numbers
+		input = "[Stu3Resource](stu3resource.html): A resource";
+		expected = "[Stu3Resource](https://hl7.org/fhir/R4/stu3resource.html): A resource";
+		assertThat(ServerCapabilityStatementProvider.transformRelativeUrls(input, FhirVersionEnum.R4))
+			.isEqualTo(expected);
 	}
 
 	public static class BulkDataExportProvider {


### PR DESCRIPTION
…te HL7 FHIR URLs

  Search parameter descriptions from the FHIR spec contain relative markdown
  links like [CarePlan](careplan.html) which don't resolve correctly when
  displayed in capability statements outside the HL7 website context.

  This change transforms these relative links to absolute URLs pointing to
  the correct FHIR version-specific HL7 specification, e.g.:
  [CarePlan](careplan.html) -> [CarePlan](https://hl7.org/fhir/R4/careplan.html)

  The transformation is FHIR version-aware, using the appropriate base URL
  for each version (DSTU2, STU3, R4, R4B, R5).

This relates to https://github.com/hapifhir/hapi-fhir/issues/7508