### PR TITLE
added versionPolicy configuration to package installer

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7512-add-versionPolicy-to-package-installation.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7512-add-versionPolicy-to-package-installation.yaml
@@ -1,0 +1,8 @@
+---
+type: add
+issue: 7512
+title: "Added a new `versionPolicy` parameter to PackageInstallationSpec that 
+controls how resource versions are handled during package installation in STORE_AND_INSTALL mode. 
+The `MULTI_VERSION` policy (default) assigns server-generated IDs and matches existing resources by both canonical URL 
+and version, allowing multiple versions of the installed resources to coexist. The `SINGLE_VERSION` policy retains 
+client-assigned IDs and matches by canonical URL only, overwriting existing resources when a new version is installed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallationSpec.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallationSpec.java
@@ -41,7 +41,8 @@ import java.util.function.Supplier;
 	"installResourceTypes",
 	"validationMode",
 	"reloadExisting",
-	"additionalResourceFolders"
+	"additionalResourceFolders",
+	"versionPolicy"
 })
 @ExampleSupplier({PackageInstallationSpec.ExampleSupplier.class, PackageInstallationSpec.ExampleSupplier2.class})
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -97,6 +98,12 @@ public class PackageInstallationSpec {
 					"List of folders in the package to extract additional resources from. Each folder listed will be scanned for resources which will be installed as part of package installation.")
 	@JsonProperty("additionalResourceFolders")
 	private Set<String> myAdditionalResourceFolders;
+
+	@Schema(
+			description =
+					"Controls whether multiple versions of installed resources can coexist in the repository during STORE_AND_INSTALL installation")
+	@JsonProperty("versionPolicy")
+	private VersionPolicyEnum myVersionPolicy = VersionPolicyEnum.MULTI_VERSION;
 
 	@JsonIgnore
 	private byte[] myPackageContents;
@@ -205,6 +212,15 @@ public class PackageInstallationSpec {
 		return this;
 	}
 
+	public VersionPolicyEnum getVersionPolicy() {
+		return myVersionPolicy;
+	}
+
+	public PackageInstallationSpec setVersionPolicy(VersionPolicyEnum theVersionPolicy) {
+		myVersionPolicy = theVersionPolicy;
+		return this;
+	}
+
 	public enum InstallModeEnum {
 		STORE_ONLY,
 		STORE_AND_INSTALL
@@ -213,6 +229,21 @@ public class PackageInstallationSpec {
 	public enum ValidationModeEnum {
 		NOT_AVAILABLE,
 		AVAILABLE
+	}
+
+	public enum VersionPolicyEnum {
+		/**
+		 * Default. Uses server-assigned IDs for new resources. Existing resources matched
+		 * by canonical URL + version. Supports multiple versions of installed resources.
+		 */
+		MULTI_VERSION,
+
+		/**
+		 * Uses client-assigned IDs from package. Existing resources
+		 * matched by canonical URL only (ignoring version), so installing a new version
+		 * of the same resource will overwrite the existing one.
+		 */
+		SINGLE_VERSION
 	}
 
 	public static class ExampleSupplier implements Supplier<PackageInstallationSpec> {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplRewriteHistoryTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplRewriteHistoryTest.java
@@ -42,7 +42,7 @@ public class PackageInstallerSvcImplRewriteHistoryTest extends BaseJpaR4Test {
 
 		// execute
 		// red-green this threw a NPE before the fix
-		mySvc.createOrUpdateResource(myConceptMapDao, conceptMap, null, null);
+		mySvc.createOrUpdateResource(myConceptMapDao, conceptMap, null, new PackageInstallationSpec());
 
 		// verify
 		IBundleProvider readConceptMap = myConceptMapDao.search(new SearchParameterMap().add(ConceptMap.SP_URL, new UriParam("http://example.com/ConceptMap/testcm")));

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallationSpecTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallationSpecTest.java
@@ -2,8 +2,13 @@ package ca.uhn.fhir.jpa.packages;
 
 import ca.uhn.fhir.util.JsonUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,4 +25,44 @@ public class PackageInstallationSpecTest {
 		assertThat(json).contains("\"packageUrl\" : \"classpath:/my-resources.tgz\"");
 	}
 
+	@ParameterizedTest
+	@EnumSource(PackageInstallationSpec.VersionPolicyEnum.class)
+	void testJsonSerializationWithVersionPolicy(PackageInstallationSpec.VersionPolicyEnum theVersionPolicy) throws Exception {
+		// Given: A spec with versionPolicy set
+		PackageInstallationSpec spec = new PackageInstallationSpec();
+		spec.setName("test");
+		spec.setVersion("1.0");
+		spec.setVersionPolicy(theVersionPolicy);
+
+		// When: Serialize
+		String json = JsonUtil.serialize(spec);
+
+		// Then: JSON contains the versionPolicy
+		assertThat(json).contains("\"versionPolicy\" : \"" + theVersionPolicy + "\"");
+	}
+
+	@ParameterizedTest
+	@MethodSource("versionPolicyDeserializationTestCases")
+	void testJsonDeserializationWithVersionPolicy(
+			PackageInstallationSpec.VersionPolicyEnum theInputPolicy,
+			PackageInstallationSpec.VersionPolicyEnum theExpectedPolicy) throws Exception {
+		// Build JSON with or without versionPolicy field
+		String json = theInputPolicy != null
+			? "{\"name\":\"test\",\"version\":\"1.0\",\"versionPolicy\":\"" + theInputPolicy + "\"}"
+			: "{\"name\":\"test\",\"version\":\"1.0\"}";
+
+		// When: Deserialize
+		PackageInstallationSpec spec = JsonUtil.deserialize(json, PackageInstallationSpec.class);
+
+		// Then: versionPolicy has expected value
+		assertThat(spec.getVersionPolicy()).isEqualTo(theExpectedPolicy);
+	}
+
+	static Stream<Arguments> versionPolicyDeserializationTestCases() {
+		return Stream.of(
+			Arguments.of(PackageInstallationSpec.VersionPolicyEnum.SINGLE_VERSION, PackageInstallationSpec.VersionPolicyEnum.SINGLE_VERSION),
+			Arguments.of(PackageInstallationSpec.VersionPolicyEnum.MULTI_VERSION, PackageInstallationSpec.VersionPolicyEnum.MULTI_VERSION),
+			Arguments.of(null, PackageInstallationSpec.VersionPolicyEnum.MULTI_VERSION)  // missing defaults to MULTI_VERSION
+		);
+	}
 }


### PR DESCRIPTION
Summary                                                                                                                                                                                                                             
                                                                                                                                                                                                                                      
  Added a new versionPolicy parameter to PackageInstallationSpec that controls how resource versions are handled during package installation in STORE_AND_INSTALL mode.                                                               
                                                                                                                                                                                                                                      
  ### Background                                                                                                                                                                                                                          
                                                                                                                                                                                                                                      
  When installing FHIR packages using STORE_AND_INSTALL mode, users need flexibility in how resources (StructureDefinitions, ValueSets, etc.) are installed. Some use cases require multiple versions of the same profile to   
  coexist (for multi-version validation), while others need a single authoritative version that gets updated when new packages are installed.                                                                                         
                                                                                                                                                                                                                                      
  ### Changes                                                                                                                                                                                                                             
                                                                                                                                                                                                                                      
  New versionPolicy Parameter                                                                                                                                                                                                         
                                                                                                                                                                                                                                      
  Two policies are now available:                                                                                                                                                                                                     
                                                                                                                                                                                                                                      
  - MULTI_VERSION (default): Uses server-assigned IDs for new resources. Existing resources are matched by both canonical URL and version. This allows multiple versions of the same profile to coexist in the repository.            
  - SINGLE_VERSION: Uses client-assigned IDs from the package. Existing resources are matched by canonical URL only (version is ignored). Installing a new version of a profile will overwrite the existing one.                      
                                                                                                                                                                                                                                      
  Note: SearchParameter resources always use client-assigned IDs regardless of the versionPolicy setting, as only one version of a SearchParameter can exist per URL + base combination.                                              
                                                                                                                                                                                                                                      
  Implementation Details                                                                                                                                                                                                              
                                                                                                                                                                                                                                      
  - Added VersionPolicyEnum to PackageInstallationSpec                                                                                                                                                                                
  - Refactored PackageInstallerSvcImpl.createOrUpdateResource() for clarity, as it was too convoluted. I split into multiple methods.                                                                                                                                                           
  - Search queries now include _sort=_pid:desc for deterministic resource selection when multiple versions exist                                                                                                                      
  - meta.source is now set for all package resources regardless of version policy, as this shows from which package and version a resource came from.                                                                                                                                    
                                                                                                                                                                                                                                      
                                                                                                                          
                                                                                                                                                                                                                                      
  Migration Notes                                                                                                                                                                                                                     
                                                                                                                                                                                                                                      
  The current default behavior (MULTI_VERSION) is preserved, so shouldn't be considered a breaking change.      


closes: https://github.com/hapifhir/hapi-fhir/issues/7512