### PR TITLE
potential fix for flaky ResourceProviderR4Test

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/r4/FhirContextR4Config.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/r4/FhirContextR4Config.java
@@ -47,7 +47,14 @@ public class FhirContextR4Config {
 		return retVal;
 	}
 
-	public static FhirContext configureFhirContext(FhirContext theFhirContext) {
+	/**
+	 * Configures the default parser options for a FhirContext based on the FHIR version.
+	 * This method sets up the paths where version references should be preserved
+	 * (not stripped) during serialization.
+	 *
+	 * @param theFhirContext the FhirContext to configure
+	 */
+	public static void configureDefaultParserOptions(FhirContext theFhirContext) {
 		// Don't strip versions in some places
 		ParserOptions parserOptions = theFhirContext.getParserOptions();
 		if (theFhirContext.getVersion().getVersion().isOlderThan(FhirVersionEnum.DSTU3)) {
@@ -57,6 +64,10 @@ public class FhirContextR4Config {
 		} else {
 			parserOptions.setDontStripVersionsFromReferencesAtPaths(DEFAULT_PRESERVE_VERSION_REFS_R4_AND_LATER);
 		}
+	}
+
+	public static FhirContext configureFhirContext(FhirContext theFhirContext) {
+		configureDefaultParserOptions(theFhirContext);
 
 		// We use this context to create subscription deliveries and that kind of thing. It doesn't
 		// make much sense to let the HTTP client pool be a blocker since we have delivery queue

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -37,6 +37,7 @@ import ca.uhn.fhir.jpa.api.svc.ISearchCoordinatorSvc;
 import ca.uhn.fhir.jpa.bulk.export.api.IBulkDataExportJobSchedulingHelper;
 import ca.uhn.fhir.jpa.cache.IResourceTypeCacheSvc;
 import ca.uhn.fhir.jpa.config.JpaConfig;
+import ca.uhn.fhir.jpa.config.r4.FhirContextR4Config;
 import ca.uhn.fhir.jpa.config.util.ResourceTypeUtil;
 import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
 import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
@@ -481,6 +482,8 @@ public abstract class BaseJpaTest extends BaseTest {
 
 		ParserOptions defaultParserOptions = new ParserOptions();
 		BeanUtils.copyProperties(defaultParserOptions, myFhirContext.getParserOptions());
+		// version stripping parser options configured through this function, not in the class itself, so apply them, this function supports multiple fhir versions
+		FhirContextR4Config.configureDefaultParserOptions(myFhirContext);
 
 		PartitionSettings defaultPartConfig = new PartitionSettings();
 		BeanUtils.copyProperties(defaultPartConfig, myPartitionSettings);


### PR DESCRIPTION
The following test is failing intermittently, I couldn't reproduce the failure locally, but it is possible that it is related to parser options is not reset to default properly for stripping versions after another test. So if a test suite is changing this config, another test that relies on the default behaviour could fail. This PR attempts to fix this restoring strip version policy to the default values after each test. 
 
ResourceProviderR4Test.testPreserveVersionsOnAuditEvent:3626 Patient/14796 ==> expected: <true> but was: <false>