### PR TITLE
Add IPS narrative templates for MedicationAdministration and MedicationDispense

### DIFF
--- a/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/ips-narratives.properties
+++ b/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/ips-narratives.properties
@@ -10,6 +10,14 @@ ips-medicationsummary.resourceType=Bundle
 ips-medicationsummary.profile=https://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips-definitions.html#Composition.section:sectionMedications
 ips-medicationsummary.narrative=classpath:ca/uhn/fhir/jpa/ips/narrative/medicationsummary.html
 
+ips-medicationadministration.resourceType=Bundle
+ips-medicationadministration.profile=https://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips-definitions.html#Composition.section:sectionMedications
+ips-medicationadministration.narrative=classpath:ca/uhn/fhir/jpa/ips/narrative/medicationadministration.html
+
+ips-medicationdispense.resourceType=Bundle
+ips-medicationdispense.profile=https://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips-definitions.html#Composition.section:sectionMedications
+ips-medicationdispense.narrative=classpath:ca/uhn/fhir/jpa/ips/narrative/medicationdispense.html
+
 ips-problemlist.resourceType=Bundle
 ips-problemlist.profile=https://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips-definitions.html#Composition.section:sectionProblems
 ips-problemlist.narrative=classpath:ca/uhn/fhir/jpa/ips/narrative/problemlist.html

--- a/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/medicationadministration.html
+++ b/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/medicationadministration.html
@@ -1,0 +1,60 @@
+<!--/* MedicationAdministration -->
+<!--
+Medication: MedicationAdministration.medicationCodeableConcept.text || MedicationAdministration.medicationCodeableConcept.coding[x].display (separated by <br />) || Medication.code.text || Medication.code.coding[x].display (separated by <br />)
+Status: MedicationAdministration.status.display
+Route: MedicationAdministration.dosage.route.text || MedicationAdministration.dosage.route.coding[x].display (separated by <br />)
+Dose: MedicationAdministration.dosage.dose.value + MedicationAdministration.dosage.dose.unit
+Effective Time: MedicationAdministration.effectiveDateTime || MedicationAdministration.effectivePeriod.start
+Performer: Practitioner.name.text || Practitioner.name.family + Practitioner.name.given
+Comments: MedicationAdministration.note[x].text (separated by <br />)
+*/-->
+// Created by Claude Opus 4.5
+<div xmlns:th="http://www.thymeleaf.org">
+	<h5>Medication Administration</h5>
+	<table class="hapiPropertyTable">
+		<thead>
+		<tr>
+			<th>Medication</th>
+			<th>Status</th>
+			<th>Route</th>
+			<th>Dose</th>
+			<th>Effective Time</th>
+			<th>Performer</th>
+			<th>Comments</th>
+		</tr>
+		</thead>
+		<tbody>
+		<th:block th:each="entry : ${resource.entry}" th:object="${entry.getResource()}">
+			<th:block th:if='*{getResourceType().name() == "MedicationAdministration"}'>
+				<th:block
+					th:with="extension=${entry.getResource().getExtensionByUrl('http://hl7.org/fhir/StructureDefinition/narrativeLink')}">
+					<tr th:id="${extension != null} ? ${#strings.arraySplit(extension.getValue().getValue(), '#')[1]} : ''">
+						<td th:insert="~{IpsUtilityFragments :: renderMedication (medicationType=${entry.getResource()})}">
+							Medication
+						</td>
+						<td th:text="*{getStatus() != null} ? *{getStatus().getDisplay()} : ''">Status</td>
+						<td th:insert="~{IpsUtilityFragments :: codeableConcept (cc=*{getDosage().getRoute()},attr='display')}">Route</td>
+						<td>
+							<th:block th:if="*{getDosage().getDose() != null}" th:object="*{getDosage().getDose()}">
+								<span th:text="*{getValue()}">Dose</span>
+								<span th:text="*{getUnit()}">Unit</span>
+							</th:block>
+						</td>
+						<td th:insert="~{IpsUtilityFragments :: renderTime (time=*{getEffective()})}">Effective Time</td>
+						<td>
+							<th:block th:if="*{!getPerformer().isEmpty()}" th:with="performerRef=*{getPerformer().get(0).getActor()}">
+								<th:block th:if="${performerRef != null}" th:with="performer = ${#fhirpath.evaluateFirst(performerRef, 'resolve()')}">
+									<th:block th:if="${performer != null && performer.getResourceType().name() == 'Practitioner'}">
+										<span th:text="${performer.getNameFirstRep().getNameAsSingleString()}">Performer</span>
+									</th:block>
+								</th:block>
+							</th:block>
+						</td>
+						<td th:insert="~{IpsUtilityFragments :: concat (list=*{getNote()},attr='text')}">Comments</td>
+					</tr>
+				</th:block>
+			</th:block>
+		</th:block>
+		</tbody>
+	</table>
+</div>

--- a/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/medicationdispense.html
+++ b/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/medicationdispense.html
@@ -1,0 +1,59 @@
+<!--/* MedicationDispense -->
+<!--
+Medication: MedicationDispense.medicationCodeableConcept.text || MedicationDispense.medicationCodeableConcept.coding[x].display (separated by <br />) || Medication.code.text || Medication.code.coding[x].display (separated by <br />)
+Status: MedicationDispense.status.display
+Quantity: MedicationDispense.quantity.value + MedicationDispense.quantity.unit
+Days Supply: MedicationDispense.daysSupply.value + MedicationDispense.daysSupply.unit
+When Handed Over: MedicationDispense.whenHandedOver
+Dosage Instructions: MedicationDispense.dosageInstruction[x].text (display all instructions separated by <br />)
+Comments: MedicationDispense.note[x].text (separated by <br />)
+*/-->
+// Created by Claude Opus 4.5
+<div xmlns:th="http://www.thymeleaf.org">
+	<h5>Medication Dispense</h5>
+	<table class="hapiPropertyTable">
+		<thead>
+		<tr>
+			<th>Medication</th>
+			<th>Status</th>
+			<th>Quantity</th>
+			<th>Days Supply</th>
+			<th>When Handed Over</th>
+			<th>Dosage Instructions</th>
+			<th>Comments</th>
+		</tr>
+		</thead>
+		<tbody>
+		<th:block th:each="entry : ${resource.entry}" th:object="${entry.getResource()}">
+			<th:block th:if='*{getResourceType().name() == "MedicationDispense"}'>
+				<th:block
+					th:with="extension=${entry.getResource().getExtensionByUrl('http://hl7.org/fhir/StructureDefinition/narrativeLink')}">
+					<tr th:id="${extension != null} ? ${#strings.arraySplit(extension.getValue().getValue(), '#')[1]} : ''">
+						<td th:insert="~{IpsUtilityFragments :: renderMedication (medicationType=${entry.getResource()})}">
+							Medication
+						</td>
+						<td th:text="*{getStatus() != null} ? *{getStatus().getDisplay()} : ''">Status</td>
+						<td>
+							<th:block th:if="*{getQuantity() != null}" th:object="*{getQuantity()}">
+								<span th:text="*{getValue()}">Quantity</span>
+								<span th:text="*{getUnit()}">Unit</span>
+							</th:block>
+						</td>
+						<td>
+							<th:block th:if="*{getDaysSupply() != null}" th:object="*{getDaysSupply()}">
+								<span th:text="*{getValue()}">Days</span>
+								<span th:text="*{getUnit()}">Unit</span>
+							</th:block>
+						</td>
+						<td th:insert="~{IpsUtilityFragments :: renderTime (time=*{getWhenHandedOverElement()})}">When Handed Over</td>
+						<td th:insert="~{IpsUtilityFragments :: concat (list=*{getDosageInstruction()},attr='text')}">
+							Dosage Instructions
+						</td>
+						<td th:insert="~{IpsUtilityFragments :: concat (list=*{getNote()},attr='text')}">Comments</td>
+					</tr>
+				</th:block>
+			</th:block>
+		</th:block>
+		</tbody>
+	</table>
+</div>


### PR DESCRIPTION
Fixes #4836

This PR adds narrative templates for the MedicationAdministration and MedicationDispense resource types in the IPS module.

## Changes

- Added `medicationadministration.html` template with fields: Medication, Status, Route, Dose, Effective Time, Performer, and Comments
- Added `medicationdispense.html` template with fields: Medication, Status, Quantity, Days Supply, When Handed Over, Dosage Instructions, and Comments
- Updated `ips-narratives.properties` to register both templates with appropriate profile URLs

## Implementation Notes

- Templates follow existing IPS narrative patterns using Thymeleaf
- Utilized `IpsUtilityFragments` for common rendering operations (renderMedication, codeableConcept, concat, renderTime)
- Field mappings documented in template header comments per IPS specification
- Build completed successfully with FASTINSTALL profile

Both templates are now ready to render medication administration and dispense data in International Patient Summary documents.