### PR TITLE
Upgrading to container version 7.17.25 to fix pipeline issue

### DIFF
--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestElasticsearchContainerHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestElasticsearchContainerHelper.java
@@ -34,7 +34,7 @@ public class TestElasticsearchContainerHelper {
 	private static final Logger ourLog = LoggerFactory.getLogger(TestElasticsearchContainerHelper.class);
 
 
-	public static final String ELASTICSEARCH_VERSION = "7.17.3";
+	public static final String ELASTICSEARCH_VERSION = "7.17.25";
 	public static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:" + ELASTICSEARCH_VERSION;
 
 	public static ElasticsearchContainer getEmbeddedElasticSearch() {


### PR DESCRIPTION
There's a failure with test ElasticsearchPrefixTest.test.

docker logs focused_mahavira (docker.elastic.co/elasticsearch/elasticsearch:7.17.3)
```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:80)
	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:114)
	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:177)
	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:689)
	at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(ManagementFactory.java:389)
	at org.elasticsearch.tools.launchers.DefaultSystemMemoryInfo.<init>(DefaultSystemMemoryInfo.java:29)
	at org.elasticsearch.tools.launchers.JvmOptionsParser.jvmOptions(JvmOptionsParser.java:125)
	at org.elasticsearch.tools.launchers.JvmOptionsParser.main(JvmOptionsParser.java:86)

```

before bumping the version, tried adding `-XX:-UseContainerSupport` to the container java environment (see line 44) but that did not work.  

bumping the version locally fixed the issue.  pipeline run will tell.
