### PR TITLE
Fix: Parse query string parameters for POST _search requests

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7567-restfulserver-ignores-post-requested-url-parameters.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7567-restfulserver-ignores-post-requested-url-parameters.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7567
+title: "Previously, query string parameters on POST _search requests without a form-encoded body
+  were silently ignored (e.g. POST /Patient/_search?_id=aaa). This has been fixed so that
+  query string parameters are now correctly parsed for both GET and POST search requests."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -1081,7 +1081,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 							&& contentType.startsWith(Constants.CT_X_FORM_URLENCODED)) {
 						String requestBody = toUtf8String(requestDetails.loadRequestContents());
 						params = UrlUtil.parseQueryStrings(theRequest.getQueryString(), requestBody);
-					} else if (theRequestType == RequestTypeEnum.GET) {
+					} else if (theRequestType == RequestTypeEnum.GET || theRequestType == RequestTypeEnum.POST) {
 						params = UrlUtil.parseQueryString(theRequest.getQueryString());
 					}
 				}


### PR DESCRIPTION
Previously, query string parameters were only parsed for GET requests in RestfulServer. This meant POST /Resource/_search?param=value requests without a form-encoded body had their query string params silently ignored. Extend the condition to also parse query strings for POST requests while keeping PUT/DELETE/PATCH unchanged.