### PR TITLE
Exclude commons-logging from htmlunit to avoid spring-jcl conflict wa…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1987,6 +1987,11 @@
 						<groupId>org.eclipse.jetty.websocket</groupId>
 						<artifactId>websocket-client</artifactId>
 					</exclusion>
+					<exclusion>
+						<!-- spring-jcl already provides the commons-logging API -->
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Exclude commons-logging from htmlunit to avoid spring-jcl conflict warning

htmlunit 4.6.0 transitively pulls in commons-logging 1.3.4, which
conflicts with spring-jcl and causes a warning on stdout at startup.
Exclude it, matching the existing pattern for naming-java and json-lib.