### PR TITLE
[7571] FHIR endpoint is not handling Consent resourceType on GET request

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7571-fhir-endpoint-is-not-handling-consent-resourcetype-on-get-request.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7571-fhir-endpoint-is-not-handling-consent-resourcetype-on-get-request.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7571
+jira: SMILE-11340
+title: "Previously, when the `Populate Response Coding Displays` property was enabled on the FHIR endpoint, requests 
+to retrieve a Consent resource would fail if the Consent contained a CodeSystem concept with a BOOLEAN-typed property. 
+This issue has now been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -2789,6 +2789,11 @@ public class TermReadSvcImpl implements ITermReadSvc, IHasScheduledJobs {
 						IValidationSupport.StringConceptProperty property =
 								new IValidationSupport.StringConceptProperty(next.getKey(), next.getValue());
 						result.getProperties().add(property);
+					} else if (next.getType() == TermConceptPropertyTypeEnum.BOOLEAN) {
+						IValidationSupport.BooleanConceptProperty property =
+								new IValidationSupport.BooleanConceptProperty(
+										next.getKey(), Boolean.parseBoolean(next.getValue()));
+						result.getProperties().add(property);
 					} else {
 						throw new InternalErrorException(Msg.code(905) + "Unknown type: " + next.getType());
 					}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TerminologyTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4TerminologyTest.java
@@ -1,6 +1,8 @@
 package ca.uhn.fhir.jpa.dao.r4;
 
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.context.support.LookupCodeRequest;
+import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.context.support.ValueSetExpansionOptions;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
@@ -28,10 +30,15 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCategory;
 import org.hl7.fhir.r4.model.AuditEvent;
+import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.CodeSystem.CodeSystemContentMode;
 import org.hl7.fhir.r4.model.CodeSystem.ConceptDefinitionComponent;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DecimalType;
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.InstantType;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -41,10 +48,12 @@ import org.hl7.fhir.r4.model.ValueSet.FilterOperator;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetComposeComponent;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionContainsComponent;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -1405,6 +1414,34 @@ public class FhirResourceDaoR4TerminologyTest extends BaseJpaR4Test {
 
 		assertThat(termConceptDesignationFromDb.getValue())
 			.isEqualTo(stringWith8000Chars);
+	}
+
+	@Test
+	void testLookupCode_withCodeSystemContainingBooleanProperty() {
+		// Set up
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl("http://example.com/test-cs");
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		cs.addProperty().setCode("conductible").setType(CodeSystem.PropertyType.BOOLEAN);
+
+		CodeSystem.ConceptDefinitionComponent concept = cs.addConcept();
+		concept.setCode("TEST");
+		concept.setDisplay("Test Code");
+		concept.addProperty().setCode("conductible").setValue(new BooleanType(true));
+
+		myCodeSystemDao.create(cs, mySrd);
+
+		// Execute
+		IValidationSupport.LookupCodeResult result = myValidationSupport.lookupCode(
+			new ValidationSupportContext(myValidationSupport),
+			new LookupCodeRequest("http://example.com/test-cs", "TEST")
+		);
+
+		// Verify
+		assertThat(result).isNotNull();
+		assertThat(result.isFound()).isTrue();
+		assertThat(result.getProperties()).hasSize(1);
 	}
 
 	private ArrayList<String> toCodesContains(List<ValueSetExpansionContainsComponent> theContains) {


### PR DESCRIPTION
### Problem Statement

When the `Populate Response Coding Displays` property was enabled on the FHIR endpoint, requests
to retrieve a Consent resource would fail with error "HAPI-0905: Unknown type: BOOLEAN" if the Consent contained a CodeSystem concept with a BOOLEAN-typed property

### Cause

When `Populate Response Coding Displays` is enabled in the FHIR endpoint, CDR attempts to generate displays for the encoded values based on the loaded code systems. However, the existing service did not handle Boolean type when process CodeSystem concept properties.

### Fix

Handled Boolean-typed term concept properties
