### PR TITLE
Fix JSON Patch add on empty repeating elements (#7578)

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7578-json-patch-empty-array.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7578-json-patch-empty-array.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7578
+title: "Previously, JSON Patch add operations failed with HAPI-1272 when targeting an empty
+  repeating element (e.g., adding a member to a Group with no existing members). The serialized
+  JSON omitted the empty array, causing the patch path to be unresolvable. This has been fixed
+  by pre-populating missing parent arrays before applying the patch."


### PR DESCRIPTION
Fixes #7578

## Summary

JSON Patch (RFC 6902) "add" operations fail with HAPI-1272 when targeting a repeating FHIR element that has no existing entries, because HAPI's JSON serializer omits empty arrays entirely, leaving the parent path unresolvable. This fix pre-populates missing parent arrays in the serialized JSON document before applying the patch, so that paths like `/member/0` or `/member/-` resolve correctly even when the resource has never had values in that field.

1. Added `ensureParentArraysExist()` to `JsonPatchUtils` that inspects each "add" operation in the patch, detects paths targeting array elements (numeric index or `-` append), and inserts an empty JSON array for the parent field if it is absent from the serialized document.
2. Added two unit tests covering the primary scenario (adding a member to an empty Group at `/member/0`) and the append-path variant (`/member/-`), as well as unit tests which do this via a transaction bundle, and via the endpoint. 


Coauthored by Claude Opus 4.6