### PR TITLE
SMILE-9135: Fix _include/_revinclude transitive results without _iterate

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/SMILE-9135-revinclude-no-iterate.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/SMILE-9135-revinclude-no-iterate.yaml
@@ -2,8 +2,8 @@
 type: fix
 jira: SMILE-9135
 issue: 7626
-title: "Previously, when a search used both _revinclude and _include without _iterate, the
-  _include parameter was incorrectly applied to revincluded resources in addition to the
+title: "Previously, when a search used both `_revinclude` and `_include` without `:iterate`, the
+  `_include` parameter was incorrectly applied to revincluded resources in addition to the
   initial search results. This caused extra resources to be returned that the FHIR specification
-  only permits when _iterate is specified. The _include expansion is now correctly scoped to
+  only permits when `:iterate` is specified. The `_include` expansion is now correctly scoped to
   the original search result set only, matching the expected non-iterative behaviour."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
@@ -476,11 +476,11 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 		if (mySearchEntity.getSearchType() == SearchTypeEnum.SEARCH) {
 			Integer maxIncludes = myStorageSettings.getMaximumIncludesToLoadPerPage();
 
-			// Save original search result PIDs — non-iterate _include must apply only to initial results, not to
-			// revinclude results
+			// Save original search result PIDs — non-iterate `_include` must apply only to initial results, not to
+			// `_revinclude` results
 			Set<JpaPid> originalPids = new HashSet<>(thePids);
 
-			// Load non-iterate _revincludes
+			// Load non-iterate `_revinclude`
 			Set<JpaPid> nonIterateRevIncludedPids = theSearchBuilder.loadIncludes(
 					myContext,
 					myEntityManager,
@@ -497,8 +497,8 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 			thePids.addAll(nonIterateRevIncludedPids);
 			includedPidList.addAll(nonIterateRevIncludedPids);
 
-			// Load non-iterate _includes (use originalPids so _include only applies to the
-			// initial search results, not to revincluded resources — per FHIR spec, without _iterate)
+			// Load non-iterate `_include` (use originalPids so `_include` only applies to the
+			// initial search results, not to revincluded resources — per FHIR spec, without `:iterate`)
 			Set<JpaPid> nonIterateIncludedPids = theSearchBuilder.loadIncludes(
 					myContext,
 					myEntityManager,
@@ -515,7 +515,7 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 			thePids.addAll(nonIterateIncludedPids);
 			includedPidList.addAll(nonIterateIncludedPids);
 
-			// Load iterate _revinclude
+			// Load `_revinclude:iterate`
 			Set<JpaPid> iterateRevIncludedPids = theSearchBuilder.loadIncludes(
 					myContext,
 					myEntityManager,
@@ -532,7 +532,7 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 			thePids.addAll(iterateRevIncludedPids);
 			includedPidList.addAll(iterateRevIncludedPids);
 
-			// Load iterate _includes
+			// Load `_include:iterate`
 			Set<JpaPid> iterateIncludedPids = theSearchBuilder.loadIncludes(
 					myContext,
 					myEntityManager,

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SynchronousSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/SynchronousSearchSvcImpl.java
@@ -230,7 +230,7 @@ public class SynchronousSearchSvcImpl implements ISynchronousSearchSvc {
 							.filter(Include::isRecurse)
 							.collect(Collectors.toSet());
 
-					// Phase 1: non-iterate _revincludes on original search result PIDs
+					// Phase 1: non-iterate `_revinclude` on original search result PIDs
 					if (!nonIterateRevIncludes.isEmpty()) {
 						Set<JpaPid> revIncludedPids = theSb.loadIncludes(
 								myContext,
@@ -249,9 +249,9 @@ public class SynchronousSearchSvcImpl implements ISynchronousSearchSvc {
 						allIncludedPidsList.addAll(revIncludedPids);
 					}
 
-					// Phase 2: non-iterate _includes on original search result PIDs
-					// (use originalPids so _include only applies to the initial search results,
-					// not to revincluded resources — per FHIR spec, without _iterate)
+					// Phase 2: non-iterate `_include` on original search result PIDs
+					// (use originalPids so `_include` only applies to the initial search results,
+					// not to revincluded resources — per FHIR spec, without `:iterate`)
 					if (theParams.getEverythingMode() == null
 							&& !nonIterateIncludes.isEmpty()
 							&& (maxIncludes == null || maxIncludes > 0)) {
@@ -272,7 +272,7 @@ public class SynchronousSearchSvcImpl implements ISynchronousSearchSvc {
 						allIncludedPidsList.addAll(forwardIncludedPids);
 					}
 
-					// Phase 3: iterate _revincludes on expanded PIDs (including non-iterate revinclude results)
+					// Phase 3: `_revinclude:iterate` on expanded PIDs (including non-iterate revinclude results)
 					if (!iterateRevIncludes.isEmpty() && (maxIncludes == null || maxIncludes > 0)) {
 						Set<JpaPid> iterateRevIncludedPids = theSb.loadIncludes(
 								myContext,
@@ -291,7 +291,7 @@ public class SynchronousSearchSvcImpl implements ISynchronousSearchSvc {
 						allIncludedPidsList.addAll(iterateRevIncludedPids);
 					}
 
-					// Phase 4: iterate _includes on all expanded PIDs (including revinclude results)
+					// Phase 4: `_include:iterate` on all expanded PIDs (including revinclude results)
 					if (theParams.getEverythingMode() == null
 							&& !iterateIncludes.isEmpty()
 							&& (maxIncludes == null || maxIncludes > 0)) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderRevIncludeTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderRevIncludeTest.java
@@ -225,18 +225,18 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 	}
 
 	/**
-	 * Reproduces SMILE-9135: When _include and _revinclude are used together WITHOUT _iterate,
-	 * _include should only apply to the initial search result set, not to revincluded resources.
+	 * Reproduces SMILE-9135: When `_include` and `_revinclude` are used together WITHOUT `:iterate`,
+	 * `_include` should only apply to the initial search result set, not to revincluded resources.
 	 * <p>
 	 * Setup:
 	 * - SR/A: no replaces (initial search target)
-	 * - SR/B: no replaces (should NOT appear without _iterate)
-	 * - SR/C: replaces = [SR/A, SR/B] (found via _revinclude of SR/A)
+	 * - SR/B: no replaces (should NOT appear without `:iterate`)
+	 * - SR/C: replaces = [SR/A, SR/B] (found via `_revinclude` of SR/A)
 	 * <p>
 	 * Query: ServiceRequest?_id=A&_include=ServiceRequest:replaces&_revinclude=ServiceRequest:replaces
 	 * <p>
 	 * Expected: SR/A + SR/C only (2 resources)
-	 * Bug: SR/B is also returned because _include is applied to revincluded SR/C
+	 * Bug: SR/B is also returned because `_include` is applied to revincluded SR/C
 	 */
 	@Test
 	void testRevIncludeDoesNotIncludeFromIncludedResources() {
@@ -257,7 +257,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 		Set<String> foundIds = extractResourceIds(bundle);
 
 		// SR/A (initial result) and SR/C (revinclude) should be present;
-		// SR/B should NOT appear without _iterate
+		// SR/B should NOT appear without `:iterate`
 		assertThat(foundIds)
 			.contains(srAId.getValue(), srCId.getValue())
 			.doesNotContain(srBId.getValue())
@@ -265,7 +265,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 	}
 
 	/**
-	 * SMILE-9135: _revinclude without _include should still return only direct results.
+	 * SMILE-9135: `_revinclude` without `_include` should still return only direct results.
 	 */
 	@Test
 	void testRevIncludeAloneDoesNotProduceTransitiveResults() {
@@ -291,8 +291,8 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 	}
 
 	/**
-	 * SMILE-9135: _include without _revinclude should only return direct results.
-	 * Since SR/A has no replaces references, _include adds nothing.
+	 * SMILE-9135: `_include` without `_revinclude` should only return direct results.
+	 * Since SR/A has no replaces references, `_include` adds nothing.
 	 */
 	@Test
 	void testIncludeAloneDoesNotProduceTransitiveResults() {
@@ -310,7 +310,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 
 		Set<String> foundIds = extractResourceIds(bundle);
 
-		// SR/A has no replaces, so _include adds nothing
+		// SR/A has no replaces, so `_include` adds nothing
 		assertThat(foundIds)
 			.contains(srAId.getValue())
 			.doesNotContain(srBId.getValue())
@@ -318,8 +318,8 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 	}
 
 	/**
-	 * SMILE-9135: With _iterate, _include SHOULD cascade through revincluded resources.
-	 * This is the correct behavior when iterate is specified — SR/B should appear.
+	 * SMILE-9135: With `:iterate`, `_include` SHOULD cascade through revincluded resources.
+	 * This is the correct behavior when `:iterate` is specified — SR/B should appear.
 	 */
 	@Test
 	void testRevIncludeWithIncludeIterateProducesTransitiveResults() {
@@ -339,7 +339,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 
 		Set<String> foundIds = extractResourceIds(bundle);
 
-		// With _iterate, SR/B SHOULD be included (SR/C.replaces -> SR/B is followed iteratively)
+		// With `:iterate`, SR/B SHOULD be included (SR/C.replaces -> SR/B is followed iteratively)
 		assertThat(foundIds)
 			.contains(srAId.getValue(), srBId.getValue(), srCId.getValue())
 			.hasSize(3);
@@ -385,7 +385,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 		ourLog.info("Synchronous path (non-iterate) found {} resources: {}", resources.size(), foundIds);
 
 		// SR/A (initial result) and SR/C (revinclude) should be present;
-		// SR/B should NOT appear without _iterate
+		// SR/B should NOT appear without `:iterate`
 		assertThat(foundIds)
 			.contains(srAId.getValue(), srCId.getValue())
 			.doesNotContain(srBId.getValue())
@@ -393,10 +393,10 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 	}
 
 	/**
-	 * SMILE-9135: Verify that _revinclude + _include:iterate works correctly on the synchronous path.
+	 * SMILE-9135: Verify that `_revinclude` + `_include:iterate` works correctly on the synchronous path.
 	 * <p>
 	 * The synchronous path (SearchParameterMap.newSynchronous()) is taken when isLoadSynchronous() = true.
-	 * With _include:iterate, _include SHOULD cascade through revincluded resources, so SR/B must appear.
+	 * With `_include:iterate`, `_include` SHOULD cascade through revincluded resources, so SR/B must appear.
 	 */
 	@Test
 	void testSynchronousPathRevIncludeWithIncludeIterateProducesTransitiveResults() {
@@ -419,7 +419,7 @@ public class ResourceProviderRevIncludeTest extends BaseResourceProviderR4Test {
 			.collect(Collectors.toSet());
 		ourLog.info("Synchronous path found {} resources: {}", resources.size(), foundIds);
 
-		// With _iterate, SR/B SHOULD be included (SR/C.replaces -> SR/B is followed iteratively)
+		// With `:iterate`, SR/B SHOULD be included (SR/C.replaces -> SR/B is followed iteratively)
 		assertThat(foundIds)
 			.contains(srAId.getValue(), srBId.getValue(), srCId.getValue())
 			.hasSize(3);

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoR5SearchIncludeTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirResourceDaoR5SearchIncludeTest.java
@@ -239,8 +239,8 @@ public class FhirResourceDaoR5SearchIncludeTest extends BaseJpaR5Test {
 			.addRevInclude(new Include("*").setRecurse(true));
 		IBundleProvider results = myEpisodeOfCareDao.search(map, mySrd);
 		List<String> ids = toUnqualifiedVersionlessIdValues(results);
-		// Phase 2 (_include=*) finds ORG-0 from EOC-0.managingOrganization.
-		// Phase 3 (_revinclude=*:iterate) then cascades through ORG-0, finding EOC-1..9.
+		// Phase 2 (`_include=*`) finds ORG-0 from EOC-0.managingOrganization.
+		// Phase 3 (`_revinclude=*:iterate`) then cascades through ORG-0, finding EOC-1..9.
 		List<String> expected = IntStream.range(0, 10)
 			.mapToObj(t -> "EpisodeOfCare/EOC-" + t)
 			.collect(Collectors.toList());
@@ -283,8 +283,8 @@ public class FhirResourceDaoR5SearchIncludeTest extends BaseJpaR5Test {
 			.addRevInclude(new Include("*").setRecurse(true));
 		IBundleProvider results = myOrganizationDao.search(map, mySrd);
 		List<String> ids = toUnqualifiedVersionlessIdValues(results);
-		// Phase 2 (_include=*) finds ORG-P from ORG-0.partOf (uses 1 of 5 include slots).
-		// Phase 3 (_revinclude=*:iterate) on {ORG-0, ORG-P} finds resources referencing either.
+		// Phase 2 (`_include=*`) finds ORG-P from ORG-0.partOf (uses 1 of 5 include slots).
+		// Phase 3 (`_revinclude=*:iterate`) on {ORG-0, ORG-P} finds resources referencing either.
 		// ORG-0 is itself a revinclude of ORG-P (via partOf), consuming 1 slot before being
 		// filtered as already-present, leaving 3 slots for EOCs. Total: ORG-0 + ORG-P + 3 EOCs.
 		assertThat(ids)


### PR DESCRIPTION
## Summary

This fixes a FHIR spec violation where `_include` was incorrectly applied to resources found via `_revinclude`, producing transitive include results that are only permitted when `_iterate` is specified. The root cause was that both `PersistedJpaBundleProvider` and `SynchronousSearchSvcImpl` mutated the working PID set after loading `_revinclude` results, then passed the expanded set to the subsequent `_include` call. A secondary issue discovered during review was that `SynchronousSearchSvcImpl` was missing `_iterate` support entirely — it only ran `_revinclude` then `_include` with no phase separation.

1. `PersistedJpaBundleProvider`: capture original search result PIDs before `_revinclude` expansion, pass `originalPids` (not the expanded set) to the non-iterate `_include` call.
2. `SynchronousSearchSvcImpl`: replace the flat 2-phase include/revinclude sequence with the correct 4-phase algorithm — non-iterate revinclude, non-iterate include, iterate revinclude, iterate include — matching `PersistedJpaBundleProvider`.
3. `ResourceProviderRevIncludeTest`: 8 new tests cover the non-iterate and iterate combinations on both the async (`myClient`) and synchronous DAO paths, including a dedicated test that exercises `SynchronousSearchSvcImpl` directly via `SearchParameterMap.newSynchronous()`.

---

## Code Review Suggestions

- [ ] **Phase ordering in `SynchronousSearchSvcImpl`** — The new 4-phase sequence runs non-iterate revinclude (Phase 1) before non-iterate include (Phase 2). `PersistedJpaBundleProvider` uses the same ordering. The FHIR spec does not mandate ordering between non-iterate `_include` and `_revinclude` when used together, but both sides of the fix must agree on which PID set is passed to each phase. Confirm the ordering is intentional and consistent between the two implementations.
- [ ] **`everythingMode` guard moved** — In the original `SynchronousSearchSvcImpl`, the `everythingMode == null` guard wrapped the entire include+revinclude block. In the new code, the guard is applied to Phase 2 (non-iterate includes) and Phase 4 (iterate includes) separately, but not to Phase 1 (non-iterate revinclude) or Phase 3 (iterate revinclude). Verify this is the correct scope — the guard was previously inherited from `PersistedJpaBundleProvider` behaviour and may need to cover revinclude phases too.
- [ ] **`maxIncludes` budget shared across all 4 phases** — The single `maxIncludes` counter is decremented across phases in order. If Phase 1 exhausts the budget, Phases 2-4 are silently skipped (the `maxIncludes > 0` guard short-circuits). This matches the existing behaviour in `PersistedJpaBundleProvider`. Confirm this page-level cap is still the intended ceiling for the synchronous path.
- [ ] **`allIncludedPidsList` used for total count correction** — The bundle size calculation subtracts `allIncludedPidsList.size()` from `resources.size()`. The old code subtracted `includedPidsList.size()`, which in the original also accumulated both include and revinclude results. The semantics are the same, but worth verifying that the list is accumulated identically across all 4 phases (no phase conditionally skips adding to it when it should not).
- [ ] **`originalPids` as `HashSet` vs the incoming `pids` list type** — `originalPids` is a `HashSet<JpaPid>` snapshot. `loadIncludes` accepts a `Collection<JpaPid>`; confirm `HashSet` iteration order does not affect correctness (it should not, since inclusion is a set operation, but worth a second look given the PID type).

---

## QA Test Suggestions

### Setup

- [ ] Stand up a HAPI JPA server (R4). Create three `ServiceRequest` resources: SR/A (no `replaces`), SR/B (no `replaces`), SR/C (`replaces` both SR/A and SR/B).

### Non-iterate path (the bug fix)

- [ ] `GET /ServiceRequest?_id=<A>&_include=ServiceRequest:replaces&_revinclude=ServiceRequest:replaces` — response must contain SR/A and SR/C only; SR/B must not appear.
- [ ] `GET /ServiceRequest?_id=<A>&_revinclude=ServiceRequest:replaces` — response must contain SR/A and SR/C only; SR/B must not appear.
- [ ] `GET /ServiceRequest?_id=<A>&_include=ServiceRequest:replaces` — response must contain SR/A only; SR/B and SR/C must not appear.

### Iterate path (regression guard — must still work)

- [ ] `GET /ServiceRequest?_id=<A>&_include:iterate=ServiceRequest:replaces&_revinclude:iterate=ServiceRequest:replaces` — response must contain all three: SR/A, SR/B, and SR/C.
- [ ] Repeat the iterate test using a client configured to go through the synchronous code path (small page size, or a DAO-layer call with `SearchParameterMap.newSynchronous()`) to exercise `SynchronousSearchSvcImpl` Phase 3 and Phase 4 directly.

### Edge cases

- [ ] Run the same `_include`/`_revinclude` non-iterate query against a resource type that has no matching revinclude results — confirm the response contains only the direct search result with no extras and no server error.
- [ ] Run a search that would hit the `maxIncludes` page cap across multiple phases — confirm the total count in the returned bundle is correct and does not include included resources in the match count.

Closes #7626 