### PR TITLE
SMILE-11363: Fix _text search when fulltext indexing disabled but Hibernate Search enabled

### DIFF
--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -172,7 +172,6 @@ ca.uhn.fhir.jpa.term.TermConceptMappingSvcImpl.matchesFound=Matches found
 ca.uhn.fhir.jpa.term.TermConceptMappingSvcImpl.noMatchesFound=No Matches found
 ca.uhn.fhir.jpa.term.TermConceptMappingSvcImpl.onlyNegativeMatchesFound=Only negative matches found
 
-ca.uhn.fhir.jpa.dao.FulltextSearchSvcImpl.fullTextSearchingNotPossible=Fulltext searching is not enabled on this server, can not support the parameter(s): {0}
 ca.uhn.fhir.jpa.dao.FulltextSearchSvcImpl.fullTextSearchingNotPossibleForResourceType=Fulltext searching is not enabled on this server for resource type {0}, can not support the parameter(s): {1}
 ca.uhn.fhir.jpa.dao.JpaResourceDaoSearchParameter.invalidSearchParamExpression=The expression "{0}" can not be evaluated and may be invalid: {1}
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/SMILE-11363-text-content-search-fulltext-disabled.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/SMILE-11363-text-content-search-fulltext-disabled.yaml
@@ -1,0 +1,11 @@
+---
+type: fix
+jira: SMILE-11363
+title: "Previously, using the _text or _content search parameters when Hibernate Search was enabled
+  but the fulltext content index (HibernateSearchIndexFullText) was set to false would result in
+  an error (HAPI-2566: Fulltext searching is not enabled on this server). This was a regression
+  introduced in HAPI 8.0.0: a validation check was added that incorrectly blocked _text and _content
+  queries whenever fulltext content auto-indexing was disabled, even though Hibernate Search was
+  fully operational. The overly strict validation check has been removed and _text/_content search
+  parameter registration is now unconditional when Hibernate Search is enabled, restoring the
+  behaviour from HAPI 7.6.0 and earlier."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/FulltextSearchSvcImpl.java
@@ -328,18 +328,6 @@ public class FulltextSearchSvcImpl implements IFulltextSearchSvc {
 			return;
 		}
 
-		// Can't use _content or _text if FullText indexing is disabled
-		if (!myStorageSettings.isHibernateSearchIndexFullText()) {
-			String failingParams = theParams.keySet().stream()
-					.filter(t -> t.equals(Constants.PARAM_TEXT) || t.equals(Constants.PARAM_CONTENT))
-					.sorted()
-					.collect(Collectors.joining(", "));
-			String msg = myFhirContext
-					.getLocalizer()
-					.getMessage(FulltextSearchSvcImpl.class, "fullTextSearchingNotPossible", failingParams);
-			throw new InvalidRequestException(Msg.code(2566) + msg);
-		}
-
 		List<String> failingParams = null;
 
 		// theResourceType is null for $everything queries

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImpl.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImpl.java
@@ -269,25 +269,25 @@ public class SearchParamRegistryImpl
 		}
 
 		// Auto-register: _content and _text
-		if (myStorageSettings.isHibernateSearchIndexFullText()) {
-			registerImplicitSearchParam(
-					searchParams,
-					Constants.PARAM_TEXT_URL,
-					Constants.PARAM_TEXT,
-					PARAM_TEXT_DESCRIPTION,
-					"Resource",
-					RestSearchParameterTypeEnum.STRING);
-			registerImplicitSearchParam(
-					searchParams,
-					Constants.PARAM_CONTENT_URL,
-					Constants.PARAM_CONTENT,
-					PARAM_CONTENT_DESCRIPTION,
-					"Resource",
-					RestSearchParameterTypeEnum.STRING);
-		} else {
-			unregisterImplicitSearchParam(searchParams, Constants.PARAM_CONTENT);
-			unregisterImplicitSearchParam(searchParams, Constants.PARAM_TEXT);
-		}
+		// These are always registered as implicit search parameters. If Hibernate Search
+		// is not enabled, the search will fail at execution time with an appropriate error
+		// (HAPI-1192). Previously, these were gated behind isHibernateSearchIndexFullText()
+		// but that setting only controls auto-indexing of fulltext data, not whether
+		// _text/_content searches should be allowed when HS is enabled.
+		registerImplicitSearchParam(
+				searchParams,
+				Constants.PARAM_TEXT_URL,
+				Constants.PARAM_TEXT,
+				PARAM_TEXT_DESCRIPTION,
+				"Resource",
+				RestSearchParameterTypeEnum.STRING);
+		registerImplicitSearchParam(
+				searchParams,
+				Constants.PARAM_CONTENT_URL,
+				Constants.PARAM_CONTENT,
+				PARAM_CONTENT_DESCRIPTION,
+				"Resource",
+				RestSearchParameterTypeEnum.STRING);
 
 		removeInactiveSearchParams(searchParams);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchFtTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchFtTest.java
@@ -5,8 +5,8 @@ import ca.uhn.fhir.jpa.api.dao.PatientEverythingParameters;
 import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
 import ca.uhn.fhir.jpa.search.autocomplete.ValueSetAutocompleteOptions;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
-import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.CompositeAndListParam;
@@ -671,8 +671,9 @@ public class FhirResourceDaoR4SearchFtTest extends BaseJpaR4Test {
 	/**
 	 * Adjacent test: when HibernateSearchIndexFullText is false, the search parameter
 	 * registry should still register _text and _content as active search parameters
-	 * (since Hibernate Search is enabled). Currently, the registry gates these params
-	 * behind isHibernateSearchIndexFullText(), which is a secondary bug.
+	 * (since Hibernate Search is enabled). Previously, the registry gated these params
+	 * behind isHibernateSearchIndexFullText(), which was a secondary bug fixed alongside
+	 * the HAPI-2566 regression.
 	 */
 	@Test
 	void testSearchParamRegistry_withFullTextIndexDisabled_shouldStillRegisterTextParam() {
@@ -680,14 +681,21 @@ public class FhirResourceDaoR4SearchFtTest extends BaseJpaR4Test {
 		myStorageSettings.setHibernateSearchIndexFullText(false);
 		mySearchParamRegistry.forceRefresh();
 
-		// Assert: _text should still be registered as an active search parameter
+		// Assert: _text and _content should still be registered as active search parameters
 		boolean hasTextParam = mySearchParamRegistry.hasActiveSearchParam(
 			"Patient",
 			Constants.PARAM_TEXT,
 			ISearchParamRegistry.SearchParamLookupContextEnum.SEARCH);
+		boolean hasContentParam = mySearchParamRegistry.hasActiveSearchParam(
+			"Patient",
+			Constants.PARAM_CONTENT,
+			ISearchParamRegistry.SearchParamLookupContextEnum.SEARCH);
 
 		assertThat(hasTextParam)
 			.as("_text search parameter should be active when Hibernate Search is enabled, regardless of fulltext indexing setting")
+			.isTrue();
+		assertThat(hasContentParam)
+			.as("_content search parameter should be active when Hibernate Search is enabled, regardless of fulltext indexing setting")
 			.isTrue();
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchFtTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchFtTest.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.jpa.api.dao.PatientEverythingParameters;
 import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
 import ca.uhn.fhir.jpa.search.autocomplete.ValueSetAutocompleteOptions;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
@@ -610,6 +611,84 @@ public class FhirResourceDaoR4SearchFtTest extends BaseJpaR4Test {
 		map.add(SP_VALUE_QUANTITY, new QuantityParam("lt90"));
 		assertThat(toUnqualifiedVersionlessIdValues(myObservationDao.search(map))).containsExactly(toValues(id2));
 
+	}
+
+	/**
+	 * When Hibernate Search is enabled but HibernateSearchIndexFullText is false,
+	 * a _text search should still be permitted (returning empty results if nothing
+	 * was indexed). This is a regression from HAPI 8.0.0 where an overly strict
+	 * validation check was added that throws HAPI-2566.
+	 *
+	 * @see <a href="https://smile-cdr.atlassian.net/browse/SMILE-11363">SMILE-11363</a>
+	 */
+	@Test
+	void testTextSearch_withHibernateSearchEnabled_andFullTextIndexDisabled_shouldNotThrowError() {
+		// Setup: disable fulltext indexing but keep Hibernate Search enabled (bean is present)
+		myStorageSettings.setHibernateSearchIndexFullText(false);
+		mySearchParamRegistry.forceRefresh();
+
+		// Create a patient with narrative text (manually populated, not auto-indexed)
+		Patient patient = new Patient();
+		patient.getText().setDivAsString("<div>Some narrative text for searching</div>");
+		patient.addName().addGiven("TestPatient");
+		myPatientDao.create(patient, mySrd);
+
+		// Test: _text search should execute without error
+		// The desired behavior is that the search succeeds (empty or with results),
+		// NOT that it throws HAPI-2566
+		SearchParameterMap map = new SearchParameterMap();
+		map.add(Constants.PARAM_TEXT, new StringParam("narrative"));
+		IBundleProvider results = myPatientDao.search(map, mySrd);
+
+		// Assert: we get a result bundle (possibly empty), not an exception
+		assertThat(results).isNotNull();
+		assertThat(results.getAllResources()).isNotNull();
+	}
+
+	/**
+	 * Adjacent test: _text search with HibernateSearchIndexFullText=true should work normally.
+	 * This verifies the standard (non-regression) path still functions.
+	 */
+	@Test
+	void testTextSearch_withHibernateSearchEnabled_andFullTextIndexEnabled_shouldWork() {
+		// Setup: both HS and fulltext indexing enabled (the @BeforeEach default)
+		// myStorageSettings.setHibernateSearchIndexFullText(true) is already set in @BeforeEach
+
+		Patient patient = new Patient();
+		patient.getText().setDivAsString("<div>DIVTEXT</div>");
+		patient.addName().addGiven("TestPatient");
+		IIdType patientId = myPatientDao.create(patient, mySrd).getId().toUnqualifiedVersionless();
+
+		// Test: _text search should work and return the patient
+		SearchParameterMap map = new SearchParameterMap();
+		map.add(Constants.PARAM_TEXT, new StringParam("DIVTEXT"));
+		IBundleProvider results = myPatientDao.search(map, mySrd);
+
+		assertThat(results).isNotNull();
+		assertThat(toUnqualifiedVersionlessIdValues(results)).containsExactly(toValues(patientId));
+	}
+
+	/**
+	 * Adjacent test: when HibernateSearchIndexFullText is false, the search parameter
+	 * registry should still register _text and _content as active search parameters
+	 * (since Hibernate Search is enabled). Currently, the registry gates these params
+	 * behind isHibernateSearchIndexFullText(), which is a secondary bug.
+	 */
+	@Test
+	void testSearchParamRegistry_withFullTextIndexDisabled_shouldStillRegisterTextParam() {
+		// Setup: disable fulltext indexing but keep Hibernate Search enabled
+		myStorageSettings.setHibernateSearchIndexFullText(false);
+		mySearchParamRegistry.forceRefresh();
+
+		// Assert: _text should still be registered as an active search parameter
+		boolean hasTextParam = mySearchParamRegistry.hasActiveSearchParam(
+			"Patient",
+			Constants.PARAM_TEXT,
+			ISearchParamRegistry.SearchParamLookupContextEnum.SEARCH);
+
+		assertThat(hasTextParam)
+			.as("_text search parameter should be active when Hibernate Search is enabled, regardless of fulltext indexing setting")
+			.isTrue();
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -2453,29 +2453,20 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		"/Patient/A/$everything?_content=HELLO"
 	})
 	public void testFullTextIndexingDisabled(String theUri) throws IOException {
-		// Setup
+		// Setup: disable fulltext auto-indexing but Hibernate Search is still enabled
 		myStorageSettings.setHibernateSearchIndexFullText(false);
+		mySearchParamRegistry.forceRefresh();
 		createPatient(withId("A"), withActiveTrue());
 
-		// Test
+		// Test: _text/_content searches should still be allowed when HS is enabled,
+		// even if fulltext auto-indexing is disabled. The search returns empty results
+		// since nothing was indexed, but no error is thrown.
 		HttpGet get = new HttpGet(myServerBase + theUri);
 		try (CloseableHttpResponse response = ourHttpClient.execute(get)) {
 
-			// Verify
+			// Verify: expect HTTP 200 (success), not HTTP 400
 			String resp = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-			assertEquals(400, response.getStatusLine().getStatusCode(), resp);
-			String expectedParams = null;
-			if (theUri.contains("_content")) {
-				expectedParams = "_content";
-			}
-			if (theUri.contains("_text")) {
-				if (expectedParams != null) {
-					expectedParams += ", _text";
-				} else {
-					expectedParams = "_text";
-				}
-			}
-			assertThat(resp).contains("Fulltext searching is not enabled on this server, can not support the parameter(s): " + expectedParams);
+			assertThat(response.getStatusLine().getStatusCode()).as(resp).isEqualTo(200);
 		}
 
 	}


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in HAPI 8.0.0 where `_text` and `_content` search parameters stopped working when Hibernate Search is enabled but the `HibernateSearchIndexFullText` storage setting is `false`. The root cause was an overly strict validation check added in commit `28d4f65d794` that conflated the auto-indexing setting with the ability to execute fulltext searches. The fix removes this incorrect guard and aligns the search parameter registry to always register `_text`/`_content` as active when Hibernate Search is enabled.

1. Removed the `isHibernateSearchIndexFullText()` guard in `FulltextSearchSvcImpl.verifyContentAndTextParamsAreSupportedIfUsed()` that was incorrectly blocking `_text`/`_content` searches when fulltext auto-indexing is disabled but Hibernate Search is still running.
2. Updated `SearchParamRegistryImpl` to always register `_text` and `_content` as implicit search parameters — removing the secondary gate that was hiding these params when `HibernateSearchIndexFullText=false`.
3. Added three new tests to `FhirResourceDaoR4SearchFtTest` covering the primary regression scenario, the standard (both flags enabled) path, and the search param registry registration behavior.
4. Updated `ResourceProviderR4Test.testFullTextIndexingDisabled()` to reflect the corrected behavior: the search returns HTTP 200 (not HTTP 400) when Hibernate Search is enabled and fulltext indexing is disabled.

**Version Analysis:** Regression verified present on v8.2.1 and absent on v7.6.0. The regression was introduced in HAPI v8.0.0 via commit `28d4f65d794` ("Add option to disable FullText indexing even if HS is enabled").

## Code Review Suggestions

- [ ] **`FulltextSearchSvcImpl` — guard removal scope.** The deleted block (lines 331–341 in the original) was the only place that checked `isHibernateSearchIndexFullText()` for search permission. Confirm there is no other code path that needs a corresponding update (e.g., `$everything` handling in `doSearch()`) — the lower check for `isHibernateSearchIndexSearchParams()` remains and is unrelated.
- [ ] **`SearchParamRegistryImpl` — unconditional registration when HS is fully disabled.** The new code always registers `_text`/`_content` regardless of any Hibernate Search setting. When Hibernate Search is entirely absent (no `FulltextSearchSvc` bean), `SearchBuilder.failIfUsed()` throws HAPI-1192 at query time. Verify that this late-failure path is still reachable and returns a sensible error for users who have Hibernate Search completely disabled.
- [ ] **`testFullTextIndexingDisabled` test update — behavioral inversion.** The test was asserting HTTP 400 + a specific error message; it now asserts HTTP 200. The updated assertion only checks the status code, not the response body. Consider also asserting that the returned bundle is a valid FHIR Bundle and does not contain an OperationOutcome, so the test is not a false positive if the server returns a 200 with an error body.
- [ ] **New test: `testTextSearch_withHibernateSearchEnabled_andFullTextIndexDisabled_shouldNotThrowError`.** The test creates a patient with narrative text and then searches with `_text=narrative`. Because `HibernateSearchIndexFullText=false`, Hibernate Search will not have auto-indexed the narrative, so the result will be empty. The assertion checks for a non-null result list but not for the empty-result case explicitly. A comment clarifying why an empty result is expected (and acceptable) would help future readers.
- [ ] **`mySearchParamRegistry.forceRefresh()` calls in new tests.** The new DAO-level tests call `forceRefresh()` after changing the storage setting. Confirm that `BaseJpaR4Test`'s `@AfterEach` teardown restores `HibernateSearchIndexFullText` to its default and that the registry is re-initialized between tests — otherwise a test that sets `false` could contaminate subsequent tests in the class.

## QA Test Suggestions

### Setup
- [ ] Deploy a HAPI-FHIR JPA server (or CDR) with Hibernate Search (Lucene) **enabled** and `HibernateSearchIndexFullText` **set to `false`** (CDR setting: `lucene.enabled=true`, `db.hibernate_search.index.fulltext_content=false`).
- [ ] POST at least one Patient resource with a populated narrative div to the server.

### Test Cases
- [ ] **Primary regression:** `GET /Patient?_text=<word-from-narrative>` — confirm HTTP 200 is returned (not HTTP 400 with HAPI-2566). The result bundle may be empty if Hibernate Search did not auto-index the text, but no exception should be thrown.
- [ ] **`_content` parameter parity:** `GET /Patient?_content=<word>` — confirm the same fix applies: HTTP 200, no HAPI-2566 error.
- [ ] **`$everything` with `_text`/`_content`:** `GET /Patient/A/$everything?_text=foo` and `GET /Patient/A/$everything?_content=foo` — confirm these also return 200, not 400, matching the updated `testFullTextIndexingDisabled` parameterized cases.
- [ ] **Standard path unaffected:** With `HibernateSearchIndexFullText=true` and Hibernate Search enabled, POST a Patient with a known narrative word, then `GET /Patient?_text=<word>` — confirm the patient is returned in results (fulltext indexing and search both work normally).
- [ ] **HS fully disabled still errors correctly:** Deploy with Hibernate Search completely disabled. `GET /Patient?_text=foo` should return HTTP 400 with HAPI-1192 ("Full text searching is not enabled on this server"), confirming the correct lower-level guard is still in place.
- [ ] **Capability statement:** With `HibernateSearchIndexFullText=false` and HS enabled, `GET /metadata` — confirm `_text` and `_content` appear in the server's CapabilityStatement search parameters (since `SearchParamRegistryImpl` now always registers them).
