### PR TITLE
7573: Upgrade tomcat-embed-* to 10.1.52 to fix CVE-2026-24734

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7573-bump-tomcat-embed-core-cve-2026-24734.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7573-bump-tomcat-embed-core-cve-2026-24734.yaml
@@ -1,0 +1,6 @@
+---
+type: security
+issue: 7573
+title: "CVE-2026-24734: The tomcat-embed-core dependency used by the Spring Boot sample
+  modules has been upgraded from 10.1.48 to 10.1.52 to address an OCSP response
+  verification bypass vulnerability in Apache Tomcat Native."

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -21,6 +21,22 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- Pinned here for CVE: CVE-2026-24734 -->
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-core</artifactId>
+				<version>${tomcat_embed_core_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-el</artifactId>
+				<version>${tomcat_embed_core_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-websocket</artifactId>
+				<version>${tomcat_embed_core_version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1092,6 +1092,8 @@
 		<spring_data_bom_version>2024.0.5</spring_data_bom_version>
 		<spring_framework_bom_version>6.2.12</spring_framework_bom_version>
 		<spring_boot_version>3.4.11</spring_boot_version>
+		<!-- Pinned here for CVE: CVE-2026-24734 -->
+		<tomcat_embed_core_version>10.1.52</tomcat_embed_core_version>
 		<spring_retry_version>2.0.10</spring_retry_version>
 		<json_path_version>2.9.0</json_path_version>
 		<jboss_logging_version>3.6.1.Final</jboss_logging_version>


### PR DESCRIPTION
Fixes #7573, Fixes #7572 and Fixes #7574

  Pins tomcat-embed-core, tomcat-embed-el, and tomcat-embed-websocket to
  10.1.52 in the Spring Boot sample modules to address CVE-2026-24734
  (OCSP response verification bypass in Apache Tomcat Native).