### PR TITLE
7621: Upgrade Jetty to 12.0.32 to fix CVE-2026-1605

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7621-bump-jetty-12_0_32-cve-2026-1605.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7621-bump-jetty-12_0_32-cve-2026-1605.yaml
@@ -2,4 +2,4 @@
 type: security
 issue: 7621
 title: "CVE-2026-1605: The Jetty dependency has been upgraded from 12.0.25 to 12.0.32
-  to address a GzipHandler resource leak vulnerability."
+  to address a GzipHandler resource leak vulnerability. Fix contributed by Faisal Dilawar."

--- a/pom.xml
+++ b/pom.xml
@@ -988,6 +988,10 @@
 			<id>dnaworks</id>
 			<name>Donald Wheeler</name>
 		</developer>
+		<developer>
+			<id>kathbigra</id>
+			<name>Faisal Dilawar</name>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Fixes #7621 and Fixes #7622

Upgrade jetty to v12.0.32 to address CVE-2026-1605