### PR TITLE
fix(7630): Integer overflow during comparison of `@Interceptor` and `@Hook` order values

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/executor/BaseInterceptorService.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/executor/BaseInterceptorService.java
@@ -263,7 +263,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 		theObjects.sort((a, b) -> {
 			Integer orderA = interceptorToOrder.get(a);
 			Integer orderB = interceptorToOrder.get(b);
-			return orderA - orderB;
+			return Integer.compare(orderA, orderB);
 		});
 	}
 
@@ -686,7 +686,7 @@ public abstract class BaseInterceptorService<POINTCUT extends Enum<POINTCUT> & I
 
 		@Override
 		public int compareTo(IInvoker theInvoker) {
-			return myOrder - theInvoker.getOrder();
+			return Integer.compare(myOrder, theInvoker.getOrder());
 		}
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7630-fix-integer-overflow-in-baseinterceptorservice-compareto.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7630-fix-integer-overflow-in-baseinterceptorservice-compareto.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7630
+title: "Previously, the `compareTo` method used to determine interceptor invocation order could return an incorrect result 
+        due to integer overflow when comparing two `@Interceptor` or `@Hook` order values, when the difference between them overflows int range (e.g., Integer.MIN_VALUE - 100). 
+        Fix submitted by Tue Toft Nørgård (@ttnTrifork)"

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/util/CompositeInterceptorBroadcasterTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/util/CompositeInterceptorBroadcasterTest.java
@@ -259,6 +259,41 @@ class CompositeInterceptorBroadcasterTest {
 		);
 	}
 
+	@Test
+	public void testCompositeBroadcasterBroadcastsInOrder_withExtremeOrderValues() {
+		// Setup - register interceptors with order value differences that overflow int range (e.g., Integer.MIN_VALUE - 100)
+		InterceptorService svc0 = new InterceptorService();
+		svc0.registerInterceptor(new Interceptor0());
+		InterceptorService svc1 = new InterceptorService();
+		svc1.registerInterceptor(new Interceptor1());
+		svc1.registerInterceptor(new InterceptorMinValue());
+		InterceptorService svc2 = new InterceptorService();
+		svc2.registerInterceptor(new Interceptor2());
+		InterceptorService[] services = new InterceptorService[]{svc0, svc1, svc2};
+
+		IInterceptorBroadcaster compositeBroadcaster = CompositeInterceptorBroadcaster
+			.newCompositeBroadcaster(services);
+
+		// Test
+		HookParams hookParams = new HookParams()
+			.add(String.class, "PARAM_A")
+			.add(String.class, "PARAM_B");
+		compositeBroadcaster.callHooksAndReturnObject(Pointcut.TEST_RO, hookParams);
+
+		// Verify
+		assertThat(myOrders).asList().containsExactly(
+			Integer.MIN_VALUE, -2, -1, 0, 1, 2, 3
+		);
+	}
+
+	@Interceptor
+	private class InterceptorMinValue {
+		@Hook(value = Pointcut.TEST_RO, order = Integer.MIN_VALUE)
+		public BaseServerResponseException hook() {
+			myOrders.add(Integer.MIN_VALUE);
+			return null;
+		}
+	}
 
 	@Interceptor
 	private class Interceptor0 {

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/interceptor/executor/InterceptorServiceTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/fhir/interceptor/executor/InterceptorServiceTest.java
@@ -293,6 +293,20 @@ class InterceptorServiceTest {
 	}
 
 	@Test
+	public void testInvokeInterceptor_withExtremeOrderValues() {
+		// Setup - register interceptors with order value differences that overflow int range (e.g., Integer.MIN_VALUE - 100)
+		InterceptorService svc = new InterceptorService();
+		svc.registerInterceptor(new MyTestInterceptorMinValue());
+		svc.registerInterceptor(new MyTestInterceptorOne());
+
+		// Test
+		List<Object> globalInterceptors = svc.getGlobalInterceptorsForUnitTest();
+		assertThat(globalInterceptors).hasSize(2);
+		assertInstanceOf(MyTestInterceptorMinValue.class, globalInterceptors.get(0), globalInterceptors.get(0).getClass().toString());
+		assertInstanceOf(MyTestInterceptorOne.class, globalInterceptors.get(1), globalInterceptors.get(1).getClass().toString());
+	}
+
+	@Test
 	void testInvokeGlobalInterceptorMethods() {
 		InterceptorService svc = new InterceptorService();
 
@@ -790,6 +804,24 @@ class InterceptorServiceTest {
 		@Hook(Pointcut.INTERCEPTOR_REGISTERED)
 		void registered();
 
+	}
+
+	@Interceptor(order = Integer.MIN_VALUE)
+	public class MyTestInterceptorMinValue {
+
+		private String myLastString0;
+		private boolean myNextReturn = true;
+
+		public MyTestInterceptorMinValue() {
+			super();
+		}
+
+		@Hook(Pointcut.TEST_RB)
+		public boolean testRb(String theString0) {
+			myLastString0 = theString0;
+			myInvocations.add("MyTestInterceptorMinValue.testRb");
+			return myNextReturn;
+		}
 	}
 
 	@Interceptor(order = 100)


### PR DESCRIPTION
Comparison of `@Interceptor` and `@Hook` order values can no longer cause integer overflow and lead to incorrect order when the difference between them overflows int range (e.g., Integer.MIN_VALUE - 100)

This fixes https://github.com/hapifhir/hapi-fhir/issues/7630