### PR TITLE
GL-7767: Fix OOM during $reindex with chained reference SearchParameters in Lucene/ES mode

### DIFF
--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorServiceTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorServiceTest.java
@@ -76,36 +76,50 @@ public class SearchParamExtractorServiceTest {
 	}
 
 	/**
-	 * Test that findMatchingResourceLink handles null values from targetResourceIdMap.get() without throwing NPE.
-	 * This scenario occurs when a ResourceLink's targetResourcePk is not present in the map.
+	 * GL-7767: Test that findMatchingResourceLink handles null values from
+	 * targetResourceIdMap.get() without throwing NPE. This scenario occurs during
+	 * $reindex when a ResourceLink's targetResourcePk is present in the link but
+	 * NOT present in the translated ID map (e.g., chained reference SearchParameter
+	 * like Consent.organization.identifier).
+	 *
+	 * Before the fix (HAPI v8.8.0, commit ebca61d28f5), calling .isPresent() on a
+	 * null return from Map.get() caused an NPE that crashed the reindex batch job.
 	 */
-	// Created by Claude Sonnet 4.5
+	// Created by claude-opus-4-6
 	@Test
-	void testFindMatchingResourceLink_whenTargetResourceIdMapReturnsNull_shouldNotThrowNPE() throws Exception {
+	void testFindMatchingResourceLink_whenTargetPidNotInMap_returnsEmptyWithoutNPE() throws Exception {
 		// Setup
 		FhirContext ctx = FhirContext.forR4();
 		SearchParamExtractorService svc = new SearchParamExtractorService();
 		svc.setContextForUnitTest(ctx);
 		svc.setIdHelperServiceForUnitTest(myIdHelperService);
 
-		// Create PathAndRef with a reference to Patient/123
-		Reference reference = new Reference("Patient/123");
-		PathAndRef pathAndRef = new PathAndRef("member", "Group.member.entity", reference, false);
+		// Create PathAndRef referencing Organization/456
+		Reference reference = new Reference("Organization/456");
+		PathAndRef pathAndRef = new PathAndRef("organization", "Consent.organization", reference, false);
 
-		// Create a ResourceLink with a target PID that won't be in the map
-		ResourceTable table = new ResourceTable();
-		table.setResourceType("Group");
-		table.setId(JpaPid.fromId(123L));
-		ResourceLink resourceLink = ResourceLink.forLogicalReference("Group.member.entity", table,
-			"http://example.com", Date.from(Instant.now()));
+		// Create a ResourceLink with targetResourcePk=999 (a PID that will NOT be in the map)
+		ResourceTable sourceTable = new ResourceTable();
+		sourceTable.setResourceType("Consent");
+		sourceTable.setId(JpaPid.fromId(1L));
+		ResourceLink resourceLink = ResourceLink.forLocalReference(
+			ResourceLink.ResourceLinkForLocalReferenceParams.instance()
+				.setSourcePath("Consent.organization")
+				.setSourceResource(sourceTable)
+				.setTargetResourceType("Organization")
+				.setTargetResourcePid(999L)
+				.setTargetResourceId("456")
+				.setUpdated(Date.from(Instant.now())));
 
 		List<ResourceLink> existingResourceLinks = new ArrayList<>();
 		existingResourceLinks.add(resourceLink);
 
-		// Create a map that contains a different PID, so our lookup returns null
+		// Mock translatePidsToForcedIds to return a map that does NOT contain PID 999
+		// Map.get() for a missing key returns null — this is the bug trigger
 		Map<JpaPid, Optional<String>> idMap = new HashMap<>();
-		JpaPid differentPid = JpaPid.fromId(888L);
-		idMap.put(differentPid, Optional.of("Patient/888"));
+		// Map is intentionally empty for PID 999
+		PersistentIdToForcedIdMap<JpaPid> persistentIdMap = new PersistentIdToForcedIdMap<>(idMap);
+		when(myIdHelperService.translatePidsToForcedIds(any())).thenReturn(persistentIdMap);
 
 		// Use reflection to call the private method
 		Method method = SearchParamExtractorService.class.getDeclaredMethod(
@@ -115,11 +129,112 @@ public class SearchParamExtractorServiceTest {
 		);
 		method.setAccessible(true);
 
-		// Execute - should not throw NullPointerException
+		// Execute — should return empty Optional, NOT throw NullPointerException
 		Optional<ResourceLink> result = unsafeCast(method.invoke(svc, pathAndRef, existingResourceLinks));
 
-		// Verify - should return empty Optional since no match was found
+		// Verify
 		assertThat(result).isEmpty();
+	}
+
+	/**
+	 * Adjacent test: When targetResourcePk IS present in the map but with Optional.empty()
+	 * (no forced ID), the ID comparison is skipped and no match is found.
+	 * This tests the code path at lines 860-864 where idPartOpt.isPresent() is false.
+	 */
+	// Created by claude-opus-4-6
+	@Test
+	void testFindMatchingResourceLink_whenTargetPidInMapWithEmptyOptional_returnsEmpty() throws Exception {
+		// Setup
+		FhirContext ctx = FhirContext.forR4();
+		SearchParamExtractorService svc = new SearchParamExtractorService();
+		svc.setContextForUnitTest(ctx);
+		svc.setIdHelperServiceForUnitTest(myIdHelperService);
+
+		// Create PathAndRef referencing Organization/456
+		Reference reference = new Reference("Organization/456");
+		PathAndRef pathAndRef = new PathAndRef("organization", "Consent.organization", reference, false);
+
+		// Create a ResourceLink with targetResourcePk=999 that IS in the map
+		ResourceTable sourceTable = new ResourceTable();
+		sourceTable.setResourceType("Consent");
+		sourceTable.setId(JpaPid.fromId(1L));
+		ResourceLink resourceLink = ResourceLink.forLocalReference(
+			ResourceLink.ResourceLinkForLocalReferenceParams.instance()
+				.setSourcePath("Consent.organization")
+				.setSourceResource(sourceTable)
+				.setTargetResourceType("Organization")
+				.setTargetResourcePid(999L)
+				.setTargetResourceId("456")
+				.setUpdated(Date.from(Instant.now())));
+
+		List<ResourceLink> existingResourceLinks = new ArrayList<>();
+		existingResourceLinks.add(resourceLink);
+
+		// Mock translatePidsToForcedIds to return a map with PID 999 mapped to Optional.empty()
+		JpaPid targetPid = JpaPid.fromId(999L);
+		Map<JpaPid, Optional<String>> idMap = new HashMap<>();
+		idMap.put(targetPid, Optional.empty());
+		PersistentIdToForcedIdMap<JpaPid> persistentIdMap = new PersistentIdToForcedIdMap<>(idMap);
+		when(myIdHelperService.translatePidsToForcedIds(any())).thenReturn(persistentIdMap);
+
+		// Use reflection to call the private method
+		Method method = SearchParamExtractorService.class.getDeclaredMethod(
+			"findMatchingResourceLink",
+			PathAndRef.class,
+			Collection.class
+		);
+		method.setAccessible(true);
+
+		// Execute — should return empty because idPartOpt.isPresent() is false,
+		// so hasMatchingResourceId stays false
+		Optional<ResourceLink> result = unsafeCast(method.invoke(svc, pathAndRef, existingResourceLinks));
+
+		// Verify
+		assertThat(result).isEmpty();
+	}
+
+	/**
+	 * Adjacent test: When all ResourceLinks have null targetResourcePk (e.g., logical
+	 * references only), the pids set is empty and the method should return empty
+	 * without calling translatePidsToForcedIds.
+	 */
+	// Created by claude-opus-4-6
+	@Test
+	void testFindMatchingResourceLink_whenAllLinksHaveNullPk_returnsEmpty() throws Exception {
+		// Setup
+		FhirContext ctx = FhirContext.forR4();
+		SearchParamExtractorService svc = new SearchParamExtractorService();
+		svc.setContextForUnitTest(ctx);
+		svc.setIdHelperServiceForUnitTest(myIdHelperService);
+
+		// Create PathAndRef referencing Organization/456
+		Reference reference = new Reference("Organization/456");
+		PathAndRef pathAndRef = new PathAndRef("organization", "Consent.organization", reference, false);
+
+		// Create a ResourceLink via forLogicalReference — no targetResourcePk
+		ResourceTable sourceTable = new ResourceTable();
+		sourceTable.setResourceType("Consent");
+		sourceTable.setId(JpaPid.fromId(1L));
+		ResourceLink resourceLink = ResourceLink.forLogicalReference(
+			"Consent.organization", sourceTable, "http://example.com/Organization/456", Date.from(Instant.now()));
+
+		List<ResourceLink> existingResourceLinks = new ArrayList<>();
+		existingResourceLinks.add(resourceLink);
+
+		// Use reflection to call the private method
+		Method method = SearchParamExtractorService.class.getDeclaredMethod(
+			"findMatchingResourceLink",
+			PathAndRef.class,
+			Collection.class
+		);
+		method.setAccessible(true);
+
+		// Execute — should return empty because pids set is empty (early return)
+		Optional<ResourceLink> result = unsafeCast(method.invoke(svc, pathAndRef, existingResourceLinks));
+
+		// Verify — empty result and translatePidsToForcedIds was never called
+		assertThat(result).isEmpty();
+		verify(myIdHelperService, times(0)).translatePidsToForcedIds(any());
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
WIP: Resolving GL-7767 — OOM during $reindex when lucene.enabled=true and chained reference SearchParameters (e.g. Consent.organization.identifier) are present. Root cause: TransactionDetails resolved resource cache accumulates unboundedly during extractSearchIndexParametersForUpliftedRefchains().