### PR TITLE
Add heap to snapshot build

### DIFF
--- a/snapshot-deploy-job.yml
+++ b/snapshot-deploy-job.yml
@@ -16,6 +16,8 @@ jobs:
       - group: GPG_VARIABLE_GROUP
       - group: CENTRAL_VARIABLE_GROUP
       - group: SLACK_VARIABLE_GROUP
+      - name: MAVEN_OPTS
+        value: ''
 
     container:
       image: smilecdr/hapi-build:latest
@@ -86,12 +88,11 @@ jobs:
       # 5. Deploy SNAPSHOT build to sonatype
       - task: Maven@4
         displayName: 'Deploy to Maven Central staging'
-        env:
-          MAVEN_OPTS: "-Xmx2048m -XX:+UseG1GC"
         inputs:
           mavenPomFile: '$(System.DefaultWorkingDirectory)/pom.xml'
           goals: deploy
           options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -P DIST -DskipTests -DdeployToCentral --batch-mode --no-transfer-progress --threads 1C --fail-at-end -Dstyle.color=never '
+          mavenOptions: '-Xmx2048m -XX:+UseG1GC $(MAVEN_OPTS)'
           publishJUnitResults: false
 
       # 6. Notify Slack if the deploy failed


### PR DESCRIPTION
The Maven@4 task ignores the MAVEN_OPTS env var in favor of its own mavenOptions input (which defaults to -Xmx1024m). Move heap settings into mavenOptions directly, matching the pattern used in release-pipeline.yml.