### PR TITLE
`PointcutLatch` causes cascading test failures

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7664-fix-pointcut-latch-cascading-failure.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7664-fix-pointcut-latch-cascading-failure.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7664
+title: "Fixed PointcutLatch to avoid cascade test failures by no longer throwing immediately
+when invoke() is called outside of a session. Unexpected invocations are now collected
+silently and surfaced as an AssertionError on the test thread when clear() is called."

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/test/concurrency/PointcutLatch.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/test/concurrency/PointcutLatch.java
@@ -30,8 +30,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,7 +46,7 @@ public class PointcutLatch implements IAnonymousInterceptor, IPointcutLatch {
 	private boolean myStrict = true;
 	private final AtomicLong myLastInvoke = new AtomicLong();
 	private int myDefaultTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
-	private final List<PointcutLatchException> myUnexpectedInvocations = new ArrayList<>();
+	private final List<PointcutLatchException> myUnexpectedInvocations = new CopyOnWriteArrayList<>();
 	private final AtomicReference<PointcutLatchSession> myPointcutLatchSession = new AtomicReference<>();
 
 	public PointcutLatch(IPointcut thePointcut) {
@@ -80,6 +80,7 @@ public class PointcutLatch implements IAnonymousInterceptor, IPointcutLatch {
 	}
 
 	public void setExpectedCount(int theCount, boolean theExactMatch) {
+		checkExceptions();
 		if (myPointcutLatchSession.get() != null) {
 			String previousStack = myPointcutLatchSession.get().getStackTrace();
 			throw new PointcutLatchException(Msg.code(1480) + "setExpectedCount() called before previous awaitExpected() completed. Previous set stack:\n" + previousStack, myName);
@@ -133,7 +134,6 @@ public class PointcutLatch implements IAnonymousInterceptor, IPointcutLatch {
 	@Override
 	public void clear() {
 		ourLog.debug("Clearing latch {}", getName());
-		checkExceptions();
 		myPointcutLatchSession.set(null);
 		myUnexpectedInvocations.clear();
 	}
@@ -143,7 +143,7 @@ public class PointcutLatch implements IAnonymousInterceptor, IPointcutLatch {
 			return;
 		}
 
-		if (myUnexpectedInvocations.size() > 0) {
+		if (!myUnexpectedInvocations.isEmpty()) {
 			PointcutLatchException firstException = myUnexpectedInvocations.get(0);
 			int size = myUnexpectedInvocations.size();
 			if (firstException != null) {
@@ -156,16 +156,14 @@ public class PointcutLatch implements IAnonymousInterceptor, IPointcutLatch {
 	public void invoke(IPointcut thePointcut, HookParams theArgs) {
 		myLastInvoke.set(System.currentTimeMillis());
 
-		try {
-			PointcutLatchSession session = myPointcutLatchSession.get();
-			if (session == null) {
-				throw new PointcutLatchException(Msg.code(1485) + "invoke() called outside of setExpectedCount() .. awaitExpected().  Probably got more invocations than expected or clear() was called before invoke().", myName, theArgs);
-			}
-			session.invoke(theArgs);
-		} catch (PointcutLatchException e) {
+		PointcutLatchSession session = myPointcutLatchSession.get();
+		if (session == null) {
+			PointcutLatchException e =  new PointcutLatchException(Msg.code(1485) + "invoke() called outside of setExpectedCount() .. awaitExpected().  Probably got more invocations than expected or clear() was called before invoke().", myName, theArgs);
 			myUnexpectedInvocations.add(e);
-			throw e;
+			ourLog.error(e.getMessage(), e);
+			return;
 		}
+		session.invoke(theArgs);
 	}
 
 	public void call(Object arg) {

--- a/hapi-fhir-test-utilities/src/test/java/ca/uhn/test/concurrency/PointcutLatchTest.java
+++ b/hapi-fhir-test-utilities/src/test/java/ca/uhn/test/concurrency/PointcutLatchTest.java
@@ -1,10 +1,14 @@
 package ca.uhn.test.concurrency;
 
+import ca.uhn.fhir.interceptor.api.HookParams;
+import ca.uhn.fhir.interceptor.api.Pointcut;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -23,7 +27,6 @@ class PointcutLatchTest {
 	@AfterEach
 	void after() {
 		myPointcutLatch.clear();
-		myPointcutLatch.setStrict(true);
 	}
 
 	@Test
@@ -81,18 +84,6 @@ class PointcutLatchTest {
 	}
 
 	@Test
-	public void testInvokeCalledBeforeExpect() {
-		try {
-			invoke();
-			fail();
-		} catch (PointcutLatchException e) {
-			assertThat(e.getMessage()).startsWith(TEST_LATCH_NAME + ": HAPI-1485: invoke() called outside of setExpectedCount() .. awaitExpected().  Probably got more invocations than expected or clear() was called before invoke().");
-		}
-		// Don't blow up in the clear() called by @AfterEach
-		myPointcutLatch.setStrict(false);
-	}
-
-	@Test
 	public void testDoubleInvokeInexact() throws InterruptedException {
 		myPointcutLatch.setExpectedCount(1, false);
 		invoke();
@@ -113,24 +104,164 @@ class PointcutLatchTest {
 		}
 	}
 
+	// --- cascade-avoidance tests: invoke() outside a session never throws immediately ---
+
 	@Test
-	public void testInvokeThenClear() throws ExecutionException, InterruptedException {
-		Future<Thread> future = myExecutorService.submit(this::invoke);
+	void testInvokeCalledBeforeExpect_DoesNotThrowImmediately() {
+		// invoke() outside a session must NOT throw — the error is deferred to setExpectedCount()
+		invoke();
+
+		assertThat(myPointcutLatch.getLastInvoke()).isPositive();
+		// @AfterEach clear() is safe since clear() no longer throws
+	}
+
+	@Test
+	void testInvokeCalledBeforeExpect_ClearDoesNotThrow() {
+		invoke();
+
+		// clear() must NOT throw — error is deferred to the next setExpectedCount()
+		myPointcutLatch.clear();
+
+		assertThat(myPointcutLatch.isSet()).isFalse();
+	}
+
+	@Test
+	void testInvokeCalledBeforeExpect_ErrorSurfacedAtNextSetExpectedCount() {
+		invoke(); // unexpected invocation stored; clear() NOT called so it survives to setExpectedCount()
+
 		try {
-			future.get();
-		} catch (ExecutionException e) {
-			// This is the exception thrown on the invocation thread
-			assertThat(e.getMessage()).startsWith("ca.uhn.test.concurrency.PointcutLatchException: " + TEST_LATCH_NAME + ": HAPI-1485: invoke() called outside of setExpectedCount() .. awaitExpected().  Probably got more invocations than expected or clear() was called before invoke().");
-		}
-		try {
-			myPointcutLatch.clear();
+			myPointcutLatch.setExpectedCount(1);
+			fail();
 		} catch (AssertionError e) {
-			// This is the exception the test thread gets
 			assertThat(e.getMessage()).startsWith("HAPI-2344: " + TEST_LATCH_NAME + " PointcutLatch had 1 exceptions.  Throwing first one.");
 		}
+		// @AfterEach clear() handles cleanup
+	}
 
-		// Don't blow up in the clear() called by @AfterEach
+	@Test
+	void testInvokeInAsyncThread_DoesNotPropagateExceptionToAsyncThread()
+			throws ExecutionException, InterruptedException {
+		Future<Thread> future = myExecutorService.submit(this::invoke);
+
+		// future.get() must NOT throw ExecutionException — the async thread must complete normally
+		Thread asyncThread = future.get();
+		assertThat(asyncThread).isNotEqualTo(Thread.currentThread());
+
+		// error surfaces at next setExpectedCount() — clear() NOT called so invocation survives
+		try {
+			myPointcutLatch.setExpectedCount(1);
+			fail();
+		} catch (AssertionError e) {
+			assertThat(e.getMessage()).startsWith("HAPI-2344: " + TEST_LATCH_NAME + " PointcutLatch had 1 exceptions.  Throwing first one.");
+		}
+		// @AfterEach clear() handles cleanup
+	}
+
+	// --- constructor, convenience methods, and utility coverage ---
+
+	@Test
+	void testConstructorWithIPointcut() {
+		PointcutLatch latch = new PointcutLatch(Pointcut.SERVER_INCOMING_REQUEST_PRE_HANDLED);
+		assertThat(latch.toString()).contains(Pointcut.SERVER_INCOMING_REQUEST_PRE_HANDLED.name());
+	}
+
+	@Test
+	void testRunWithExpectedCount() throws InterruptedException {
+		myPointcutLatch.runWithExpectedCount(1, this::invoke);
+		// no exception means set, invoke, and await all succeeded
+		assertThat(myPointcutLatch.isSet()).isFalse();
+	}
+
+	@Test
+	void testSetDefaultTimeoutSeconds_AffectsAwaitExpected() throws InterruptedException {
+		myPointcutLatch.setDefaultTimeoutSeconds(1);
+		myPointcutLatch.setExpectedCount(1);
+		// invoke never called — should timeout using the 1s default
+		try {
+			myPointcutLatch.awaitExpected();
+			fail();
+		} catch (LatchTimedOutError e) {
+			assertThat(e.getMessage()).contains("timed out waiting 1 seconds");
+		}
+	}
+
+	@Test
+	void testSetExpectAtLeast_AllowsMoreInvocationsThanExpected() throws InterruptedException {
+		myPointcutLatch.setExpectAtLeast(1);
+		invoke();
+		invoke(); // second invoke should not cause failure
+		myPointcutLatch.awaitExpected();
+	}
+
+	@Test
+	void testSetStrictFalse_SuppressesUnexpectedInvocationError() throws InterruptedException {
 		myPointcutLatch.setStrict(false);
+		invoke(); // unexpected — but strict=false so checkExceptions() is a no-op
+
+		// setExpectedCount must succeed despite pending unexpected invocation
+		myPointcutLatch.setExpectedCount(1);
+		invoke();
+		myPointcutLatch.awaitExpected();
+	}
+
+	@Test
+	void testToString_ContainsName() {
+		assertThat(myPointcutLatch.toString()).contains(TEST_LATCH_NAME);
+	}
+
+	@Test
+	void testGetLatchInvocationParameter_ReturnsSingleArg() throws InterruptedException {
+		myPointcutLatch.setExpectedCount(1);
+		String payload = "test-payload";
+		myPointcutLatch.call(payload);
+		List<HookParams> hookParams = myPointcutLatch.awaitExpected();
+
+		assertThat(PointcutLatch.getLatchInvocationParameter(hookParams)).isEqualTo(payload);
+	}
+
+	@Test
+	void testGetLatchInvocationParameter_ByIndex() throws InterruptedException {
+		myPointcutLatch.setExpectedCount(2);
+		myPointcutLatch.call("first");
+		myPointcutLatch.call("second");
+		List<HookParams> hookParams = myPointcutLatch.awaitExpected();
+
+		assertThat(PointcutLatch.getLatchInvocationParameter(hookParams, 0)).isEqualTo("first");
+		assertThat(PointcutLatch.getLatchInvocationParameter(hookParams, 1)).isEqualTo("second");
+	}
+
+	@Test
+	void testGetInvocationParameterOfType_ReturnsTypedArg() throws InterruptedException {
+		myPointcutLatch.setExpectedCount(1);
+		String payload = "typed-payload";
+		myPointcutLatch.call(payload);
+		List<HookParams> hookParams = myPointcutLatch.awaitExpected();
+
+		String result = PointcutLatch.getInvocationParameterOfType(hookParams, String.class);
+		assertThat(result).isEqualTo(payload);
+	}
+
+	@Test
+	void testConcurrentUnexpectedInvocations_AllRecorded()
+			throws ExecutionException, InterruptedException {
+		// Invoke from multiple threads concurrently outside a session.
+		// CopyOnWriteArrayList must not lose or corrupt any entries.
+		ExecutorService pool = Executors.newFixedThreadPool(4);
+		List<Future<Thread>> futures = new ArrayList<>();
+		for (int i = 0; i < 4; i++) {
+			futures.add(pool.submit(this::invoke));
+		}
+		for (Future<Thread> f : futures) {
+			f.get(); // must not throw ExecutionException
+		}
+		pool.shutdown();
+
+		try {
+			myPointcutLatch.setExpectedCount(1);
+			fail();
+		} catch (AssertionError e) {
+			assertThat(e.getMessage()).contains("had 4 exceptions");
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes #7664 