### PR TITLE
Support standard FHIR concept properties in ValueSet filter expansion

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContext.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContext.java
@@ -3,6 +3,8 @@ package org.hl7.fhir.common.hapi.validation.support;
 import ca.uhn.fhir.util.FhirVersionIndependentConcept;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.ValueSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -19,14 +21,20 @@ import java.util.regex.PatternSyntaxException;
 
 /**
  * Class to apply ValueSet filters during in-memory expansion.
- * Will only work on 'code', 'concept' and 'display' property types.
+ * Will only work on 'code', 'concept', 'display', and the standard FHIR concept properties
+ * ('child', 'parent', 'inactive', 'notSelectable').
  *
  * Supports: equal | is-a | descendent-of | is-not-a | regex | in | not-in | generalizes | child-of | descendent-leaf | exists
  */
 public class ValueSetExpansionFilterContext {
+	private static final Logger ourLog = LoggerFactory.getLogger(ValueSetExpansionFilterContext.class);
+
 	private final Map<String, Map<String, String>> propertyIndex = new HashMap<>();
 
 	private final Map<String, Set<String>> conceptCodeTree = new HashMap<>();
+	private final Set<String> conceptsWithParent = new HashSet<>();
+	private final Set<String> inactiveCodes = new HashSet<>();
+	private final Set<String> notSelectableCodes = new HashSet<>();
 	private final Set<String> allCodes = new HashSet<>();
 	private final Set<String> allCodesLower = new HashSet<>();
 	private final Map<String, Set<String>> inSetsMap = new HashMap<>();
@@ -66,18 +74,47 @@ public class ValueSetExpansionFilterContext {
 					filter.hasProperty() ? filter.getProperty().toLowerCase(Locale.ROOT) : "concept";
 			boolean onCode = theFilterProperty.equals("concept") || theFilterProperty.equals("code");
 			boolean onDisplay = theFilterProperty.equals("display");
+			boolean onChild = theFilterProperty.equals("child");
+			boolean onParent = theFilterProperty.equals("parent");
+			boolean onInactive = theFilterProperty.equals("inactive");
+			boolean onNotSelectable = theFilterProperty.equals("notselectable");
 
-			/**
-			 * Only code/display supported in the in-memory validation support, so reject any custom concept properties,
-			 * even though that should technically be supported by the FHIR spec.
-			 *
-			 * @see <a href="https://build.fhir.org/codesystem.html#properties">
-			 *      FHIR CodeSystem Concept Properties (4.8.11)</a>
-			 * @see <a href="https://build.fhir.org/codesystem.html#defined-props">
-			 *      FHIR CodeSystem Defined Concept Properties (4.8.12)</a>
-			 */
+			// Handle standard FHIR concept properties (child, parent, inactive, notSelectable).
+			// These are structural/boolean in nature, so only EXISTS is meaningful in-memory.
+			// For any other operator, pass through rather than silently filtering everything out.
+			if (onChild || onParent || onInactive || onNotSelectable) {
+				if (filter.getOp() != org.hl7.fhir.r5.model.Enumerations.FilterOperator.EXISTS) {
+					ourLog.warn(
+							"In-memory ValueSet expansion does not support operator '{}' for property '{}'; filter will be ignored.",
+							filter.getOp().toCode(),
+							filter.getProperty());
+					return true;
+				}
+				boolean wantExists = Boolean.parseBoolean(filter.getValue());
+				String theConceptCode = concept.getCode();
+				if (onChild) {
+					return wantExists
+							== !conceptCodeTree
+									.getOrDefault(theConceptCode, Collections.emptySet())
+									.isEmpty();
+				}
+				if (onParent) {
+					return wantExists == conceptsWithParent.contains(theConceptCode);
+				}
+				if (onInactive) {
+					return wantExists == inactiveCodes.contains(theConceptCode);
+				}
+				// onNotSelectable
+				return wantExists == notSelectableCodes.contains(theConceptCode);
+			}
+
+			// For unrecognized properties, pass through with a warning rather than silently producing
+			// an empty ValueSet expansion when an unsupported-but-valid filter is encountered.
 			if (!onCode && !onDisplay) {
-				return false;
+				ourLog.warn(
+						"In-memory ValueSet expansion does not support property '{}'; filter will be ignored.",
+						filter.getProperty());
+				return true;
 			}
 
 			String theFilterValue = filter.getValue();
@@ -316,6 +353,7 @@ public class ValueSetExpansionFilterContext {
 			// 2) Index immediate children
 			for (var child : def.getConcept()) {
 				conceptCodeTree.computeIfAbsent(code, k -> new HashSet<>()).add(child.getCode());
+				conceptsWithParent.add(child.getCode());
 			}
 
 			// 3) Index the "code" property
@@ -324,7 +362,17 @@ public class ValueSetExpansionFilterContext {
 			// 4) Index the "display" property
 			propertyIndex.computeIfAbsent("display", k -> new HashMap<>()).put(code, display);
 
-			// 5) Recurse
+			// 5) Index standard boolean concept properties
+			for (var prop : def.getProperty()) {
+				String propCode = prop.getCode();
+				if ("inactive".equals(propCode) && prop.hasValueBooleanType()) {
+					inactiveCodes.add(code);
+				} else if ("notSelectable".equals(propCode) && prop.hasValueBooleanType()) {
+					notSelectableCodes.add(code);
+				}
+			}
+
+			// 6) Recurse
 			buildIndexes(def.getConcept());
 		}
 	}

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContextTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValueSetExpansionFilterContextTest.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.common.hapi.validation.support;
 
 import ca.uhn.fhir.util.FhirVersionIndependentConcept;
+import org.hl7.fhir.r5.model.BooleanType;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.Enumerations.FilterOperator;
 import org.hl7.fhir.r5.model.ValueSet;
@@ -234,15 +235,15 @@ class ValueSetExpansionFilterContextTest {
 	}
 
 	@Test
-	void unsupportedPropertyYieldsEmpty() {
+	void testUnknownPropertyPassesThrough() {
 		CodeSystem cs = flatCodeSystem(false, "A", "B");
 		ValueSet.ConceptSetFilterComponent f = new ValueSet.ConceptSetFilterComponent()
-			.setProperty("severity")   // not code/display
+			.setProperty("severity")   // not code/display/any known standard property
 			.setOp(FilterOperator.EQUAL)
 			.setValue("A");
 		boolean filtered = new ValueSetExpansionFilterContext(cs, List.of(f))
 			.isFiltered(new FhirVersionIndependentConcept(cs.getUrl(), "A"));
-		assertThat(filtered).isTrue();  // always filtered out
+		assertThat(filtered).isFalse();  // passes through rather than silently emptying the ValueSet
 	}
 
 
@@ -567,6 +568,88 @@ class ValueSetExpansionFilterContextTest {
 			.as("DESCENDENT-LEAF[%s] on code '%s' (caseSensitive=%b)",
 				filterValue, testCode, caseSensitive)
 			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[child-exists] wantExists={0}, code={1} ⇒ filtered={2}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+			// wantExists | code | expectedIsFiltered
+			"false | P  | true",   // P has children → child exists → filtered when wantExists=false
+			"false | C1 | true",   // C1 has child C2 → filtered
+			"false | C2 | false",  // C2 is a leaf → child does not exist → not filtered
+			"false | C3 | false",  // C3 is a leaf → not filtered
+			"true  | P  | false",  // P has children → not filtered when wantExists=true
+			"true  | C1 | false",  // C1 has children → not filtered
+			"true  | C2 | true",   // C2 is leaf → filtered when wantExists=true
+			"true  | C3 | true",   // C3 is leaf → filtered
+		})
+	void testChildPropertyExistsFilter(boolean wantExists, String code, boolean expectedIsFiltered) {
+		CodeSystem cs = hierarchicalCS(false);
+		boolean actual = isFilteredWithProperty(
+			cs, "child", FilterOperator.EXISTS, Boolean.toString(wantExists),
+			new FhirVersionIndependentConcept(cs.getUrl(), code));
+		assertThat(actual)
+			.as("child exists %s on code '%s'", wantExists, code)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@ParameterizedTest(name = "[parent-exists] wantExists={0}, code={1} ⇒ filtered={2}")
+	@CsvSource(
+		delimiter = '|',
+		value = {
+			// wantExists | code | expectedIsFiltered
+			"false | P  | false",  // P is root, has no parent → not filtered
+			"false | C1 | true",   // C1 has parent P → filtered
+			"false | C2 | true",   // C2 has parent C1 → filtered
+			"false | C3 | true",   // C3 has parent P → filtered
+			"true  | P  | true",   // P is root → filtered when wantExists=true
+			"true  | C1 | false",  // C1 has a parent → not filtered
+			"true  | C2 | false",
+			"true  | C3 | false",
+		})
+	void testParentPropertyExistsFilter(boolean wantExists, String code, boolean expectedIsFiltered) {
+		CodeSystem cs = hierarchicalCS(false);
+		boolean actual = isFilteredWithProperty(
+			cs, "parent", FilterOperator.EXISTS, Boolean.toString(wantExists),
+			new FhirVersionIndependentConcept(cs.getUrl(), code));
+		assertThat(actual)
+			.as("parent exists %s on code '%s'", wantExists, code)
+			.isEqualTo(expectedIsFiltered);
+	}
+
+	@Test
+	void testInactivePropertyExistsFilter() {
+		CodeSystem cs = new CodeSystem().setUrl("http://example.org/cs").setCaseSensitive(true);
+		cs.addConcept().setCode("ACTIVE");
+		cs.addConcept().setCode("INACTIVE")
+			.addProperty().setCode("inactive").setValue(new BooleanType(true));
+
+		assertThat(isFilteredWithProperty(cs, "inactive", FilterOperator.EXISTS, "true",
+			new FhirVersionIndependentConcept(cs.getUrl(), "INACTIVE"))).isFalse();
+		assertThat(isFilteredWithProperty(cs, "inactive", FilterOperator.EXISTS, "true",
+			new FhirVersionIndependentConcept(cs.getUrl(), "ACTIVE"))).isTrue();
+		assertThat(isFilteredWithProperty(cs, "inactive", FilterOperator.EXISTS, "false",
+			new FhirVersionIndependentConcept(cs.getUrl(), "ACTIVE"))).isFalse();
+		assertThat(isFilteredWithProperty(cs, "inactive", FilterOperator.EXISTS, "false",
+			new FhirVersionIndependentConcept(cs.getUrl(), "INACTIVE"))).isTrue();
+	}
+
+	@Test
+	void testNotSelectablePropertyExistsFilter() {
+		CodeSystem cs = new CodeSystem().setUrl("http://example.org/cs").setCaseSensitive(true);
+		cs.addConcept().setCode("SELECTABLE");
+		cs.addConcept().setCode("NOT_SELECTABLE")
+			.addProperty().setCode("notSelectable").setValue(new BooleanType(true));
+
+		assertThat(isFilteredWithProperty(cs, "notSelectable", FilterOperator.EXISTS, "true",
+			new FhirVersionIndependentConcept(cs.getUrl(), "NOT_SELECTABLE"))).isFalse();
+		assertThat(isFilteredWithProperty(cs, "notSelectable", FilterOperator.EXISTS, "true",
+			new FhirVersionIndependentConcept(cs.getUrl(), "SELECTABLE"))).isTrue();
+		assertThat(isFilteredWithProperty(cs, "notSelectable", FilterOperator.EXISTS, "false",
+			new FhirVersionIndependentConcept(cs.getUrl(), "SELECTABLE"))).isFalse();
+		assertThat(isFilteredWithProperty(cs, "notSelectable", FilterOperator.EXISTS, "false",
+			new FhirVersionIndependentConcept(cs.getUrl(), "NOT_SELECTABLE"))).isTrue();
 	}
 
 	@ParameterizedTest(name = "[exists] cs={0}, property={1}, want={2}, code={3} ⇒ filtered={4}")


### PR DESCRIPTION
Fixes: #7667
  - Handle 'child exists' filter to include/exclude leaf concepts
  - Handle 'parent exists' filter to include/exclude root concepts
  - Handle 'inactive exists' and 'notSelectable exists' filters
  - Pass through unknown properties with a warning instead of silently producing an empty ValueSet