### PR TITLE
fix(7683): meta.versionId was also stale for resources in Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -1889,7 +1889,7 @@ public enum Pointcut implements IPointcut {
 	 * </p>
 	 * Hooks may accept the following parameters:
 	 * <ul>
-	 * <li>org.hl7.fhir.instance.model.api.IBaseResource - The resource being deleted</li>
+	 * <li>org.hl7.fhir.instance.model.api.IBaseResource - The resource being deleted. Its idElement, meta.versionId, and meta.lastUpdated will reflect the version and time of deletion, but all other content reflects the state prior to deletion.</li>
 	 * <li>
 	 * ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is about to be processed, including details such as the
 	 * resource type and logical ID (if any) and other FHIR-specific aspects of the request which have been

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7683-stale-lastupdated-in-precommit-deleted-pointcut.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7683-stale-lastupdated-in-precommit-deleted-pointcut.yaml
@@ -1,7 +1,0 @@
----
-type: fix
-issue: 7683
-title: "Previously, the resource provided in Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED had an updated versionId reflecting the new deleted version, 
-        but a meta.lastUpdated value reflecting the last modification before the delete. 
-        Now meta.lastUpdated correctly reflects the time of deletion, matching the versionId. 
-        Fix submitted by Tue Toft Nørgård (@ttnTrifork)"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7683-stale-meta-data-in-precommit-deleted-pointcut.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7683-stale-meta-data-in-precommit-deleted-pointcut.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7683
+title: "Previously, the resource provided in Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED had an updated idElement.versionId reflecting the new deleted version, 
+        but a meta.versionId and meta.lastUpdated value reflecting the version and last modification before the delete. 
+        Now meta.versionId and meta.lastUpdated correctly reflect the version and time of deletion, matching the idElement.versionId. 
+        Fix submitted by Tue Toft Nørgård (@ttnTrifork)"

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -881,6 +881,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		IIdType idBeforeDelete = new IdDt(resourceToDelete.getIdElement());
 		resourceToDelete.setId(entity.getIdDt());
 		resourceToDelete.getMeta().setLastUpdated(savedEntity.getUpdatedDate());
+		resourceToDelete.getMeta().setVersionId(savedEntity.getIdDt().getVersionIdPart());
 
 		// Notify JPA interceptors
 		HookParams hookParams = new HookParams()
@@ -1072,6 +1073,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			IdType oldVersionId = new IdType(entity.getIdDt().getValue());
 			resourceToDelete.setId(entity.getIdDt());
 			resourceToDelete.getMeta().setLastUpdated(entity.getUpdatedDate());
+			resourceToDelete.getMeta().setVersionId(entity.getIdDt().getVersionIdPart());
 
 			// Notify JPA interceptors
 			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4DeleteTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4DeleteTest.java
@@ -13,6 +13,7 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
+import org.hl7.fhir.instance.model.api.IBaseMetaType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -285,56 +285,60 @@ public class FhirResourceDaoR4DeleteTest extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void testDeletedResourceInPrecommitHookHasCorrectLastUpdated() {
+	public void testDeletedResourceInPrecommitHookHasCorrectMetaData() {
 		// Setup - create a patient
 		Patient p = new Patient();
 		p.setActive(true);
 		IIdType id = myPatientDao.create(p, mySrd).getId().toUnqualifiedVersionless();
 
 		// Register interceptor to capture the resource from the PRECOMMIT hook
-		AtomicReference<Date> hookLastUpdated = new AtomicReference<>();
+		AtomicReference<IBaseMetaType> hookMeta = new AtomicReference<>();
 		myInterceptorRegistry.registerAnonymousInterceptor(
 			Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED, (thePointcut, theParams) -> {
 				IBaseResource resource = theParams.get(IBaseResource.class, 0);
-				hookLastUpdated.set(resource.getMeta().getLastUpdated());
+				hookMeta.set(resource.getMeta());
 			});
 
 		// Test - delete the patient
 		myPatientDao.delete(id, mySrd);
 
-		// Verify - the hook resource's lastUpdated should match the DB entity
-		assertNotNull(hookLastUpdated.get(), "Hook should have captured lastUpdated");
+		// Verify - the hook resource's meta data should match the DB entity
+		assertNotNull(hookMeta.get(), "Hook should have captured Meta element");
 		runInTransaction(() -> {
 			ResourceTable entity = myResourceTableDao.findById(id.getIdPartAsLong()).orElseThrow();
-			assertEquals(entity.getUpdatedDate(), hookLastUpdated.get(),
-				"Resource lastUpdated in STORAGE_PRECOMMIT_RESOURCE_DELETED hook should match the entity's updated timestamp in the DB");
+			assertEquals(entity.getIdDt().getVersionIdPart(), hookMeta.get().getVersionId(),
+				"Resource meta.versionId in STORAGE_PRECOMMIT_RESOURCE_DELETED hook should match the entity's updated version id in the DB");
+			assertEquals(entity.getUpdatedDate(), hookMeta.get().getLastUpdated(),
+				"Resource meta.lastUpdated in STORAGE_PRECOMMIT_RESOURCE_DELETED hook should match the entity's updated timestamp in the DB");
 		});
 	}
 
 	@Test
-	void testDeleteByUrl_PrecommitHookHasCorrectLastUpdated() {
+	void testDeleteByUrl_PrecommitHookHasCorrectMetaData() {
 		// Setup - create a patient with a searchable attribute
 		Patient p = new Patient();
 		p.setActive(true);
 		IIdType id = myPatientDao.create(p, mySrd).getId().toUnqualifiedVersionless();
 
 		// Register interceptor to capture the resource from the PRECOMMIT hook
-		AtomicReference<Date> hookLastUpdated = new AtomicReference<>();
+		AtomicReference<IBaseMetaType> hookMeta = new AtomicReference<>();
 		myInterceptorRegistry.registerAnonymousInterceptor(
 			Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED, (thePointcut, theParams) -> {
 				IBaseResource resource = theParams.get(IBaseResource.class, 0);
-				hookLastUpdated.set(resource.getMeta().getLastUpdated());
+				hookMeta.set(resource.getMeta());
 			});
 
 		// Test - delete by URL (triggers deletePidList path)
 		myPatientDao.deleteByUrl("Patient?active=true", mySrd);
 
-		// Verify - the hook resource's lastUpdated should match the DB entity
-		assertNotNull(hookLastUpdated.get(), "Hook should have captured lastUpdated");
+		// Verify - the hook resource's meta data should match the DB entity
+		assertNotNull(hookMeta.get(), "Hook should have captured Meta element");
 		runInTransaction(() -> {
 			ResourceTable entity = myResourceTableDao.findById(id.getIdPartAsLong()).orElseThrow();
-			assertEquals(entity.getUpdatedDate(), hookLastUpdated.get(),
-				"Resource lastUpdated in STORAGE_PRECOMMIT_RESOURCE_DELETED hook should match the entity's updated timestamp in the DB");
+			assertEquals(entity.getIdDt().getVersionIdPart(), hookMeta.get().getVersionId(),
+				"Resource meta.versionId in STORAGE_PRECOMMIT_RESOURCE_DELETED hook should match the entity's updated version id in the DB");
+			assertEquals(entity.getUpdatedDate(), hookMeta.get().getLastUpdated(),
+				"Resource meta.lastUpdated in STORAGE_PRECOMMIT_RESOURCE_DELETED hook should match the entity's updated timestamp in the DB");
 		});
 	}
 }


### PR DESCRIPTION
meta.versionId for resources in Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED now also correctly reflects the versionId of the deletion, matching the idElement.versionId

This is a continuation of PR #7683 in response to additional findings on issue https://github.com/hapifhir/hapi-fhir/issues/7683#issuecomment-4111602754