### PR TITLE
Fix PatientIdPartitionInterceptor to include default partition for NON_UNIQUE_COMPARTMENT_IN_DEFAULT (#7699)

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7699-patientid-interceptor-nonunique-default-partition.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7699-patientid-interceptor-nonunique-default-partition.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7699
+title: "There was a bug where PatientIdPartitionInterceptor did not include the default partition when
+  searching for resources with NON_UNIQUE_COMPARTMENT_IN_DEFAULT policy, causing resources stored in the
+  default partition (due to referencing multiple patients) to be missed during searches. This has been fixed."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -79,6 +79,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Propagation;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -97,6 +100,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Import({PatientIdPartitionInterceptorR4Test.TestConfig.class, TestDaoSearch.Config.class})
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4Test {
+	// Captures the contents between parentheses in a "PARTITION_ID IN (...)" SQL clause
+	private static final Pattern PARTITION_ID_IN_PATTERN = Pattern.compile("PARTITION_ID IN \\(([^)]+)\\)");
 	public static final int ALTERNATE_DEFAULT_ID = -1;
 	public static final int PATIENT_A_COMPARTMENT_ID = 65;
 
@@ -422,7 +427,7 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 			MANDATORY_SINGLE_COMPARTMENT      , 65                , FAIL             , true                     , 65
 			ALWAYS_USE_PARTITION_ID/5         , 5                 , 5                , true                     , 5
 			NON_UNIQUE_COMPARTMENT_IN_DEFAULT , 65                , -1               , false                    , ALL
-			NON_UNIQUE_COMPARTMENT_IN_DEFAULT , 65                , -1               , true                     , 65
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT , 65                , -1               , true                     , '65,-1'
 			""")
 	void testResourceTypePolicies_PatientCompartmentResource(String thePolicyString, int thePatientSpecificDocRefCompartmentId, String theDocRefNoPatientCompartmentString, boolean theIncludePatientIdInSearch, String theExpectedSearchPartitionString) {
 		/*
@@ -480,7 +485,16 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 			assertTrue(searchQuery.getRequestPartitionId().isAllPartitions());
 			assertThat(searchQuery.getSql(true, true)).doesNotContain("PARTITION_ID =");
 			assertThat(searchQuery.getSql(true, true)).doesNotContain("PARTITION_ID IN");
+		} else if (theExpectedSearchPartitionString.contains(",")) {
+			// Multiple expected partitions — verify PARTITION_ID IN (...) clause
+			List<Integer> expectedPartitions = Arrays.stream(theExpectedSearchPartitionString.split(","))
+				.map(String::trim)
+				.map(Integer::parseInt)
+				.toList();
+			assertThat(searchQuery.getRequestPartitionId().getPartitionIds()).containsExactlyInAnyOrderElementsOf(expectedPartitions);
+			assertThat(parseMultiplePartitionIdsFromSqlInClause(searchQuery.getSql(true, true))).containsExactlyInAnyOrderElementsOf(expectedPartitions);
 		} else {
+			// Single expected partition — verify PARTITION_ID = ... clause
 			int partition = Integer.parseInt(theExpectedSearchPartitionString);
 			assertThat(searchQuery.getRequestPartitionId().getPartitionIds()).containsExactly(partition);
 			assertThat(searchQuery.getSql(true, true)).containsAnyOf(
@@ -1093,6 +1107,19 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 			ResourceTable table = myResourceTableDao.findByTypeAndFhirId(theResourceId.getResourceType(), theResourceId.getIdPart()).orElseThrow();
 			assertEquals(theExpectedPartitionId, Objects.requireNonNull(table.getPartitionId().getPartitionId()).intValue());
 		});
+	}
+
+	/**
+	 * Extracts partition IDs from a PARTITION_ID IN (...) clause in a SQL string.
+	 */
+	private List<Integer> parseMultiplePartitionIdsFromSqlInClause(String theSql) {
+		Matcher matcher = PARTITION_ID_IN_PATTERN.matcher(theSql);
+		assertThat(matcher.find()).as("Expected PARTITION_ID IN (...) in SQL: " + theSql).isTrue();
+		return Arrays.stream(matcher.group(1).split(","))
+			.map(String::trim)
+			.map(s -> s.replace("'", ""))
+			.map(Integer::parseInt)
+			.toList();
 	}
 
 	private int getResourcePartition(IIdType theResourceId) {

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesTestHelper.java
@@ -122,10 +122,7 @@ public class ReplaceReferencesTestHelper {
 	public List<IBaseResource> searchProvenance(IIdType theTargetId) {
 		SearchParameterMap map = new SearchParameterMap();
 		map.add("target", new ReferenceParam(theTargetId.toUnqualifiedVersionless()));
-		// Use all-partitions request to find Provenance regardless of which partition it's stored in.
-		// In patient-id partitioning mode with NON_UNIQUE_COMPARTMENT_IN_DEFAULT policy, merge Provenance
-		// referencing multiple patients is stored in the default partition, not a patient-specific partition.
-		IBundleProvider searchBundle = myProvenanceDao.search(map, SystemRequestDetails.forAllPartitions());
+		IBundleProvider searchBundle = myProvenanceDao.search(map, mySrd);
 		return searchBundle.getAllResources();
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -406,7 +406,20 @@ public class PatientIdPartitionInterceptor {
 							List<String> idParts = getResourceIdsForSearchParam(params, paramName);
 							if (!idParts.isEmpty()) {
 								ResourceCompartmentStoragePolicy policy = getPolicyForResourceType(theReadDetails);
-								return provideMultipleCompartmentPartition(theRequestDetails, idParts);
+								RequestPartitionId partitionId =
+										provideMultipleCompartmentPartition(theRequestDetails, idParts);
+								// If the policy defines a non-unique compartment partition (e.g.
+								// NON_UNIQUE_COMPARTMENT_IN_DEFAULT uses the default partition), include
+								// it in the search. A resource could live in the patient's partition
+								// (single-patient reference) or the non-unique compartment partition
+								// (multi-patient reference), so we need to search both.
+								Optional<RequestPartitionId> nonUniqueCompartmentPartition =
+										policy.getPartitionIdForNonUniqueCompartment(myPartitionSettings);
+								if (nonUniqueCompartmentPartition.isPresent()) {
+									partitionId =
+											nonUniqueCompartmentPartition.get().mergeIds(partitionId);
+								}
+								return partitionId;
 							}
 						}
 					}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
@@ -31,7 +31,6 @@ import ca.uhn.fhir.rest.api.SortOrderEnum;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.util.FhirTerser;
 import jakarta.annotation.Nullable;
@@ -238,10 +237,7 @@ public class ReplaceReferencesProvenanceSvc {
 		// we want the most recent one.
 		map.setSort(new SortSpec("recorded", SortOrderEnum.DESC));
 
-		// TODO: PatientIdPartitionInterceptor should be returning the default partition as a part of
-		// the response when Provenance has policy `NON_UNIQUE_COMPARTMENT_IN_DEFAULT`. It doesn't
-		// currently. We shouldn't hardcode allPartitions once we fix that.
-		IBundleProvider searchBundle = myProvenanceDao.search(map, SystemRequestDetails.forAllPartitions());
+		IBundleProvider searchBundle = myProvenanceDao.search(map, theRequestDetails);
 		// 'activity' is not available as a search parameter in r4, was added in r5,
 		// so we need to filter the results manually.
 		return filterByActivity(searchBundle.getAllResources());


### PR DESCRIPTION
Fixes #7699

## Summary
- There was a bug where PatientIdPartitionInterceptor.identifyForRead did not include the default partition when searching for resources with NON_UNIQUE_COMPARTMENT_IN_DEFAULT policy. Resources stored in the default partition (due to referencing multiple patients, e.g., merge Provenance) were missed during searches.
- The fix merges the non-unique compartment partition (default partition) into the search partition set when the policy allows it.
- Removed the forAllPartitions() workarounds in ReplaceReferencesProvenanceSvc and ReplaceReferencesTestHelper that were bypassing the interceptor.