### PR TITLE
GL-8591: Fix cross-version package dependency resolution

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
@@ -76,6 +76,7 @@ page.server_jpa.fhir_patch=FHIR Patch
 page.server_jpa.lastn=LastN Operation
 page.server_jpa.elastic=Lucene/Elasticsearch Indexing
 page.server_jpa.terminology=Terminology
+page.server_jpa.packages=FHIR Package Registry
 page.server_jpa.ips=International Patient Summary (IPS)
 
 chapter.server_jpa_mdm.title=JPA Server: MDM

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/packages.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/packages.md
@@ -1,0 +1,70 @@
+# FHIR Package Registry
+
+The HAPI FHIR JPA Server includes a built-in FHIR package registry that supports uploading and managing FHIR NPM packages, also known as FHIR Implementation Guides (IGs). Packages stored in the registry are automatically made available to the built-in [Instance Validator](../validation/instance_validator.html) so that resources can be validated against custom profiles without any additional configuration.
+
+# Uploading Packages
+
+Packages can be uploaded to the JPA server using the FHIR package registry REST API:
+
+```http
+PUT [base]/Package/[id]/$package
+Content-Type: application/tar+gzip
+
+[binary package content]
+```
+
+HAPI FHIR also supports uploading packages directly from the [FHIR NPM package registry](https://packages.fhir.org) using the `PackageInstallationSpec` API in Java:
+
+```java
+PackageInstallationSpec spec = new PackageInstallationSpec()
+    .setName("hl7.fhir.us.core")
+    .setVersion("7.0.0")
+    .setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL)
+    .setFetchDependencies(true);
+
+myPackageInstallerSvc.install(spec);
+```
+
+# Fetching Transitive Dependencies
+
+When `setFetchDependencies(true)` is set on the `PackageInstallationSpec`, the installer recursively fetches and installs all transitive dependencies declared in each package's `package.json` file. Dependencies are resolved from the local package cache first, then fetched from the [packages.fhir.org](https://packages.fhir.org) registry if not found locally.
+
+# Cross-Version Package Dependencies
+
+Some FHIR packages are designed to work across multiple FHIR versions. For example, `hl7.fhir.uv.extensions` is a cross-version extensions package that declares FHIR version `5.0.0` in its package metadata, even though it is commonly used as a dependency of R4 Implementation Guides.
+
+When the JPA server is running in R4 mode and `fetchDependencies=true` is enabled, the package installer performs **automatic version-specific substitution** for cross-version dependencies:
+
+1. After loading a transitive dependency, the installer compares the dependency's declared FHIR version against the server's FHIR version.
+2. If the versions are incompatible, the installer attempts to load a version-specific variant of the package by appending a FHIR version suffix to the package ID:
+
+| Server FHIR Version | Suffix applied |
+|---------------------|----------------|
+| R4 or R4B           | `.r4`          |
+| R5                  | `.r5`          |
+| DSTU3               | `.r3`          |
+
+3. For example, if an R4 server encounters a dependency on `hl7.fhir.uv.extensions` (which declares FHIR 5.0.0), the installer automatically attempts to load `hl7.fhir.uv.extensions.r4` at the same version.
+4. If the version-specific variant is found in the local cache or on packages.fhir.org, it is substituted for the original dependency and installation continues.
+5. If the variant cannot be found, a warning is logged and installation continues with the original package, which may produce a version compatibility error.
+
+This behavior avoids installation failures caused by cross-version packages that are declared as FHIR 5.0.0 but have an R4-specific counterpart available on the package registry.
+
+<p class="doc_info_bubble">
+<b>Note:</b> The substitution is attempted silently. If a version-specific variant does not exist on the package registry, the server falls back to the original (incompatible-version) package and logs a warning. Installation may still succeed if the package content is otherwise compatible, but a version mismatch error will be raised if the contents are genuinely incompatible.
+</p>
+
+# Version Compatibility Checking
+
+When a package is installed, the server verifies that the package's declared FHIR version is compatible with the server's running FHIR version. If the versions are incompatible and no version-specific variant is available, the installation will fail with an error (HAPI-1288).
+
+The following version pairs are treated as compatible:
+
+* R4 and R4B are treated as compatible with each other (both are considered `R4`-family).
+* All other version combinations are treated as incompatible and will trigger the cross-version substitution logic described above.
+
+# Using Installed Packages for Validation
+
+Once a package is installed, its conformance resources (StructureDefinitions, ValueSets, CodeSystems, etc.) are stored in the JPA server database and automatically included in the validation support chain. No additional configuration is needed to validate against profiles from installed packages.
+
+See [Validating Using Packages](../validation/instance_validator.html#packages) for details on how validation uses package content.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -62,7 +62,6 @@ import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
-import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -403,19 +402,12 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		String dependencyFhirVersion = theDependency.fhirVersion();
 		String serverFhirVersion = myFhirContext.getVersion().getVersion().getFhirVersionString();
 
-		FhirVersionEnum dependencyVersionEnum = FhirVersionEnum.forVersionString(dependencyFhirVersion);
-		FhirVersionEnum serverVersionEnum = FhirVersionEnum.forVersionString(serverFhirVersion);
-
-		if (dependencyVersionEnum == null || serverVersionEnum == null) {
+		if (areFhirVersionsCompatible(dependencyFhirVersion, serverFhirVersion)) {
 			return theDependency;
 		}
 
-		boolean versionsAreCompatible = dependencyVersionEnum.equals(serverVersionEnum);
-		if (!versionsAreCompatible && dependencyFhirVersion.startsWith("R4") && serverFhirVersion.startsWith("R4")) {
-			versionsAreCompatible = true;
-		}
-
-		if (versionsAreCompatible) {
+		FhirVersionEnum serverVersionEnum = FhirVersionEnum.forVersionString(serverFhirVersion);
+		if (serverVersionEnum == null) {
 			return theDependency;
 		}
 
@@ -481,20 +473,34 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 	protected void assertFhirVersionsAreCompatible(String fhirVersion, String currentFhirVersion)
 			throws ImplementationGuideInstallationException {
 
-		FhirVersionEnum fhirVersionEnum = FhirVersionEnum.forVersionString(fhirVersion);
-		FhirVersionEnum currentFhirVersionEnum = FhirVersionEnum.forVersionString(currentFhirVersion);
-		Validate.notNull(fhirVersionEnum, "Invalid FHIR version string: %s", fhirVersion);
-		Validate.notNull(currentFhirVersionEnum, "Invalid FHIR version string: %s", currentFhirVersion);
-		boolean compatible = fhirVersionEnum.equals(currentFhirVersionEnum);
-		if (!compatible && fhirVersion.startsWith("R4") && currentFhirVersion.startsWith("R4")) {
-			compatible = true;
-		}
-		if (!compatible) {
+		if (!areFhirVersionsCompatible(fhirVersion, currentFhirVersion)) {
 			throw new ImplementationGuideInstallationException(Msg.code(1288)
 					+ String.format(
 							"Cannot install implementation guide: FHIR versions mismatch (expected <=%s, package uses %s)",
 							currentFhirVersion, fhirVersion));
 		}
+	}
+
+	/**
+	 * Checks whether two FHIR version strings are compatible. Versions are compatible if they
+	 * resolve to the same {@link FhirVersionEnum}, or if both are in the R4 family (R4 or R4B).
+	 *
+	 * @param theFhirVersion the package's FHIR version string (e.g., "4.0.1", "4.3.0")
+	 * @param theCurrentFhirVersion the server's FHIR version string
+	 * @return {@code true} if the versions are compatible
+	 */
+	private static boolean areFhirVersionsCompatible(String theFhirVersion, String theCurrentFhirVersion) {
+		FhirVersionEnum fhirVersionEnum = FhirVersionEnum.forVersionString(theFhirVersion);
+		FhirVersionEnum currentFhirVersionEnum = FhirVersionEnum.forVersionString(theCurrentFhirVersion);
+		if (fhirVersionEnum == null || currentFhirVersionEnum == null) {
+			return false;
+		}
+		if (fhirVersionEnum.equals(currentFhirVersionEnum)) {
+			return true;
+		}
+		boolean bothR4Family = (fhirVersionEnum == FhirVersionEnum.R4 || fhirVersionEnum == FhirVersionEnum.R4B)
+				&& (currentFhirVersionEnum == FhirVersionEnum.R4 || currentFhirVersionEnum == FhirVersionEnum.R4B);
+		return bothR4Family;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -363,6 +363,11 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 
 						// resolve in local cache or on packages.fhir.org
 						NpmPackage dependency = myPackageCacheManager.loadPackage(id, ver);
+
+						// If the dependency's FHIR version is incompatible with the server,
+						// attempt to load a version-specific variant (e.g., {id}.r4 for R4 servers)
+						dependency = substituteVersionSpecificPackageIfNeeded(dependency, id, ver);
+
 						// recursive call to install dependencies of a package before
 						// installing the package
 						fetchAndInstallDependencies(dependency, theInstallationSpec, theOutcome);
@@ -377,6 +382,95 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 							Msg.code(1287) + String.format("Cannot resolve dependency %s#%s", id, ver), e);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Checks if a dependency package's FHIR version is compatible with the server's FHIR version.
+	 * If incompatible, attempts to load a version-specific variant by appending a FHIR version
+	 * suffix (e.g., ".r4" for R4/R4B servers, ".r5" for R5, ".r3" for DSTU3).
+	 * <p>
+	 * This handles cross-version packages like {@code hl7.fhir.uv.extensions} which declare
+	 * FHIR version 5.0.0 but have R4-specific counterparts like {@code hl7.fhir.uv.extensions.r4}.
+	 *
+	 * @param theDependency the loaded dependency package
+	 * @param theId the package ID
+	 * @param theVersion the package version
+	 * @return the original package if compatible, or the version-specific variant if found
+	 */
+	private NpmPackage substituteVersionSpecificPackageIfNeeded(
+			NpmPackage theDependency, String theId, String theVersion) {
+		String dependencyFhirVersion = theDependency.fhirVersion();
+		String serverFhirVersion = myFhirContext.getVersion().getVersion().getFhirVersionString();
+
+		FhirVersionEnum dependencyVersionEnum = FhirVersionEnum.forVersionString(dependencyFhirVersion);
+		FhirVersionEnum serverVersionEnum = FhirVersionEnum.forVersionString(serverFhirVersion);
+
+		if (dependencyVersionEnum == null || serverVersionEnum == null) {
+			return theDependency;
+		}
+
+		boolean versionsAreCompatible = dependencyVersionEnum.equals(serverVersionEnum);
+		if (!versionsAreCompatible && dependencyFhirVersion.startsWith("R4") && serverFhirVersion.startsWith("R4")) {
+			versionsAreCompatible = true;
+		}
+
+		if (versionsAreCompatible) {
+			return theDependency;
+		}
+
+		String suffix = getVersionSpecificSuffix(serverVersionEnum);
+		if (suffix == null) {
+			return theDependency;
+		}
+
+		String variantId = theId + suffix;
+		ourLog.warn(
+				"Dependency {}#{} declares FHIR version {} which is incompatible with server FHIR version {}. "
+						+ "Attempting to load version-specific variant: {}#{}",
+				theId,
+				theVersion,
+				dependencyFhirVersion,
+				serverFhirVersion,
+				variantId,
+				theVersion);
+
+		try {
+			NpmPackage variant = myPackageCacheManager.loadPackage(variantId, theVersion);
+			ourLog.info(
+					"Successfully substituted {}#{} with version-specific variant {}#{}",
+					theId,
+					theVersion,
+					variantId,
+					theVersion);
+			return variant;
+		} catch (IOException e) {
+			ourLog.warn(
+					"Could not find version-specific variant {}#{}. "
+							+ "Proceeding with original package {}#{} which may fail version compatibility checks.",
+					variantId,
+					theVersion,
+					theId,
+					theVersion);
+			return theDependency;
+		}
+	}
+
+	/**
+	 * Returns the version-specific package suffix for the given FHIR version,
+	 * or {@code null} if no suffix mapping exists.
+	 */
+	private static String getVersionSpecificSuffix(FhirVersionEnum theVersion) {
+		switch (theVersion) {
+			case R4:
+			case R4B:
+				return ".r4";
+			case R5:
+				return ".r5";
+			case DSTU3:
+				return ".r3";
+			default:
+				return null;
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
@@ -76,7 +76,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -488,9 +487,7 @@ public class PackageInstallerSvcImplTest {
 			// When the installer loads the cross-version dep, return the R5 package
 			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
 				.thenReturn(theCrossVersionDep);
-			// FIXME: remove lenient() once the fix makes the code reach this stub
-			lenient()
-				.when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
+			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
 				.thenReturn(theR4Variant);
 
 			PackageInstallationSpec theSpec = new PackageInstallationSpec();
@@ -580,10 +577,6 @@ public class PackageInstallerSvcImplTest {
 		/**
 		 * When a cross-version dependency has no version-specific variant available,
 		 * the installation should still fail with HAPI-1288 — there is no fallback.
-		 * <p>
-		 * Note: The .r4 variant mock uses lenient() because the current code (before
-		 * the fix) throws on the R5 dep before attempting substitution. After the fix,
-		 * the code will try loading the .r4 variant and then fail cleanly.
 		 */
 		@Test
 		void testFetchDependencies_crossVersionDependencyWithNoR4Variant_shouldFail() throws Exception {
@@ -602,9 +595,7 @@ public class PackageInstallerSvcImplTest {
 			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
 			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
 				.thenReturn(theCrossVersionDep);
-			// FIXME: remove lenient() once the fix makes the code reach this stub
-			lenient()
-				.when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
+			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
 				.thenThrow(new IOException("Package not found: " + CROSS_VERSION_R4_PKG_ID));
 
 			PackageInstallationSpec theSpec = new PackageInstallationSpec();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
@@ -459,53 +459,48 @@ public class PackageInstallerSvcImplTest {
 		 * dependency declares FHIR version 5.0.0 (a cross-version package), the installer
 		 * should attempt to load the version-specific variant (e.g., {package}.r4) instead
 		 * of failing with HAPI-1288.
-		 * <p>
-		 * Currently FAILS because fetchAndInstallDependencies() does not perform
-		 * version-specific substitution — it passes the R5 dependency directly to
-		 * install() which calls assertFhirVersionsAreCompatible() and throws.
 		 */
 		@Test
 		void testFetchDependencies_crossVersionDependencyWithR4Variant_shouldSubstituteAndSucceed() throws Exception {
 			// Setup: main R4 package that depends on a cross-version (R5) package
-			NpmPackage theMainPackage = createPackageWithDependency(
+			NpmPackage mainPackage = createPackageWithDependency(
 				MAIN_PKG_ID, MAIN_PKG_VERSION,
 				FhirVersionEnum.R4.getFhirVersionString(),
 				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION);
 
 			// The cross-version dependency declares FHIR version 5.0.0
-			NpmPackage theCrossVersionDep = createSimplePackage(
+			NpmPackage crossVersionDep = createSimplePackage(
 				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION,
 				FhirVersionEnum.R5.getFhirVersionString());
 
 			// The R4-specific variant that should be substituted
-			NpmPackage theR4Variant = createSimplePackage(
+			NpmPackage r4Variant = createSimplePackage(
 				CROSS_VERSION_R4_PKG_ID, CROSS_VERSION_PKG_VERSION,
 				FhirVersionEnum.R4.getFhirVersionString());
 
 			when(myPackageVersionDao.findByPackageIdAndVersion(any(), any())).thenReturn(Optional.empty());
-			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
+			when(myPackageCacheManager.installPackage(any())).thenReturn(mainPackage);
 			// When the installer loads the cross-version dep, return the R5 package
 			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
-				.thenReturn(theCrossVersionDep);
+				.thenReturn(crossVersionDep);
 			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
-				.thenReturn(theR4Variant);
+				.thenReturn(r4Variant);
 
-			PackageInstallationSpec theSpec = new PackageInstallationSpec();
-			theSpec.setName(MAIN_PKG_ID);
-			theSpec.setVersion(MAIN_PKG_VERSION);
-			theSpec.setFetchDependencies(true);
-			theSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
-			ByteArrayOutputStream theStream = new ByteArrayOutputStream();
-			theMainPackage.save(theStream);
-			theSpec.setPackageContents(theStream.toByteArray());
+			PackageInstallationSpec spec = new PackageInstallationSpec();
+			spec.setName(MAIN_PKG_ID);
+			spec.setVersion(MAIN_PKG_VERSION);
+			spec.setFetchDependencies(true);
+			spec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+			ByteArrayOutputStream stream = new ByteArrayOutputStream();
+			mainPackage.save(stream);
+			spec.setPackageContents(stream.toByteArray());
 
 			// Test: install should succeed by substituting the .r4 variant
-			// Currently FAILS with HAPI-1288 because no substitution logic exists
-			PackageInstallOutcomeJson theOutcome = mySvc.install(theSpec);
+			PackageInstallOutcomeJson outcome = mySvc.install(spec);
 
 			// Verify: the installation completed without error
-			assertThat(theOutcome).isNotNull();
-			assertThat(theOutcome.getMessage()).isNotEmpty();
+			assertThat(outcome).isNotNull();
+			assertThat(outcome.getMessage()).isNotEmpty();
 		}
 
 		/**
@@ -515,22 +510,19 @@ public class PackageInstallerSvcImplTest {
 		 */
 		@Test
 		void testAssertFhirVersionsAreCompatible_r5PackageOnR4Server_throwsHapi1288() {
-			String theR5Version = FhirVersionEnum.R5.getFhirVersionString();
-			String theR4Version = FhirVersionEnum.R4.getFhirVersionString();
+			String r5Version = FhirVersionEnum.R5.getFhirVersionString();
+			String r4Version = FhirVersionEnum.R4.getFhirVersionString();
 
-			assertThatThrownBy(() -> mySvc.assertFhirVersionsAreCompatible(theR5Version, theR4Version))
+			assertThatThrownBy(() -> mySvc.assertFhirVersionsAreCompatible(r5Version, r4Version))
 				.isInstanceOf(ImplementationGuideInstallationException.class)
 				.hasMessageContaining("HAPI-1288");
 		}
 
 		/**
 		 * Regression guard: R4 and R4B versions must remain compatible.
-		 * The assertFhirVersionsAreCompatible method uses startsWith("R4") on
-		 * the raw string arguments — this works when the caller passes enum-style
-		 * names like "R4" and "R4B" (as the existing testPackageCompatibility does).
-		 * Note: the actual NpmPackage.fhirVersion() returns version strings like "4.0.1"
-		 * and "4.3.0", NOT enum names, so the startsWith("R4") fallback does not apply
-		 * in the real dependency-fetching code path.
+		 * Both enum-style names ("R4", "R4B") and numeric version strings ("4.0.1", "4.3.0")
+		 * are resolved via {@link FhirVersionEnum#forVersionString} and then compared using
+		 * the R4-family check in {@code areFhirVersionsCompatible}.
 		 */
 		@Test
 		void testAssertFhirVersionsAreCompatible_r4AndR4b_areCompatible() {
@@ -547,30 +539,30 @@ public class PackageInstallerSvcImplTest {
 		@Test
 		void testFetchDependencies_excludedCrossVersionDep_shouldBeSkipped() throws Exception {
 			// Setup: main R4 package that depends on a cross-version (R5) package
-			NpmPackage theMainPackage = createPackageWithDependency(
+			NpmPackage mainPackage = createPackageWithDependency(
 				MAIN_PKG_ID, MAIN_PKG_VERSION,
 				FhirVersionEnum.R4.getFhirVersionString(),
 				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION);
 
 			when(myPackageVersionDao.findByPackageIdAndVersion(any(), any())).thenReturn(Optional.empty());
-			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
+			when(myPackageCacheManager.installPackage(any())).thenReturn(mainPackage);
 
-			PackageInstallationSpec theSpec = new PackageInstallationSpec();
-			theSpec.setName(MAIN_PKG_ID);
-			theSpec.setVersion(MAIN_PKG_VERSION);
-			theSpec.setFetchDependencies(true);
-			theSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+			PackageInstallationSpec spec = new PackageInstallationSpec();
+			spec.setName(MAIN_PKG_ID);
+			spec.setVersion(MAIN_PKG_VERSION);
+			spec.setFetchDependencies(true);
+			spec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
 			// Exclude the cross-version dependency by regex
-			theSpec.addDependencyExclude("hl7\\.fhir\\.uv\\.extensions");
-			ByteArrayOutputStream theStream = new ByteArrayOutputStream();
-			theMainPackage.save(theStream);
-			theSpec.setPackageContents(theStream.toByteArray());
+			spec.addDependencyExclude("hl7\\.fhir\\.uv\\.extensions");
+			ByteArrayOutputStream stream = new ByteArrayOutputStream();
+			mainPackage.save(stream);
+			spec.setPackageContents(stream.toByteArray());
 
 			// Test: install should succeed because the problematic dep is excluded
-			PackageInstallOutcomeJson theOutcome = mySvc.install(theSpec);
+			PackageInstallOutcomeJson outcome = mySvc.install(spec);
 
 			// Verify: installation completed and the dep was never loaded
-			assertThat(theOutcome).isNotNull();
+			assertThat(outcome).isNotNull();
 			verify(myPackageCacheManager, never()).loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION));
 		}
 
@@ -581,34 +573,34 @@ public class PackageInstallerSvcImplTest {
 		@Test
 		void testFetchDependencies_crossVersionDependencyWithNoR4Variant_shouldFail() throws Exception {
 			// Setup: main R4 package that depends on a cross-version (R5) package
-			NpmPackage theMainPackage = createPackageWithDependency(
+			NpmPackage mainPackage = createPackageWithDependency(
 				MAIN_PKG_ID, MAIN_PKG_VERSION,
 				FhirVersionEnum.R4.getFhirVersionString(),
 				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION);
 
 			// The cross-version dependency declares FHIR version 5.0.0
-			NpmPackage theCrossVersionDep = createSimplePackage(
+			NpmPackage crossVersionDep = createSimplePackage(
 				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION,
 				FhirVersionEnum.R5.getFhirVersionString());
 
 			when(myPackageVersionDao.findByPackageIdAndVersion(any(), any())).thenReturn(Optional.empty());
-			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
+			when(myPackageCacheManager.installPackage(any())).thenReturn(mainPackage);
 			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
-				.thenReturn(theCrossVersionDep);
+				.thenReturn(crossVersionDep);
 			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
 				.thenThrow(new IOException("Package not found: " + CROSS_VERSION_R4_PKG_ID));
 
-			PackageInstallationSpec theSpec = new PackageInstallationSpec();
-			theSpec.setName(MAIN_PKG_ID);
-			theSpec.setVersion(MAIN_PKG_VERSION);
-			theSpec.setFetchDependencies(true);
-			theSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
-			ByteArrayOutputStream theStream = new ByteArrayOutputStream();
-			theMainPackage.save(theStream);
-			theSpec.setPackageContents(theStream.toByteArray());
+			PackageInstallationSpec spec = new PackageInstallationSpec();
+			spec.setName(MAIN_PKG_ID);
+			spec.setVersion(MAIN_PKG_VERSION);
+			spec.setFetchDependencies(true);
+			spec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+			ByteArrayOutputStream stream = new ByteArrayOutputStream();
+			mainPackage.save(stream);
+			spec.setPackageContents(stream.toByteArray());
 
 			// Test: install should fail because no .r4 variant is available
-			assertThatThrownBy(() -> mySvc.install(theSpec))
+			assertThatThrownBy(() -> mySvc.install(spec))
 				.isInstanceOf(ImplementationGuideInstallationException.class)
 				.hasMessageContaining("HAPI-1288");
 		}
@@ -617,25 +609,25 @@ public class PackageInstallerSvcImplTest {
 		private NpmPackage createPackageWithDependency(
 				String theName, String theVersion, String theFhirVersion,
 				String theDepName, String theDepVersion) {
-			PackageGenerator theManifest = new PackageGenerator();
-			theManifest.name(theName);
-			theManifest.version(theVersion);
-			theManifest.description("a test package");
-			theManifest.fhirVersions(List.of(theFhirVersion));
-			theManifest.dependency(theDepName, theDepVersion);
+			PackageGenerator manifest = new PackageGenerator();
+			manifest.name(theName);
+			manifest.version(theVersion);
+			manifest.description("a test package");
+			manifest.fhirVersions(List.of(theFhirVersion));
+			manifest.dependency(theDepName, theDepVersion);
 
-			return NpmPackage.empty(theManifest);
+			return NpmPackage.empty(manifest);
 		}
 
 		@Nonnull
 		private NpmPackage createSimplePackage(String theName, String theVersion, String theFhirVersion) {
-			PackageGenerator theManifest = new PackageGenerator();
-			theManifest.name(theName);
-			theManifest.version(theVersion);
-			theManifest.description("a test package");
-			theManifest.fhirVersions(List.of(theFhirVersion));
+			PackageGenerator manifest = new PackageGenerator();
+			manifest.name(theName);
+			manifest.version(theVersion);
+			manifest.description("a test package");
+			manifest.fhirVersions(List.of(theFhirVersion));
 
-			return NpmPackage.empty(theManifest);
+			return NpmPackage.empty(manifest);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
@@ -62,6 +62,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -69,10 +70,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -438,6 +442,210 @@ public class PackageInstallerSvcImplTest {
 		Communication communication = new Communication();
 		communication.setStatus(theCommunicationStatus);
 		return communication;
+	}
+
+	@Nested
+	class CrossVersionDependencyTest {
+
+		private static final String CROSS_VERSION_PKG_ID = "hl7.fhir.uv.extensions";
+		private static final String CROSS_VERSION_PKG_VERSION = "5.1.0-snapshot1";
+		private static final String CROSS_VERSION_R4_PKG_ID = "hl7.fhir.uv.extensions.r4";
+		private static final String MAIN_PKG_ID = "hl7.fhir.us.core";
+		private static final String MAIN_PKG_VERSION = "8.0.1";
+
+		/**
+		 * Primary reproduction test for GL-8591.
+		 * <p>
+		 * When an R4 server installs an IG with fetchDependencies=true and a transitive
+		 * dependency declares FHIR version 5.0.0 (a cross-version package), the installer
+		 * should attempt to load the version-specific variant (e.g., {package}.r4) instead
+		 * of failing with HAPI-1288.
+		 * <p>
+		 * Currently FAILS because fetchAndInstallDependencies() does not perform
+		 * version-specific substitution — it passes the R5 dependency directly to
+		 * install() which calls assertFhirVersionsAreCompatible() and throws.
+		 */
+		@Test
+		void testFetchDependencies_crossVersionDependencyWithR4Variant_shouldSubstituteAndSucceed() throws Exception {
+			// Setup: main R4 package that depends on a cross-version (R5) package
+			NpmPackage theMainPackage = createPackageWithDependency(
+				MAIN_PKG_ID, MAIN_PKG_VERSION,
+				FhirVersionEnum.R4.getFhirVersionString(),
+				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION);
+
+			// The cross-version dependency declares FHIR version 5.0.0
+			NpmPackage theCrossVersionDep = createSimplePackage(
+				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION,
+				FhirVersionEnum.R5.getFhirVersionString());
+
+			// The R4-specific variant that should be substituted
+			NpmPackage theR4Variant = createSimplePackage(
+				CROSS_VERSION_R4_PKG_ID, CROSS_VERSION_PKG_VERSION,
+				FhirVersionEnum.R4.getFhirVersionString());
+
+			when(myPackageVersionDao.findByPackageIdAndVersion(any(), any())).thenReturn(Optional.empty());
+			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
+			// When the installer loads the cross-version dep, return the R5 package
+			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
+				.thenReturn(theCrossVersionDep);
+			// FIXME: remove lenient() once the fix makes the code reach this stub
+			lenient()
+				.when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
+				.thenReturn(theR4Variant);
+
+			PackageInstallationSpec theSpec = new PackageInstallationSpec();
+			theSpec.setName(MAIN_PKG_ID);
+			theSpec.setVersion(MAIN_PKG_VERSION);
+			theSpec.setFetchDependencies(true);
+			theSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+			ByteArrayOutputStream theStream = new ByteArrayOutputStream();
+			theMainPackage.save(theStream);
+			theSpec.setPackageContents(theStream.toByteArray());
+
+			// Test: install should succeed by substituting the .r4 variant
+			// Currently FAILS with HAPI-1288 because no substitution logic exists
+			PackageInstallOutcomeJson theOutcome = mySvc.install(theSpec);
+
+			// Verify: the installation completed without error
+			assertThat(theOutcome).isNotNull();
+			assertThat(theOutcome.getMessage()).isNotEmpty();
+		}
+
+		/**
+		 * When assertFhirVersionsAreCompatible is called with R5 version (5.0.0) and
+		 * R4 version (4.0.1), it should throw HAPI-1288. This is the CORRECT behavior —
+		 * genuinely incompatible versions must be rejected.
+		 */
+		@Test
+		void testAssertFhirVersionsAreCompatible_r5PackageOnR4Server_throwsHapi1288() {
+			String theR5Version = FhirVersionEnum.R5.getFhirVersionString();
+			String theR4Version = FhirVersionEnum.R4.getFhirVersionString();
+
+			assertThatThrownBy(() -> mySvc.assertFhirVersionsAreCompatible(theR5Version, theR4Version))
+				.isInstanceOf(ImplementationGuideInstallationException.class)
+				.hasMessageContaining("HAPI-1288");
+		}
+
+		/**
+		 * Regression guard: R4 and R4B versions must remain compatible.
+		 * The assertFhirVersionsAreCompatible method uses startsWith("R4") on
+		 * the raw string arguments — this works when the caller passes enum-style
+		 * names like "R4" and "R4B" (as the existing testPackageCompatibility does).
+		 * Note: the actual NpmPackage.fhirVersion() returns version strings like "4.0.1"
+		 * and "4.3.0", NOT enum names, so the startsWith("R4") fallback does not apply
+		 * in the real dependency-fetching code path.
+		 */
+		@Test
+		void testAssertFhirVersionsAreCompatible_r4AndR4b_areCompatible() {
+			// Using the enum name strings — this is what the existing test does
+			// and how the R4↔R4B compatibility path is exercised
+			mySvc.assertFhirVersionsAreCompatible("R4", "R4B");
+			mySvc.assertFhirVersionsAreCompatible("R4B", "R4");
+		}
+
+		/**
+		 * When a cross-version dependency is excluded via dependencyExcludes, it should
+		 * be skipped entirely — no version check, no substitution needed.
+		 */
+		@Test
+		void testFetchDependencies_excludedCrossVersionDep_shouldBeSkipped() throws Exception {
+			// Setup: main R4 package that depends on a cross-version (R5) package
+			NpmPackage theMainPackage = createPackageWithDependency(
+				MAIN_PKG_ID, MAIN_PKG_VERSION,
+				FhirVersionEnum.R4.getFhirVersionString(),
+				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION);
+
+			when(myPackageVersionDao.findByPackageIdAndVersion(any(), any())).thenReturn(Optional.empty());
+			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
+
+			PackageInstallationSpec theSpec = new PackageInstallationSpec();
+			theSpec.setName(MAIN_PKG_ID);
+			theSpec.setVersion(MAIN_PKG_VERSION);
+			theSpec.setFetchDependencies(true);
+			theSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+			// Exclude the cross-version dependency by regex
+			theSpec.addDependencyExclude("hl7\\.fhir\\.uv\\.extensions");
+			ByteArrayOutputStream theStream = new ByteArrayOutputStream();
+			theMainPackage.save(theStream);
+			theSpec.setPackageContents(theStream.toByteArray());
+
+			// Test: install should succeed because the problematic dep is excluded
+			PackageInstallOutcomeJson theOutcome = mySvc.install(theSpec);
+
+			// Verify: installation completed and the dep was never loaded
+			assertThat(theOutcome).isNotNull();
+			verify(myPackageCacheManager, never()).loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION));
+		}
+
+		/**
+		 * When a cross-version dependency has no version-specific variant available,
+		 * the installation should still fail with HAPI-1288 — there is no fallback.
+		 * <p>
+		 * Note: The .r4 variant mock uses lenient() because the current code (before
+		 * the fix) throws on the R5 dep before attempting substitution. After the fix,
+		 * the code will try loading the .r4 variant and then fail cleanly.
+		 */
+		@Test
+		void testFetchDependencies_crossVersionDependencyWithNoR4Variant_shouldFail() throws Exception {
+			// Setup: main R4 package that depends on a cross-version (R5) package
+			NpmPackage theMainPackage = createPackageWithDependency(
+				MAIN_PKG_ID, MAIN_PKG_VERSION,
+				FhirVersionEnum.R4.getFhirVersionString(),
+				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION);
+
+			// The cross-version dependency declares FHIR version 5.0.0
+			NpmPackage theCrossVersionDep = createSimplePackage(
+				CROSS_VERSION_PKG_ID, CROSS_VERSION_PKG_VERSION,
+				FhirVersionEnum.R5.getFhirVersionString());
+
+			when(myPackageVersionDao.findByPackageIdAndVersion(any(), any())).thenReturn(Optional.empty());
+			when(myPackageCacheManager.installPackage(any())).thenReturn(theMainPackage);
+			when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
+				.thenReturn(theCrossVersionDep);
+			// FIXME: remove lenient() once the fix makes the code reach this stub
+			lenient()
+				.when(myPackageCacheManager.loadPackage(eq(CROSS_VERSION_R4_PKG_ID), eq(CROSS_VERSION_PKG_VERSION)))
+				.thenThrow(new IOException("Package not found: " + CROSS_VERSION_R4_PKG_ID));
+
+			PackageInstallationSpec theSpec = new PackageInstallationSpec();
+			theSpec.setName(MAIN_PKG_ID);
+			theSpec.setVersion(MAIN_PKG_VERSION);
+			theSpec.setFetchDependencies(true);
+			theSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+			ByteArrayOutputStream theStream = new ByteArrayOutputStream();
+			theMainPackage.save(theStream);
+			theSpec.setPackageContents(theStream.toByteArray());
+
+			// Test: install should fail because no .r4 variant is available
+			assertThatThrownBy(() -> mySvc.install(theSpec))
+				.isInstanceOf(ImplementationGuideInstallationException.class)
+				.hasMessageContaining("HAPI-1288");
+		}
+
+		@Nonnull
+		private NpmPackage createPackageWithDependency(
+				String theName, String theVersion, String theFhirVersion,
+				String theDepName, String theDepVersion) {
+			PackageGenerator theManifest = new PackageGenerator();
+			theManifest.name(theName);
+			theManifest.version(theVersion);
+			theManifest.description("a test package");
+			theManifest.fhirVersions(List.of(theFhirVersion));
+			theManifest.dependency(theDepName, theDepVersion);
+
+			return NpmPackage.empty(theManifest);
+		}
+
+		@Nonnull
+		private NpmPackage createSimplePackage(String theName, String theVersion, String theFhirVersion) {
+			PackageGenerator theManifest = new PackageGenerator();
+			theManifest.name(theName);
+			theManifest.version(theVersion);
+			theManifest.description("a test package");
+			theManifest.fhirVersions(List.of(theFhirVersion));
+
+			return NpmPackage.empty(theManifest);
+		}
 	}
 
 }


### PR DESCRIPTION
## Important Note

I have confirmed that U.S. Core 8.0.1 loads without errors with this fix.

## Summary

When an R4 server installs an Implementation Guide with `fetchDependencies=true`, transitive dependencies that declare a FHIR version incompatible with the server (for example, `hl7.fhir.uv.extensions` which declares FHIR 5.0.0) would immediately fail with HAPI-1288 even though a version-specific counterpart (e.g., `hl7.fhir.uv.extensions.r4`) exists on the package registry. This PR adds automatic cross-version package substitution to `PackageInstallerSvcImpl` so the installer recovers gracefully by trying the versioned variant before raising a compatibility error.

1. Added `substituteVersionSpecificPackageIfNeeded()` — called after each transitive dependency is loaded; if the package's FHIR version is incompatible with the server, the method appends a version suffix (`.r4`, `.r5`, `.r3`) to the package ID and attempts to load the variant from the cache/registry.
2. Extracted `areFhirVersionsCompatible()` as a shared private static method, removing duplicate version-comparison logic from `assertFhirVersionsAreCompatible()`.
3. Added `getVersionSpecificSuffix()` mapping R4/R4B → `.r4`, R5 → `.r5`, DSTU3 → `.r3`; unknown/unsupported versions return `null` and skip substitution.
4. Added a `CrossVersionDependencyTest` nested test class with four scenarios: successful substitution, no variant available (expected HAPI-1288 failure), excluded dependency (verify `loadPackage` is never called), and R4/R4B compatibility regression guard.
5. Added `hapi-fhir-docs/server_jpa/packages.md` documenting package upload, transitive dependency fetching, cross-version substitution behavior, and validation usage.

## Code Review Suggestions

- [ ] **Fallback behavior after failed variant lookup** — `substituteVersionSpecificPackageIfNeeded` catches `IOException` and returns the original (incompatible) package with only a warning log. The caller (`fetchAndInstallDependencies`) will subsequently call `assertFhirVersionsAreCompatible`, which will throw HAPI-1288. Confirm this is the intended user experience: a warning is logged, then the error fires a few lines later, rather than failing immediately with a clearer message in the substitution method itself.
- [ ] **`NpmPackage.fhirVersion()` contract** — The substitution logic calls `theDependency.fhirVersion()` to detect incompatibility. Verify that `fhirVersion()` returns a value that `FhirVersionEnum.forVersionString()` can parse for the known cross-version packages (e.g., `hl7.fhir.uv.extensions` which may return `"5.0.0"` rather than `"R5"`). The test mocks use `FhirVersionEnum.R5.getFhirVersionString()` — confirm the real package metadata uses the same format.
- [ ] **R4B suffix mapping** — R4B is mapped to `.r4` (same as R4). Check whether there are real packages with an `.r4b` suffix that should be preferred for R4B servers, or whether `.r4` is intentionally correct for R4B.
- [ ] **`areFhirVersionsCompatible` null-return semantics** — When either version string cannot be resolved to a `FhirVersionEnum`, the method returns `false`. This means `assertFhirVersionsAreCompatible` will throw HAPI-1288 on an unrecognized version string, whereas the previous code threw an `IllegalArgumentException` via `Validate.notNull`. Confirm this change in error type is acceptable to callers.
- [ ] **`files.properties` entry** — Confirm the new `packages.md` doc page is registered correctly in `files.properties` and that the cross-links to `instance_validator.html` resolve in the built docs site.

## QA Test Suggestions

### Setup
- [ ] Stand up a HAPI FHIR JPA server configured for **R4** (FhirContext R4).
- [ ] Ensure the server has outbound access to `packages.fhir.org`, or pre-load the relevant packages into the local package cache.

### Test Cases
- [ ] **Happy path — cross-version substitution succeeds**: Install `hl7.fhir.us.core` (latest R4 version) with `fetchDependencies=true`. Confirm the installer logs a warning about `hl7.fhir.uv.extensions` FHIR version mismatch and then logs a success message for `hl7.fhir.uv.extensions.r4`. Confirm the install completes without HAPI-1288.
- [ ] **No variant available**: Install a test package whose dependency declares FHIR 5.0.0 but has no `.r4` variant on the registry. Confirm the installer logs the "Could not find version-specific variant" warning and then fails with HAPI-1288.
- [ ] **Excluded cross-version dependency**: Install the same IG with `addDependencyExclude("hl7\\.fhir\\.uv\\.extensions")`. Confirm the install completes, the excluded package is never fetched, and no HAPI-1288 error is raised.
- [ ] **R4B server**: Configure the server for R4B and install an IG with a cross-version dependency. Confirm the installer attempts the `.r4` variant (not `.r4b`) and succeeds.
- [ ] **R5 server**: Configure the server for R5 and install an IG that depends on a cross-version package with a `.r5` variant. Confirm the `.r5` variant is substituted and installed successfully.
- [ ] **Regression — R4/R4B compatibility unchanged**: Install an R4B package on an R4 server (or vice versa) without cross-version packages in the dependency tree. Confirm there is no HAPI-1288 error and no substitution warning logged.
