### PR TITLE
Add patient-compartment extension for partition selection

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -22,6 +22,19 @@ package ca.uhn.fhir.util;
 public class HapiExtensions {
 
 	/**
+	 * When a resource belongs to multiple Patient compartments, this extension specifies
+	 * which Patient should be considered the primary compartment owner for partition assignment.
+	 * <p>
+	 * This extension should be of type <code>Reference</code> (to a Patient resource)
+	 * and should be placed on the resource itself.
+	 * </p>
+	 *
+	 * @since 8.10.0
+	 */
+	public static final String EXT_PRIMARY_PATIENT_COMPARTMENT =
+			"http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment";
+
+	/**
 	 * <p>
 	 * This extension should be of type <code>string</code> and should be
 	 * placed on the <code>Subscription.channel</code> element

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiExtensions.java
@@ -22,19 +22,6 @@ package ca.uhn.fhir.util;
 public class HapiExtensions {
 
 	/**
-	 * When a resource belongs to multiple Patient compartments, this extension specifies
-	 * which Patient should be considered the primary compartment owner for partition assignment.
-	 * <p>
-	 * This extension should be of type <code>Reference</code> (to a Patient resource)
-	 * and should be placed on the resource itself.
-	 * </p>
-	 *
-	 * @since 8.10.0
-	 */
-	public static final String EXT_PRIMARY_PATIENT_COMPARTMENT =
-			"http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment";
-
-	/**
 	 * <p>
 	 * This extension should be of type <code>string</code> and should be
 	 * placed on the <code>Subscription.channel</code> element
@@ -243,6 +230,24 @@ public class HapiExtensions {
 	 */
 	public static final String EXTENSION_TRANSACTION_ENTRY_PARTITION_IDS =
 			"http://hapifhir.io/fhir/ns/StructureDefinition/request-partition-ids";
+
+	/**
+	 * Specifies the Patient compartment assignment for a resource when using PatientIdPartitionInterceptor.
+	 * <p>
+	 * This extension should be of type <code>string</code> with one of two allowed values:
+	 * <ul>
+	 *   <li><code>"Patient/&lt;id&gt;"</code> — assign to the specified Patient's partition</li>
+	 *   <li><code>"NONE"</code> — no Patient compartment; route to the default partition</li>
+	 * </ul>
+	 * Only affects compartment-based policies, not <code>ALWAYS_USE_*</code> policies.
+	 * </p>
+	 *
+	 * @see ca.uhn.fhir.jpa.interceptor.ResourceCompartmentStoragePolicy
+	 * @since 8.10.0
+	 */
+	public static final String EXT_PATIENT_COMPARTMENT =
+			"http://hapifhir.io/fhir/StructureDefinition/patient-compartment";
+
 	/**
 	 * Non instantiable
 	 */

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7738-primary-patient-compartment-extension.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7738-primary-patient-compartment-extension.yaml
@@ -1,10 +1,11 @@
 ---
 type: add
 issue: 7738
-title: "When using Patient ID Partition Mode, resources belonging to multiple Patient
-  compartments can now optionally specify a primary-patient-compartment extension
-  to indicate which Patient should determine the partition. This avoids errors
-  when using the MANDATORY_SINGLE_COMPARTMENT and OPTIONAL_SINGLE_COMPARTMENT
-  policies with multi-compartment resources. The Provenance resources created
-  during Patient merge and replace-references operations now use this extension
-  automatically."
+title: "When using PatientIdPartitionInterceptor with compartmental policies
+  (MANDATORY_SINGLE_COMPARTMENT, OPTIONAL_SINGLE_COMPARTMENT, or
+  NON_UNIQUE_COMPARTMENT_IN_DEFAULT), a patient-compartment extension can now be set
+  on resources to control partition assignment. This allows specifying which
+  Patient should determine the partition for resources with multiple Patient
+  references, or routing a resource to the non-compartmental (default) partition.
+  The Provenance resources created during Patient merge and replace-references
+  operations now use this extension automatically."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7738-primary-patient-compartment-extension.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7738-primary-patient-compartment-extension.yaml
@@ -1,0 +1,10 @@
+---
+type: add
+issue: 7738
+title: "When using Patient ID Partition Mode, resources belonging to multiple Patient
+  compartments can now optionally specify a primary-patient-compartment extension
+  to indicate which Patient should determine the partition. This avoids errors
+  when using the MANDATORY_SINGLE_COMPARTMENT and OPTIONAL_SINGLE_COMPARTMENT
+  policies with multi-compartment resources. The Provenance resources created
+  during Patient merge and replace-references operations now use this extension
+  automatically."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -2,5 +2,5 @@
 type: fix
 issue: 7744
 title: "Previously, the `$lookup` operation would return stale results after updating an externally loaded `CodeSystem` 
-using [$apply-codesystem-delta-add](/docs/terminology/uploading.html#delta-add-operation) 
-or [$apply-codesystem-delta-remove](/docs/terminology/uploading.html#delta-remove-operation). This has been fixed."
+using `$apply-codesystem-delta-add`
+or `$apply-codesystem-delta-remove`. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -3,4 +3,4 @@ type: fix
 issue: 7744
 title: "Previously, the `$lookup` operation would return stale results after updating an externally loaded `CodeSystem` 
 using [$apply-codesystem-delta-add](/docs/terminology/uploading.html#delta-add-operation) 
-or [$apply-codesystem-delta-add](/docs/terminology/uploading.html#delta-remove-operation). This has been fixed."
+or [$apply-codesystem-delta-remove](/docs/terminology/uploading.html#delta-remove-operation). This has been fixed."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -232,6 +232,30 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 			.hasMessageContaining("Policy does not allow resource of type \"Provenance\" to be created in multiple Patient compartments: Patient/A, Patient/B");
 	}
 
+	@ParameterizedTest
+	@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
+	void testCreateProvenance_InMultiplePatientCompartments_withPrimaryCompartmentExtension(String thePolicy) {
+		// Setup
+		myPartitionSettings.setAllowReferencesAcrossPartitions(PartitionSettings.CrossPartitionReferenceMode.ALLOWED_UNQUALIFIED);
+		mySvc.setResourceTypePolicies(Map.of("Provenance", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+		createPatient(withId("A"), withActiveTrue());
+		createPatient(withId("B"), withActiveTrue());
+
+		// Test
+		Provenance provenance = new Provenance();
+		provenance.addTarget().setReference("Patient/A");
+		provenance.addTarget().setReference("Patient/B");
+		provenance.addExtension()
+			.setUrl("http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment")
+			.setValue(new Reference("Patient/A"));
+		IIdType provenanceId = myProvenanceDao.create(provenance, newSrd()).getId();
+
+		// Verify
+		int patientBPartitionId = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("B");
+		assertThat(PATIENT_A_COMPARTMENT_ID).isNotEqualTo(patientBPartitionId);
+		assertResourceIsInPartition(PATIENT_A_COMPARTMENT_ID, provenanceId);
+	}
+
 	@Test
 	public void testCreatePatient_ClientAssignedId() {
 		createPatientA();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -64,6 +64,7 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -233,8 +234,8 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 	}
 
 	@ParameterizedTest
-	@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
-	void testCreateProvenance_InMultiplePatientCompartments_withPrimaryCompartmentExtension(String thePolicy) {
+	@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT", "NON_UNIQUE_COMPARTMENT_IN_DEFAULT"})
+	void testCreateProvenance_InMultiplePatientCompartments_withCompartmentExtension(String thePolicy) {
 		// Setup
 		myPartitionSettings.setAllowReferencesAcrossPartitions(PartitionSettings.CrossPartitionReferenceMode.ALLOWED_UNQUALIFIED);
 		mySvc.setResourceTypePolicies(Map.of("Provenance", ResourceCompartmentStoragePolicy.parse(thePolicy)));
@@ -246,13 +247,13 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 		provenance.addTarget().setReference("Patient/A");
 		provenance.addTarget().setReference("Patient/B");
 		provenance.addExtension()
-			.setUrl("http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment")
-			.setValue(new Reference("Patient/A"));
+			.setUrl("http://hapifhir.io/fhir/StructureDefinition/patient-compartment")
+			.setValue(new StringType("Patient/A"));
 		IIdType provenanceId = myProvenanceDao.create(provenance, newSrd()).getId();
 
 		// Verify
 		int patientBPartitionId = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("B");
-		assertThat(PATIENT_A_COMPARTMENT_ID).isNotEqualTo(patientBPartitionId);
+		assertThat(patientBPartitionId).isNotEqualTo(PATIENT_A_COMPARTMENT_ID);
 		assertResourceIsInPartition(PATIENT_A_COMPARTMENT_ID, provenanceId);
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/CrossPartitionMergePatientIdModeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/CrossPartitionMergePatientIdModeR4Test.java
@@ -1,7 +1,6 @@
 package ca.uhn.fhir.jpa.provider.merge;
 
 import ca.uhn.fhir.jpa.interceptor.PatientIdPartitionInterceptor;
-import ca.uhn.fhir.jpa.interceptor.ResourceCompartmentStoragePolicy;
 import ca.uhn.fhir.jpa.merge.MergeOperationTestHelper;
 import ca.uhn.fhir.jpa.merge.MergeTestParameters;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
@@ -84,8 +83,6 @@ public class CrossPartitionMergePatientIdModeR4Test extends BaseResourceProvider
 
 		myPartitionInterceptor = new PatientIdPartitionInterceptor(
 			getFhirContext(), mySearchParamExtractor, myPartitionSettings, myDaoRegistry);
-		myPartitionInterceptor.setResourceTypePolicies(Map.of(
-			"Provenance", ResourceCompartmentStoragePolicy.nonUniqueCompartmentInDefault()));
 		registerInterceptor(myPartitionInterceptor);
 
 		myPartitionSettings.setPartitioningEnabled(true);

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -38,6 +38,7 @@ import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
 import ca.uhn.fhir.jpa.util.ResourceCompartmentUtil;
 import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -62,7 +63,10 @@ import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.IdType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
@@ -94,7 +98,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  */
 @Interceptor
 public class PatientIdPartitionInterceptor {
+	private static final Logger ourLog = LoggerFactory.getLogger(PatientIdPartitionInterceptor.class);
 	private static final String PATIENT_STR = "Patient";
+	public static final String PATIENT_COMPARTMENT_NONE = "NONE";
 	public static final String PLACEHOLDER_TO_REFERENCE_KEY =
 			PatientIdPartitionInterceptor.class.getName() + "_placeholderToResource";
 
@@ -213,12 +219,15 @@ public class PatientIdPartitionInterceptor {
 	public RequestPartitionId identifyForCreate(IBaseResource theResource, RequestDetails theRequestDetails) {
 		RuntimeResourceDefinition resourceDef = myFhirContext.getResourceDefinition(theResource);
 		ResourceCompartmentStoragePolicy policy = getPolicyForResourceType(resourceDef);
+		List<RuntimeSearchParam> compartmentSps =
+				ResourceCompartmentUtil.getPatientCompartmentSearchParams(resourceDef);
 
-		Optional<RequestPartitionId> partitionFromPolicy = policy.getUsePartitionId(myPartitionSettings);
-		if (partitionFromPolicy.isPresent()) {
-			return partitionFromPolicy.get();
-		}
+		// Validate extension applicability before any policy-specific routing.
+		// This rejects the extension on Patient and non-patient-compartment resources, and logs a
+		// warning when it's present on a compartment resource under an ALWAYS_USE_* policy.
+		validateExtensionApplicability(theResource, policy, compartmentSps);
 
+		// Patient resources are always partitioned by their own ID — no policy override allowed.
 		if (resourceDef.getName().equals(PATIENT_STR)) {
 			IIdType idElement = theResource.getIdElement();
 			if (idElement.getIdPart() == null || idElement.isUuid()) {
@@ -227,119 +236,237 @@ public class PatientIdPartitionInterceptor {
 								+ "Patient resource IDs must be client-assigned in patient compartment mode, or server id strategy must be UUID");
 			}
 			return provideSingleCompartmentPartition(theRequestDetails, idElement.getIdPart());
+		}
+
+		// ALWAYS_USE_* policies pin the partition for this resource type.
+		Optional<RequestPartitionId> partitionFromPolicy = policy.getUsePartitionId(myPartitionSettings);
+		if (partitionFromPolicy.isPresent()) {
+			return partitionFromPolicy.get();
+		}
+
+		IBaseResource resource = theResource;
+		if (theResource.isDeleted()) {
+			// when a resource is deleted, the current version of the deleted resource is empty
+			// and will definitely not have references to a patient.  in order to determine the
+			// patient compartment of a deleted resource, we need to get its previous version.
+			resource = getPreviousVersion(theResource);
+		}
+
+		Collection<String> oCompartmentIdentity = ResourceCompartmentUtil.getResourceCompartments(
+				"Patient", resource, compartmentSps, mySearchParamExtractor);
+		oCompartmentIdentity = deDuplicateCompartmentList(oCompartmentIdentity);
+
+		// Check for patient-compartment extension override
+		Optional<RequestPartitionId> partitionFromExtension =
+				getPartitionFromCompartmentExtension(resource, theRequestDetails, policy, oCompartmentIdentity);
+		if (partitionFromExtension.isPresent()) {
+			return partitionFromExtension.get();
+		}
+
+		if (!oCompartmentIdentity.isEmpty()) {
+
+			// One compartment
+			if (oCompartmentIdentity.size() == 1) {
+				return provideMultipleCompartmentPartition(theRequestDetails, oCompartmentIdentity);
+			}
+
+			// Multiple compartments
+			Optional<RequestPartitionId> nonUniqueCompartmentPolicy =
+					policy.getPartitionIdForNonUniqueCompartment(myPartitionSettings);
+			if (nonUniqueCompartmentPolicy.isPresent()) {
+				return nonUniqueCompartmentPolicy.get();
+			}
+
+			throw new InvalidRequestException(Msg.code(1324) + "Policy does not allow resource of type \""
+					+ resourceDef.getName()
+					+ "\" to be created in multiple Patient compartments: "
+					+ oCompartmentIdentity.stream().map(t -> "Patient/" + t).collect(Collectors.joining(", ")));
+
 		} else {
-			IBaseResource resource = theResource;
-			if (theResource.isDeleted()) {
-				// when a resource is deleted, the current version of the deleted resource is empty
-				// and will definitely not have references to a patient.  in order to determine the
-				// patient compartment of a deleted resource, we need to get its previous version.
-				resource = getPreviousVersion(theResource);
-			}
-
-			List<RuntimeSearchParam> compartmentSps =
-					ResourceCompartmentUtil.getPatientCompartmentSearchParams(resourceDef);
-
-			Collection<String> oCompartmentIdentity = ResourceCompartmentUtil.getResourceCompartments(
-					"Patient", resource, compartmentSps, mySearchParamExtractor);
-			oCompartmentIdentity = deDuplicateCompartmentList(oCompartmentIdentity);
-
-			if (!oCompartmentIdentity.isEmpty()) {
-
-				// One compartment
-				if (oCompartmentIdentity.size() == 1) {
-					return provideMultipleCompartmentPartition(theRequestDetails, oCompartmentIdentity);
+			Set<RequestPartitionId> compartments =
+					getPartitionViaPartiallyProcessedReference(theRequestDetails, policy, resource);
+			if (compartments.size() == 1) {
+				return compartments.iterator().next();
+			} else if (compartments.isEmpty()) {
+				Optional<RequestPartitionId> partitionId = policy.getPartitionIdForNoCompartment(myPartitionSettings);
+				if (partitionId.isPresent()) {
+					return partitionId.get();
 				}
-
-				// Multiple compartments
-				Optional<RequestPartitionId> nonUniqueCompartmentPolicy =
-						policy.getPartitionIdForNonUniqueCompartment(myPartitionSettings);
-				if (nonUniqueCompartmentPolicy.isPresent()) {
-					return nonUniqueCompartmentPolicy.get();
-				}
-
-				// Check if the resource specifies a primary patient compartment via extension
-				Optional<String> primaryPatientId = extractPrimaryPatientCompartmentId(resource, oCompartmentIdentity);
-				if (primaryPatientId.isPresent()) {
-					return provideSingleCompartmentPartition(theRequestDetails, primaryPatientId.get());
-				}
-
-				throw new InvalidRequestException(Msg.code(1324) + "Policy does not allow resource of type \""
-						+ resourceDef.getName()
-						+ "\" to be created in multiple Patient compartments: "
-						+ oCompartmentIdentity.stream().map(t -> "Patient/" + t).collect(Collectors.joining(", ")));
-
 			} else {
-				Set<RequestPartitionId> compartments =
-						getPartitionViaPartiallyProcessedReference(theRequestDetails, policy, resource);
-				if (compartments.size() == 1) {
-					return compartments.iterator().next();
-				} else if (compartments.isEmpty()) {
-					Optional<RequestPartitionId> partitionId =
-							policy.getPartitionIdForNoCompartment(myPartitionSettings);
-					if (partitionId.isPresent()) {
-						return partitionId.get();
-					}
-				} else {
-					Optional<RequestPartitionId> partitionId =
-							policy.getPartitionIdForNonUniqueCompartment(myPartitionSettings);
-					if (partitionId.isPresent()) {
-						return partitionId.get();
-					}
+				Optional<RequestPartitionId> partitionId =
+						policy.getPartitionIdForNonUniqueCompartment(myPartitionSettings);
+				if (partitionId.isPresent()) {
+					return partitionId.get();
 				}
-
-				return throwNonCompartmentMemberInstanceFailureResponse(resource);
 			}
+
+			return throwNonCompartmentMemberInstanceFailureResponse(resource);
 		}
 	}
 
 	/**
-	 * Extracts and validates the patient ID from the
-	 * {@link HapiExtensions#EXT_PRIMARY_PATIENT_COMPARTMENT} extension, if present.
+	 * Validates that the {@link HapiExtensions#EXT_PATIENT_COMPARTMENT} extension can be honored
+	 * for the given resource. This extension allows explicitly specifying which Patient compartment
+	 * a resource belongs to for partition selection. The partition is then determined based on that
+	 * compartment assignment.
+	 *
+	 * <h3>Extension Values</h3>
+	 * <ul>
+	 *   <li>{@code "Patient/<id>"} — assigns the resource to the specified Patient's compartment.
+	 *       The referenced Patient must be one of the resource's compartment members.</li>
+	 *   <li>{@code "NONE"} — marks the resource as not belonging to any Patient compartment,
+	 *       causing it to be stored in the non-compartmental (default) partition.</li>
+	 * </ul>
+	 *
+	 * <h3>Resource Type Applicability (enforced here)</h3>
+	 * <ul>
+	 *   <li><b>Patient resource</b> — rejected. Patient is routed by its own ID, so the extension
+	 *       can never be honored.</li>
+	 *   <li><b>Non-patient-compartment resource type</b> (e.g., Organization) — rejected. The
+	 *       extension only makes sense for resources that can belong to a Patient compartment.</li>
+	 * </ul>
+	 *
+	 * <h3>Behavior by Policy</h3>
+	 * <table>
+	 *   <tr><th>Policy</th><th>{@code Patient/<id>}</th><th>{@code NONE}</th></tr>
+	 *   <tr><td>MANDATORY_SINGLE_COMPARTMENT</td>
+	 *       <td>Assigns to specified Patient's compartment</td>
+	 *       <td>Rejected — this policy requires a Patient compartment</td></tr>
+	 *   <tr><td>OPTIONAL_SINGLE_COMPARTMENT</td>
+	 *       <td>Assigns to specified Patient's compartment</td>
+	 *       <td>Treated as non-compartmental; stored in the default partition. Note: patient-ref
+	 *           searches will not find resources in the default partition under this policy</td></tr>
+	 *   <tr><td>NON_UNIQUE_COMPARTMENT_IN_DEFAULT</td>
+	 *       <td>Assigns to specified Patient's compartment</td>
+	 *       <td>Treated as non-compartmental; stored in the default partition</td></tr>
+	 *   <tr><td>ALWAYS_USE_*</td>
+	 *       <td colspan="2">Extension is ignored — policy always determines the partition.
+	 *           A warning is logged. This is a deliberate design choice to keep {@code $merge} /
+	 *           {@code $replace-references} working if a user changes the policy for Provenance
+	 *           resources to a fixed partition.</td></tr>
+	 * </table>
+	 *
+	 * <p>Value-level validation (string format, {@code NONE} vs policy compatibility,
+	 * {@code Patient/<id>} membership check) is handled by
+	 * {@link #getPartitionFromCompartmentExtension}.</p>
+	 *
+	 * @param theResource the resource being created
+	 * @param thePolicy the compartment storage policy for this resource type
+	 * @param theCompartmentSearchParams the patient compartment search params for this resource
+	 *                                   type (passed in to avoid recomputation)
+	 * @throws InvalidRequestException if the extension is present on a Patient or a
+	 *                                 non-patient-compartment resource type
+	 */
+	private void validateExtensionApplicability(
+			IBaseResource theResource,
+			ResourceCompartmentStoragePolicy thePolicy,
+			List<RuntimeSearchParam> theCompartmentSearchParams) {
+		// hasExtension safely returns false for resources that don't support extensions
+		// (Bundle, Parameters, etc. — types that extend Resource directly instead of DomainResource)
+		if (!ExtensionUtil.hasExtension(theResource, HapiExtensions.EXT_PATIENT_COMPARTMENT)) {
+			return;
+		}
+
+		String resourceType = theResource.fhirType();
+
+		// Reject on Patient — Patient is routed by its own ID, the extension can never be honored
+		if (PATIENT_STR.equals(resourceType)) {
+			throw new InvalidRequestException(Msg.code(2908)
+					+ String.format(
+							"Extension %s is not applicable to Patient resources",
+							HapiExtensions.EXT_PATIENT_COMPARTMENT));
+		}
+
+		// Reject on non-patient-compartment resources — extension can never be honored.
+		if (theCompartmentSearchParams.isEmpty()) {
+			throw new InvalidRequestException(Msg.code(2909)
+					+ String.format(
+							"Extension %s is not applicable to resource type '%s': not a Patient compartment resource type",
+							HapiExtensions.EXT_PATIENT_COMPARTMENT, resourceType));
+		}
+
+		// Compartment resource with an ALWAYS_USE_* policy: both the extension and the policy
+		// want to control the partition. By design, we let the policy win and log a warning
+		// rather than rejecting the request — this keeps $merge / $replace-references working
+		// if an operator legitimately decides to pin Provenance to a fixed partition (e.g.,
+		// ALWAYS_USE_DEFAULT_PARTITION to keep audit records in the default partition).
+		if (thePolicy.getUsePartitionId(myPartitionSettings).isPresent()) {
+			ourLog.warn(
+					"Extension {} on resource type '{}' is a no-op: the active policy '{}' fixes the partition "
+							+ "and takes precedence over the extension.",
+					HapiExtensions.EXT_PATIENT_COMPARTMENT,
+					resourceType,
+					thePolicy.getName());
+		}
+	}
+
+	/**
+	 * Resolves the partition from the {@link HapiExtensions#EXT_PATIENT_COMPARTMENT} extension
+	 * value if the extension is present on the resource. Handles value-level validation:
+	 * validating the value as a string, handling the {@code NONE} sentinel (including rejecting
+	 * it under policies that require a Patient compartment), parsing {@code Patient/<id>} form,
+	 * and verifying the ID is one of the resource's patient compartments.
+	 * <p>
+	 * Resource-level applicability and the full behavior matrix by policy are documented on
+	 * {@link #validateExtensionApplicability}.
+	 * </p>
 	 *
 	 * @param theResource the resource to check for the extension
-	 * @param theCompartmentIdentities the set of patient IDs (bare ID parts) that the resource belongs to
-	 * @return the validated patient ID part, or empty if the extension is absent.
-	 * @throws InvalidRequestException if the extension is present but the value is invalid or references
-	 *         a patient not in the compartment list
+	 * @param theRequestDetails the request details
+	 * @param thePolicy the compartment storage policy for this resource type
+	 * @param theCompartmentIdentities the patient compartment IDs extracted from the resource
+	 * @return the override partition, or empty if the extension is absent
+	 * @throws InvalidRequestException if the extension is present but the value is invalid
 	 */
-	@Nonnull
-	private Optional<String> extractPrimaryPatientCompartmentId(
-			IBaseResource theResource, Collection<String> theCompartmentIdentities) {
-		IBaseExtension<?, ?> extension =
-				ExtensionUtil.getExtensionByUrl(theResource, HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT);
-		if (extension == null) {
+	private Optional<RequestPartitionId> getPartitionFromCompartmentExtension(
+			IBaseResource theResource,
+			RequestDetails theRequestDetails,
+			ResourceCompartmentStoragePolicy thePolicy,
+			Collection<String> theCompartmentIdentities) {
+		// hasExtension safely returns false for resources that don't support extensions
+		if (!ExtensionUtil.hasExtension(theResource, HapiExtensions.EXT_PATIENT_COMPARTMENT)) {
 			return Optional.empty();
 		}
+		IBaseExtension<?, ?> extension =
+				ExtensionUtil.getExtensionByUrl(theResource, HapiExtensions.EXT_PATIENT_COMPARTMENT);
 
 		IBase value = extension.getValue();
-		if (!(value instanceof IBaseReference)) {
-			throw new InvalidRequestException(Msg.code(2894) + "Extension "
-					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT + " must have a Reference value");
+		if (!(value instanceof IPrimitiveType<?> primitiveValue) || !(primitiveValue.getValue() instanceof String)) {
+			throw new InvalidRequestException(Msg.code(2894)
+					+ String.format("Extension %s must have a string value", HapiExtensions.EXT_PATIENT_COMPARTMENT));
 		}
 
-		IIdType referenceElement = ((IBaseReference) value).getReferenceElement();
-		String resourceType = referenceElement.getResourceType();
-		if (!"Patient".equals(resourceType)) {
-			throw new InvalidRequestException(Msg.code(2895) + "Extension "
-					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT
-					+ " must reference a Patient resource, but found: " + referenceElement.getValue());
+		String stringValue = (String) primitiveValue.getValue();
+
+		if (PATIENT_COMPARTMENT_NONE.equals(stringValue)) {
+			if (!thePolicy.hasPartitionIdForNoCompartment()) {
+				throw new InvalidRequestException(Msg.code(2895)
+						+ String.format(
+								"Extension %s value \"%s\" is not allowed with %s policy",
+								HapiExtensions.EXT_PATIENT_COMPARTMENT, PATIENT_COMPARTMENT_NONE, thePolicy.getName()));
+			}
+			return Optional.of(RequestPartitionId.defaultPartition(myPartitionSettings));
 		}
 
-		String idPart = referenceElement.getIdPart();
-		if (isBlank(idPart)) {
-			throw new InvalidRequestException(Msg.code(2896) + "Extension "
-					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT
-					+ " has a Patient reference with a blank ID");
+		IdDt parsedId = new IdDt(stringValue);
+		String idPart = parsedId.getIdPart();
+		if (!PATIENT_STR.equals(parsedId.getResourceType()) || isBlank(idPart)) {
+			throw new InvalidRequestException(Msg.code(2896)
+					+ String.format(
+							"Extension %s has an invalid value: \"%s\". Must be \"%s\" or \"Patient/<id>\"",
+							HapiExtensions.EXT_PATIENT_COMPARTMENT, stringValue, PATIENT_COMPARTMENT_NONE));
 		}
 
 		if (!theCompartmentIdentities.contains(idPart)) {
-			throw new InvalidRequestException(Msg.code(2897) + "Extension "
-					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT + " references Patient/" + idPart
-					+ " which is not a compartment of this resource. Compartments are: "
-					+ theCompartmentIdentities.stream().map(t -> "Patient/" + t).collect(Collectors.joining(", ")));
+			String compartments =
+					theCompartmentIdentities.stream().map(t -> "Patient/" + t).collect(Collectors.joining(", "));
+			throw new InvalidRequestException(Msg.code(2897)
+					+ String.format(
+							"Extension %s references Patient/%s which is not a compartment of this resource. Compartments are: %s",
+							HapiExtensions.EXT_PATIENT_COMPARTMENT, idPart, compartments));
 		}
 
-		return Optional.of(idPart);
+		return Optional.of(provideSingleCompartmentPartition(theRequestDetails, idPart));
 	}
 
 	private IBaseResource getPreviousVersion(IBaseResource theResource) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -47,7 +47,9 @@ import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import ca.uhn.fhir.storage.PreviousVersionReader;
 import ca.uhn.fhir.util.BundleUtil;
+import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.FhirTerser;
+import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.ResourceReferenceInfo;
 import ca.uhn.fhir.util.bundle.BundleEntryParts;
 import jakarta.annotation.Nonnull;
@@ -56,6 +58,7 @@ import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -254,6 +257,12 @@ public class PatientIdPartitionInterceptor {
 					return nonUniqueCompartmentPolicy.get();
 				}
 
+				// Check if the resource specifies a primary patient compartment via extension
+				Optional<String> primaryPatientId = extractPrimaryPatientCompartmentId(resource, oCompartmentIdentity);
+				if (primaryPatientId.isPresent()) {
+					return provideSingleCompartmentPartition(theRequestDetails, primaryPatientId.get());
+				}
+
 				throw new InvalidRequestException(Msg.code(1324) + "Policy does not allow resource of type \""
 						+ resourceDef.getName()
 						+ "\" to be created in multiple Patient compartments: "
@@ -281,6 +290,56 @@ public class PatientIdPartitionInterceptor {
 				return throwNonCompartmentMemberInstanceFailureResponse(resource);
 			}
 		}
+	}
+
+	/**
+	 * Extracts and validates the patient ID from the
+	 * {@link HapiExtensions#EXT_PRIMARY_PATIENT_COMPARTMENT} extension, if present.
+	 *
+	 * @param theResource the resource to check for the extension
+	 * @param theCompartmentIdentities the set of patient IDs (bare ID parts) that the resource belongs to
+	 * @return the validated patient ID part, or empty if the extension is absent.
+	 * @throws InvalidRequestException if the extension is present but the value is invalid or references
+	 *         a patient not in the compartment list
+	 */
+	@Nonnull
+	private Optional<String> extractPrimaryPatientCompartmentId(
+			IBaseResource theResource, Collection<String> theCompartmentIdentities) {
+		IBaseExtension<?, ?> extension =
+				ExtensionUtil.getExtensionByUrl(theResource, HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT);
+		if (extension == null) {
+			return Optional.empty();
+		}
+
+		IBase value = extension.getValue();
+		if (!(value instanceof IBaseReference)) {
+			throw new InvalidRequestException(Msg.code(2894) + "Extension "
+					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT + " must have a Reference value");
+		}
+
+		IIdType referenceElement = ((IBaseReference) value).getReferenceElement();
+		String resourceType = referenceElement.getResourceType();
+		if (!"Patient".equals(resourceType)) {
+			throw new InvalidRequestException(Msg.code(2895) + "Extension "
+					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT
+					+ " must reference a Patient resource, but found: " + referenceElement.getValue());
+		}
+
+		String idPart = referenceElement.getIdPart();
+		if (isBlank(idPart)) {
+			throw new InvalidRequestException(Msg.code(2896) + "Extension "
+					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT
+					+ " has a Patient reference with a blank ID");
+		}
+
+		if (!theCompartmentIdentities.contains(idPart)) {
+			throw new InvalidRequestException(Msg.code(2897) + "Extension "
+					+ HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT + " references Patient/" + idPart
+					+ " which is not a compartment of this resource. Compartments are: "
+					+ theCompartmentIdentities.stream().map(t -> "Patient/" + t).collect(Collectors.joining(", ")));
+		}
+
+		return Optional.of(idPart);
 	}
 
 	private IBaseResource getPreviousVersion(IBaseResource theResource) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
@@ -33,6 +33,7 @@ import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.util.FhirTerser;
+import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -130,6 +131,17 @@ public class ReplaceReferencesProvenanceSvc {
 
 		theUpdatedReferencingResourceIds.forEach(id -> provenance.addTarget(new Reference(id)));
 		theContainedResources.forEach(c -> provenance.addContained((Resource) c));
+
+		// When the target is a Patient, the Provenance targets both source and target Patients,
+		// placing it in two Patient compartments. The extension tells PatientIdPartitionInterceptor
+		// to use the target Patient's partition.
+		if ("Patient".equals(theTargetId.getResourceType())) {
+			provenance
+					.addExtension()
+					.setUrl(HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT)
+					.setValue(new Reference(theTargetId.toUnqualifiedVersionless()));
+		}
+
 		return provenance;
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/replacereferences/ReplaceReferencesProvenanceSvc.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.replacereferences;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.interceptor.PatientIdPartitionInterceptor;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.model.api.IProvenanceAgent;
 import ca.uhn.fhir.model.api.StorageResponseCodeEnum;
@@ -32,6 +33,7 @@ import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.FhirTerser;
 import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nullable;
@@ -95,7 +97,7 @@ public class ReplaceReferencesProvenanceSvc {
 
 	protected Provenance createProvenanceObject(
 			IIdType theTargetId,
-			@Nullable IIdType theSourceId,
+			IIdType theSourceId,
 			List<IIdType> theUpdatedReferencingResourceIds,
 			Date theStartTime,
 			List<IProvenanceAgent> theProvenanceAgents,
@@ -125,24 +127,41 @@ public class ReplaceReferencesProvenanceSvc {
 		provenance.addReason(activityReasonCodeableConcept);
 
 		provenance.addTarget(new Reference(theTargetId));
-		if (theSourceId != null) {
-			provenance.addTarget(new Reference(theSourceId));
-		}
+		provenance.addTarget(new Reference(theSourceId));
 
 		theUpdatedReferencingResourceIds.forEach(id -> provenance.addTarget(new Reference(id)));
 		theContainedResources.forEach(c -> provenance.addContained((Resource) c));
 
-		// When the target is a Patient, the Provenance targets both source and target Patients,
-		// placing it in two Patient compartments. The extension tells PatientIdPartitionInterceptor
-		// to use the target Patient's partition.
-		if ("Patient".equals(theTargetId.getResourceType())) {
-			provenance
-					.addExtension()
-					.setUrl(HapiExtensions.EXT_PRIMARY_PATIENT_COMPARTMENT)
-					.setValue(new Reference(theTargetId.toUnqualifiedVersionless()));
-		}
+		addPatientCompartmentExtension(provenance, theTargetId);
 
 		return provenance;
+	}
+
+	/**
+	 * Sets the {@link HapiExtensions#EXT_PATIENT_COMPARTMENT} extension on the Provenance to control
+	 * which partition it is stored in. The Provenance targets multiple resources that may span
+	 * Patient compartments, so the extension tells PatientIdPartitionInterceptor which partition to use.
+	 */
+	private void addPatientCompartmentExtension(Provenance theProvenance, IIdType theTargetId) {
+		if ("Patient".equals(theTargetId.getResourceType())) {
+			// operation on Patients: route to the target Patient's partition
+			ExtensionUtil.setExtensionAsString(
+					myFhirContext,
+					theProvenance,
+					HapiExtensions.EXT_PATIENT_COMPARTMENT,
+					theTargetId.toUnqualifiedVersionless().getValue());
+		} else {
+			// Non-Patient target: could be a compartmental resource (e.g., Observation) or a
+			// non-compartmental resource (e.g., Organization). In both cases we route the Provenance
+			// to the default partition. Even for compartmental resources, storing the Provenance in
+			// a specific Patient's partition would make it unfindable during undo — the undo search
+			// (e.g., Provenance?target=Observation/B) can't derive which Patient partition to look in.
+			ExtensionUtil.setExtensionAsString(
+					myFhirContext,
+					theProvenance,
+					HapiExtensions.EXT_PATIENT_COMPARTMENT,
+					PatientIdPartitionInterceptor.PATIENT_COMPARTMENT_NONE);
+		}
 	}
 
 	/**

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorTest.java
@@ -20,7 +20,9 @@ import ca.uhn.test.junit.StringToIntegerListArgumentConverter;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -215,6 +217,95 @@ class PatientIdPartitionInterceptorTest {
 
 		} else {
 			assertDoesNotThrow(() -> interceptor.setResourceTypePolicies(policies));
+		}
+	}
+
+	@Nested
+	class PrimaryPatientCompartmentExtension {
+
+		private Observation createObservationInMultipleCompartments() {
+			Observation obs = new Observation();
+			obs.addPerformer(new Reference("Patient/1"));
+			obs.addPerformer(new Reference("Patient/2"));
+			return obs;
+		}
+
+		private void addPrimaryCompartmentExtension(Observation theObs, String thePatientReference) {
+			theObs.addExtension()
+				.setUrl("http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment")
+				.setValue(new Reference(thePatientReference));
+		}
+
+		@ParameterizedTest
+		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
+		void testCreate_multipleCompartments_withExtension_resolvesToExtensionPatient(String thePolicy) {
+			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+
+			Observation obs = createObservationInMultipleCompartments();
+			addPrimaryCompartmentExtension(obs, "Patient/1");
+
+			RequestPartitionId actual = mySvc.identifyForCreate(obs, new ServletRequestDetails());
+
+			int patient1PartitionId = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("1");
+			int patient2PartitionId = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("2");
+			// Guard: ensure the two patients hash to different partitions, otherwise the test proves nothing
+			assertThat(patient1PartitionId).isNotEqualTo(patient2PartitionId);
+			assertFalse(actual.isAllPartitions());
+			assertThat(actual.getPartitionIds()).containsExactly(patient1PartitionId);
+		}
+
+		@ParameterizedTest
+		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
+		void testCreate_multipleCompartments_withExtension_patientNotInCompartmentList(String thePolicy) {
+			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+
+			Observation obs = createObservationInMultipleCompartments();
+			addPrimaryCompartmentExtension(obs, "Patient/999");
+
+			assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessage("HAPI-2897: Extension http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment references Patient/999 which is not a compartment of this resource. Compartments are: Patient/1, Patient/2");
+		}
+
+		@ParameterizedTest
+		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
+		void testCreate_multipleCompartments_withExtension_nonPatientResourceType(String thePolicy) {
+			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+
+			Observation obs = createObservationInMultipleCompartments();
+			addPrimaryCompartmentExtension(obs, "Observation/123");
+
+			assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessage("HAPI-2895: Extension http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment must reference a Patient resource, but found: Observation/123");
+		}
+
+		@ParameterizedTest
+		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
+		void testCreate_multipleCompartments_withExtension_nonReferenceValue(String thePolicy) {
+			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+
+			Observation obs = createObservationInMultipleCompartments();
+			obs.addExtension()
+				.setUrl("http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment")
+				.setValue(new StringType("Patient/1"));
+
+			assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessage("HAPI-2894: Extension http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment must have a Reference value");
+		}
+
+		@ParameterizedTest
+		@CsvSource({"NON_UNIQUE_COMPARTMENT_IN_DEFAULT", "ALWAYS_USE_DEFAULT_PARTITION"})
+		void testCreate_multipleCompartments_withDefaultPartitionPolicy_extensionIgnored(String thePolicy) {
+			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+
+			Observation obs = createObservationInMultipleCompartments();
+			addPrimaryCompartmentExtension(obs, "Patient/1");
+
+			RequestPartitionId actual = mySvc.identifyForCreate(obs, new ServletRequestDetails());
+
+			assertThat(actual.getPartitionIds()).containsExactly(myPartitionSettings.getDefaultPartitionId());
 		}
 	}
 

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorTest.java
@@ -17,8 +17,11 @@ import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.rest.server.util.FhirContextSearchParamRegistry;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.test.junit.StringToIntegerListArgumentConverter;
+import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
@@ -221,7 +224,7 @@ class PatientIdPartitionInterceptorTest {
 	}
 
 	@Nested
-	class PrimaryPatientCompartmentExtension {
+	class PatientCompartmentExtension {
 
 		private Observation createObservationInMultipleCompartments() {
 			Observation obs = new Observation();
@@ -230,84 +233,128 @@ class PatientIdPartitionInterceptorTest {
 			return obs;
 		}
 
-		private void addPrimaryCompartmentExtension(Observation theObs, String thePatientReference) {
-			theObs.addExtension()
-				.setUrl("http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment")
-				.setValue(new Reference(thePatientReference));
+		private void addCompartmentExtension(DomainResource theResource, String theValue) {
+			theResource.addExtension()
+				.setUrl("http://hapifhir.io/fhir/StructureDefinition/patient-compartment")
+				.setValue(new StringType(theValue));
 		}
 
-		@ParameterizedTest
-		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
-		void testCreate_multipleCompartments_withExtension_resolvesToExtensionPatient(String thePolicy) {
-			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+		@Test
+		void testCreate_extensionOnPatient_rejected() {
+			Patient patient = new Patient();
+			patient.setId("PAT-A");
+			addCompartmentExtension(patient, "Patient/PAT-A");
 
-			Observation obs = createObservationInMultipleCompartments();
-			addPrimaryCompartmentExtension(obs, "Patient/1");
-
-			RequestPartitionId actual = mySvc.identifyForCreate(obs, new ServletRequestDetails());
-
-			int patient1PartitionId = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("1");
-			int patient2PartitionId = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("2");
-			// Guard: ensure the two patients hash to different partitions, otherwise the test proves nothing
-			assertThat(patient1PartitionId).isNotEqualTo(patient2PartitionId);
-			assertFalse(actual.isAllPartitions());
-			assertThat(actual.getPartitionIds()).containsExactly(patient1PartitionId);
-		}
-
-		@ParameterizedTest
-		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
-		void testCreate_multipleCompartments_withExtension_patientNotInCompartmentList(String thePolicy) {
-			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
-
-			Observation obs = createObservationInMultipleCompartments();
-			addPrimaryCompartmentExtension(obs, "Patient/999");
-
-			assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
+			assertThatThrownBy(() -> mySvc.identifyForCreate(patient, new ServletRequestDetails()))
 				.isInstanceOf(InvalidRequestException.class)
-				.hasMessage("HAPI-2897: Extension http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment references Patient/999 which is not a compartment of this resource. Compartments are: Patient/1, Patient/2");
+				.hasMessageContaining("HAPI-2908")
+				.hasMessageContaining("is not applicable to Patient resources");
 		}
 
-		@ParameterizedTest
-		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
-		void testCreate_multipleCompartments_withExtension_nonPatientResourceType(String thePolicy) {
-			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+		@Test
+		void testCreate_extensionOnNonCompartmentResource_rejected() {
+			// Organization is not a patient-compartment resource type
+			Organization org = new Organization();
+			addCompartmentExtension(org, "Patient/1");
 
-			Observation obs = createObservationInMultipleCompartments();
-			addPrimaryCompartmentExtension(obs, "Observation/123");
-
-			assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
+			assertThatThrownBy(() -> mySvc.identifyForCreate(org, new ServletRequestDetails()))
 				.isInstanceOf(InvalidRequestException.class)
-				.hasMessage("HAPI-2895: Extension http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment must reference a Patient resource, but found: Observation/123");
+				.hasMessageContaining("HAPI-2909")
+				.hasMessageContaining("is not applicable to resource type 'Organization'");
 		}
 
-		@ParameterizedTest
-		@CsvSource({"MANDATORY_SINGLE_COMPARTMENT", "OPTIONAL_SINGLE_COMPARTMENT"})
-		void testCreate_multipleCompartments_withExtension_nonReferenceValue(String thePolicy) {
-			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
-
+		@Test
+		void testCreate_withNonStringValue_throwsError() {
 			Observation obs = createObservationInMultipleCompartments();
 			obs.addExtension()
-				.setUrl("http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment")
-				.setValue(new StringType("Patient/1"));
+				.setUrl("http://hapifhir.io/fhir/StructureDefinition/patient-compartment")
+				.setValue(new Reference("Patient/1"));
 
 			assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
 				.isInstanceOf(InvalidRequestException.class)
-				.hasMessage("HAPI-2894: Extension http://hapifhir.io/fhir/StructureDefinition/primary-patient-compartment must have a Reference value");
+				.hasMessageContaining("HAPI-2894");
 		}
 
 		@ParameterizedTest
-		@CsvSource({"NON_UNIQUE_COMPARTMENT_IN_DEFAULT", "ALWAYS_USE_DEFAULT_PARTITION"})
-		void testCreate_multipleCompartments_withDefaultPartitionPolicy_extensionIgnored(String thePolicy) {
-			mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+		@CsvSource(delimiter = '|', useHeadersInDisplayName = true, textBlock = """
+			policy                            | extensionValue   | expectedPartition | expectedErrorCode
+
+			# Patient/<id> routes to specified patient's partition
+			# (an empty policy '' falls back to MANDATORY default for patient-compartment resources)
+			MANDATORY_SINGLE_COMPARTMENT      | Patient/1        | PATIENT1          |
+			OPTIONAL_SINGLE_COMPARTMENT       | Patient/1        | PATIENT1          |
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | Patient/1        | PATIENT1          |
+			''                                | Patient/1        | PATIENT1          |
+
+			# NONE routes to default partition; rejected under MANDATORY (which is also the default) policy
+			OPTIONAL_SINGLE_COMPARTMENT       | NONE             | DEFAULT           |
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | NONE             | DEFAULT           |
+			MANDATORY_SINGLE_COMPARTMENT      | NONE             |                   | HAPI-2895
+			''                                | NONE             |                   | HAPI-2895
+
+			# ALWAYS_USE_* policies ignores the extension
+			ALWAYS_USE_DEFAULT_PARTITION      | Patient/1        | DEFAULT           |
+			ALWAYS_USE_PARTITION_ID/5         | Patient/1        | 5                 |
+
+			# Input validation error cases, validation runs before any policy-aware branch,
+			# so each invalid value must be rejected under every compartment-based policy
+			# (including the empty '' policy which falls back to the MANDATORY default)
+
+			# Patient ID is not in the resource's compartment list (resource only has Patient/1, Patient/2)
+			MANDATORY_SINGLE_COMPARTMENT      | Patient/999      |                   | HAPI-2897
+			OPTIONAL_SINGLE_COMPARTMENT       | Patient/999      |                   | HAPI-2897
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | Patient/999      |                   | HAPI-2897
+			''                                | Patient/999      |                   | HAPI-2897
+
+			# "Patient/" prefix with no ID part — fails Patient/<id> parsing
+			MANDATORY_SINGLE_COMPARTMENT      | Patient/         |                   | HAPI-2896
+			OPTIONAL_SINGLE_COMPARTMENT       | Patient/         |                   | HAPI-2896
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | Patient/         |                   | HAPI-2896
+			''                                | Patient/         |                   | HAPI-2896
+
+			# Value is neither "NONE" nor a "Patient/<id>"
+			MANDATORY_SINGLE_COMPARTMENT      | SomethingInvalid |                   | HAPI-2896
+			OPTIONAL_SINGLE_COMPARTMENT       | SomethingInvalid |                   | HAPI-2896
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | SomethingInvalid |                   | HAPI-2896
+			''                                | SomethingInvalid |                   | HAPI-2896
+
+			# Reference is to a non-Patient resource type
+			MANDATORY_SINGLE_COMPARTMENT      | Observation/1    |                   | HAPI-2896
+			OPTIONAL_SINGLE_COMPARTMENT       | Observation/1    |                   | HAPI-2896
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | Observation/1    |                   | HAPI-2896
+			''                                | Observation/1    |                   | HAPI-2896
+
+			# Empty string — doesn't match "NONE" and fails Patient/<id> parsing ('' is JUnit CSV syntax for empty)
+			MANDATORY_SINGLE_COMPARTMENT      | ''               |                   | HAPI-2896
+			OPTIONAL_SINGLE_COMPARTMENT       | ''               |                   | HAPI-2896
+			NON_UNIQUE_COMPARTMENT_IN_DEFAULT | ''               |                   | HAPI-2896
+			''                                | ''               |                   | HAPI-2896
+			""")
+		void testCreate_extensionOnCompartmentResource(String thePolicy, String theExtensionValue, String theExpectedPartition, String theExpectedErrorCode) {
+			if (isNotBlank(thePolicy)) {
+				mySvc.setResourceTypePolicies(Map.of("Observation", ResourceCompartmentStoragePolicy.parse(thePolicy)));
+			}
 
 			Observation obs = createObservationInMultipleCompartments();
-			addPrimaryCompartmentExtension(obs, "Patient/1");
+			addCompartmentExtension(obs, theExtensionValue);
 
-			RequestPartitionId actual = mySvc.identifyForCreate(obs, new ServletRequestDetails());
+			if (isNotBlank(theExpectedErrorCode)) {
+				assertThatThrownBy(() -> mySvc.identifyForCreate(obs, new ServletRequestDetails()))
+					.isInstanceOf(InvalidRequestException.class)
+					.hasMessageContaining(theExpectedErrorCode);
+			} else {
+				RequestPartitionId actual = mySvc.identifyForCreate(obs, new ServletRequestDetails());
+				assertThat(actual.getPartitionIds()).containsExactly(resolveExpectedPartitionId(theExpectedPartition));
+			}
+		}
 
-			assertThat(actual.getPartitionIds()).containsExactly(myPartitionSettings.getDefaultPartitionId());
+		private Integer resolveExpectedPartitionId(String theExpected) {
+			return switch (theExpected) {
+				case "PATIENT1" -> PatientIdPartitionInterceptor.defaultPartitionAlgorithm("1");
+				case "DEFAULT" -> myPartitionSettings.getDefaultPartitionId();
+				default -> Integer.parseInt(theExpected);
+			};
 		}
 	}
-
 
 }


### PR DESCRIPTION
## Summary
- Add `EXT_PATIENT_COMPARTMENT` extension that allows explicitly specifying which Patient compartment a resource belongs to for partition selection
- Extension accepts `Patient/<id>` (assign to a specific Patient's compartment) or `NONE` (treat as non-compartmental, stored in the default partition)
- PatientIdPartitionInterceptor validates extension applicability upfront:
  - Rejected on Patient resources and non-compartment resource types (e.g., Organization)
  - Ignored with a warning under `ALWAYS_USE_*` policies (to keep $merge/$replace-references working)
  - Value-level validation under compartment-based policies (MANDATORY rejects NONE, OPTIONAL/NON_UNIQUE allow it)
- ReplaceReferencesProvenanceSvc automatically sets this extension on Provenance resources created during Patient merge/replace-references operations
- Remove `@Nullable` from `theSourceId` parameter in `ReplaceReferencesProvenanceSvc.createProvenanceObject` (never null in any code path)

## Test plan
- [x] Unit tests in PatientIdPartitionInterceptorTest: parameterized tests covering all policy x extension value combinations, rejection on Patient and non-compartment resources, invalid value formats
- [x] Integration test in PatientIdPartitionInterceptorR4Test verifying Provenance with extension is persisted in correct partition

Closes #7738