### PR TITLE
Externally loaded `CodeSystem` $lookup operation returns incorrect results after delta operation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -1,7 +1,6 @@
 ---
 type: fix
 issue: 7744
-title: "Previously, the terminology cache was not invalidated after $apply-codesystem-delta-remove, 
-CodeSystem create/update, or CodeSystem deletion. This caused $lookup to return stale results, such as still finding 
-a concept after it was removed via delta-remove, or returning old concepts after a CodeSystem was updated or deleted. 
-This has been corrected so that the cache is now invalidated after all terminology mutations."
+title: "Previously, the `$lookup` operation would return stale results after updating an externally loaded `CodeSystem` 
+using [$apply-codesystem-delta-add](/docs/terminology/uploading.html#delta-add-operation) 
+or [$apply-codesystem-delta-add](/docs/terminology/uploading.html#delta-remove-operation). This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7744
+title: "Previously, the terminology cache was not invalidated after $apply-codesystem-delta-remove, 
+CodeSystem create/update, or CodeSystem deletion. This caused $lookup to return stale results, such as still finding 
+a concept after it was removed via delta-remove, or returning old concepts after a CodeSystem was updated or deleted. 
+This has been corrected so that the cache is now invalidated after all terminology mutations."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -1,7 +1,8 @@
 ---
 type: fix
 issue: 7744
-title: "The terminology cache was not being invalidated after $apply-codesystem-delta-add and
-  $apply-codesystem-delta-remove operations. This caused $lookup to return stale results, such as
-  continuing to find a concept after it had been removed via delta-remove. The cache is now properly
-  invalidated after both operations."
+title: "The terminology cache was not being invalidated after $apply-codesystem-delta-remove,
+  CodeSystem create/update, and CodeSystem deletion. This caused $lookup to return stale results,
+  such as continuing to find a concept after it had been removed via delta-remove, or still
+  returning old concepts after a CodeSystem was updated or deleted. The cache is now properly
+  invalidated after all terminology mutations."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 7744
+title: "The terminology cache was not being invalidated after $apply-codesystem-delta-add and
+  $apply-codesystem-delta-remove operations. This caused $lookup to return stale results, such as
+  continuing to find a concept after it had been removed via delta-remove. The cache is now properly
+  invalidated after both operations."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -1,4 +1,0 @@
----
-type: fix
-issue: 7744
-title: "Previously, the terminology cache was not invalidated after $apply-codesystem-delta-remove, CodeSystem create/update, or CodeSystem deletion. This caused $lookup to return stale results, such as still finding a concept after it was removed via delta-remove, or returning old concepts after a CodeSystem was updated or deleted. This has been corrected so that the cache is now invalidated after all terminology mutations."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7744-fix-terminology-cache-invalidation-after-delta-operations.yaml
@@ -1,8 +1,4 @@
 ---
 type: fix
 issue: 7744
-title: "The terminology cache was not being invalidated after $apply-codesystem-delta-remove,
-  CodeSystem create/update, and CodeSystem deletion. This caused $lookup to return stale results,
-  such as continuing to find a concept after it had been removed via delta-remove, or still
-  returning old concepts after a CodeSystem was updated or deleted. The cache is now properly
-  invalidated after all terminology mutations."
+title: "Previously, the terminology cache was not invalidated after $apply-codesystem-delta-remove, CodeSystem create/update, or CodeSystem deletion. This caused $lookup to return stale results, such as still finding a concept after it was removed via delta-remove, or returning old concepts after a CodeSystem was updated or deleted. This has been corrected so that the cache is now invalidated after all terminology mutations."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
@@ -531,6 +531,8 @@ public class TermCodeSystemStorageSvcImpl implements ITermCodeSystemStorageSvc {
 		if (!myDeferredStorageSvc.isStorageQueueEmpty(true)) {
 			ourLog.info("Note that some concept saving has been deferred");
 		}
+
+		myTerminologySvc.invalidateCaches();
 	}
 
 	private TermCodeSystemVersion getExistingTermCodeSystemVersion(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
@@ -185,6 +185,8 @@ public class TermCodeSystemStorageSvcImpl implements ITermCodeSystemStorageSvc {
 			addConceptInHierarchy(csv, parentCodes, nextRootConcept, retVal, codeToConcept, 0);
 		}
 
+		myTerminologySvc.invalidateCaches();
+
 		return retVal;
 	}
 
@@ -226,6 +228,8 @@ public class TermCodeSystemStorageSvcImpl implements ITermCodeSystemStorageSvc {
 		for (TermConcept code : allFoundTermConcepts) {
 			deleteEverythingRelatedToConcept(code, removeCounter);
 		}
+
+		myTerminologySvc.invalidateCaches();
 
 		return new UploadStatistics(removeCounter.get(), target);
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/api/TermCodeSystemDeleteJobSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/api/TermCodeSystemDeleteJobSvc.java
@@ -71,6 +71,9 @@ public class TermCodeSystemDeleteJobSvc implements ITermCodeSystemDeleteJobSvc {
 	@Autowired
 	private ITermDeferredStorageSvc myDeferredStorageSvc;
 
+	@Autowired
+	private ITermReadSvc myTermReadSvc;
+
 	@Override
 	public Iterator<IdAndPartitionId> getAllCodeSystemVersionForCodeSystemPid(long thePid) {
 		// TODO - make this a pageable iterator
@@ -140,6 +143,8 @@ public class TermCodeSystemDeleteJobSvc implements ITermCodeSystemDeleteJobSvc {
 			myTermCodeSystemVersionDao.delete(theTermCodeSystemVersion);
 			ourLog.info("Code system version: {} deleted", theVersionPid);
 		});
+
+		myTermReadSvc.invalidateCaches();
 	}
 
 	@Override
@@ -156,6 +161,8 @@ public class TermCodeSystemDeleteJobSvc implements ITermCodeSystemDeleteJobSvc {
 
 			ourLog.info("Code system {} deleted", thePid);
 		}
+
+		myTermReadSvc.invalidateCaches();
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
@@ -1,9 +1,8 @@
 package ca.uhn.fhir.jpa.term;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import ca.uhn.fhir.context.support.IValidationSupport;
-import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.context.support.LookupCodeRequest;
+import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.entity.TermConcept;
@@ -22,6 +21,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +35,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.leftPad;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -680,6 +680,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		assertThat(afterDeleteB.isFound()).isFalse();
 	}
 
+	@Disabled("Should be fixed by https://github.com/hapifhir/hapi-fhir/issues/7754")
 	@Test
 	public void testStoreNewCodeSystemVersion_lookupReflectsNewConcepts() {
 		// Setup: create a CodeSystem with content=complete and one concept

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
@@ -21,7 +21,6 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -587,41 +586,51 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 
 
 	@Test
-	public void testRemove_lookupCodeReturnsNotFoundAfterRemoval() {
-		// Setup: create code system and add a concept
+	void applyDeltaCodeSystemsAdd_lookupCode_returnsNewConcept() {
+		createNotPresentCodeSystem();
+
+		// Lookup primes the cache with "not found"
+		IValidationSupport.LookupCodeResult before = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(before).isNotNull();
+		assertThat(before.isFound()).isFalse();
+
+		// Delta-add the concept
 		CustomTerminologySet delta = new CustomTerminologySet();
 		delta.addRootConcept("codeA", "displayA");
-		delta.addRootConcept("codeB", "displayB");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
 
-		// Verify lookupCode succeeds for both codes
-		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
+		// Lookup should now find it
+		IValidationSupport.LookupCodeResult after = myTermSvc.lookupCode(
 			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
-		assertThat(resultA).isNotNull();
-		assertThat(resultA.isFound()).isTrue();
-		assertThat(resultA.getCodeDisplay()).isEqualTo("displayA");
+		assertThat(after).isNotNull();
+		assertThat(after.isFound()).isTrue();
+		assertThat(after.getCodeDisplay()).isEqualTo("displayA");
+	}
 
-		IValidationSupport.LookupCodeResult resultB = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
-		assertThat(resultB).isNotNull();
-		assertThat(resultB.isFound()).isTrue();
+	@Test
+	void applyDeltaCodeSystemsRemove_lookupCode_returnsNotFound() {
+		createNotPresentCodeSystem();
+		CustomTerminologySet delta = new CustomTerminologySet();
+		delta.addRootConcept("codeA", "displayA");
+		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
 
-		// Remove codeA
+		// Lookup primes the cache with "found"
+		IValidationSupport.LookupCodeResult before = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(before).isNotNull();
+		assertThat(before.isFound()).isTrue();
+
+		// Delta-remove the concept
 		CustomTerminologySet removeDelta = new CustomTerminologySet();
 		removeDelta.addRootConcept("codeA");
 		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsRemove("http://foo/cs", removeDelta);
 
-		// Verify lookupCode fails for removed code and succeeds for remaining code
-		IValidationSupport.LookupCodeResult afterRemoveA = myTermSvc.lookupCode(
+		// Lookup should no longer find it
+		IValidationSupport.LookupCodeResult after = myTermSvc.lookupCode(
 			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
-		assertThat(afterRemoveA).isNotNull();
-		assertThat(afterRemoveA.isFound()).isFalse();
-
-		IValidationSupport.LookupCodeResult afterRemoveB = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
-		assertThat(afterRemoveB).isNotNull();
-		assertThat(afterRemoveB.isFound()).isTrue();
-		assertThat(afterRemoveB.getCodeDisplay()).isEqualTo("displayB");
+		assertThat(after).isNotNull();
+		assertThat(after.isFound()).isFalse();
 	}
 
 	@Test
@@ -645,78 +654,6 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		vs = myValueSetDao.expand(vs, null);
 		ourLog.debug(myFhirContext.newXmlParser().setPrettyPrint(true).encodeResourceToString(vs));
 		return vs;
-	}
-
-	@Test
-	public void testDeleteCodeSystem_lookupReturnsNotFoundAfterDeletion() {
-		// Setup: create a CodeSystem with concepts
-		CodeSystem cs = new CodeSystem();
-		cs.setUrl("http://foo/cs");
-		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
-		cs.addConcept().setCode("codeA").setDisplay("displayA");
-		cs.addConcept().setCode("codeB").setDisplay("displayB");
-		myCodeSystemDao.create(cs, mySrd);
-
-		// Verify lookup succeeds (populates the cache)
-		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
-		assertThat(resultA).isNotNull();
-		assertThat(resultA.isFound()).isTrue();
-
-		// Delete via the FHIR DAO (same as a user calling DELETE /CodeSystem/...)
-		myCodeSystemDao.deleteByUrl("CodeSystem?url=http://foo/cs", mySrd);
-		myTerminologyDeferredStorageSvc.saveDeferred();
-		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete("termCodeSystemDeleteJob");
-
-		// Verify lookup fails after deletion
-		IValidationSupport.LookupCodeResult afterDeleteA = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
-		assertThat(afterDeleteA).isNotNull();
-		assertThat(afterDeleteA.isFound()).isFalse();
-
-		IValidationSupport.LookupCodeResult afterDeleteB = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
-		assertThat(afterDeleteB).isNotNull();
-		assertThat(afterDeleteB.isFound()).isFalse();
-	}
-
-	@Disabled("Should be fixed by https://github.com/hapifhir/hapi-fhir/issues/7754")
-	@Test
-	public void testStoreNewCodeSystemVersion_lookupReflectsNewConcepts() {
-		// Setup: create a CodeSystem with content=complete and one concept
-		CodeSystem cs = new CodeSystem();
-		cs.setUrl("http://foo/cs");
-		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
-		cs.addConcept().setCode("codeA").setDisplay("displayA");
-		myCodeSystemDao.create(cs, mySrd);
-
-		// Verify initial lookup succeeds
-		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
-		assertThat(resultA).isNotNull();
-		assertThat(resultA.isFound()).isTrue();
-		assertThat(resultA.getCodeDisplay()).isEqualTo("displayA");
-
-		// Update the CodeSystem with different concepts
-		CodeSystem csUpdated = new CodeSystem();
-		csUpdated.setUrl("http://foo/cs");
-		csUpdated.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
-		csUpdated.addConcept().setCode("codeB").setDisplay("displayB");
-		csUpdated.addConcept().setCode("codeC").setDisplay("displayC");
-		myCodeSystemDao.update(csUpdated, mySrd);
-
-		// Verify new concepts are found
-		IValidationSupport.LookupCodeResult resultB = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
-		assertThat(resultB).isNotNull();
-		assertThat(resultB.isFound()).isTrue();
-		assertThat(resultB.getCodeDisplay()).isEqualTo("displayB");
-
-		// Verify old concept from replaced version is no longer found
-		IValidationSupport.LookupCodeResult resultAAfter = myTermSvc.lookupCode(
-			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
-		assertThat(resultAAfter).isNotNull();
-		assertThat(resultAAfter.isFound()).isFalse();
 	}
 
 	private void createNotPresentCodeSystem() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
@@ -587,6 +587,43 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 
 
 	@Test
+	public void testRemove_lookupCodeReturnsNotFoundAfterRemoval() {
+		// Setup: create code system and add a concept
+		CustomTerminologySet delta = new CustomTerminologySet();
+		delta.addRootConcept("codeA", "displayA");
+		delta.addRootConcept("codeB", "displayB");
+		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsAdd("http://foo/cs", delta);
+
+		// Verify lookupCode succeeds for both codes
+		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultA).isNotNull();
+		assertThat(resultA.isFound()).isTrue();
+		assertThat(resultA.getCodeDisplay()).isEqualTo("displayA");
+
+		IValidationSupport.LookupCodeResult resultB = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
+		assertThat(resultB).isNotNull();
+		assertThat(resultB.isFound()).isTrue();
+
+		// Remove codeA
+		CustomTerminologySet removeDelta = new CustomTerminologySet();
+		removeDelta.addRootConcept("codeA");
+		myTermCodeSystemStorageSvc.applyDeltaCodeSystemsRemove("http://foo/cs", removeDelta);
+
+		// Verify lookupCode fails for removed code and succeeds for remaining code
+		IValidationSupport.LookupCodeResult afterRemoveA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(afterRemoveA.isFound()).isFalse();
+
+		IValidationSupport.LookupCodeResult afterRemoveB = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
+		assertThat(afterRemoveB).isNotNull();
+		assertThat(afterRemoveB.isFound()).isTrue();
+		assertThat(afterRemoveB.getCodeDisplay()).isEqualTo("displayB");
+	}
+
+	@Test
 	public void testRemove_UnknownSystem() {
 
 		CustomTerminologySet delta = new CustomTerminologySet();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcDeltaR4Test.java
@@ -614,6 +614,7 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		// Verify lookupCode fails for removed code and succeeds for remaining code
 		IValidationSupport.LookupCodeResult afterRemoveA = myTermSvc.lookupCode(
 			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(afterRemoveA).isNotNull();
 		assertThat(afterRemoveA.isFound()).isFalse();
 
 		IValidationSupport.LookupCodeResult afterRemoveB = myTermSvc.lookupCode(
@@ -644,6 +645,77 @@ public class TerminologySvcDeltaR4Test extends BaseJpaR4Test {
 		vs = myValueSetDao.expand(vs, null);
 		ourLog.debug(myFhirContext.newXmlParser().setPrettyPrint(true).encodeResourceToString(vs));
 		return vs;
+	}
+
+	@Test
+	public void testDeleteCodeSystem_lookupReturnsNotFoundAfterDeletion() {
+		// Setup: create a CodeSystem with concepts
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl("http://foo/cs");
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.addConcept().setCode("codeA").setDisplay("displayA");
+		cs.addConcept().setCode("codeB").setDisplay("displayB");
+		myCodeSystemDao.create(cs, mySrd);
+
+		// Verify lookup succeeds (populates the cache)
+		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultA).isNotNull();
+		assertThat(resultA.isFound()).isTrue();
+
+		// Delete via the FHIR DAO (same as a user calling DELETE /CodeSystem/...)
+		myCodeSystemDao.deleteByUrl("CodeSystem?url=http://foo/cs", mySrd);
+		myTerminologyDeferredStorageSvc.saveDeferred();
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete("termCodeSystemDeleteJob");
+
+		// Verify lookup fails after deletion
+		IValidationSupport.LookupCodeResult afterDeleteA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(afterDeleteA).isNotNull();
+		assertThat(afterDeleteA.isFound()).isFalse();
+
+		IValidationSupport.LookupCodeResult afterDeleteB = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
+		assertThat(afterDeleteB).isNotNull();
+		assertThat(afterDeleteB.isFound()).isFalse();
+	}
+
+	@Test
+	public void testStoreNewCodeSystemVersion_lookupReflectsNewConcepts() {
+		// Setup: create a CodeSystem with content=complete and one concept
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl("http://foo/cs");
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.addConcept().setCode("codeA").setDisplay("displayA");
+		myCodeSystemDao.create(cs, mySrd);
+
+		// Verify initial lookup succeeds
+		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultA).isNotNull();
+		assertThat(resultA.isFound()).isTrue();
+		assertThat(resultA.getCodeDisplay()).isEqualTo("displayA");
+
+		// Update the CodeSystem with different concepts
+		CodeSystem csUpdated = new CodeSystem();
+		csUpdated.setUrl("http://foo/cs");
+		csUpdated.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		csUpdated.addConcept().setCode("codeB").setDisplay("displayB");
+		csUpdated.addConcept().setCode("codeC").setDisplay("displayC");
+		myCodeSystemDao.update(csUpdated, mySrd);
+
+		// Verify new concepts are found
+		IValidationSupport.LookupCodeResult resultB = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
+		assertThat(resultB).isNotNull();
+		assertThat(resultB.isFound()).isTrue();
+		assertThat(resultB.getCodeDisplay()).isEqualTo("displayB");
+
+		// Verify old concept from replaced version is no longer found
+		IValidationSupport.LookupCodeResult resultAAfter = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultAAfter).isNotNull();
+		assertThat(resultAAfter.isFound()).isFalse();
 	}
 
 	private void createNotPresentCodeSystem() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplR4Test.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import ca.uhn.fhir.context.support.ConceptValidationOptions;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.context.support.LookupCodeRequest;
 import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
@@ -23,6 +24,7 @@ import org.hl7.fhir.r4.model.ConceptMap;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.r4.model.codesystems.HttpVerb;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -565,6 +567,78 @@ public class TerminologySvcImplR4Test extends BaseTermR4Test {
 			TermCodeSystem termCodeSystem = myTermCodeSystemDao.findByResourcePid(JpaPid.fromId(id.getIdPartAsLong()));
 			assertEquals("1", termCodeSystem.getCurrentVersion().getCodeSystemVersionId());
 		});
+	}
+
+	@Test
+	void deleteCodeSystem_lookupCode_returnsNotFound() {
+		// Setup: create a CodeSystem with concepts
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl("http://foo/cs");
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.addConcept().setCode("codeA").setDisplay("displayA");
+		cs.addConcept().setCode("codeB").setDisplay("displayB");
+		myCodeSystemDao.create(cs, mySrd);
+
+		// Verify lookup succeeds (populates the cache)
+		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultA).isNotNull();
+		assertThat(resultA.isFound()).isTrue();
+
+		// Delete via the FHIR DAO (same as a user calling DELETE /CodeSystem/...)
+		myCodeSystemDao.deleteByUrl("CodeSystem?url=http://foo/cs", mySrd);
+		myTerminologyDeferredStorageSvc.saveDeferred();
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete("termCodeSystemDeleteJob");
+
+		// Verify lookup fails after deletion
+		IValidationSupport.LookupCodeResult afterDeleteA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(afterDeleteA).isNotNull();
+		assertThat(afterDeleteA.isFound()).isFalse();
+
+		IValidationSupport.LookupCodeResult afterDeleteB = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
+		assertThat(afterDeleteB).isNotNull();
+		assertThat(afterDeleteB.isFound()).isFalse();
+	}
+
+	@Disabled("Should be fixed by https://github.com/hapifhir/hapi-fhir/issues/7754")
+	@Test
+	void updateCodeSystem_lookupCode_reflectsNewConcepts() {
+		// Setup: create a CodeSystem with content=complete and one concept
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl("http://foo/cs");
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.addConcept().setCode("codeA").setDisplay("displayA");
+		myCodeSystemDao.create(cs, mySrd);
+
+		// Verify initial lookup succeeds
+		IValidationSupport.LookupCodeResult resultA = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultA).isNotNull();
+		assertThat(resultA.isFound()).isTrue();
+		assertThat(resultA.getCodeDisplay()).isEqualTo("displayA");
+
+		// Update the CodeSystem with different concepts
+		CodeSystem csUpdated = new CodeSystem();
+		csUpdated.setUrl("http://foo/cs");
+		csUpdated.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		csUpdated.addConcept().setCode("codeB").setDisplay("displayB");
+		csUpdated.addConcept().setCode("codeC").setDisplay("displayC");
+		myCodeSystemDao.update(csUpdated, mySrd);
+
+		// Verify new concepts are found
+		IValidationSupport.LookupCodeResult resultB = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeB"));
+		assertThat(resultB).isNotNull();
+		assertThat(resultB.isFound()).isTrue();
+		assertThat(resultB.getCodeDisplay()).isEqualTo("displayB");
+
+		// Verify old concept from replaced version is no longer found
+		IValidationSupport.LookupCodeResult resultAAfter = myTermSvc.lookupCode(
+			new ValidationSupportContext(myValidationSupport), new LookupCodeRequest("http://foo/cs", "codeA"));
+		assertThat(resultAAfter).isNotNull();
+		assertThat(resultAAfter.isFound()).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #7744. See description for details about the fixed issue(s).

**Root Cause**

This issue is likely to have been introduced by #6522.

 `TermReadSvcImpl.getCurrentCodeSystemVersion()` caches `TermCodeSystemVersionDetails` in the `CodeSystem` resource's userData map. The following operations modify terminology tables but never call `invalidateCaches()`:
- `applyDeltaCodeSystemsAdd()`
- `applyDeltaCodeSystemsRemove()`

**Fix**
Added `invalidateCaches()` as part of terminology delta operations in `TermCodeSystemStorageSvcImpl`.
