### PR TITLE
Fix $validate crash on MeasureReport with versioned measure reference

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7200-fix-validate-crash-versioned-measure-reference.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7200-fix-validate-crash-versioned-measure-reference.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 7200
+title: "Previously, the $validate operation would crash when validating a MeasureReport whose
+  measure element contained a versioned canonical reference (e.g. http://example.org/Measure/MyMeasure|1.0.0).
+  This was caused by WorkerContextValidationSupportAdapter.fetchResourceVersions() being
+  unimplemented. The method now delegates to the existing fetchResource infrastructure to
+  resolve resources by their canonical URL."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/VersionSpecificWorkerContextR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/VersionSpecificWorkerContextR4Test.java
@@ -9,6 +9,7 @@ import org.hl7.fhir.common.hapi.validation.validator.WorkerContextValidationSupp
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.ElementDefinition;
+import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,6 +105,36 @@ public class VersionSpecificWorkerContextR4Test extends BaseResourceProviderR4Te
 			// verify that the sub-subsequent fetchResource returns the same resource instance from the cache
 			org.hl7.fhir.r5.model.ValueSet fetchedCodeSystem2 = myWorkerContext.fetchResource(org.hl7.fhir.r5.model.ValueSet.class, resourceUrl);
 			assertThat(fetchedCodeSystem2).isSameAs(fetchedCodeSystem1);
+		}
+
+		@Test
+		void fetchResourceVersions_withMeasure_returnsMatchingResource() {
+			// setup
+			final String measureUrl = "http://example.com/Measure/example-measure";
+			final String measureVersion = "1.0.0";
+			Measure measure = new Measure();
+			measure.setUrl(measureUrl);
+			measure.setVersion(measureVersion);
+			measure.setName("ExampleMeasure");
+			myDaoRegistry.getResourceDao(Measure.class).create(measure, mySrd);
+
+			// execute
+			List<org.hl7.fhir.r5.model.Measure> results = myWorkerContext.fetchResourceVersions(
+				org.hl7.fhir.r5.model.Measure.class, measureUrl);
+
+			// validate
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getVersion()).isEqualTo(measureVersion);
+		}
+
+		@Test
+		void fetchResourceVersions_withNonExistentResource_returnsEmptyList() {
+			// execute
+			List<org.hl7.fhir.r5.model.Measure> results = myWorkerContext.fetchResourceVersions(
+				org.hl7.fhir.r5.model.Measure.class, "http://example.com/Measure/non-existent");
+
+			// validate
+			assertThat(results).isEmpty();
 		}
 
 		@Test

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
@@ -985,8 +985,13 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 		throw new UnsupportedOperationException(Msg.code(650) + "Unable to fetch resources of type: " + theClass);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public <T extends Resource> List<T> fetchResourceVersions(Class<T> class_, String url) {
+		T resource = fetchResource(class_, url, null);
+		if (resource != null) {
+			return List.of(resource);
+		}
 		return List.of();
 	}
 


### PR DESCRIPTION
Summary

- Implement WorkerContextValidationSupportAdapter.fetchResourceVersions() which was previously a stub returning an empty list (and in older versions threw UnsupportedOperationException). The FHIR core MeasureValidator calls this method when a MeasureReport references a Measure with a versioned canonical URL (e.g., http://example.org/Measure/MyMeasure|1.0.0). The method now delegates to the existing fetchResource  infrastructure to resolve the resource by its base canonical URL.

Test plan

- fetchResourceVersions_withMeasure_returnsMatchingResource — creates a Measure, verifies fetchResourceVersions returns it by canonical URL   
- fetchResourceVersions_withNonExistentResource_returnsEmptyList — verifies graceful empty return for unknown URLs
- All existing VersionSpecificWorkerContextR4Test tests pass (7/7)                                                                            

Fixes #7200 