### PR TITLE
Register in-flight transaction resources with TransactionDetails

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7768-register-tx-resources-with-txdetails.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7768-register-tx-resources-with-txdetails.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+jira: SMILE-11786
+issue: 7768
+title: "While processing a FHIR Transaction, stored resources are added to the TransactionDetails so that
+  interceptors have a way of resolving them for pointcuts which occur during the transaction processing."

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
@@ -14,7 +14,6 @@ import ca.uhn.fhir.jpa.entity.TermValueSet;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.model.api.StorageResponseCodeEnum;
-import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
 import ca.uhn.fhir.rest.param.StringParam;
@@ -23,7 +22,6 @@ import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
-import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.util.BundleBuilder;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -69,6 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("unchecked")
 public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 
 	@Override
@@ -97,7 +96,7 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 
 
 	/**
-	 * If an inline match URL is the same as a conditional create in the same transaction, make sure we
+	 * If an inline match URL is the same as a conditional-create in the same transaction, make sure we
 	 * don't issue a select for it
 	 */
 	@ParameterizedTest(name = "{index}: {0}")
@@ -1025,13 +1024,23 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 		assertEquals("HELLO", actual.getNameFirstRep().getFamily());
 	}
 
-
+	/**
+	 * Given: A FHIR transaction which creates/updates an Organization, and a Patient with a reference to that
+	 * Organization.
+	 * <p>
+	 * Expect: An interceptor on the XXX_PRESTORAGE pointcuts should be able to look up the Organization by
+	 * reference from within the {@link TransactionDetails}.
+	 */
 	@ParameterizedTest
 	@CsvSource(textBlock = """
-		true
-		false
+		# PatientAlreadyExists , OrgAction      , ExpectFound
+		true                   , CREATE         , true
+		true                   , UPDATE         , true
+		true                   , COND_CREATE    , true
+		true                   , COND_UPDATE    , true
+		false                  , COND_UPDATE    , true
 		""")
-	void testInterceptorCanResolveReferenceTargetWithinTransaction(boolean theReferenceSourceAlreadyExists) {
+	void testInterceptorCanResolveReferenceTargetWithinTransaction(boolean theReferenceSourceAlreadyExists, String theOrgAction, boolean theExpectFound) {
 		AtomicBoolean foundOrganization = new AtomicBoolean(false);
 
 		if (theReferenceSourceAlreadyExists) {
@@ -1070,19 +1079,32 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 
 		String organizationUuid = IdType.newRandomUuid().getValue();
 		BundleBuilder bb = new BundleBuilder(myFhirContext);
-		bb.addTransactionUpdateEntry(buildOrganization(withIdentifier("http://orgs", "123")), null, organizationUuid)
-			.conditional("Organization?identifier=http://orgs|123");
+		switch (theOrgAction) {
+			case "CREATE" ->
+				bb.addTransactionCreateEntry(buildOrganization(withId("O1"), withIdentifier("http://orgs", "123")), organizationUuid);
+			case "UPDATE" ->
+				bb.addTransactionUpdateEntry(buildOrganization(withId("O1"), withIdentifier("http://orgs", "123")), "Organization/O1", organizationUuid);
+			case "COND_CREATE" ->
+				bb.addTransactionCreateEntry(buildOrganization(withIdentifier("http://orgs", "123")), organizationUuid)
+					.conditional("Organization?identifier=http://orgs|123");
+			case "COND_UPDATE" ->
+				bb.addTransactionUpdateEntry(buildOrganization(withIdentifier("http://orgs", "123")), null, organizationUuid)
+					.conditional("Organization?identifier=http://orgs|123");
+		}
+
 		bb.addTransactionUpdateEntry(buildPatient(withIdentifier("http://patients", "123"), withOrganization(organizationUuid)))
 			.conditional("Patient?identifier=http://patients|123");
 		Bundle requestBundle = bb.getBundleTyped();
+
 		ourLog.info("HC45560: requestBundle: {}", myFhirCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(requestBundle));
 
 		mySystemDao.transaction(newSrd(), requestBundle);
 
-		assertTrue(foundOrganization.get());
+		assertEquals(theExpectFound, foundOrganization.get());
 	}
 
 
+	@SuppressWarnings("unchecked")
 	@Test
 	void testMetaAdd_Added() {
 		// Setup
@@ -1223,8 +1245,7 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 
 	@Nonnull
 	private static List<String> toMetaTagCodes(Patient actualA) {
-		List<String> metaTagCodes = actualA.getMeta().getTag().stream().map(Coding::getCode).toList();
-		return metaTagCodes;
+		return actualA.getMeta().getTag().stream().map(Coding::getCode).toList();
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
@@ -1026,11 +1026,18 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 	}
 
 
-	@Test
-	void testInterceptorAccessToTransactionContents() {
-		createPatient(withId("A"), withIdentifier("http://patients", "123"));
-
+	@ParameterizedTest
+	@CsvSource(textBlock = """
+		true
+		false
+		""")
+	void testInterceptorCanResolveReferenceTargetWithinTransaction(boolean theReferenceSourceAlreadyExists) {
 		AtomicBoolean foundOrganization = new AtomicBoolean(false);
+
+		if (theReferenceSourceAlreadyExists) {
+			createPatient(withId("A"), withIdentifier("http://patients", "123"));
+		}
+
 
 		@Interceptor
 		class MyInterceptor {
@@ -1049,12 +1056,8 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 			}
 
 			private void processResource(IBaseResource resource, TransactionDetails transactionDetails) {
-				Reference reference = null;
 				if (resource instanceof Patient patient) {
-					reference = patient.getManagingOrganization();
-				}
-
-				if (reference != null) {
+					Reference reference = patient.getManagingOrganization();
 					IBaseResource target = transactionDetails.getResolvedResource(reference.getReferenceElement());
 					if (target != null) {
 						foundOrganization.set(true);

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
@@ -14,13 +14,16 @@ import ca.uhn.fhir.jpa.entity.TermValueSet;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.model.api.StorageResponseCodeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.api.server.storage.TransactionDetails;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.util.BundleBuilder;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -51,7 +54,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static ca.uhn.fhir.interceptor.api.Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED;
+import static ca.uhn.fhir.interceptor.api.Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED;
 import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -988,7 +994,7 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 		createPatient(withId("A"), withFamily("HELLO"), withActiveTrue());
 
 		class MyInterceptor {
-			@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+			@Hook(STORAGE_PRESTORAGE_RESOURCE_UPDATED)
 			public void onResourceUpdated(IBaseResource theOldResource, IBaseResource theNewResource) {
 				Patient patient = (Patient) theNewResource;
 				patient.getNameFirstRep().setFamily("HELLO");
@@ -1017,6 +1023,60 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 		// Verify
 		Patient actual = myPatientDao.read(new IdType("Patient/A"), mySrd);
 		assertEquals("HELLO", actual.getNameFirstRep().getFamily());
+	}
+
+
+	@Test
+	void testInterceptorAccessToTransactionContents() {
+		createPatient(withId("A"), withIdentifier("http://patients", "123"));
+
+		AtomicBoolean foundOrganization = new AtomicBoolean(false);
+
+		@Interceptor
+		class MyInterceptor {
+
+			@Hook(STORAGE_PRESTORAGE_RESOURCE_CREATED)
+			public void resourceCreated(IBaseResource resource, TransactionDetails transactionDetails) {
+				processResource(resource, transactionDetails);
+			}
+
+			@Hook(STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+			public void resourceUpdated(
+				IBaseResource oldResource,
+				IBaseResource newResource,
+				TransactionDetails transactionDetails) {
+				processResource(newResource, transactionDetails);
+			}
+
+			private void processResource(IBaseResource resource, TransactionDetails transactionDetails) {
+				Reference reference = null;
+				if (resource instanceof Patient patient) {
+					reference = patient.getManagingOrganization();
+				}
+
+				if (reference != null) {
+					IBaseResource target = transactionDetails.getResolvedResource(reference.getReferenceElement());
+					if (target != null) {
+						foundOrganization.set(true);
+					}
+				}
+			}
+
+		}
+		registerInterceptor(new MyInterceptor());
+
+		String organizationUuid = IdType.newRandomUuid().getValue();
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionUpdateEntry(buildOrganization(withIdentifier("http://orgs", "123")), null, organizationUuid)
+			.conditional("Organization?identifier=http://orgs|123");
+		bb.addTransactionUpdateEntry(buildPatient(withIdentifier("http://patients", "123"), withOrganization(organizationUuid)))
+			.conditional("Patient?identifier=http://patients|123");
+		Bundle requestBundle = bb.getBundleTyped();
+		ourLog.info("HC45560: requestBundle: {}", myFhirCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(requestBundle));
+
+		mySystemDao.transaction(newSrd(), requestBundle);
+
+		assertTrue(foundOrganization.get());
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/FhirSystemDaoTransactionR5Test.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static ca.uhn.fhir.interceptor.api.Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED;
 import static ca.uhn.fhir.interceptor.api.Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED;
@@ -91,7 +92,7 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 			myPartitionSettings.setPartitioningEnabled(defaults.isPartitioningEnabled());
 		}
 
-		myInterceptorRegistry.unregisterInterceptorsIf(t->t instanceof FixedPartitionInterceptor);
+		myInterceptorRegistry.unregisterInterceptorsIf(t -> t instanceof FixedPartitionInterceptor);
 	}
 
 
@@ -736,7 +737,7 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 		logAllResources();
 		logAllResourceVersions();
 
-		assertThrows(ResourceGoneException.class, ()->myPatientDao.read(resourceId.withVersion("2"), mySrd));
+		assertThrows(ResourceGoneException.class, () -> myPatientDao.read(resourceId.withVersion("2"), mySrd));
 		actual = myPatientDao.read(resourceId.withVersion("3"), mySrd);
 		assertEquals("3", actual.getIdElement().getVersionIdPart());
 		actual = myPatientDao.read(resourceId.toVersionless(), mySrd);
@@ -853,8 +854,6 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 		assertFalse(actual.isDeleted());
 		assertFalse(actual.getActive());
 	}
-
-
 
 
 	/**
@@ -998,11 +997,13 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 				Patient patient = (Patient) theNewResource;
 				patient.getNameFirstRep().setFamily("HELLO");
 			}
+
 			@Hook(Pointcut.STORAGE_PRESEARCH_REGISTERED)
 			public void onPreSearch(SearchParameterMap theSearchParameterMap) {
 				theSearchParameterMap.remove("family");
 				theSearchParameterMap.add("family", new StringParam("HELLO"));
 			}
+
 			@Hook(Pointcut.STORAGE_PREVERIFY_CONDITIONAL_MATCH_CRITERIA)
 			public void onPreVerifyConditionalUrl(PreVerifyConditionalMatchCriteriaRequest theRequest) {
 				theRequest.setConditionalUrl("Patient?family=HELLO");
@@ -1033,15 +1034,23 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 	 */
 	@ParameterizedTest
 	@CsvSource(textBlock = """
-		# PatientAlreadyExists , OrgAction      , ExpectFound
-		true                   , CREATE         , true
-		true                   , UPDATE         , true
-		true                   , COND_CREATE    , true
-		true                   , COND_UPDATE    , true
-		false                  , COND_UPDATE    , true
+		# PatientAlreadyExists , PatientAction , OrgAction      , ExpectFound
+		true                   , COND_UPDATE   , CREATE         , true
+		true                   , COND_UPDATE   , UPDATE         , true
+		true                   , COND_UPDATE   , COND_CREATE    , true
+		true                   , COND_UPDATE   , COND_UPDATE    , true
+		false                  , COND_UPDATE   , COND_UPDATE    , true
+		# If the Patient has a POST verb, it will happen first because of the FHIR
+		# transaction processing rules, so we can't make the reference target resolvable at the time
+		# it is processed
+		true                   , CREATE        , COND_UPDATE    , false
+		false                  , CREATE        , COND_UPDATE    , false
+		true                   , COND_CREATE   , COND_UPDATE    , false
+		false                  , COND_CREATE   , COND_UPDATE    , false
 		""")
-	void testInterceptorCanResolveReferenceTargetWithinTransaction(boolean theReferenceSourceAlreadyExists, String theOrgAction, boolean theExpectFound) {
+	void testInterceptorCanResolveReferenceTargetWithinTransaction(boolean theReferenceSourceAlreadyExists, String thePatientAction, String theOrgAction, boolean theExpectFound) {
 		AtomicBoolean foundOrganization = new AtomicBoolean(false);
+		AtomicInteger interceptorCallCount = new AtomicInteger(0);
 
 		if (theReferenceSourceAlreadyExists) {
 			createPatient(withId("A"), withIdentifier("http://patients", "123"));
@@ -1066,6 +1075,7 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 
 			private void processResource(IBaseResource resource, TransactionDetails transactionDetails) {
 				if (resource instanceof Patient patient) {
+					interceptorCallCount.incrementAndGet();
 					Reference reference = patient.getManagingOrganization();
 					IBaseResource target = transactionDetails.getResolvedResource(reference.getReferenceElement());
 					if (target != null) {
@@ -1090,17 +1100,28 @@ public class FhirSystemDaoTransactionR5Test extends BaseJpaR5Test {
 			case "COND_UPDATE" ->
 				bb.addTransactionUpdateEntry(buildOrganization(withIdentifier("http://orgs", "123")), null, organizationUuid)
 					.conditional("Organization?identifier=http://orgs|123");
+			default -> throw new IllegalArgumentException("Unknown action: " + theOrgAction);
 		}
 
-		bb.addTransactionUpdateEntry(buildPatient(withIdentifier("http://patients", "123"), withOrganization(organizationUuid)))
-			.conditional("Patient?identifier=http://patients|123");
+		switch (thePatientAction) {
+			case "CREATE" ->
+				bb.addTransactionCreateEntry(buildPatient(withIdentifier("http://patients", "123"), withOrganization(organizationUuid)));
+			case "COND_CREATE" ->
+				bb.addTransactionCreateEntry(buildPatient(withIdentifier("http://patients", "123"), withOrganization(organizationUuid)))
+					.conditional("Patient?identifier=http://patients|123");
+			case "COND_UPDATE" ->
+				bb.addTransactionUpdateEntry(buildPatient(withIdentifier("http://patients", "123"), withOrganization(organizationUuid)))
+					.conditional("Patient?identifier=http://patients|123");
+			default -> throw new IllegalArgumentException("Unknown action: " + theOrgAction);
+		}
 		Bundle requestBundle = bb.getBundleTyped();
-
-		ourLog.info("HC45560: requestBundle: {}", myFhirCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(requestBundle));
 
 		mySystemDao.transaction(newSrd(), requestBundle);
 
 		assertEquals(theExpectFound, foundOrganization.get());
+		if (theExpectFound) {
+			assertEquals(1, interceptorCallCount.get());
+		}
 	}
 
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -338,7 +338,8 @@ public abstract class BaseTransactionProcessor {
 			IBase theNewEntry,
 			String theResourceType,
 			IBaseResource theRes,
-			RequestDetails theRequestDetails) {
+			RequestDetails theRequestDetails,
+			TransactionDetails theTransactionDetails) {
 		IIdType newId = theOutcome.getId().toUnqualified();
 		IIdType resourceId =
 				isPlaceholder(theNextResourceId) ? theNextResourceId : theNextResourceId.toUnqualifiedVersionless();
@@ -347,6 +348,8 @@ public abstract class BaseTransactionProcessor {
 				theIdSubstitutions.put(resourceId, newId);
 			}
 			if (isPlaceholder(resourceId)) {
+				theTransactionDetails.addResolvedResource(resourceId, theRes);
+
 				/*
 				 * The correct way for substitution IDs to be is to be with no resource type, but we'll accept the qualified kind too just to be lenient.
 				 */
@@ -1459,7 +1462,8 @@ public abstract class BaseTransactionProcessor {
 									nextRespEntry,
 									resourceType,
 									res,
-									requestDetailsForEntry);
+									requestDetailsForEntry,
+									theTransactionDetails);
 						}
 						entriesToProcess.put(nextRespEntry, outcome.getId(), nextRespEntry);
 						theTransactionDetails.addResolvedResource(outcome.getId(), outcome::getResource);
@@ -1500,9 +1504,6 @@ public abstract class BaseTransactionProcessor {
 								deletedResources.add(deleted.getIdDt()
 										.toUnqualifiedVersionless()
 										.getValueAsString());
-							}
-							if (allDeleted.isEmpty()) {
-								status = Constants.STATUS_HTTP_204_NO_CONTENT;
 							}
 
 							myVersionAdapter.setResponseOutcome(nextRespEntry, deleteOutcome.getOperationOutcome());
@@ -1566,7 +1567,8 @@ public abstract class BaseTransactionProcessor {
 								nextRespEntry,
 								resourceType,
 								res,
-								requestDetailsForEntry);
+								requestDetailsForEntry,
+								theTransactionDetails);
 						entriesToProcess.put(nextRespEntry, outcome.getId(), nextRespEntry);
 						break;
 					}
@@ -1651,7 +1653,8 @@ public abstract class BaseTransactionProcessor {
 									nextRespEntry,
 									resourceType,
 									res,
-									requestDetailsForEntry);
+									requestDetailsForEntry,
+									theTransactionDetails);
 						}
 						entriesToProcess.put(nextRespEntry, outcome.getId(), nextRespEntry);
 

--- a/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/ITestDataBuilder.java
+++ b/hapi-fhir-test-utilities/src/main/java/ca/uhn/fhir/test/utilities/ITestDataBuilder.java
@@ -302,6 +302,10 @@ public interface ITestDataBuilder {
 		return createResource("Organization", theModifiers);
 	}
 
+	default IBaseResource buildOrganization(ICreationArgument... theModifiers) {
+		return buildResource("Organization", theModifiers);
+	}
+
 	default IIdType createPractitioner(ICreationArgument... theModifiers) {
 		return createResource("Practitioner", theModifiers);
 	}
@@ -504,13 +508,13 @@ public interface ITestDataBuilder {
 	/**
 	 * Sets the <code>managingOrganization</code> element on a Patient
 	 */
-	default ICreationArgument withOrganization(@Nullable String theHasMember) {
-		IIdType id = theHasMember != null ? getFhirContext().getVersion().newIdType(theHasMember) : null;
+	default ICreationArgument withOrganization(@Nullable String theOrganizationId) {
+		IIdType id = theOrganizationId != null ? getFhirContext().getVersion().newIdType(theOrganizationId) : null;
 		return withReference("managingOrganization", id);
 	}
 
-	default ICreationArgument withOrganization(@Nullable IIdType theHasMember) {
-		return withReference("managingOrganization", theHasMember);
+	default ICreationArgument withOrganization(@Nullable IIdType theOrganizationId) {
+		return withReference("managingOrganization", theOrganizationId);
 	}
 
 	/**


### PR DESCRIPTION
As we work through the operations in a FHIR transaction, we should register any resources we've created/updated with the TransactionDetails so that any interceptors have a way of accessing them.