### PR TITLE
Change default Provenance compartment policy to NON_UNIQUE_COMPARTMENT_IN_DEFAULT

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>8.9.14-SNAPSHOT</version>
+		 <version>8.9.15-SNAPSHOT</version>
 
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>8.9.14-SNAPSHOT</version>
+	<version>8.9.15-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-apache-http5/pom.xml
+++ b/hapi-fhir-client-apache-http5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpa-hibernate-services/pom.xml
+++ b/hapi-fhir-jpa-hibernate-services/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-ips/pom.xml
+++ b/hapi-fhir-jpaserver-ips/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-dstu2/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-dstu3/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu3/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -227,13 +227,29 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 		createPatient(withId("A"), withActiveTrue());
 		createPatient(withId("B"), withActiveTrue());
 
-		// Test / Verify
+		// Test
 		Provenance provenance = new Provenance();
 		provenance.addTarget().setReference("Patient/A");
 		provenance.addTarget().setReference("Patient/B");
-		assertThatThrownBy(()->myProvenanceDao.create(provenance, newSrd()))
-			.isInstanceOf(InvalidRequestException.class)
-			.hasMessageContaining("Policy does not allow resource of type \"Provenance\" to be created in multiple Patient compartments: Patient/A, Patient/B");
+		IIdType provenanceId = myProvenanceDao.create(provenance, newSrd()).getId();
+
+		// Verify - default policy for Provenance is NON_UNIQUE_COMPARTMENT_IN_DEFAULT,
+		// so multi-patient Provenance goes to default partition
+		assertResourceIsInPartition(ALTERNATE_DEFAULT_ID, provenanceId);
+	}
+
+	@Test
+	void testCreateProvenance_NoPatientCompartment() {
+		// Setup
+		createResource("Organization", withId("O"), withName("Test Org"));
+
+		// Test
+		Provenance provenance = new Provenance();
+		provenance.addTarget().setReference("Organization/O");
+		IIdType provenanceId = myProvenanceDao.create(provenance, newSrd()).getId();
+
+		// Verify - Provenance with no Patient targets goes to default partition
+		assertResourceIsInPartition(ALTERNATE_DEFAULT_ID, provenanceId);
 	}
 
 	@ParameterizedTest

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/PatientIdModeNonPatientMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/PatientIdModeNonPatientMergeR4Test.java
@@ -1,0 +1,253 @@
+package ca.uhn.fhir.jpa.provider.merge;
+
+import ca.uhn.fhir.jpa.interceptor.PatientIdPartitionInterceptor;
+import ca.uhn.fhir.jpa.merge.MergeOperationTestHelper;
+import ca.uhn.fhir.jpa.merge.MergeTestParameters;
+import ca.uhn.fhir.jpa.model.config.PartitionSettings;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
+import ca.uhn.fhir.jpa.test.Batch2JobHelper;
+import ca.uhn.fhir.merge.ResourceLinkServiceFactory;
+import ca.uhn.fhir.parser.StrictErrorHandler;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Set;
+
+import static ca.uhn.fhir.jpa.config.r4.FhirContextR4Config.DEFAULT_PRESERVE_VERSION_REFS_R4_AND_LATER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for non-Patient resource $merge in PATIENT_ID unnamed partition mode.
+ *
+ * <p>Verifies that merging non-Patient resources (Observation, Organization) succeeds
+ * when {@code PatientIdPartitionInterceptor} is active, now that Provenance uses the
+ * {@code NON_UNIQUE_COMPARTMENT_IN_DEFAULT} policy.
+ */
+// Created by claude-opus-4-6
+class PatientIdModeNonPatientMergeR4Test extends BaseResourceProviderR4Test {
+
+	@Autowired
+	private Batch2JobHelper myBatch2JobHelper;
+	@Autowired
+	private ISearchParamExtractor mySearchParamExtractor;
+	@Autowired
+	private ResourceLinkServiceFactory myResourceLinkServiceFactory;
+	private MergeOperationTestHelper myMergeHelper;
+
+	@Override
+	@BeforeEach
+	public void before() throws Exception {
+		super.before();
+
+		// Registered here, unregistered automatically by BaseJpaTest.@AfterEach
+		PatientIdPartitionInterceptor partitionInterceptor = new PatientIdPartitionInterceptor(
+			getFhirContext(), mySearchParamExtractor, myPartitionSettings, myDaoRegistry);
+		registerInterceptor(partitionInterceptor);
+
+		myPartitionSettings.setPartitioningEnabled(true);
+		myPartitionSettings.setUnnamedPartitionMode(true);
+		myPartitionSettings.setAllowReferencesAcrossPartitions(
+			PartitionSettings.CrossPartitionReferenceMode.ALLOWED_UNQUALIFIED);
+
+		myFhirContext.setParserErrorHandler(new StrictErrorHandler());
+		myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths("Provenance.target");
+
+		myMergeHelper = new MergeOperationTestHelper(
+			myClient, myBatch2JobHelper, myFhirContext, myResourceLinkServiceFactory, myDaoRegistry);
+	}
+
+	@Override
+	@AfterEach
+	public void after() throws Exception {
+		super.after();
+
+		PartitionSettings defaultPartitionSettings = new PartitionSettings();
+		myPartitionSettings.setPartitioningEnabled(defaultPartitionSettings.isPartitioningEnabled());
+		myPartitionSettings.setUnnamedPartitionMode(defaultPartitionSettings.isUnnamedPartitionMode());
+		myPartitionSettings.setAllowReferencesAcrossPartitions(
+			defaultPartitionSettings.getAllowReferencesAcrossPartitions());
+
+		myFhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths(
+			DEFAULT_PRESERVE_VERSION_REFS_R4_AND_LATER);
+	}
+
+	private Integer getPartitionId(IIdType theId) {
+		return runInTransaction(() -> {
+			ResourceTable resourceTable = myResourceTableDao
+				.findByTypeAndFhirId(theId.getResourceType(), theId.getIdPart())
+				.orElseThrow(() -> new AssertionError("Resource not found: " + theId.toUnqualifiedVersionless()));
+			return resourceTable.getPartitionId().getPartitionId();
+		});
+	}
+
+	private void assertInSamePartition(IIdType theId1, IIdType theId2) {
+		Integer partitionId1 = getPartitionId(theId1);
+		Integer partitionId2 = getPartitionId(theId2);
+		assertThat(partitionId1)
+			.as("Expected %s and %s to be in the same partition", theId1, theId2)
+			.isEqualTo(partitionId2);
+	}
+
+	private <T extends IBaseResource> T readResource(Class<T> theType, IIdType theId) {
+		return myClient.read().resource(theType).withId(theId).execute();
+	}
+
+	private Identifier createTestIdentifier(String theValue) {
+		return new Identifier().setSystem("http://test").setValue(theValue);
+	}
+
+	// Observation merge in Patient ID Partition mode: both Observations reference the same Patient
+	// and are in the same partition.
+	@Test
+	void testMergeObservations_ThenUndoMergeThem_BothSucceed() {
+		// Setup: create a Patient for the Observations to reference
+		Patient patient = new Patient();
+		patient.setId("Patient/obs-owner");
+		myClient.update().resource(patient).execute();
+		IIdType patientId = new IdType("Patient/obs-owner");
+
+		// Setup: two Observations referencing the same Patient (same compartment)
+		Observation sourceObs = new Observation();
+		sourceObs.getSubject().setReference(patientId.getValue());
+		sourceObs.addIdentifier(createTestIdentifier("obs-source"));
+		IIdType sourceObsId = myClient.create().resource(sourceObs).execute().getId().toUnqualifiedVersionless();
+
+		Observation targetObs = new Observation();
+		targetObs.getSubject().setReference(patientId.getValue());
+		targetObs.addIdentifier(createTestIdentifier("obs-target"));
+		IIdType targetObsId = myClient.create().resource(targetObs).execute().getId().toUnqualifiedVersionless();
+
+		assertInSamePartition(sourceObsId, targetObsId);
+
+		// Create a DiagnosticReport that references the source Observation
+		DiagnosticReport report = new DiagnosticReport();
+		report.getSubject().setReference(patientId.getValue());
+		report.addResult().setReference(sourceObsId.getValue());
+		IIdType reportId = myClient.create().resource(report).execute().getId().toUnqualifiedVersionless();
+
+		// Save snapshots before merge
+		IBaseResource sourceObsBefore = readResource(Observation.class, sourceObsId);
+		IBaseResource targetObsBefore = readResource(Observation.class, targetObsId);
+		IBaseResource reportBefore = readResource(DiagnosticReport.class, reportId);
+
+		// Execute: merge Observation via $hapi.fhir.merge
+		MergeTestParameters params = new MergeTestParameters()
+			.sourceResource(new Reference(sourceObsId))
+			.targetResource(new Reference(targetObsId))
+			.deleteSource(false);
+		Parameters result = myMergeHelper.callMergeOperation("Observation", params, false);
+
+		// Verify: merge succeeded
+		myMergeHelper.validateSyncMergeOutcome(result, params.asParametersResource(), targetObsId);
+
+		// Validate resources after merge
+		IIdType expectedVersionedSourceId = sourceObsId.withVersion("2");
+		IIdType expectedVersionedTargetId = targetObsId.withVersion("2");
+		IIdType expectedVersionedReportId = reportId.withVersion("2");
+		List<IIdType> referencingResourceIds = List.of(reportId);
+		Set<String> expectedProvenanceTargets = Set.of(
+			expectedVersionedSourceId.toString(),
+			expectedVersionedTargetId.toString(),
+			expectedVersionedReportId.toString());
+		List<Identifier> sourceIdentifiers = List.of(createTestIdentifier("obs-source"));
+		List<Identifier> targetIdentifiers = List.of(createTestIdentifier("obs-target"));
+		List<Identifier> expectedTargetIdentifiers = myMergeHelper.computeIdentifiersExpectedOnTargetAfterMerge(
+			targetIdentifiers, sourceIdentifiers, null);
+		myMergeHelper.validateResourcesAfterMerge(params,
+			expectedVersionedSourceId, expectedVersionedTargetId,
+			referencingResourceIds, expectedProvenanceTargets,
+			expectedTargetIdentifiers, null);
+
+		// Undo merge
+		Parameters undoParams = new Parameters();
+		undoParams.addParameter().setName("source-resource").setValue(new Reference(sourceObsId));
+		undoParams.addParameter().setName("target-resource").setValue(new Reference(targetObsId));
+		myMergeHelper.callUndoMergeOperation("Observation", undoParams);
+
+		// Verify: all resources match their pre-merge state
+		myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(sourceObsBefore, readResource(Observation.class, sourceObsId));
+		myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(targetObsBefore, readResource(Observation.class, targetObsId));
+		myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(reportBefore, readResource(DiagnosticReport.class, reportId));
+	}
+
+	// Organization merge in Patient ID Partition mode: Organizations are not in the Patient
+	// compartment (ALWAYS_USE_DEFAULT_PARTITION policy), so they live in the default partition.
+	@Test
+	void testMergeOrganizations_ThenUndoMergeThem_BothSucceed() {
+		Organization sourceOrg = new Organization();
+		sourceOrg.setName("Source Org");
+		sourceOrg.addIdentifier(createTestIdentifier("org-source"));
+		IIdType sourceOrgId = myClient.create().resource(sourceOrg).execute().getId().toUnqualifiedVersionless();
+
+		Organization targetOrg = new Organization();
+		targetOrg.setName("Target Org");
+		targetOrg.addIdentifier(createTestIdentifier("org-target"));
+		IIdType targetOrgId = myClient.create().resource(targetOrg).execute().getId().toUnqualifiedVersionless();
+
+		// Create a Patient that references the source Organization
+		Patient patient = new Patient();
+		patient.setId("Patient/org-patient");
+		patient.getManagingOrganization().setReference(sourceOrgId.getValue());
+		myClient.update().resource(patient).execute();
+		IIdType patientId = new IdType("Patient/org-patient");
+
+		// Save snapshots before merge
+		IBaseResource sourceOrgBefore = readResource(Organization.class, sourceOrgId);
+		IBaseResource targetOrgBefore = readResource(Organization.class, targetOrgId);
+		IBaseResource patientBefore = readResource(Patient.class, patientId);
+
+		// Execute
+		MergeTestParameters params = new MergeTestParameters()
+			.sourceResource(new Reference(sourceOrgId))
+			.targetResource(new Reference(targetOrgId))
+			.deleteSource(false);
+		Parameters result = myMergeHelper.callMergeOperation("Organization", params, false);
+
+		// Verify: merge succeeded
+		myMergeHelper.validateSyncMergeOutcome(result, params.asParametersResource(), targetOrgId);
+
+		// Validate resources after merge
+		IIdType expectedVersionedSourceId = sourceOrgId.withVersion("2");
+		IIdType expectedVersionedTargetId = targetOrgId.withVersion("2");
+		IIdType expectedVersionedPatientId = patientId.withVersion("2");
+		List<IIdType> referencingResourceIds = List.of(patientId);
+		Set<String> expectedProvenanceTargets = Set.of(
+			expectedVersionedSourceId.toString(),
+			expectedVersionedTargetId.toString(),
+			expectedVersionedPatientId.toString());
+		List<Identifier> sourceIdentifiers = List.of(createTestIdentifier("org-source"));
+		List<Identifier> targetIdentifiers = List.of(createTestIdentifier("org-target"));
+		List<Identifier> expectedTargetIdentifiers = myMergeHelper.computeIdentifiersExpectedOnTargetAfterMerge(
+			targetIdentifiers, sourceIdentifiers, null);
+		myMergeHelper.validateResourcesAfterMerge(params,
+			expectedVersionedSourceId, expectedVersionedTargetId,
+			referencingResourceIds, expectedProvenanceTargets,
+			expectedTargetIdentifiers, null);
+
+		// Undo merge
+		Parameters undoParams = new Parameters();
+		undoParams.addParameter().setName("source-resource").setValue(new Reference(sourceOrgId));
+		undoParams.addParameter().setName("target-resource").setValue(new Reference(targetOrgId));
+		myMergeHelper.callUndoMergeOperation("Organization", undoParams);
+
+		// Verify: all resources match their pre-merge state
+		myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(sourceOrgBefore, readResource(Organization.class, sourceOrgId));
+		myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(targetOrgBefore, readResource(Organization.class, targetOrgId));
+		myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(patientBefore, readResource(Patient.class, patientId));
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/PatientIdModePatientMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/PatientIdModePatientMergeR4Test.java
@@ -59,9 +59,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * patients that reside in different partitions (as determined by {@code PatientIdPartitionInterceptor}).
  */
 // Created by claude-opus-4-6
-public class CrossPartitionMergePatientIdModeR4Test extends BaseResourceProviderR4Test {
+public class PatientIdModePatientMergeR4Test extends BaseResourceProviderR4Test {
 
-	private static final Logger ourLog = LoggerFactory.getLogger(CrossPartitionMergePatientIdModeR4Test.class);
+	private static final Logger ourLog = LoggerFactory.getLogger(PatientIdModePatientMergeR4Test.class);
 
 	@Autowired
 	private Batch2JobHelper myBatch2JobHelper;

--- a/hapi-fhir-jpaserver-test-r4b/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/pom.xml
+++ b/hapi-fhir-jpaserver-test-r5/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-repositories/pom.xml
+++ b/hapi-fhir-repositories/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>8.9.14-SNAPSHOT</version>
+			<version>8.9.15-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>8.9.14-SNAPSHOT</version>
+      <version>8.9.15-SNAPSHOT</version>
 
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/pom.xml
+++ b/hapi-fhir-storage-batch2-test-utilities/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -90,6 +90,7 @@ import java.util.stream.Collectors;
 import static ca.uhn.fhir.interceptor.model.RequestPartitionId.getPartitionFromUserDataIfPresent;
 import static ca.uhn.fhir.jpa.interceptor.ResourceCompartmentStoragePolicy.alwaysUseDefaultPartition;
 import static ca.uhn.fhir.jpa.interceptor.ResourceCompartmentStoragePolicy.mandatorySingleCompartment;
+import static ca.uhn.fhir.jpa.interceptor.ResourceCompartmentStoragePolicy.nonUniqueCompartmentInDefault;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -149,6 +150,9 @@ public class PatientIdPartitionInterceptor {
 	 * </li>
 	 * <li>
 	 * The <b>Group</b> and <b>List</b> resource: {@link ResourceCompartmentStoragePolicy#alwaysUseDefaultPartition()}
+	 * </li>
+	 * <li>
+	 * The <b>Provenance</b> resource: {@link ResourceCompartmentStoragePolicy#nonUniqueCompartmentInDefault()}
 	 * </li>
 	 * <li>
 	 * Any other resources in the
@@ -578,20 +582,35 @@ public class PatientIdPartitionInterceptor {
 	private ResourceCompartmentStoragePolicy getPolicyForResourceType(RuntimeResourceDefinition resourceDef) {
 		ResourceCompartmentStoragePolicy retVal = myResourceTypeToCompartmentPolicy.get(resourceDef.getName());
 		if (retVal == null) {
-			retVal = switch (resourceDef.getName()) {
-				case "Group", "List" -> alwaysUseDefaultPartition();
-				case "Patient" -> mandatorySingleCompartment();
-				default -> {
-					List<RuntimeSearchParam> compartmentSps =
-							ResourceCompartmentUtil.getPatientCompartmentSearchParams(resourceDef);
-					if (compartmentSps.isEmpty()) {
-						yield alwaysUseDefaultPartition();
-					} else {
-						yield mandatorySingleCompartment();
-					}
-				}};
+			retVal = getDefaultPolicyForResourceType(resourceDef);
 		}
 		return retVal;
+	}
+
+	/**
+	 * Returns the default {@link ResourceCompartmentStoragePolicy} for a given resource type
+	 * when no explicit policy has been set via {@link #setResourceTypePolicies(Map)}.
+	 *
+	 * <p>Subclasses may override this method to change the default policy for specific resource types.
+	 *
+	 * @see #setResourceTypePolicies(Map) for a description of the default policies
+	 */
+	@Nonnull
+	protected ResourceCompartmentStoragePolicy getDefaultPolicyForResourceType(RuntimeResourceDefinition resourceDef) {
+		return switch (resourceDef.getName()) {
+			case "Group", "List" -> alwaysUseDefaultPartition();
+			case "Patient" -> mandatorySingleCompartment();
+			case "Provenance" -> nonUniqueCompartmentInDefault();
+			default -> {
+				List<RuntimeSearchParam> compartmentSps =
+						ResourceCompartmentUtil.getPatientCompartmentSearchParams(resourceDef);
+				if (compartmentSps.isEmpty()) {
+					yield alwaysUseDefaultPartition();
+				} else {
+					yield mandatorySingleCompartment();
+				}
+			}
+		};
 	}
 
 	/**

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4b/pom.xml
+++ b/hapi-fhir-validation-resources-r4b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>8.9.14-SNAPSHOT</version>
+	<version>8.9.15-SNAPSHOT</version>
 
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.9.14-SNAPSHOT</version>
+		<version>8.9.15-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>


### PR DESCRIPTION
## Summary

- Change the default compartment policy for Provenance in PatientIdPartitionInterceptor from MANDATORY_SINGLE_COMPARTMENT to NON_UNIQUE_COMPARTMENT_IN_DEFAULT, since Provenance resources are not required to have Patient references
- Extract getDefaultPolicyForResourceType as a protected method so CDR subclasses can override the default per resource type
- Rename CrossPartitionMergePatientIdModeR4Test to PatientIdModePatientMergeR4Test
- Add PatientIdModeNonPatientMergeR4Test with Observation and Organization merge tests that verify merge succeeds, validates post-merge state, and undo restores original state

Closes #7771