### PR TITLE
7764: Upgrade tomcat-embed-* to 10.1.53 to fix CVE-2026-24880

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7764-bump-tomcat-embed-core-cve-2026-24880.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7764-bump-tomcat-embed-core-cve-2026-24880.yaml
@@ -1,0 +1,4 @@
+---
+type: security
+issue: 7764
+title: "CVE-2026-24880: The tomcat-embed-core dependency has been upgraded from 10.1.52 to 10.1.53 and Spring Boot has been upgraded from 3.4.11 to 3.4.12 to address an HTTP Request/Response Smuggling vulnerability via invalid chunk extensions in Apache Tomcat."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7764-bump-tomcat-embed-core-cve-2026-24880.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7764-bump-tomcat-embed-core-cve-2026-24880.yaml
@@ -1,4 +1,4 @@
 ---
 type: security
 issue: 7764
-title: "CVE-2026-24880: The tomcat-embed-core dependency has been upgraded from 10.1.52 to 10.1.53 and Spring Boot has been upgraded from 3.4.11 to 3.4.12 to address an HTTP Request/Response Smuggling vulnerability via invalid chunk extensions in Apache Tomcat."
+title: "CVE-2026-24880, CVE-2026-22731, CVE-2026-22733: The tomcat-embed-core dependency has been upgraded from 10.1.52 to 10.1.54 and Spring Boot has been upgraded from 3.4.11 to 3.5.12 to address HTTP Request/Response Smuggling and Actuator authentication bypass vulnerabilities."

--- a/pom.xml
+++ b/pom.xml
@@ -1102,9 +1102,9 @@
 		<spring_version>6.2.12</spring_version>
 		<spring_data_bom_version>2024.0.5</spring_data_bom_version>
 		<spring_framework_bom_version>6.2.12</spring_framework_bom_version>
-		<spring_boot_version>3.4.12</spring_boot_version>
-		<!-- Pinned here for CVE: CVE-2026-24880 -->
-		<tomcat_embed_core_version>10.1.53</tomcat_embed_core_version>
+		<spring_boot_version>3.5.12</spring_boot_version>
+		<!-- Pinned here for CVE: CVE-2026-24880, CVE-2026-34487, CVE-2026-34486, CVE-2026-34483, CVE-2026-34500 -->
+		<tomcat_embed_core_version>10.1.54</tomcat_embed_core_version>
 		<spring_retry_version>2.0.10</spring_retry_version>
 		<json_path_version>2.9.0</json_path_version>
 		<jboss_logging_version>3.6.1.Final</jboss_logging_version>

--- a/pom.xml
+++ b/pom.xml
@@ -1102,9 +1102,9 @@
 		<spring_version>6.2.12</spring_version>
 		<spring_data_bom_version>2024.0.5</spring_data_bom_version>
 		<spring_framework_bom_version>6.2.12</spring_framework_bom_version>
-		<spring_boot_version>3.4.11</spring_boot_version>
-		<!-- Pinned here for CVE: CVE-2026-24734 -->
-		<tomcat_embed_core_version>10.1.52</tomcat_embed_core_version>
+		<spring_boot_version>3.4.12</spring_boot_version>
+		<!-- Pinned here for CVE: CVE-2026-24880 -->
+		<tomcat_embed_core_version>10.1.53</tomcat_embed_core_version>
 		<spring_retry_version>2.0.10</spring_retry_version>
 		<json_path_version>2.9.0</json_path_version>
 		<jboss_logging_version>3.6.1.Final</jboss_logging_version>


### PR DESCRIPTION
Fixes #7764, Fixes #7763, Fixes #7762, Fixes #7761, Fixes #7760, Fixes #7758, Fixes #7757, Fixes #7756 , Fixes #7755

Pins tomcat-embed-core, tomcat-embed-el, and tomcat-embed-websocket to 10.1.54 and spring boot version to 3.5.12 in the Spring Boot sample modules to address:
- Fixes CVE-2026-22731 (Actuator authentication bypass)
- Fixes CVE-2026-22733 (Actuator CloudFoundry endpoint bypass)
- Upgrade tomcat-embed-core from 10.1.52 to 10.1.54
- Fixes CVE-2026-24880 (HTTP request smuggling)
- Fixes CVE-2026-34487, CVE-2026-34486, CVE-2026-34483
- Fixes CVE-2026-34500