### PR TITLE
[7767] validate expression type prefix against base when creating search parameter

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
@@ -534,11 +534,7 @@ public class SearchParameterUtil {
 	 * @return the extracted resource type prefix (e.g. "Patient") if present, or {@code null}
 	 *         if no type-qualified prefix is found.
 	 */
-	public static String extractTypePrefix(String thePath) {
-		if (thePath == null) {
-			throw new IllegalArgumentException("thePath must not be null");
-		}
-
+	public static String extractTypePrefix(@Nonnull String thePath) {
 		int start = 0;
 		while (start < thePath.length() && (thePath.charAt(start) == '(' || thePath.charAt(start) == ' ')) {
 			start++;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
@@ -520,4 +520,37 @@ public class SearchParameterUtil {
 
 		return true;
 	}
+
+	/**
+	 * Extracts the resource type prefix from a FHIRPath expression path segment.
+	 * <p>
+	 * This method strips any leading opening parentheses and spaces, then examines the
+	 * first path segment (the characters before the first dot). If that segment begins
+	 * with an upper-case letter it is treated as a resource type prefix and returned.
+	 * Otherwise, null is returned to indicate no type-qualified prefix is present.
+	 * </p>
+	 *
+	 * @param thePath the FHIRPath expression or path segment to inspect. Must not be null.
+	 * @return the extracted resource type prefix (e.g. "Patient") if present, or {@code null}
+	 *         if no type-qualified prefix is found.
+	 */
+	public static String extractTypePrefix(String thePath) {
+		if (thePath == null) {
+			throw new IllegalArgumentException("thePath must not be null");
+		}
+
+		int start = 0;
+		while (start < thePath.length() && (thePath.charAt(start) == '(' || thePath.charAt(start) == ' ')) {
+			start++;
+		}
+		String trimmed = thePath.substring(start);
+		int dotIndex = trimmed.indexOf('.');
+		if (dotIndex > 0) {
+			String candidate = trimmed.substring(0, dotIndex);
+			if (Character.isUpperCase(candidate.charAt(0))) {
+				return candidate;
+			}
+		}
+		return null;
+	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7767-validate-expression-against-base-when-creating-search-parameter.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7767-validate-expression-against-base-when-creating-search-parameter.yaml
@@ -1,0 +1,10 @@
+---
+type: fix
+issue: 7767
+title: "Previously, when creating a custom SearchParameter, the server did not validate
+  that the FHIRPath expression's resource type prefix was consistent with the declared
+  base resource types. For example, a SearchParameter with base PractitionerRole could
+  be created with an expression starting with Person. without any error. Now, validation
+  ensures that each declared base resource type has at least one matching expression
+  path prefix, and that SearchParameters with a generic base (Resource or DomainResource)
+  do not use a specific resource type prefix in their expression."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7767-validate-expression-against-base-when-creating-sp.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7767-validate-expression-against-base-when-creating-sp.yaml
@@ -1,10 +1,11 @@
 ---
 type: fix
 issue: 7767
+jira: SMILE-11879
 title: "Previously, when creating a custom SearchParameter, the server did not validate
   that the FHIRPath expression's resource type prefix was consistent with the declared
-  base resource types. For example, a SearchParameter with base PractitionerRole could
-  be created with an expression starting with Person. without any error. Now, validation
+  base resource types. For example, a SearchParameter with base `PractitionerRole` could
+  be created with an expression starting with `Person` without any error. Now, validation
   ensures that each declared base resource type has at least one matching expression
   path prefix, and that SearchParameters with a generic base (Resource or DomainResource)
   do not use a specific resource type prefix in their expression."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7767-validate-expression-against-base-when-creating-sp.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7767-validate-expression-against-base-when-creating-sp.yaml
@@ -2,10 +2,9 @@
 type: fix
 issue: 7767
 jira: SMILE-11879
-title: "Previously, when creating a custom SearchParameter, the server did not validate
-  that the FHIRPath expression's resource type prefix was consistent with the declared
-  base resource types. For example, a SearchParameter with base `PractitionerRole` could
-  be created with an expression starting with `Person` without any error. Now, validation
-  ensures that each declared base resource type has at least one matching expression
-  path prefix, and that SearchParameters with a generic base (Resource or DomainResource)
-  do not use a specific resource type prefix in their expression."
+title: "Previously, when creating a custom SearchParameter, the server did not validate that the FHIRPath expression's 
+resource type prefix was consistent with the declared base resource types. For example, a SearchParameter with base 
+`PractitionerRole` or `Resource` could be created with an expression starting with `Person` without any error. Now, 
+validation ensures that each declared base resource type has at least one matching expression path prefix, and that 
+SearchParameters with a generic base (Resource or DomainResource) do not use a specific resource type prefix in 
+their expression."

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
@@ -3,15 +3,12 @@ package ca.uhn.fhir.util;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeSearchParam;
-import ca.uhn.fhir.rest.client.method.SearchParameter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -19,6 +16,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -110,4 +108,21 @@ class SearchParameterUtilTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	public void extractTypePrefix_null_throws() {
+		assertThrows(IllegalArgumentException.class, () -> SearchParameterUtil.extractTypePrefix(null));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"Patient.name", "(Patient.name)", "  Patient.name "})
+	public void extractTypePrefix_validPathWithPrefix_returnPrefix(String thePath) {
+		assertThat(SearchParameterUtil.extractTypePrefix(thePath)).isEqualTo("Patient");
+	}
+
+
+	@ParameterizedTest
+	@ValueSource(strings = {"patient.name", "Patient", ".name"})
+	public void extractTypePrefix_invalidPrefix_returnsNull(String thePath) {
+		assertThat(SearchParameterUtil.extractTypePrefix(thePath)).isNull();
+	}
 }

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
@@ -3,7 +3,6 @@ package ca.uhn.fhir.util;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeSearchParam;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -16,7 +15,6 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -106,11 +104,6 @@ class SearchParameterUtilTest {
 
 		// Verify
 		assertEquals(expected, actual);
-	}
-
-	@Test
-	public void extractTypePrefix_null_throws() {
-		assertThrows(IllegalArgumentException.class, () -> SearchParameterUtil.extractTypePrefix(null));
 	}
 
 	@ParameterizedTest

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/ResourceProviderDstu3Test.java
@@ -282,7 +282,7 @@ public class ResourceProviderDstu3Test extends BaseResourceProviderDstu3Test {
 		searchParameter.setCode("myGender");
 		searchParameter.addBase("Patient").addBase("Person");
 		searchParameter.setType(Enumerations.SearchParamType.TOKEN);
-		searchParameter.setExpression("Patient.gender|Person.gender");
+		searchParameter.setExpression("Patient.gender | Person.gender");
 
 		MethodOutcome result= myClient.create().resource(searchParameter).execute();
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
@@ -1036,7 +1036,7 @@ public class FhirResourceDaoR4SearchOptimizedTest extends BaseJpaR4Test {
 		searchParameter1.addBase("BodyStructure").addBase("Procedure");
 		searchParameter1.setCode("focalAccess");
 		searchParameter1.setType(Enumerations.SearchParamType.REFERENCE);
-		searchParameter1.setExpression("Procedure.extension('Procedure#focalAccess') | BodyStructure.location");
+		searchParameter1.setExpression("Procedure.extension('Procedure#focalAccess') | BodyStructure.extension('BodyStructure#focalAccess')");
 		searchParameter1.setXpathUsage(SearchParameter.XPathUsageType.NORMAL);
 		searchParameter1.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		IIdType sp1Id = mySearchParameterDao.create(searchParameter1).getId().toUnqualifiedVersionless();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchOptimizedTest.java
@@ -1036,7 +1036,7 @@ public class FhirResourceDaoR4SearchOptimizedTest extends BaseJpaR4Test {
 		searchParameter1.addBase("BodyStructure").addBase("Procedure");
 		searchParameter1.setCode("focalAccess");
 		searchParameter1.setType(Enumerations.SearchParamType.REFERENCE);
-		searchParameter1.setExpression("Procedure.extension('Procedure#focalAccess')");
+		searchParameter1.setExpression("Procedure.extension('Procedure#focalAccess') | BodyStructure.location");
 		searchParameter1.setXpathUsage(SearchParameter.XPathUsageType.NORMAL);
 		searchParameter1.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		IIdType sp1Id = mySearchParameterDao.create(searchParameter1).getId().toUnqualifiedVersionless();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -352,7 +352,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 		searchParameter.setCode("myGender");
 		searchParameter.addBase("Patient").addBase("Person");
 		searchParameter.setType(Enumerations.SearchParamType.TOKEN);
-		searchParameter.setExpression("Patient.gender|Person.gender");
+		searchParameter.setExpression("Patient.gender | Person.gender");
 
 		MethodOutcome result = myClient.create().resource(searchParameter).execute();
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4Test.java
@@ -180,7 +180,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -310,7 +309,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 	@Test
 	public void testParameterWithNoValueThrowsError_InvalidChainOnCustomSearch() throws IOException {
 		SearchParameter searchParameter = new SearchParameter();
-		searchParameter.addBase("BodyStructure").addBase("Procedure");
+		searchParameter.addBase("Procedure");
 		searchParameter.setCode("focalAccess");
 		searchParameter.setType(Enumerations.SearchParamType.REFERENCE);
 		searchParameter.setExpression("Procedure.extension('Procedure#focalAccess')");
@@ -363,7 +362,7 @@ public class ResourceProviderR4Test extends BaseResourceProviderR4Test {
 	@Test
 	public void testParameterWithNoValueThrowsError_InvalidRootParam() throws IOException {
 		SearchParameter searchParameter = new SearchParameter();
-		searchParameter.addBase("BodyStructure").addBase("Procedure");
+		searchParameter.addBase("Procedure");
 		searchParameter.setCode("focalAccess");
 		searchParameter.setType(Enumerations.SearchParamType.REFERENCE);
 		searchParameter.setExpression("Procedure.extension('Procedure#focalAccess')");

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
@@ -38,8 +38,11 @@ import static org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE;
 import static org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING;
 import static org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN;
 import static org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI;
+import static org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.DOMAINRESOURCE;
 import static org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.OBSERVATION;
 import static org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.PATIENT;
+import static org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.PRACTITIONERROLE;
+import static org.hl7.fhir.r5.model.Enumerations.VersionIndependentResourceTypesAll.RESOURCE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -196,6 +199,152 @@ public class SearchParameterDaoValidatorTest {
                 .setDefinition(SP_COMPONENT_DEFINITION_OF_TYPE_DATE).setExpression("Observation"));
 
         mySvc.validate(theSearchParameter);
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_specificBase_expressionMatchesBase_succeeds() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/practitionerrole-practitioner");
+        sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+        sp.addBase(PRACTITIONERROLE);
+        sp.setCode("practitioner");
+        sp.setType(REFERENCE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("PractitionerRole.practitioner");
+
+        mySvc.validate(sp);
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_specificBase_expressionDoesNotMatchBase_fails() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/practitionerrole-practitioner");
+        sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+        sp.addBase(PRACTITIONERROLE);
+        sp.setCode("practitioner");
+        sp.setType(REFERENCE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("Person.practitioner");
+
+        assertThatThrownBy(() -> mySvc.validate(sp))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessageContaining("HAPI-2911")
+                .hasMessageContaining("does not match any of the declared base resource types")
+                .hasMessageContaining("PractitionerRole");
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_resourceBase_withSpecificExpressionPrefix_fails() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/resource-person-practitioner");
+        sp.setUrl("http://example.org/SearchParameter/resource-person-practitioner");
+        sp.addBase(RESOURCE);
+        sp.setCode("practitioner");
+        sp.setType(REFERENCE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("Person.practitioner");
+
+        assertThatThrownBy(() -> mySvc.validate(sp))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessageContaining("HAPI-2910")
+                .hasMessageContaining("Person")
+                .hasMessageContaining("Resource");
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_resourceBase_withResourceExpressionPrefix_succeeds() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/resource-meta");
+        sp.setUrl("http://example.org/SearchParameter/resource-meta");
+        sp.addBase(RESOURCE);
+        sp.setCode("_lastUpdated");
+        sp.setType(DATE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("Resource.meta.lastUpdated");
+
+        mySvc.validate(sp);
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_domainResourceBase_withSpecificExpressionPrefix_fails() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/domainresource-person");
+        sp.setUrl("http://example.org/SearchParameter/domainresource-person");
+        sp.addBase(DOMAINRESOURCE);
+        sp.setCode("practitioner");
+        sp.setType(REFERENCE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("Person.practitioner");
+
+        assertThatThrownBy(() -> mySvc.validate(sp))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessageContaining("HAPI-2910")
+                .hasMessageContaining("Person")
+                .hasMessageContaining("DomainResource");
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_multiPathExpression_atLeastOnePathMatchesBase_succeeds() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/practitionerrole-practitioner");
+        sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+        sp.addBase(PRACTITIONERROLE);
+        sp.setCode("practitioner");
+        sp.setType(REFERENCE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("PractitionerRole.practitioner | Person.name");
+
+        mySvc.validate(sp);
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_multiPathExpression_noPathMatchesBase_fails() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/practitionerrole-practitioner");
+        sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+        sp.addBase(PRACTITIONERROLE);
+        sp.setCode("practitioner");
+        sp.setType(REFERENCE);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("Person.practitioner | Observation.name");
+
+        assertThatThrownBy(() -> mySvc.validate(sp))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessageContaining("HAPI-2911")
+                .hasMessageContaining("PractitionerRole");
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_multipleSpecificBases_expressionMatchesAllBases_succeeds() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/multi-base");
+        sp.setUrl("http://example.org/SearchParameter/multi-base");
+        sp.addBase(PRACTITIONERROLE);
+        sp.addBase(PATIENT);
+        sp.setCode("name");
+        sp.setType(STRING);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("PractitionerRole.practitioner | Patient.name");
+
+        mySvc.validate(sp);
+    }
+
+    @Test
+    void testValidateExpressionAgainstBase_multipleSpecificBases_expressionMissingOneBase_fails() {
+        SearchParameter sp = new SearchParameter();
+        sp.setId("SearchParameter/multi-base");
+        sp.setUrl("http://example.org/SearchParameter/multi-base");
+        sp.addBase(PRACTITIONERROLE);
+        sp.addBase(PATIENT);
+        sp.setCode("name");
+        sp.setType(STRING);
+        sp.setStatus(ACTIVE);
+        sp.setExpression("PractitionerRole.practitioner");
+
+        assertThatThrownBy(() -> mySvc.validate(sp))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessageContaining("HAPI-2911")
+                .hasMessageContaining("Patient");
     }
 
     private static SearchParameter createSearchParameter(Enumerations.SearchParamType theType, String theId, String theCodeValue, String theExpression) {

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
@@ -207,9 +207,7 @@ public class SearchParameterDaoValidatorTest {
         sp.setId("SearchParameter/practitionerrole-practitioner");
         sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
         sp.addBase(PRACTITIONERROLE);
-        sp.setCode("practitioner");
-        sp.setType(REFERENCE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
         sp.setExpression("PractitionerRole.practitioner");
 
         mySvc.validate(sp);
@@ -221,9 +219,7 @@ public class SearchParameterDaoValidatorTest {
         sp.setId("SearchParameter/practitionerrole-practitioner");
         sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
         sp.addBase(PRACTITIONERROLE);
-        sp.setCode("practitioner");
-        sp.setType(REFERENCE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
         sp.setExpression("Person.practitioner");
 
 		assertThatThrownBy(() -> mySvc.validate(sp))
@@ -233,34 +229,13 @@ public class SearchParameterDaoValidatorTest {
 			.hasMessageContaining("PractitionerRole");
     }
 
-	@Test
-	void testValidateExpressionAgainstBase_mixedBase_expressionDoesNotMatchBase_fails() {
-		SearchParameter sp = new SearchParameter();
-		sp.setId("SearchParameter/practitionerrole-practitioner");
-		sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
-		sp.addBase(RESOURCE);
-		sp.addBase(PRACTITIONERROLE);
-		sp.setCode("practitioner");
-		sp.setType(REFERENCE);
-		sp.setStatus(ACTIVE);
-		sp.setExpression("Person.practitioner");
-
-		assertThatThrownBy(() -> mySvc.validate(sp))
-			.isInstanceOf(UnprocessableEntityException.class)
-			.hasMessageContaining("HAPI-2911")
-			.hasMessageContaining("No path in expression")
-			.hasMessageContaining("PractitionerRole");
-	}
-
     @Test
     void testValidateExpressionAgainstBase_resourceBase_withSpecificExpressionPrefix_fails() {
         SearchParameter sp = new SearchParameter();
         sp.setId("SearchParameter/resource-person-practitioner");
         sp.setUrl("http://example.org/SearchParameter/resource-person-practitioner");
         sp.addBase(RESOURCE);
-        sp.setCode("practitioner");
-        sp.setType(REFERENCE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
         sp.setExpression("Person.practitioner");
 
         assertThatThrownBy(() -> mySvc.validate(sp))
@@ -276,9 +251,7 @@ public class SearchParameterDaoValidatorTest {
         sp.setId("SearchParameter/resource-meta");
         sp.setUrl("http://example.org/SearchParameter/resource-meta");
         sp.addBase(RESOURCE);
-        sp.setCode("_lastUpdated");
-        sp.setType(DATE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("_lastUpdated").setType(DATE).setStatus(ACTIVE);
         sp.setExpression("Resource.meta.lastUpdated");
 
         mySvc.validate(sp);
@@ -290,9 +263,7 @@ public class SearchParameterDaoValidatorTest {
         sp.setId("SearchParameter/domainresource-person");
         sp.setUrl("http://example.org/SearchParameter/domainresource-person");
         sp.addBase(DOMAINRESOURCE);
-        sp.setCode("practitioner");
-        sp.setType(REFERENCE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
         sp.setExpression("Person.practitioner");
 
         assertThatThrownBy(() -> mySvc.validate(sp))
@@ -308,9 +279,7 @@ public class SearchParameterDaoValidatorTest {
         sp.setId("SearchParameter/practitionerrole-practitioner");
         sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
         sp.addBase(PRACTITIONERROLE);
-        sp.setCode("practitioner");
-        sp.setType(REFERENCE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
         sp.setExpression("PractitionerRole.practitioner | Person.name");
 
         mySvc.validate(sp);
@@ -322,9 +291,7 @@ public class SearchParameterDaoValidatorTest {
         sp.setId("SearchParameter/practitionerrole-practitioner");
         sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
         sp.addBase(PRACTITIONERROLE);
-        sp.setCode("practitioner");
-        sp.setType(REFERENCE);
-        sp.setStatus(ACTIVE);
+        sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
         sp.setExpression("Person.practitioner | Observation.name");
 
         assertThatThrownBy(() -> mySvc.validate(sp))
@@ -334,30 +301,24 @@ public class SearchParameterDaoValidatorTest {
     }
 
     @Test
-    void testValidateExpressionAgainstBase_multipleSpecificBases_expressionMatchesAllBases_succeeds() {
+    void testValidateExpressionAgainstBase_multiBases_expressionMatchesAllBases_succeeds() {
         SearchParameter sp = new SearchParameter();
         sp.setId("SearchParameter/multi-base");
         sp.setUrl("http://example.org/SearchParameter/multi-base");
-        sp.addBase(PRACTITIONERROLE);
-        sp.addBase(PATIENT);
-        sp.setCode("name");
-        sp.setType(STRING);
-        sp.setStatus(ACTIVE);
-        sp.setExpression("PractitionerRole.practitioner | Patient.name");
+        sp.addBase(PRACTITIONERROLE).addBase(PATIENT);
+        sp.setCode("name").setType(REFERENCE).setStatus(ACTIVE);
+        sp.setExpression("PractitionerRole.practitioner | Patient.generalPractitioner");
 
         mySvc.validate(sp);
     }
 
     @Test
-    void testValidateExpressionAgainstBase_multipleSpecificBases_expressionMissingOneBase_fails() {
+    void testValidateExpressionAgainstBase_multiBases_expressionMissingOneBase_fails() {
         SearchParameter sp = new SearchParameter();
         sp.setId("SearchParameter/multi-base");
         sp.setUrl("http://example.org/SearchParameter/multi-base");
-        sp.addBase(PRACTITIONERROLE);
-        sp.addBase(PATIENT);
-        sp.setCode("name");
-        sp.setType(STRING);
-        sp.setStatus(ACTIVE);
+        sp.addBase(PRACTITIONERROLE).addBase(PATIENT);
+        sp.setCode("name").setType(STRING).setStatus(ACTIVE);
         sp.setExpression("PractitionerRole.practitioner");
 
         assertThatThrownBy(() -> mySvc.validate(sp))
@@ -365,6 +326,22 @@ public class SearchParameterDaoValidatorTest {
                 .hasMessageContaining("HAPI-2911")
                 .hasMessageContaining("Patient");
     }
+
+	@Test
+	void testValidateExpressionAgainstBase_multiBasesWithResource_expressionMissingOneBase_fails() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/practitionerrole-practitioner");
+		sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+		sp.addBase(RESOURCE).addBase(PRACTITIONERROLE);
+		sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
+		sp.setExpression("PractionerRole.practitioner");
+
+		assertThatThrownBy(() -> mySvc.validate(sp))
+			.isInstanceOf(UnprocessableEntityException.class)
+			.hasMessageContaining("HAPI-2911")
+			.hasMessageContaining("No path in expression")
+			.hasMessageContaining("PractitionerRole");
+	}
 
     private static SearchParameter createSearchParameter(Enumerations.SearchParamType theType, String theId, String theCodeValue, String theExpression) {
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
@@ -338,6 +338,21 @@ public class SearchParameterDaoValidatorTest {
                 .hasMessageContaining("Patient");
     }
 
+	@Test
+	void testValidateExpressionAgainstBase_whereClauseWithInnerPipe_baseMismatch_shouldFail() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/practitionerrole-telecom-where");
+		sp.setUrl("http://example.org/SearchParameter/practitionerrole-telecom-where");
+		sp.addBase(PRACTITIONERROLE);
+		sp.setCode("telecom").setType(TOKEN).setStatus(ACTIVE);
+		sp.setExpression("Patient.telecom.where(system='mail' | system='phone')");
+
+		assertThatThrownBy(() -> mySvc.validate(sp))
+			.isInstanceOf(UnprocessableEntityException.class)
+			.hasMessageContaining("HAPI-2911")
+			.hasMessageContaining("PractitionerRole");
+	}
+
     private static SearchParameter createSearchParameter(Enumerations.SearchParamType theType, String theId, String theCodeValue, String theExpression) {
 
         SearchParameter retVal = new SearchParameter();

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
@@ -257,6 +257,17 @@ public class SearchParameterDaoValidatorTest {
         mySvc.validate(sp);
     }
 
+	@Test
+	void testValidateExpressionAgainstBase_resourceMixedWithSpecificBases_expressionMatchesSpecific_success() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/practitionerrole-practitioner");
+		sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+		sp.addBase(RESOURCE).addBase(PRACTITIONERROLE);
+		sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
+		sp.setExpression("PractitionerRole.practitioner");
+		mySvc.validate(sp);
+	}
+
     @Test
     void testValidateExpressionAgainstBase_domainResourceBase_withSpecificExpressionPrefix_fails() {
         SearchParameter sp = new SearchParameter();
@@ -326,22 +337,6 @@ public class SearchParameterDaoValidatorTest {
                 .hasMessageContaining("HAPI-2911")
                 .hasMessageContaining("Patient");
     }
-
-	@Test
-	void testValidateExpressionAgainstBase_multiBasesWithResource_expressionMissingOneBase_fails() {
-		SearchParameter sp = new SearchParameter();
-		sp.setId("SearchParameter/practitionerrole-practitioner");
-		sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
-		sp.addBase(RESOURCE).addBase(PRACTITIONERROLE);
-		sp.setCode("practitioner").setType(REFERENCE).setStatus(ACTIVE);
-		sp.setExpression("PractionerRole.practitioner");
-
-		assertThatThrownBy(() -> mySvc.validate(sp))
-			.isInstanceOf(UnprocessableEntityException.class)
-			.hasMessageContaining("HAPI-2911")
-			.hasMessageContaining("No path in expression")
-			.hasMessageContaining("PractitionerRole");
-	}
 
     private static SearchParameter createSearchParameter(Enumerations.SearchParamType theType, String theId, String theCodeValue, String theExpression) {
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidatorTest.java
@@ -226,12 +226,31 @@ public class SearchParameterDaoValidatorTest {
         sp.setStatus(ACTIVE);
         sp.setExpression("Person.practitioner");
 
-        assertThatThrownBy(() -> mySvc.validate(sp))
-                .isInstanceOf(UnprocessableEntityException.class)
-                .hasMessageContaining("HAPI-2911")
-                .hasMessageContaining("does not match any of the declared base resource types")
-                .hasMessageContaining("PractitionerRole");
+		assertThatThrownBy(() -> mySvc.validate(sp))
+			.isInstanceOf(UnprocessableEntityException.class)
+			.hasMessageContaining("HAPI-2911")
+			.hasMessageContaining("No path in expression")
+			.hasMessageContaining("PractitionerRole");
     }
+
+	@Test
+	void testValidateExpressionAgainstBase_mixedBase_expressionDoesNotMatchBase_fails() {
+		SearchParameter sp = new SearchParameter();
+		sp.setId("SearchParameter/practitionerrole-practitioner");
+		sp.setUrl("http://example.org/SearchParameter/practitionerrole-practitioner");
+		sp.addBase(RESOURCE);
+		sp.addBase(PRACTITIONERROLE);
+		sp.setCode("practitioner");
+		sp.setType(REFERENCE);
+		sp.setStatus(ACTIVE);
+		sp.setExpression("Person.practitioner");
+
+		assertThatThrownBy(() -> mySvc.validate(sp))
+			.isInstanceOf(UnprocessableEntityException.class)
+			.hasMessageContaining("HAPI-2911")
+			.hasMessageContaining("No path in expression")
+			.hasMessageContaining("PractitionerRole");
+	}
 
     @Test
     void testValidateExpressionAgainstBase_resourceBase_withSpecificExpressionPrefix_fails() {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
@@ -199,12 +199,9 @@ public class SearchParameterDaoValidator {
 	}
 
 	/**
-	 * Validates that the FHIRPath expression's resource type prefix is consistent with the declared
-	 * base resource types. If base is a specific resource type (e.g. PractitionerRole), at least one
-	 * expression path segment must start with that resource type. If base is Resource or DomainResource,
-	 * the expression must use a Resource. or DomainResource. prefix — a specific type prefix (e.g. Person.)
-	 * is rejected as a misconfiguration since the parameter would be registered against all resource types
-	 * but only extract values from that one specific type.
+	 * Validate expression prefixes against declared base(s):
+	 * - For generic bases (Resource or DomainResource), prefixes must be Resource or DomainResource.
+	 * - For a specific base (e.g. PractitionerRole), at least one path must start with that type.
 	 */
 	private void validateExpressionAgainstBase(SearchParameter theSearchParameter) {
 		String expression = getExpression(theSearchParameter);
@@ -219,9 +216,9 @@ public class SearchParameterDaoValidator {
 
 		String[] paths = expression.split("\\|");
 
-		boolean allBasesAreGeneric = bases.stream().allMatch(b -> RESOURCE.equals(b) || DOMAIN_RESOURCE.equals(b));
+		boolean allBasesGeneric = bases.stream().allMatch(b -> RESOURCE.equals(b) || DOMAIN_RESOURCE.equals(b));
 
-		if (allBasesAreGeneric) {
+		if (allBasesGeneric) {
 			for (String path : paths) {
 				String prefix = extractTypePrefix(path.trim());
 				if (prefix != null && !RESOURCE.equals(prefix) && !DOMAIN_RESOURCE.equals(prefix)) {
@@ -231,26 +228,26 @@ public class SearchParameterDaoValidator {
 							+ "]. Expression must use Resource or DomainResource prefix when base is generic.");
 				}
 			}
-		} else {
-			for (String base : bases) {
-				if (RESOURCE.equals(base) || DOMAIN_RESOURCE.equals(base)) {
-					continue;
+			return;
+		}
+		for (String base : bases) {
+			if (RESOURCE.equals(base) || DOMAIN_RESOURCE.equals(base)) {
+				continue;
+			}
+			boolean anyPathMatchesBase = false;
+			for (String path : paths) {
+				String prefix = extractTypePrefix(path.trim());
+				if (prefix == null
+						|| base.equals(prefix)
+						|| RESOURCE.equals(prefix)
+						|| DOMAIN_RESOURCE.equals(prefix)) {
+					anyPathMatchesBase = true;
+					break;
 				}
-				boolean anyPathMatchesBase = false;
-				for (String path : paths) {
-					String prefix = extractTypePrefix(path.trim());
-					if (prefix == null
-							|| base.equals(prefix)
-							|| RESOURCE.equals(prefix)
-							|| DOMAIN_RESOURCE.equals(prefix)) {
-						anyPathMatchesBase = true;
-						break;
-					}
-				}
-				if (!anyPathMatchesBase) {
-					throw new UnprocessableEntityException(Msg.code(2911) + "No path in expression '" + expression
-							+ "' matches the base [" + base + "].");
-				}
+			}
+			if (!anyPathMatchesBase) {
+				throw new UnprocessableEntityException(
+						Msg.code(2911) + "No path in expression '" + expression + "' matches the base [" + base + "].");
 			}
 		}
 	}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
@@ -30,6 +30,7 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.util.ElementUtil;
 import ca.uhn.fhir.util.HapiExtensions;
+import ca.uhn.fhir.util.SearchParameterUtil;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r5.model.Enumerations;
 import org.hl7.fhir.r5.model.SearchParameter;
@@ -205,23 +206,26 @@ public class SearchParameterDaoValidator {
 	 */
 	private void validateExpressionAgainstBase(SearchParameter theSearchParameter) {
 		String expression = getExpression(theSearchParameter);
+		if (isBlank(expression)) {
+			return;
+		}
+
 		List<String> bases = theSearchParameter.getBase().stream()
 				.map(IPrimitiveType::getValueAsString)
 				.filter(Objects::nonNull)
 				.toList();
-
 		if (bases.isEmpty()) {
 			return;
 		}
 
-		String[] paths = expression.split("\\|");
+		String[] paths = SearchParameterUtil.splitSearchParameterExpressions(expression);
 
-		boolean allBasesGeneric = bases.stream().allMatch(b -> RESOURCE.equals(b) || DOMAIN_RESOURCE.equals(b));
+		boolean allBasesGeneric = bases.stream().allMatch(SearchParameterDaoValidator::isGenericBase);
 
 		if (allBasesGeneric) {
 			for (String path : paths) {
-				String prefix = extractTypePrefix(path.trim());
-				if (prefix != null && !RESOURCE.equals(prefix) && !DOMAIN_RESOURCE.equals(prefix)) {
+				String prefix = SearchParameterUtil.extractTypePrefix(path.trim());
+				if (prefix != null && !isGenericBase(prefix)) {
 					throw new UnprocessableEntityException(Msg.code(2910) + "SearchParameter.expression '" + expression
 							+ "' uses type-specific prefix '" + prefix
 							+ "' but base is [" + String.join(", ", bases)
@@ -231,16 +235,13 @@ public class SearchParameterDaoValidator {
 			return;
 		}
 		for (String base : bases) {
-			if (RESOURCE.equals(base) || DOMAIN_RESOURCE.equals(base)) {
+			if (isGenericBase(base)) {
 				continue;
 			}
 			boolean anyPathMatchesBase = false;
 			for (String path : paths) {
-				String prefix = extractTypePrefix(path.trim());
-				if (prefix == null
-						|| base.equals(prefix)
-						|| RESOURCE.equals(prefix)
-						|| DOMAIN_RESOURCE.equals(prefix)) {
+				String prefix = SearchParameterUtil.extractTypePrefix(path.trim());
+				if (prefix == null || base.equals(prefix) || isGenericBase(prefix)) {
 					anyPathMatchesBase = true;
 					break;
 				}
@@ -252,25 +253,8 @@ public class SearchParameterDaoValidator {
 		}
 	}
 
-	/**
-	 * Extracts the resource type prefix from a FHIRPath expression path segment.
-	 * Returns null if no type-qualified prefix is present.
-	 */
-	private static String extractTypePrefix(String thePath) {
-		// Strip any leading parentheses or spaces
-		int start = 0;
-		while (start < thePath.length() && (thePath.charAt(start) == '(' || thePath.charAt(start) == ' ')) {
-			start++;
-		}
-		String trimmed = thePath.substring(start);
-		int dotIndex = trimmed.indexOf('.');
-		if (dotIndex > 0) {
-			String candidate = trimmed.substring(0, dotIndex);
-			if (Character.isUpperCase(candidate.charAt(0))) {
-				return candidate;
-			}
-		}
-		return null;
+	private static boolean isGenericBase(String base) {
+		return RESOURCE.equals(base) || DOMAIN_RESOURCE.equals(base);
 	}
 
 	private void validateExpressionIsParsable(SearchParameter theSearchParameter) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
@@ -253,8 +253,8 @@ public class SearchParameterDaoValidator {
 		}
 	}
 
-	private static boolean isGenericBase(String base) {
-		return RESOURCE.equals(base) || DOMAIN_RESOURCE.equals(base);
+	private static boolean isGenericBase(String theBase) {
+		return RESOURCE.equals(theBase) || DOMAIN_RESOURCE.equals(theBase);
 	}
 
 	private void validateExpressionIsParsable(SearchParameter theSearchParameter) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
@@ -53,6 +53,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class SearchParameterDaoValidator {
 
 	private static final Pattern REGEX_SP_EXPRESSION_HAS_PATH = Pattern.compile("[( ]*([A-Z][a-zA-Z]+\\.)?[a-z].*");
+	private static final String RESOURCE = "Resource";
+	private static final String DOMAIN_RESOURCE = "DomainResource";
 
 	private final FhirContext myFhirContext;
 	private final JpaStorageSettings myStorageSettings;
@@ -217,21 +219,21 @@ public class SearchParameterDaoValidator {
 
 		String[] paths = expression.split("\\|");
 
-		boolean allBasesAreGeneric = bases.stream().allMatch(b -> "Resource".equals(b) || "DomainResource".equals(b));
+		boolean allBasesAreGeneric = bases.stream().allMatch(b -> RESOURCE.equals(b) || DOMAIN_RESOURCE.equals(b));
 
 		if (allBasesAreGeneric) {
 			for (String path : paths) {
 				String prefix = extractTypePrefix(path.trim());
-				if (prefix != null && !"Resource".equals(prefix) && !"DomainResource".equals(prefix)) {
-					throw new UnprocessableEntityException(Msg.code(2910) + "SearchParameter.expression " + expression
-							+ " uses type-specific prefix " + prefix
-							+ " but base is [" + String.join(", ", bases)
+				if (prefix != null && !RESOURCE.equals(prefix) && !DOMAIN_RESOURCE.equals(prefix)) {
+					throw new UnprocessableEntityException(Msg.code(2910) + "SearchParameter.expression '" + expression
+							+ "' uses type-specific prefix '" + prefix
+							+ "' but base is [" + String.join(", ", bases)
 							+ "]. Expression must use Resource or DomainResource prefix when base is generic.");
 				}
 			}
 		} else {
 			for (String base : bases) {
-				if ("Resource".equals(base) || "DomainResource".equals(base)) {
+				if (RESOURCE.equals(base) || DOMAIN_RESOURCE.equals(base)) {
 					continue;
 				}
 				boolean anyPathMatchesBase = false;
@@ -239,21 +241,15 @@ public class SearchParameterDaoValidator {
 					String prefix = extractTypePrefix(path.trim());
 					if (prefix == null
 							|| base.equals(prefix)
-							|| "Resource".equals(prefix)
-							|| "DomainResource".equals(prefix)) {
+							|| RESOURCE.equals(prefix)
+							|| DOMAIN_RESOURCE.equals(prefix)) {
 						anyPathMatchesBase = true;
 						break;
 					}
 				}
 				if (!anyPathMatchesBase) {
-					List<String> expressionPrefixes = java.util.Arrays.stream(paths)
-							.map(p -> extractTypePrefix(p.trim()))
-							.filter(Objects::nonNull)
-							.toList();
-					throw new UnprocessableEntityException(Msg.code(2911) + "SearchParameter.expression \"" + expression
-							+ "\" does not match any of the declared base resource types [" + base
-							+ "]. Expression type prefix(es) " + expressionPrefixes
-							+ " do not match the declared base.");
+					throw new UnprocessableEntityException(Msg.code(2911) +
+						"No path in expression '" + expression +  "' matches the base [" + base + "].");
 				}
 			}
 		}

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
@@ -35,6 +35,7 @@ import org.hl7.fhir.r5.model.Enumerations;
 import org.hl7.fhir.r5.model.SearchParameter;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -189,6 +190,94 @@ public class SearchParameterDaoValidator {
 			throw new UnprocessableEntityException(Msg.code(1120) + "SearchParameter.expression value \"" + expression
 					+ "\" is invalid due to missing/incorrect path");
 		}
+
+		if (!isResourceOfTypeComposite && !isResourceOfTypeSpecial) {
+			validateExpressionAgainstBase(theSearchParameter);
+		}
+	}
+
+	/**
+	 * Validates that the FHIRPath expression's resource type prefix is consistent with the declared
+	 * base resource types. If base is a specific resource type (e.g. PractitionerRole), at least one
+	 * expression path segment must start with that resource type. If base is Resource or DomainResource,
+	 * the expression must use a Resource. or DomainResource. prefix — a specific type prefix (e.g. Person.)
+	 * is rejected as a misconfiguration since the parameter would be registered against all resource types
+	 * but only extract values from that one specific type.
+	 */
+	private void validateExpressionAgainstBase(SearchParameter theSearchParameter) {
+		String expression = getExpression(theSearchParameter);
+		List<String> bases = theSearchParameter.getBase().stream()
+				.map(IPrimitiveType::getValueAsString)
+				.filter(Objects::nonNull)
+				.toList();
+
+		if (bases.isEmpty()) {
+			return;
+		}
+
+		String[] paths = expression.split("\\|");
+
+		boolean allBasesAreGeneric = bases.stream().allMatch(b -> "Resource".equals(b) || "DomainResource".equals(b));
+
+		if (allBasesAreGeneric) {
+			for (String path : paths) {
+				String prefix = extractTypePrefix(path.trim());
+				if (prefix != null && !"Resource".equals(prefix) && !"DomainResource".equals(prefix)) {
+					throw new UnprocessableEntityException(Msg.code(2910) + "SearchParameter.expression " + expression
+							+ " uses type-specific prefix " + prefix
+							+ " but base is [" + String.join(", ", bases)
+							+ "]. Expression must use Resource or DomainResource prefix when base is generic.");
+				}
+			}
+		} else {
+			for (String base : bases) {
+				if ("Resource".equals(base) || "DomainResource".equals(base)) {
+					continue;
+				}
+				boolean anyPathMatchesBase = false;
+				for (String path : paths) {
+					String prefix = extractTypePrefix(path.trim());
+					if (prefix == null
+							|| base.equals(prefix)
+							|| "Resource".equals(prefix)
+							|| "DomainResource".equals(prefix)) {
+						anyPathMatchesBase = true;
+						break;
+					}
+				}
+				if (!anyPathMatchesBase) {
+					List<String> expressionPrefixes = java.util.Arrays.stream(paths)
+							.map(p -> extractTypePrefix(p.trim()))
+							.filter(Objects::nonNull)
+							.toList();
+					throw new UnprocessableEntityException(Msg.code(2911) + "SearchParameter.expression \"" + expression
+							+ "\" does not match any of the declared base resource types [" + base
+							+ "]. Expression type prefix(es) " + expressionPrefixes
+							+ " do not match the declared base.");
+				}
+			}
+		}
+	}
+
+	/**
+	 * Extracts the resource type prefix from a FHIRPath expression path segment.
+	 * Returns null if no type-qualified prefix is present.
+	 */
+	private static String extractTypePrefix(String thePath) {
+		// Strip any leading parentheses or spaces
+		int start = 0;
+		while (start < thePath.length() && (thePath.charAt(start) == '(' || thePath.charAt(start) == ' ')) {
+			start++;
+		}
+		String trimmed = thePath.substring(start);
+		int dotIndex = trimmed.indexOf('.');
+		if (dotIndex > 0) {
+			String candidate = trimmed.substring(0, dotIndex);
+			if (Character.isUpperCase(candidate.charAt(0))) {
+				return candidate;
+			}
+		}
+		return null;
 	}
 
 	private void validateExpressionIsParsable(SearchParameter theSearchParameter) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/validation/SearchParameterDaoValidator.java
@@ -248,8 +248,8 @@ public class SearchParameterDaoValidator {
 					}
 				}
 				if (!anyPathMatchesBase) {
-					throw new UnprocessableEntityException(Msg.code(2911) +
-						"No path in expression '" + expression +  "' matches the base [" + base + "].");
+					throw new UnprocessableEntityException(Msg.code(2911) + "No path in expression '" + expression
+							+ "' matches the base [" + base + "].");
 				}
 			}
 		}


### PR DESCRIPTION
### Issue ###
A user created a SearchParameter using PUT with 
- `"id": "PractitionerRole-practitioner",`
- `base: ["Resource"]`, 
- `code: "practitioner"`, 
- `expression: "Person.practitioner"`,

Attempt to search for PractitionerRole by practitioner, e.g. `GET /PractitionerRole?practitioner=Practitioner/123` failed.

### Cause ###
The server validated syntactic FHIRPath correctness but did not cross-check the expression's resource type prefix against the declared base values.

- When the base is `Resource`, the system expands "Resource" into every known resource type and registers the search parameter against all of them, overwriting the original built-in.

- expression is "Person.practitioner" instead of "PractitionerRole.practitioner" — the FHIRPath expression prefix doesn't match the actual resource type being indexed, so no i`HFJ_RES_LINK` are created.

### Fix ###
Add validation to ensure that each declared specific base resource type has at least one matching expression path prefix, and that SearchParameters with a generic base (Resource or DomainResource) do not use a specific resource type prefix in 
their expression.

Closes #7767 