### PR TITLE
Jr 20260415 error handling

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -403,9 +403,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 					// If the dependency's FHIR version is incompatible with the server,
 					// attempt to load a version-specific variant (e.g., {id}.r4 for R4 servers)
 					dependency = substituteVersionSpecificPackageIfNeeded(
-							dependency,
-							nextPackage.name(),
-							nextPackage.version());
+							dependency, nextPackage.name(), nextPackage.version());
 
 					// recursive call to install dependencies of a package before
 					// installing the package

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -403,7 +403,9 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 					// If the dependency's FHIR version is incompatible with the server,
 					// attempt to load a version-specific variant (e.g., {id}.r4 for R4 servers)
 					dependency = substituteVersionSpecificPackageIfNeeded(
-							dependency, nextPackage.name(), nextPackage.version());
+							dependency,
+							nextPackage.name(),
+							nextPackage.version());
 
 					// recursive call to install dependencies of a package before
 					// installing the package
@@ -437,7 +439,8 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 	 * @param theVersion the package version
 	 * @return the original package if compatible, or the version-specific variant if found
 	 */
-	private NpmPackage substituteVersionSpecificPackageIfNeeded(
+	@Override
+	public NpmPackage substituteVersionSpecificPackageIfNeeded(
 			NpmPackage theDependency, String theId, String theVersion) {
 		String dependencyFhirVersion = theDependency.fhirVersion();
 		String serverFhirVersion = myFhirContext.getVersion().getVersion().getFhirVersionString();

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -201,7 +201,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		if (enabled) {
 			try {
 
-				validatePackageAlreadyExists(theInstallationSpec);
+				logIfPackageAlreadyInstalled(theInstallationSpec);
 
 				NpmPackage npmPackage = myPackageCacheManager.installPackage(theInstallationSpec);
 				if (npmPackage == null) {
@@ -242,7 +242,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		return retVal;
 	}
 
-	private void validatePackageAlreadyExists(PackageInstallationSpec theInstallationSpec) {
+	private void logIfPackageAlreadyInstalled(PackageInstallationSpec theInstallationSpec) {
 		boolean exists = myTxService
 				.withSystemRequest()
 				.withRequestPartitionId(myPartitionSettings.getDefaultRequestPartitionId())
@@ -334,10 +334,12 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 				}
 			}
 		}
-		ourLog.info(String.format("Finished installation of package %s#%s:", name, version));
+		ourLog.info("Finished installation of package {}#{}:", name, version);
 
-		for (int i = 0; i < count.length; i++) {
-			ourLog.info(String.format("-- Created or updated %s resources of type %s", count[i], installTypes.get(i)));
+		if (ourLog.isInfoEnabled()) {
+			for (int i = 0; i < count.length; i++) {
+				ourLog.info("-- Created or updated {} resources of type {}", count[i], installTypes.get(i));
+			}
 		}
 	}
 
@@ -356,7 +358,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 			return null;
 		}
 
-		validatePackageAlreadyExists(theInstallationSpec);
+		logIfPackageAlreadyInstalled(theInstallationSpec);
 
 		PackageInstallationJobParameters parameters = new PackageInstallationJobParameters();
 		parameters.setInstallationSpec(theInstallationSpec);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -201,20 +201,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		if (enabled) {
 			try {
 
-				boolean exists = myTxService
-						.withSystemRequest()
-						.withRequestPartitionId(myPartitionSettings.getDefaultRequestPartitionId())
-						.execute(() -> {
-							Optional<NpmPackageVersionEntity> existing = myPackageVersionDao.findByPackageIdAndVersion(
-									theInstallationSpec.getName(), theInstallationSpec.getVersion());
-							return existing.isPresent();
-						});
-				if (exists) {
-					ourLog.info(
-							"Package {}#{} is already installed",
-							theInstallationSpec.getName(),
-							theInstallationSpec.getVersion());
-				}
+				validatePackageAlreadyExists(theInstallationSpec);
 
 				NpmPackage npmPackage = myPackageCacheManager.installPackage(theInstallationSpec);
 				if (npmPackage == null) {
@@ -253,6 +240,23 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		}
 
 		return retVal;
+	}
+
+	private void validatePackageAlreadyExists(PackageInstallationSpec theInstallationSpec) {
+		boolean exists = myTxService
+				.withSystemRequest()
+				.withRequestPartitionId(myPartitionSettings.getDefaultRequestPartitionId())
+				.execute(() -> {
+					Optional<NpmPackageVersionEntity> existing = myPackageVersionDao.findByPackageIdAndVersion(
+							theInstallationSpec.getName(), theInstallationSpec.getVersion());
+					return existing.isPresent();
+				});
+		if (exists) {
+			ourLog.info(
+					"Package {}#{} is already installed",
+					theInstallationSpec.getName(),
+					theInstallationSpec.getVersion());
+		}
 	}
 
 	/**
@@ -344,6 +348,16 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 	 */
 	@Override
 	public String installAsynchronously(PackageInstallationSpec theInstallationSpec) {
+		if (!enabled) {
+			ourLog.info(
+					"Package installation is not supported for FHIR version {}",
+					myFhirContext.getVersion().getVersion());
+
+			return null;
+		}
+
+		validatePackageAlreadyExists(theInstallationSpec);
+
 		PackageInstallationJobParameters parameters = new PackageInstallationJobParameters();
 		parameters.setInstallationSpec(theInstallationSpec);
 		JobInstanceStartRequest startRequest =

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ConsolidateDependenciesStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ConsolidateDependenciesStep.java
@@ -30,17 +30,23 @@ import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageContentsJson;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageInstallationJobParameters;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageWithDependenciesJson;
 import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
+import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import ca.uhn.fhir.util.JsonUtil;
 import jakarta.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class ConsolidateDependenciesStep
 		implements IJobStepWorker<PackageInstallationJobParameters, PackageWithDependenciesJson, PackageContentsJson> {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(ConsolidateDependenciesStep.class);
 
 	private final IJobCoordinator myJobCoordinator;
 
@@ -68,11 +74,24 @@ public class ConsolidateDependenciesStep
 			throw new RetryChunkLaterException(Msg.code(2907));
 		}
 
-		List<PackageInstallOutcomeJson> dependencyOutcomes = jobInstances.stream()
-				.map(JobInstance::getReport)
-				.filter(Objects::nonNull)
-				.map(t -> JsonUtil.deserialize(t, PackageInstallOutcomeJson.class))
-				.toList();
+		List<PackageInstallOutcomeJson> dependencyOutcomes = new ArrayList<>();
+		for (JobInstance jobInstance : jobInstances) {
+			if (jobInstance.getStatus() == StatusEnum.COMPLETED) {
+				if (jobInstance.getReport() != null) {
+					dependencyOutcomes.add(
+							JsonUtil.deserialize(jobInstance.getReport(), PackageInstallOutcomeJson.class));
+				}
+			} else {
+				PackageInstallationJobParameters parameters =
+						JsonUtil.deserialize(jobInstance.getParameters(), PackageInstallationJobParameters.class);
+				PackageInstallationSpec installationSpec = parameters.getInstallationSpec();
+				String message = String.format(
+						"Package installation job for %s#%s terminated in status %s",
+						installationSpec.getName(), installationSpec.getVersion(), jobInstance.getStatus());
+				ourLog.warn(message);
+				theDataSink.recoveredError(message);
+			}
+		}
 
 		// pass the bytes along unchanged
 		PackageContentsJson packageContentsJson = new PackageContentsJson();

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
@@ -27,6 +27,7 @@ import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.api.VoidModel;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageContentsJson;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageInstallationJobParameters;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.packages.IHapiPackageCacheManager;
 import ca.uhn.fhir.jpa.packages.NpmPackageUtils;
 import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
@@ -39,8 +40,6 @@ import java.io.ByteArrayOutputStream;
 import java.util.Base64;
 
 public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallationJobParameters, PackageContentsJson> {
-
-	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(FetchPackageStep.class);
 
 	private final IHapiPackageCacheManager myPackageCacheManager;
 
@@ -62,8 +61,7 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 
 			if (npmPackage == null) {
 				String message = formatErrorMessage(installationSpec);
-				ourLog.error(message);
-				throw new JobExecutionFailedException(message);
+				throw new JobExecutionFailedException(Msg.code(2915) + message);
 			}
 
 			// We need to convert the package back to bytes so we can serialize it between steps
@@ -80,7 +78,7 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 			contents.setReport(outcome);
 			theDataSink.accept(contents);
 		} catch (Exception e) {
-			throw new JobExecutionFailedException("Error occurred while retrieving package", e);
+			throw new JobExecutionFailedException(Msg.code(2916) + "Error occurred while retrieving package", e);
 		}
 
 		return RunOutcome.SUCCESS;

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
@@ -30,14 +30,17 @@ import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageInstallationJobParame
 import ca.uhn.fhir.jpa.packages.IHapiPackageCacheManager;
 import ca.uhn.fhir.jpa.packages.NpmPackageUtils;
 import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
+import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import jakarta.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.Base64;
 
 public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallationJobParameters, PackageContentsJson> {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(FetchPackageStep.class);
 
 	private final IHapiPackageCacheManager myPackageCacheManager;
 
@@ -53,8 +56,15 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 			throws JobExecutionFailedException {
 
 		try {
-			NpmPackage npmPackage = myPackageCacheManager.installPackage(
-					theStepExecutionDetails.getParameters().getInstallationSpec());
+			PackageInstallationSpec installationSpec =
+					theStepExecutionDetails.getParameters().getInstallationSpec();
+			NpmPackage npmPackage = myPackageCacheManager.installPackage(installationSpec);
+
+			if (npmPackage == null) {
+				String message = formatErrorMessage(installationSpec);
+				ourLog.error(message);
+				throw new JobExecutionFailedException(message);
+			}
 
 			// We need to convert the package back to bytes so we can serialize it between steps
 			// Note that these are not the identical bytes that were found by the cache,
@@ -69,10 +79,27 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 			contents.setContents(Base64.getEncoder().encode(outputStream.toByteArray()));
 			contents.setReport(outcome);
 			theDataSink.accept(contents);
-		} catch (IOException e) {
-			// We're only concerned with the happy path for now - error handling is a separate MR
+		} catch (Exception e) {
+			throw new JobExecutionFailedException("Error occurred while retrieving package", e);
 		}
 
 		return RunOutcome.SUCCESS;
+	}
+
+	@Nonnull
+	private static String formatErrorMessage(PackageInstallationSpec theInstallationSpec) {
+		String message;
+		if (StringUtils.isNotBlank(theInstallationSpec.getPackageUrl())) {
+			message = String.format("Unable to retrieve NPM package from URL %s.", theInstallationSpec.getPackageUrl());
+		} else if (theInstallationSpec.getPackageContents() != null) {
+			message = "Unable to install NPM package from contained bytes.";
+		} else if (StringUtils.isNoneBlank(theInstallationSpec.getName(), theInstallationSpec.getVersion())) {
+			message = String.format(
+					"Unable to retrieve NPM package %s#%s.",
+					theInstallationSpec.getName(), theInstallationSpec.getVersion());
+		} else {
+			message = "Unable to identify NPM package to install.";
+		}
+		return message;
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageContentsJson;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageInstallationJobParameters;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.packages.IHapiPackageCacheManager;
+import ca.uhn.fhir.jpa.packages.IPackageInstallerSvc;
 import ca.uhn.fhir.jpa.packages.NpmPackageUtils;
 import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
@@ -42,9 +43,13 @@ import java.util.Base64;
 public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallationJobParameters, PackageContentsJson> {
 
 	private final IHapiPackageCacheManager myPackageCacheManager;
+	private final IPackageInstallerSvc myPackageInstallerSvc;
 
-	public FetchPackageStep(IHapiPackageCacheManager thePackageCacheManager) {
+	public FetchPackageStep(
+			IHapiPackageCacheManager thePackageCacheManager,
+			IPackageInstallerSvc thePackageInstallerSvc) {
 		this.myPackageCacheManager = thePackageCacheManager;
+		this.myPackageInstallerSvc = thePackageInstallerSvc;
 	}
 
 	@Nonnull
@@ -58,6 +63,14 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 			PackageInstallationSpec installationSpec =
 					theStepExecutionDetails.getParameters().getInstallationSpec();
 			NpmPackage npmPackage = myPackageCacheManager.installPackage(installationSpec);
+
+			if (theStepExecutionDetails.getParameters().isDependencyJob()) {
+				// Adjust the dependency package as needed to match the FHIR version of the server
+				npmPackage = myPackageInstallerSvc.substituteVersionSpecificPackageIfNeeded(
+						npmPackage,
+						installationSpec.getName(),
+						installationSpec.getVersion());
+			}
 
 			if (npmPackage == null) {
 				String message = formatErrorMessage(installationSpec);

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStep.java
@@ -46,8 +46,7 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 	private final IPackageInstallerSvc myPackageInstallerSvc;
 
 	public FetchPackageStep(
-			IHapiPackageCacheManager thePackageCacheManager,
-			IPackageInstallerSvc thePackageInstallerSvc) {
+			IHapiPackageCacheManager thePackageCacheManager, IPackageInstallerSvc thePackageInstallerSvc) {
 		this.myPackageCacheManager = thePackageCacheManager;
 		this.myPackageInstallerSvc = thePackageInstallerSvc;
 	}
@@ -67,9 +66,7 @@ public class FetchPackageStep implements IFirstJobStepWorker<PackageInstallation
 			if (theStepExecutionDetails.getParameters().isDependencyJob()) {
 				// Adjust the dependency package as needed to match the FHIR version of the server
 				npmPackage = myPackageInstallerSvc.substituteVersionSpecificPackageIfNeeded(
-						npmPackage,
-						installationSpec.getName(),
-						installationSpec.getVersion());
+						npmPackage, installationSpec.getName(), installationSpec.getVersion());
 			}
 
 			if (npmPackage == null) {

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStep.java
@@ -36,15 +36,18 @@ import ca.uhn.fhir.jpa.packages.util.PackageUtils;
 import ca.uhn.fhir.util.Batch2JobDefinitionConstants;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
 public class InitializeDependenciesStep
 		implements IJobStepWorker<PackageInstallationJobParameters, PackageContentsJson, PackageWithDependenciesJson> {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(InitializeDependenciesStep.class);
 
 	private final IJobCoordinator myJobCoordinator;
 
@@ -86,11 +89,15 @@ public class InitializeDependenciesStep
 			List<PackageUtils.DependentPackage> dependencies =
 					PackageUtils.extractDependentPackages(npmPackage, installationSpec, outcome);
 
-			List<String> jobIds = launchChildJobs(theStepExecutionDetails, dependencies);
+			List<String> jobIds = launchChildJobs(theStepExecutionDetails, dependencies, theDataSink);
 
 			result.setDependencyJobIds(jobIds);
-		} catch (IOException e) {
-			// error handling is in the scope of a later ticket
+		} catch (Exception e) {
+			String message = String.format(
+					"Failed to process dependencies for package %s#%s",
+					installationSpec.getName(), installationSpec.getVersion());
+			ourLog.warn(message, e);
+			theDataSink.recoveredError(message);
 		}
 
 		theDataSink.accept(result);
@@ -101,7 +108,8 @@ public class InitializeDependenciesStep
 	private List<String> launchChildJobs(
 			@Nonnull
 					StepExecutionDetails<PackageInstallationJobParameters, PackageContentsJson> theStepExecutionDetails,
-			List<PackageUtils.DependentPackage> theDependencies) {
+			List<PackageUtils.DependentPackage> theDependencies,
+			@Nonnull IJobDataSink<PackageWithDependenciesJson> theDataSink) {
 		List<String> jobIds = new ArrayList<>();
 
 		PackageInstallationSpec installationSpec =
@@ -109,17 +117,27 @@ public class InitializeDependenciesStep
 		PackageInstallOutcomeJson outcome = theStepExecutionDetails.getData().getReport();
 
 		for (PackageUtils.DependentPackage nextDependency : theDependencies) {
-			if (installationSpec.isDryRun()) {
-				outcome.getMessage()
-						.add(String.format(
-								"Installation would install %s#%s", nextDependency.name(), nextDependency.version()));
-			} else {
-				// create a new installation spec, retaining all the control parameters, but targeting the dependency
-				// package
-				JobInstanceStartRequest startRequest = buildStartRequest(nextDependency, installationSpec);
-				Batch2JobStartResponse response =
-						myJobCoordinator.startInstance(theStepExecutionDetails.newSystemRequestDetails(), startRequest);
-				jobIds.add(response.getInstanceId());
+			try {
+				if (installationSpec.isDryRun()) {
+					outcome.getMessage()
+							.add(String.format(
+									"Installation would install %s#%s",
+									nextDependency.name(), nextDependency.version()));
+				} else {
+					// create a new installation spec, retaining all the control parameters, but targeting the
+					// dependency
+					// package
+					JobInstanceStartRequest startRequest = buildStartRequest(nextDependency, installationSpec);
+					Batch2JobStartResponse response = myJobCoordinator.startInstance(
+							theStepExecutionDetails.newSystemRequestDetails(), startRequest);
+					jobIds.add(response.getInstanceId());
+				}
+			} catch (Exception e) {
+				String message = String.format(
+						"Failed to launch child child job for dependency package %s#%s. Skipping this dependency.",
+						nextDependency.name(), nextDependency.version());
+				ourLog.warn(message, e);
+				theDataSink.recoveredError(message);
 			}
 		}
 

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStep.java
@@ -134,7 +134,7 @@ public class InitializeDependenciesStep
 				}
 			} catch (Exception e) {
 				String message = String.format(
-						"Failed to launch child child job for dependency package %s#%s. Skipping this dependency.",
+						"Failed to launch child job for dependency package %s#%s. Skipping this dependency.",
 						nextDependency.name(), nextDependency.version());
 				ourLog.warn(message, e);
 				theDataSink.recoveredError(message);

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InstallPackageAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InstallPackageAppCtx.java
@@ -54,7 +54,7 @@ public class InstallPackageAppCtx {
 						"fetch-package",
 						"Fetch the NPM Package",
 						PackageContentsJson.class,
-						fetchPackageStep(thePackageCacheManager))
+						fetchPackageStep(thePackageCacheManager, thePackageInstallerSvc))
 				.addIntermediateStep(
 						"initialize-dependencies",
 						"Spawn sub-jobs to process package dependencies",
@@ -75,8 +75,10 @@ public class InstallPackageAppCtx {
 	}
 
 	@Bean
-	public FetchPackageStep fetchPackageStep(IHapiPackageCacheManager thePackageCacheManager) {
-		return new FetchPackageStep(thePackageCacheManager);
+	public FetchPackageStep fetchPackageStep(
+			IHapiPackageCacheManager thePackageCacheManager,
+			IPackageInstallerSvc thePackageInstallerSvc) {
+		return new FetchPackageStep(thePackageCacheManager, thePackageInstallerSvc);
 	}
 
 	@Bean

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InstallPackageAppCtx.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/InstallPackageAppCtx.java
@@ -76,8 +76,7 @@ public class InstallPackageAppCtx {
 
 	@Bean
 	public FetchPackageStep fetchPackageStep(
-			IHapiPackageCacheManager thePackageCacheManager,
-			IPackageInstallerSvc thePackageInstallerSvc) {
+			IHapiPackageCacheManager thePackageCacheManager, IPackageInstallerSvc thePackageInstallerSvc) {
 		return new FetchPackageStep(thePackageCacheManager, thePackageInstallerSvc);
 	}
 

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStep.java
@@ -34,15 +34,17 @@ import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import ca.uhn.fhir.jpa.searchparam.registry.ISearchParamRegistryController;
 import jakarta.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Base64;
 
 public class ProcessPackageStep
 		implements IReductionStepWorker<
 				PackageInstallationJobParameters, PackageContentsJson, PackageInstallOutcomeJson> {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ProcessPackageStep.class);
 
 	IPackageInstallerSvc myPackageInstallerSvc;
 
@@ -99,6 +101,9 @@ public class ProcessPackageStep
 	@Override
 	public ChunkOutcome consume(
 			ChunkExecutionDetails<PackageInstallationJobParameters, PackageContentsJson> theChunkDetails) {
+		PackageInstallationJobParameters parameters = theChunkDetails.getParameters();
+		PackageInstallationSpec installationSpec = parameters.getInstallationSpec();
+
 		try {
 			PackageContentsJson packageContents = theChunkDetails.getData();
 			byte[] encodedContents = packageContents.getContents();
@@ -108,8 +113,6 @@ public class ProcessPackageStep
 			// we will be appending new data to the report we received from upstream
 			PackageInstallOutcomeJson packageOutcome = packageContents.getReport();
 
-			PackageInstallationJobParameters parameters = theChunkDetails.getParameters();
-			PackageInstallationSpec installationSpec = parameters.getInstallationSpec();
 			if (installationSpec.getInstallMode() == PackageInstallationSpec.InstallModeEnum.INSTALL_ONLY
 					|| installationSpec.getInstallMode() == PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL) {
 				myPackageInstallerSvc.installPackage(npmPackage, installationSpec, packageOutcome);
@@ -123,9 +126,26 @@ public class ProcessPackageStep
 			}
 
 			myPackageOutcome = packageOutcome;
-		} catch (IOException e) {
-			// error handling is in the scope of a later ticket
+		} catch (Exception e) {
+			String message = formatErrorMessage(installationSpec);
+			ourLog.error(message, e);
+			throw new JobExecutionFailedException(message, e);
 		}
 		return ChunkOutcome.SUCCESS();
+	}
+
+	@Nonnull
+	private static String formatErrorMessage(PackageInstallationSpec theInstallationSpec) {
+		String message;
+		if (StringUtils.isNotBlank(theInstallationSpec.getPackageUrl())) {
+			message = String.format("Unable to install NPM package from URL %s.", theInstallationSpec.getPackageUrl());
+		} else if (theInstallationSpec.getPackageContents() != null) {
+			message = "Unable to install NPM package from contained bytes.";
+		} else {
+			message = String.format(
+					"Unable to install NPM package %s#%s.",
+					theInstallationSpec.getName(), theInstallationSpec.getVersion());
+		}
+		return message;
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStep.java
@@ -45,13 +45,13 @@ public class ProcessPackageStep
 		implements IReductionStepWorker<
 				PackageInstallationJobParameters, PackageContentsJson, PackageInstallOutcomeJson> {
 
-	IPackageInstallerSvc myPackageInstallerSvc;
+	private final IPackageInstallerSvc myPackageInstallerSvc;
 
-	ISearchParamRegistryController mySearchParamRegistryController;
+	private final ISearchParamRegistryController mySearchParamRegistryController;
 
-	IValidationSupport myValidationSupport;
+	private final IValidationSupport myValidationSupport;
 
-	PackageInstallOutcomeJson myPackageOutcome;
+	private PackageInstallOutcomeJson myPackageOutcome;
 
 	public ProcessPackageStep(
 			IPackageInstallerSvc thePackageInstallerSvc,

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStep.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageContentsJson;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageInstallationJobParameters;
 import ca.uhn.fhir.batch2.model.ChunkOutcome;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.packages.IPackageInstallerSvc;
 import ca.uhn.fhir.jpa.packages.PackageInstallOutcomeJson;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
@@ -43,8 +44,6 @@ import java.util.Base64;
 public class ProcessPackageStep
 		implements IReductionStepWorker<
 				PackageInstallationJobParameters, PackageContentsJson, PackageInstallOutcomeJson> {
-
-	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ProcessPackageStep.class);
 
 	IPackageInstallerSvc myPackageInstallerSvc;
 
@@ -128,8 +127,7 @@ public class ProcessPackageStep
 			myPackageOutcome = packageOutcome;
 		} catch (Exception e) {
 			String message = formatErrorMessage(installationSpec);
-			ourLog.error(message, e);
-			throw new JobExecutionFailedException(message, e);
+			throw new JobExecutionFailedException(Msg.code(2917) + message, e);
 		}
 		return ChunkOutcome.SUCCESS();
 	}

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/ConsolidateDependenciesStepTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/ConsolidateDependenciesStepTest.java
@@ -56,6 +56,8 @@ public class ConsolidateDependenciesStepTest {
 	private IJobDataSink<PackageContentsJson> myJobDataSink;
 	@Captor
 	private ArgumentCaptor<PackageContentsJson> myPackageContentsCaptor;
+	@Captor
+	private ArgumentCaptor<String> myStringCaptor;
 	@Mock
 	private IJobStepExecutionServices myJobStepExecutionServices;
 
@@ -156,8 +158,16 @@ public class ConsolidateDependenciesStepTest {
 		packageWithDependencies.setReport(report);
 		packageWithDependencies.setDependencyJobIds(List.of(DEPENDENCY_JOB_ID, DEPENDENCY_JOB_2_ID));
 
-		JobInstance jobInstance1 = createJobInstance(DEPENDENCY_JOB_ID, List.of("SearchParameter", "SearchParameter", "StructureDefinition"));
-		JobInstance jobInstance2 = createJobInstance(DEPENDENCY_JOB_2_ID, List.of("SearchParameter", "CodeSystem", "ValueSet"));
+		JobInstance jobInstance1 = createJobInstance(
+			DEPENDENCY_JOB_ID,
+			params,
+			StatusEnum.COMPLETED,
+			List.of("SearchParameter", "SearchParameter", "StructureDefinition"));
+		JobInstance jobInstance2 = createJobInstance(
+			DEPENDENCY_JOB_2_ID,
+			params,
+			StatusEnum.COMPLETED,
+			List.of("SearchParameter", "CodeSystem", "ValueSet"));
 
 		when(myJobCoordinator.getInstance(anyString())).thenReturn(jobInstance1, jobInstance2);
 
@@ -187,11 +197,59 @@ public class ConsolidateDependenciesStepTest {
 		assertThat(packageContentsJson.getReport().getResourcesInstalled()).isEqualTo(expectedResources);
 	}
 
+	@Test
+	public void testRun_dependencyJobFailed_skipAndContinue() {
+		// set up
+		PackageInstallationSpec installationSpec = new PackageInstallationSpec();
+		installationSpec.setName("hl7.fhir.us.core");
+		installationSpec.setVersion("8.0.1");
+		installationSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.INSTALL_ONLY);
+		installationSpec.setFetchDependencies(true);
+
+		PackageInstallationJobParameters params = new PackageInstallationJobParameters();
+		params.setInstallationSpec(installationSpec);
+
+		String fakePackageContents = "pass through data";
+		byte[] encodedBytes = Base64.getEncoder().encode(fakePackageContents.getBytes());
+
+		PackageInstallOutcomeJson report = new PackageInstallOutcomeJson();
+		report.getMessage().add("Main package message");
+
+		PackageWithDependenciesJson packageWithDependencies = new PackageWithDependenciesJson();
+		packageWithDependencies.setContents(encodedBytes);
+		packageWithDependencies.setReport(report);
+		packageWithDependencies.setDependencyJobIds(List.of(DEPENDENCY_JOB_ID));
+
+		JobInstance jobInstance1 = createJobInstance(
+			DEPENDENCY_JOB_ID,
+			params,
+			StatusEnum.FAILED,
+			List.of("SearchParameter", "SearchParameter", "StructureDefinition"));
+
+		when(myJobCoordinator.getInstance(anyString())).thenReturn(jobInstance1);
+
+		StepExecutionDetails<PackageInstallationJobParameters, PackageWithDependenciesJson> details =
+			new StepExecutionDetails<>(params, packageWithDependencies, ourTestInstance, new WorkChunk().setId(CHUNK_ID), myJobStepExecutionServices);
+
+		// execute
+		RunOutcome outcome = myStep.run(details, myJobDataSink);
+
+		// validate
+		assertThat(outcome).isEqualTo(RunOutcome.SUCCESS);
+
+		verify(myJobCoordinator, times(1)).getInstance(anyString());
+
+		verify(myJobDataSink).recoveredError(myStringCaptor.capture());
+		assertThat(myStringCaptor.getValue())
+			.isEqualTo("Package installation job for hl7.fhir.us.core#8.0.1 terminated in status FAILED");
+	}
+
 	@Nonnull
-	private static JobInstance createJobInstance(String theInstanceId, List<String> theResourceTypes) {
+	private static JobInstance createJobInstance(String theInstanceId, PackageInstallationJobParameters theParameters, StatusEnum theStatus, List<String> theResourceTypes) {
 		JobInstance jobInstance = new JobInstance();
 		jobInstance.setInstanceId(theInstanceId);
-		jobInstance.setStatus(StatusEnum.COMPLETED);
+		jobInstance.setParameters(JsonUtil.serialize(theParameters));
+		jobInstance.setStatus(theStatus);
 
 		PackageInstallOutcomeJson report = new PackageInstallOutcomeJson();
 		report.getMessage().add("Message from dependent job " + theInstanceId);

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStepTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStepTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.batch2.jobs.installpackage;
 
 import ca.uhn.fhir.batch2.api.IJobDataSink;
 import ca.uhn.fhir.batch2.api.IJobStepExecutionServices;
+import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
 import ca.uhn.fhir.batch2.api.RunOutcome;
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.api.VoidModel;
@@ -25,6 +26,7 @@ import java.io.InputStream;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -94,5 +96,24 @@ public class FetchPackageStepTest {
 		for (String key : jobPackage.getFolders().keySet()) {
 			assertThat(jobPackage.list(key)).containsExactlyInAnyOrderElementsOf(npmPackage.list(key));
 		}
+	}
+
+	@Test
+	public void testRun_packageUnavailable_throws() throws Exception {
+		// set up
+		when(myPackageLoader.installPackage(any())).thenReturn(null);
+
+		PackageInstallationSpec theInstallationSpec = new PackageInstallationSpec();
+		theInstallationSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.INSTALL_ONLY);
+		theInstallationSpec.setFetchDependencies(false);
+
+		PackageInstallationJobParameters params = new PackageInstallationJobParameters();
+		params.setInstallationSpec(theInstallationSpec);
+
+		StepExecutionDetails<PackageInstallationJobParameters, VoidModel> details =
+			new StepExecutionDetails<>(params, null, ourTestInstance, new WorkChunk().setId(CHUNK_ID), myJobStepExecutionServices);
+
+		// execute and validate
+		assertThatThrownBy(() -> step.run(details, myJobDataSink)).isInstanceOf(JobExecutionFailedException.class);
 	}
 }

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStepTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/FetchPackageStepTest.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageInstallationJobParame
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.jpa.packages.IHapiPackageCacheManager;
+import ca.uhn.fhir.jpa.packages.IPackageInstallerSvc;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,8 @@ public class FetchPackageStepTest {
 
 	@Mock
 	private IHapiPackageCacheManager myPackageLoader;
+	@Mock
+	private IPackageInstallerSvc myPackageInstallerSvc;
 
 	private FetchPackageStep step;
 
@@ -52,7 +55,7 @@ public class FetchPackageStepTest {
 
 	@BeforeEach
 	public void beforeEach() {
-		step = new FetchPackageStep(myPackageLoader);
+		step = new FetchPackageStep(myPackageLoader, myPackageInstallerSvc);
 	}
 
 	@Test

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStepTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStepTest.java
@@ -320,7 +320,7 @@ public class InitializeDependenciesStepTest {
 		assertThat(outcomeJson.getDependencyJobIds()).isEmpty();
 
 		verify(myJobDataSink, atLeastOnce()).recoveredError(myStringCaptor.capture());
-		assertThat(myStringCaptor.getAllValues()).contains("Failed to launch child child job for dependency package hl7.fhir.r4.core#4.0.1. Skipping this dependency.");
+		assertThat(myStringCaptor.getAllValues()).contains("Failed to launch child job for dependency package hl7.fhir.r4.core#4.0.1. Skipping this dependency.");
 
 	}
 

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStepTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/InitializeDependenciesStepTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -54,6 +55,8 @@ public class InitializeDependenciesStepTest {
 	private IJobDataSink<PackageWithDependenciesJson> myJobDataSink;
 	@Captor
 	private ArgumentCaptor<PackageWithDependenciesJson> myPackageWithDependenciesCaptor;
+	@Captor
+	private ArgumentCaptor<String> myStringCaptor;
 	@Mock
 	private IJobStepExecutionServices myJobStepExecutionServices;
 	@Captor
@@ -243,6 +246,82 @@ public class InitializeDependenciesStepTest {
 				"Installation would install us.nlm.vsac#0.24.0");
 
 		verify(myJobCoordinator, never()).startInstance(any(), any());
+	}
+
+	@Test
+	public void testRun_badPackage_skipAndContinue() throws Exception {
+		// set up
+		PackageInstallationSpec installationSpec = new PackageInstallationSpec();
+		installationSpec.setName("hl7.fhir.us.core");
+		installationSpec.setVersion("8.0.1");
+		installationSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.INSTALL_ONLY);
+		installationSpec.setFetchDependencies(true);
+
+		PackageInstallationJobParameters params = new PackageInstallationJobParameters();
+		params.setInstallationSpec(installationSpec);
+
+		byte[] encodedBytes = Base64.getEncoder().encode("This is not a valid NPM package".getBytes());
+		PackageContentsJson packageContentsJson = new PackageContentsJson();
+		packageContentsJson.setContents(encodedBytes);
+		packageContentsJson.setReport(new PackageInstallOutcomeJson());
+
+		StepExecutionDetails<PackageInstallationJobParameters, PackageContentsJson> details =
+			new StepExecutionDetails<>(params, packageContentsJson, ourTestInstance, new WorkChunk().setId(CHUNK_ID), myJobStepExecutionServices);
+
+		// execute
+		RunOutcome outcome = myStep.run(details, myJobDataSink);
+
+		// validate
+		assertThat(outcome).isEqualTo(RunOutcome.SUCCESS);
+
+		verify(myJobDataSink).accept(myPackageWithDependenciesCaptor.capture());
+		PackageWithDependenciesJson outcomeJson = myPackageWithDependenciesCaptor.getValue();
+		assertThat(outcomeJson).isNotNull();
+		assertThat(outcomeJson.getContents()).isEqualTo(encodedBytes);
+		assertThat(outcomeJson.getDependencyJobIds()).isEmpty();
+
+		verify(myJobDataSink).recoveredError("Failed to process dependencies for package hl7.fhir.us.core#8.0.1");
+
+		verify(myJobCoordinator, never()).startInstance(any(), any());
+	}
+
+	@Test
+	public void testRun_cannotLaunchChildJobs_skipAndContinue() throws Exception {
+		// set up
+		PackageInstallationSpec installationSpec = new PackageInstallationSpec();
+		installationSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.INSTALL_ONLY);
+		installationSpec.setFetchDependencies(true);
+
+		PackageInstallationJobParameters params = new PackageInstallationJobParameters();
+		params.setInstallationSpec(installationSpec);
+
+		InputStream stream = InitializeDependenciesStepTest.class.getResourceAsStream("usCorePackage.tgz");
+		byte[] packageBytes = stream.readAllBytes();
+		byte[] encodedBytes = Base64.getEncoder().encode(packageBytes);
+		PackageContentsJson packageContentsJson = new PackageContentsJson();
+		packageContentsJson.setContents(encodedBytes);
+		packageContentsJson.setReport(new PackageInstallOutcomeJson());
+
+		StepExecutionDetails<PackageInstallationJobParameters, PackageContentsJson> details =
+			new StepExecutionDetails<>(params, packageContentsJson, ourTestInstance, new WorkChunk().setId(CHUNK_ID), myJobStepExecutionServices);
+
+		when(myJobCoordinator.startInstance(any(), any())).thenThrow(new IllegalStateException());
+
+		// execute
+		RunOutcome outcome = myStep.run(details, myJobDataSink);
+
+		// validate
+		assertThat(outcome).isEqualTo(RunOutcome.SUCCESS);
+
+		verify(myJobDataSink).accept(myPackageWithDependenciesCaptor.capture());
+		PackageWithDependenciesJson outcomeJson = myPackageWithDependenciesCaptor.getValue();
+		assertThat(outcomeJson).isNotNull();
+		assertThat(outcomeJson.getContents()).isEqualTo(encodedBytes);
+		assertThat(outcomeJson.getDependencyJobIds()).isEmpty();
+
+		verify(myJobDataSink, atLeastOnce()).recoveredError(myStringCaptor.capture());
+		assertThat(myStringCaptor.getAllValues()).contains("Failed to launch child child job for dependency package hl7.fhir.r4.core#4.0.1. Skipping this dependency.");
+
 	}
 
 	private static class JobIdIncrementor implements Answer<Batch2JobStartResponse> {

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStepTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/installpackage/ProcessPackageStepTest.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.batch2.jobs.installpackage;
 import ca.uhn.fhir.batch2.api.ChunkExecutionDetails;
 import ca.uhn.fhir.batch2.api.IJobDataSink;
 import ca.uhn.fhir.batch2.api.IJobStepExecutionServices;
+import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
 import ca.uhn.fhir.batch2.api.RunOutcome;
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.jobs.installpackage.model.PackageContentsJson;
@@ -31,11 +32,14 @@ import java.io.InputStream;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessPackageStepTest {
@@ -174,5 +178,34 @@ public class ProcessPackageStepTest {
 
 		verifyNoInteractions(mySearchParamRegistryController);
 		verifyNoInteractions(myValidationSupport);
+	}
+
+	@Test
+	public void testRun_installFails_throwsException() throws Exception {
+		// set up
+		PackageInstallationSpec installationSpec = new PackageInstallationSpec();
+		installationSpec.setName("hl7.fhir.us.core");
+		installationSpec.setVersion("8.0.1");
+		installationSpec.setInstallMode(PackageInstallationSpec.InstallModeEnum.INSTALL_ONLY);
+		installationSpec.setFetchDependencies(false);
+
+		PackageInstallationJobParameters params = new PackageInstallationJobParameters();
+		params.setInstallationSpec(installationSpec);
+
+		InputStream stream = ProcessPackageStepTest.class.getResourceAsStream("usCorePackage.tgz");
+		byte[] packageBytes = stream.readAllBytes();
+		PackageInstallOutcomeJson expectedReport = new PackageInstallOutcomeJson();
+
+		PackageContentsJson packageContentsJson = new PackageContentsJson();
+		packageContentsJson.setContents(Base64.getEncoder().encode(packageBytes));
+		packageContentsJson.setReport(expectedReport);
+
+		ChunkExecutionDetails<PackageInstallationJobParameters, PackageContentsJson> chunkDetails =
+			new ChunkExecutionDetails<>(packageContentsJson, params, INSTANCE_ID, CHUNK_ID);
+
+		doThrow(new IllegalArgumentException()).when(myPackageInstallerSvc).installPackage(any(), any(), any());
+
+		// execute and validate
+		assertThatThrownBy(() -> myStep.consume(chunkDetails)).isInstanceOf(JobExecutionFailedException.class);
 	}
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/packages/IPackageInstallerSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/packages/IPackageInstallerSvc.java
@@ -84,6 +84,5 @@ public interface IPackageInstallerSvc {
 	 * @param theVersion the package version
 	 * @return the original package if compatible, or the version-specific variant if found
 	 */
-	NpmPackage substituteVersionSpecificPackageIfNeeded(
-			NpmPackage theDependency, String theId, String theVersion);
+	NpmPackage substituteVersionSpecificPackageIfNeeded(NpmPackage theDependency, String theId, String theVersion);
 }

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/packages/IPackageInstallerSvc.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/packages/IPackageInstallerSvc.java
@@ -70,4 +70,20 @@ public interface IPackageInstallerSvc {
 	 * @return a JSON object containing the status report
 	 */
 	PackageInstallationStatusJson checkInstallationStatus(String theJobId);
+
+	/**
+	 * Checks if a dependency package's FHIR version is compatible with the server's FHIR version.
+	 * If incompatible, attempts to load a version-specific variant by appending a FHIR version
+	 * suffix (e.g., ".r4" for R4/R4B servers, ".r5" for R5, ".r3" for DSTU3).
+	 * <p>
+	 * This handles cross-version packages like {@code hl7.fhir.uv.extensions} which declare
+	 * FHIR version 5.0.0 but have R4-specific counterparts like {@code hl7.fhir.uv.extensions.r4}.
+	 *
+	 * @param theDependency the loaded dependency package
+	 * @param theId the package ID
+	 * @param theVersion the package version
+	 * @return the original package if compatible, or the version-specific variant if found
+	 */
+	NpmPackage substituteVersionSpecificPackageIfNeeded(
+			NpmPackage theDependency, String theId, String theVersion);
 }


### PR DESCRIPTION
This is the fifth and final stage of the async package installation epic.

Notable changes include:
- ensure that the server supports package installation before launching the root job
- if a package cannot be retrieved or cannot be installed, fail the job
- if a dependency job cannot be launched, or terminates in failure, log the outcome, skip the dependency, and proceed to install the rest of the package
- hook up the cross-version package dependency resolution code that was implemented on the synchronous path in https://github.com/hapifhir/hapi-fhir/pull/7731