### PR TITLE
Fix narrowing of SearchParameter with abstract base on package install

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
@@ -35,6 +35,7 @@ import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -198,7 +199,6 @@ public class SearchParameterUtil {
 		return new ArrayList<>(result);
 	}
 
-	// Created by Claude Opus 4.7
 	/**
 	 * Returns the concrete resource types whose implementing class has an ancestor with the given
 	 * abstract-base name in its superclass chain. Used by {@link #expandBaseWhenNeeded} to perform
@@ -207,13 +207,12 @@ public class SearchParameterUtil {
 	private static List<String> getConcreteTypesExtending(FhirContext theContext, String theAbstractBase) {
 		List<String> result = new ArrayList<>();
 		for (String concreteType : theContext.getResourceTypes()) {
-			Class<?> cls = theContext.getResourceDefinition(concreteType).getImplementingClass();
-			while (cls != null && cls != Object.class) {
-				if (cls.getSimpleName().equals(theAbstractBase)) {
+			final Class<?> cls = theContext.getResourceDefinition(concreteType).getImplementingClass();
+			for (Class<?> superclass : ClassUtils.getAllSuperclasses(cls)) {
+				if (superclass.getSimpleName().equals(theAbstractBase)) {
 					result.add(concreteType);
 					break;
 				}
-				cls = cls.getSuperclass();
 			}
 		}
 		return result;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -156,23 +157,66 @@ public class SearchParameterUtil {
 	// Created by Claude Opus 4.7
 	/**
 	 * Returns true if the given SearchParameter base value represents an abstract base type
-	 * ({@code Resource} or {@code DomainResource}), meaning the parameter applies to all resource types.
+	 * ({@code Resource}, {@code DomainResource}, {@code CanonicalResource} (R5+), or
+	 * {@code MetadataResource} (R5+)), meaning the parameter applies to all resource types
+	 * that extend that abstract base.
 	 */
 	public static boolean isAbstractResourceBase(String theBase) {
-		return "Resource".equalsIgnoreCase(theBase) || "DomainResource".equalsIgnoreCase(theBase);
+		return "Resource".equals(theBase)
+				|| "DomainResource".equals(theBase)
+				|| "CanonicalResource".equals(theBase)
+				|| "MetadataResource".equals(theBase);
 	}
 
 	// Created by Claude Opus 4.7
 	/**
-	 * Expands a SearchParameter base list: if any entry is an abstract base type ({@code Resource} or
-	 * {@code DomainResource}), returns all concrete resource types known to the context; otherwise returns
-	 * the original list unchanged.
+	 * Expands a SearchParameter base list. Each entry that is an abstract base type
+	 * ({@code Resource}, {@code DomainResource}, {@code CanonicalResource}, {@code MetadataResource})
+	 * is replaced with the set of concrete resource types that extend that abstract class; concrete
+	 * entries are preserved as-is. If no entry is abstract, the original list is returned unchanged.
+	 * <p>
+	 * Abstract types expand narrowly:
+	 * <ul>
+	 *   <li>{@code Resource} → every concrete type (root of the hierarchy)</li>
+	 *   <li>{@code DomainResource} → only concrete types that extend {@code DomainResource}</li>
+	 *   <li>{@code CanonicalResource} → only concrete types that extend {@code CanonicalResource} (R5+)</li>
+	 *   <li>{@code MetadataResource} → only concrete types that extend {@code MetadataResource} (R5+)</li>
+	 * </ul>
 	 */
 	public static List<String> expandBaseAsStrings(FhirContext theContext, Collection<String> theBase) {
-		if (theBase.stream().anyMatch(SearchParameterUtil::isAbstractResourceBase)) {
-			return new ArrayList<>(theContext.getResourceTypes());
+		if (theBase.stream().noneMatch(SearchParameterUtil::isAbstractResourceBase)) {
+			return new ArrayList<>(theBase);
 		}
-		return new ArrayList<>(theBase);
+		Set<String> result = new LinkedHashSet<>();
+		for (String baseEntry : theBase) {
+			if (isAbstractResourceBase(baseEntry)) {
+				result.addAll(getConcreteTypesExtending(theContext, baseEntry));
+			} else {
+				result.add(baseEntry);
+			}
+		}
+		return new ArrayList<>(result);
+	}
+
+	// Created by Claude Opus 4.7
+	/**
+	 * Returns the concrete resource types whose implementing class has an ancestor with the given
+	 * abstract-base name in its superclass chain. Used by {@link #expandBaseAsStrings} to perform
+	 * per-abstract-type expansion rather than a blanket "all types".
+	 */
+	private static List<String> getConcreteTypesExtending(FhirContext theContext, String theAbstractBase) {
+		List<String> result = new ArrayList<>();
+		for (String concreteType : theContext.getResourceTypes()) {
+			Class<?> cls = theContext.getResourceDefinition(concreteType).getImplementingClass();
+			while (cls != null && cls != Object.class) {
+				if (cls.getSimpleName().equals(theAbstractBase)) {
+					result.add(concreteType);
+					break;
+				}
+				cls = cls.getSuperclass();
+			}
+		}
+		return result;
 	}
 
 	public static List<String> getBaseAsStrings(FhirContext theContext, IBaseResource theResource) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
@@ -43,6 +43,7 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -150,6 +151,28 @@ public class SearchParameterUtil {
 			return theCompartmentName.substring("Base FHIR compartment definition for ".length());
 		}
 		return theCompartmentName;
+	}
+
+	// Created by Claude Opus 4.7
+	/**
+	 * Returns true if the given SearchParameter base value represents an abstract base type
+	 * ({@code Resource} or {@code DomainResource}), meaning the parameter applies to all resource types.
+	 */
+	public static boolean isAbstractResourceBase(String theBase) {
+		return "Resource".equalsIgnoreCase(theBase) || "DomainResource".equalsIgnoreCase(theBase);
+	}
+
+	// Created by Claude Opus 4.7
+	/**
+	 * Expands a SearchParameter base list: if any entry is an abstract base type ({@code Resource} or
+	 * {@code DomainResource}), returns all concrete resource types known to the context; otherwise returns
+	 * the original list unchanged.
+	 */
+	public static List<String> expandBaseAsStrings(FhirContext theContext, Collection<String> theBase) {
+		if (theBase.stream().anyMatch(SearchParameterUtil::isAbstractResourceBase)) {
+			return new ArrayList<>(theContext.getResourceTypes());
+		}
+		return new ArrayList<>(theBase);
 	}
 
 	public static List<String> getBaseAsStrings(FhirContext theContext, IBaseResource theResource) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/SearchParameterUtil.java
@@ -183,7 +183,7 @@ public class SearchParameterUtil {
 	 *   <li>{@code MetadataResource} → only concrete types that extend {@code MetadataResource} (R5+)</li>
 	 * </ul>
 	 */
-	public static List<String> expandBaseAsStrings(FhirContext theContext, Collection<String> theBase) {
+	public static List<String> expandBaseWhenNeeded(FhirContext theContext, Collection<String> theBase) {
 		if (theBase.stream().noneMatch(SearchParameterUtil::isAbstractResourceBase)) {
 			return new ArrayList<>(theBase);
 		}
@@ -201,7 +201,7 @@ public class SearchParameterUtil {
 	// Created by Claude Opus 4.7
 	/**
 	 * Returns the concrete resource types whose implementing class has an ancestor with the given
-	 * abstract-base name in its superclass chain. Used by {@link #expandBaseAsStrings} to perform
+	 * abstract-base name in its superclass chain. Used by {@link #expandBaseWhenNeeded} to perform
 	 * per-abstract-type expansion rather than a blanket "all types".
 	 */
 	private static List<String> getConcreteTypesExtending(FhirContext theContext, String theAbstractBase) {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7801-fix-searchparam-abstract-base-split.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7801-fix-searchparam-abstract-base-split.yaml
@@ -3,7 +3,6 @@ type: fix
 issue: 7801
 title: "Previously, installing an IG package whose `SearchParameter` shared a `code` with an
   existing `SearchParameter` on an abstract `base` (`Resource`, `DomainResource`,
-  `CanonicalResource`, or `MetadataResource`) did not narrow the existing parameter. FHIR
-  searches using that `code` could then return results governed by the older parameter's
-  indexing, making the newly-installed `SearchParameter` fail to take effect as intended.
-  This has been fixed."
+  `CanonicalResource`, or `MetadataResource`) did not update the existing `SearchParameter.base` which means 
+  the `SearchParameter` was still operating on the old `base`. This has been fixed."
+

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7801-fix-searchparam-abstract-base-split.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7801-fix-searchparam-abstract-base-split.yaml
@@ -2,7 +2,8 @@
 type: fix
 issue: 7801
 title: "Previously, installing an IG package whose `SearchParameter` shared a `code` with an
-  existing `SearchParameter` on an abstract `base` (`Resource` or `DomainResource`) did not
-  narrow the existing parameter. FHIR searches using that `code` could then return results
-  governed by the older parameter's indexing, making the newly-installed `SearchParameter`
-  fail to take effect as intended. This has been fixed."
+  existing `SearchParameter` on an abstract `base` (`Resource`, `DomainResource`,
+  `CanonicalResource`, or `MetadataResource`) did not narrow the existing parameter. FHIR
+  searches using that `code` could then return results governed by the older parameter's
+  indexing, making the newly-installed `SearchParameter` fail to take effect as intended.
+  This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7801-fix-searchparam-abstract-base-split.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7801-fix-searchparam-abstract-base-split.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 7801
+title: "Previously, installing an IG package whose `SearchParameter` shared a `code` with an
+  existing `SearchParameter` on an abstract `base` (`Resource` or `DomainResource`) did not
+  narrow the existing parameter. FHIR searches using that `code` could then return results
+  governed by the older parameter's indexing, making the newly-installed `SearchParameter`
+  fail to take effect as intended. This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaResourceDaoSearchParameter.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/JpaResourceDaoSearchParameter.java
@@ -81,7 +81,7 @@ public class JpaResourceDaoSearchParameter<T extends IBaseResource> extends Base
 				myVersionCanonicalizer.searchParameterToCanonical(theResource);
 		List<String> base = theResource != null
 				? searchParameter.getBase().stream().map(Enumeration::getCode).collect(Collectors.toList())
-				: null;
+				: List.of();
 		requestReindexForRelatedResources(reindex, base, theRequestDetails);
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -825,8 +825,10 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 				.equals(theResource.getIdElement().getIdPart())) {
 			return false;
 		}
-		Collection<String> remainingBaseList = new HashSet<>(getBaseAsStrings(myFhirContext, theExistingResource));
-		remainingBaseList.removeAll(getBaseAsStrings(myFhirContext, theResource));
+		Collection<String> remainingBaseList = new HashSet<>(SearchParameterUtil.expandBaseAsStrings(
+				myFhirContext, getBaseAsStrings(myFhirContext, theExistingResource)));
+		remainingBaseList.removeAll(
+				SearchParameterUtil.expandBaseAsStrings(myFhirContext, getBaseAsStrings(myFhirContext, theResource)));
 		if (remainingBaseList.isEmpty()) {
 			return false;
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -825,10 +825,10 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 				.equals(theResource.getIdElement().getIdPart())) {
 			return false;
 		}
-		Collection<String> remainingBaseList = new HashSet<>(SearchParameterUtil.expandBaseAsStrings(
+		Collection<String> remainingBaseList = new HashSet<>(SearchParameterUtil.expandBaseWhenNeeded(
 				myFhirContext, getBaseAsStrings(myFhirContext, theExistingResource)));
 		remainingBaseList.removeAll(
-				SearchParameterUtil.expandBaseAsStrings(myFhirContext, getBaseAsStrings(myFhirContext, theResource)));
+				SearchParameterUtil.expandBaseWhenNeeded(myFhirContext, getBaseAsStrings(myFhirContext, theResource)));
 		if (remainingBaseList.isEmpty()) {
 			return false;
 		}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
@@ -483,6 +483,128 @@ public class PackageInstallerSvcImplTest {
 		assertEquals(theInstallBase, capturedSP.getBase().stream().map(CodeType::getCode).toList());
 	}
 
+	// Created by Claude Opus 4.7
+	@Nested
+	class SearchParameterInstallTest {
+
+		// Created by Claude Opus 4.7
+		@Test
+		void testInstall_existingSearchParamHasDomainResourceBase_splitsBaseForIncomingConcreteType() throws IOException {
+			// Existing SP covers all resources via DomainResource; incoming SP targets only Patient.
+			// Expected: existing SP is narrowed to all types except Patient, new SP created for Patient.
+			SearchParameter existingSP = createSearchParameter("existing-sp", List.of("DomainResource"));
+			SearchParameter installSP = createSearchParameter(null, List.of("Patient"));
+			PackageInstallationSpec spec = setupResourceInPackage(existingSP, installSP, mySearchParameterDao);
+
+			mySvc.install(spec);
+
+			verify(mySearchParameterDao, times(1)).update(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+			verify(mySearchParameterDao, times(1)).create(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+
+			Iterator<SearchParameter> iterator = mySearchParameterCaptor.getAllValues().iterator();
+			SearchParameter updatedExisting = iterator.next();
+			assertEquals("existing-sp", updatedExisting.getIdPart());
+			List<String> updatedBase = updatedExisting.getBase().stream().map(CodeType::getCode).toList();
+			assertThat(updatedBase).doesNotContain("Patient");
+			assertThat(updatedBase).doesNotContain("DomainResource");
+			assertThat(updatedBase).contains("Observation");
+
+			SearchParameter createdIncoming = iterator.next();
+			assertEquals(List.of("Patient"), createdIncoming.getBase().stream().map(CodeType::getCode).toList());
+		}
+
+		// Created by Claude Opus 4.7
+		@Test
+		void testInstall_incomingSearchParamHasDomainResourceBase_overridesConcreteTypedExisting() throws IOException {
+			// Incoming SP covers all resources via DomainResource; existing SP targets [Patient, Observation].
+			// Expected: incoming SP completely overrides existing SP (no split).
+			SearchParameter existingSP = createSearchParameter("individual-given", List.of("Patient", "Observation"));
+			SearchParameter installSP = createSearchParameter("us-core-all-given", List.of("DomainResource"));
+			PackageInstallationSpec spec = setupResourceInPackage(existingSP, installSP, mySearchParameterDao);
+
+			mySvc.install(spec);
+
+			verify(mySearchParameterDao, times(1)).update(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+			verify(mySearchParameterDao, never()).create(any(SearchParameter.class), any(RequestDetails.class));
+
+			SearchParameter capturedSP = mySearchParameterCaptor.getValue();
+			assertEquals("individual-given", capturedSP.getIdPart());
+			assertEquals(List.of("DomainResource"), capturedSP.getBase().stream().map(CodeType::getCode).toList());
+		}
+
+		// Created by Claude Opus 4.7
+		@Test
+		void testInstall_existingSearchParamHasResourceBase_splitsBaseForIncomingConcreteType() throws IOException {
+			// "Resource" keyword behaves identically to "DomainResource" — should expand to all concrete types.
+			SearchParameter existingSP = createSearchParameter("existing-sp", List.of("Resource"));
+			SearchParameter installSP = createSearchParameter(null, List.of("Patient"));
+			PackageInstallationSpec spec = setupResourceInPackage(existingSP, installSP, mySearchParameterDao);
+
+			mySvc.install(spec);
+
+			verify(mySearchParameterDao, times(1)).update(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+			verify(mySearchParameterDao, times(1)).create(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+
+			Iterator<SearchParameter> iterator = mySearchParameterCaptor.getAllValues().iterator();
+			SearchParameter updatedExisting = iterator.next();
+			assertEquals("existing-sp", updatedExisting.getIdPart());
+			List<String> updatedBase = updatedExisting.getBase().stream().map(CodeType::getCode).toList();
+			assertThat(updatedBase)
+				.doesNotContain("Patient")
+				.doesNotContain("Resource")
+				.contains("Observation");
+			SearchParameter createdIncoming = iterator.next();
+			assertEquals(List.of("Patient"), createdIncoming.getBase().stream().map(CodeType::getCode).toList());
+		}
+
+		// Created by Claude Opus 4.7
+		@Test
+		void testInstall_incomingSearchParamHasResourceBase_overridesConcreteTypedExisting() throws IOException {
+			// Incoming SP with "Resource" base covers all resources — should override existing without a split.
+			SearchParameter existingSP = createSearchParameter("individual-given", List.of("Patient", "Observation"));
+			SearchParameter installSP = createSearchParameter("us-core-all-given", List.of("Resource"));
+			PackageInstallationSpec spec = setupResourceInPackage(existingSP, installSP, mySearchParameterDao);
+
+			mySvc.install(spec);
+
+			verify(mySearchParameterDao, times(1)).update(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+			verify(mySearchParameterDao, never()).create(any(SearchParameter.class), any(RequestDetails.class));
+
+			SearchParameter capturedSP = mySearchParameterCaptor.getValue();
+			assertEquals("individual-given", capturedSP.getIdPart());
+			assertEquals(List.of("Resource"), capturedSP.getBase().stream().map(CodeType::getCode).toList());
+		}
+
+		// Created by Claude Opus 4.7
+		@Test
+		void testInstall_bothSearchParamsHaveDomainResourceBase_overridesExistingWithoutSplit() throws IOException {
+			// Both SPs cover all resources via DomainResource — no types remain after subtraction, so no split.
+			SearchParameter existingSP = createSearchParameter("existing-sp", List.of("DomainResource"));
+			SearchParameter installSP = createSearchParameter("incoming-sp", List.of("DomainResource"));
+			PackageInstallationSpec spec = setupResourceInPackage(existingSP, installSP, mySearchParameterDao);
+
+			mySvc.install(spec);
+
+			verify(mySearchParameterDao, times(1)).update(mySearchParameterCaptor.capture(), myRequestDetailsCaptor.capture());
+			verify(mySearchParameterDao, never()).create(any(SearchParameter.class), any(RequestDetails.class));
+
+			SearchParameter capturedSP = mySearchParameterCaptor.getValue();
+			assertEquals("existing-sp", capturedSP.getIdPart());
+			assertEquals(List.of("DomainResource"), capturedSP.getBase().stream().map(CodeType::getCode).toList());
+		}
+	}
+
+	private static SearchParameter createSearchParameter(String theId, Collection<String> theBase) {
+		SearchParameter searchParameter = new SearchParameter();
+		if (theId != null) {
+			searchParameter.setId(new IdType("SearchParameter", theId));
+		}
+		searchParameter.setCode("someCode");
+		theBase.forEach(base -> searchParameter.getBase().add(new CodeType(base)));
+		searchParameter.setExpression("someExpression");
+		return searchParameter;
+	}
+
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	private PackageInstallationSpec setupResourceInPackage(IBaseResource theExistingResource, IBaseResource theInstallResource,
 	                                                       IFhirResourceDao theFhirResourceDao) throws IOException {
@@ -526,17 +648,6 @@ public class PackageInstallerSvcImplTest {
 	private void setupSearchParameterValidationMocksForSuccess() {
 		when(myVersionCanonicalizerMock.searchParameterToCanonical(any())).thenReturn(new org.hl7.fhir.r5.model.SearchParameter());
 		doNothing().when(mySearchParameterDaoValidatorMock).validate(any());
-	}
-
-	private static SearchParameter createSearchParameter(String theId, Collection<String> theBase) {
-		SearchParameter searchParameter = new SearchParameter();
-		if (theId != null) {
-			searchParameter.setId(new IdType("SearchParameter", theId));
-		}
-		searchParameter.setCode("someCode");
-		theBase.forEach(base -> searchParameter.getBase().add(new CodeType(base)));
-		searchParameter.setExpression("someExpression");
-		return searchParameter;
 	}
 
 	private static Subscription createSubscription(Subscription.SubscriptionStatus theSubscriptionStatus) {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
@@ -141,14 +141,14 @@ class SearchParameterUtilTest {
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withResourceBase_returnsEveryConcreteType() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Resource"));
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of("Resource"));
 		assertThat(result).containsExactlyInAnyOrderElementsOf(myCtx.getResourceTypes());
 	}
 
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withDomainResourceBase_returnsOnlyDomainResourceDerivedTypes() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("DomainResource"));
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of("DomainResource"));
 		// DomainResource-derived (common examples)
 		assertThat(result).contains("Patient", "Observation", "Practitioner", "Encounter");
 		// Non-DomainResource types (extend Resource directly)
@@ -158,7 +158,7 @@ class SearchParameterUtilTest {
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withCanonicalResourceBase_returnsOnlyCanonicalResourceDerivedTypes() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("CanonicalResource"));
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of("CanonicalResource"));
 		// CanonicalResource-derived
 		assertThat(result).contains("StructureDefinition", "ValueSet", "CodeSystem", "SearchParameter");
 		// Not CanonicalResource-derived (plain DomainResource)
@@ -168,7 +168,7 @@ class SearchParameterUtilTest {
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withMetadataResourceBase_returnsOnlyMetadataResourceDerivedTypes() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("MetadataResource"));
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of("MetadataResource"));
 		// MetadataResource-derived
 		assertThat(result).contains("Library", "Measure", "PlanDefinition", "ActivityDefinition");
 		// CanonicalResource but not MetadataResource (no status/date metadata block)
@@ -180,7 +180,7 @@ class SearchParameterUtilTest {
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withMixedConcreteAndAbstractBase_unionsConcreteAndExpandedTypes() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Patient", "DomainResource"));
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of("Patient", "DomainResource"));
 		// Patient is preserved, DomainResource expands to all DomainResource-derived concrete types
 		assertThat(result).contains("Patient", "Observation", "Practitioner");
 		assertThat(result).doesNotContain("Bundle", "Binary");
@@ -189,14 +189,14 @@ class SearchParameterUtilTest {
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withOnlyConcreteBases_returnsInputUnchanged() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Patient", "Observation"));
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of("Patient", "Observation"));
 		assertThat(result).containsExactly("Patient", "Observation");
 	}
 
 	// Created by Claude Opus 4.7
 	@Test
 	void testExpandBaseAsStrings_withEmptyList_returnsEmpty() {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of());
+		List<String> result = SearchParameterUtil.expandBaseWhenNeeded(myCtx, List.of());
 		assertThat(result).isEmpty();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
@@ -114,15 +114,21 @@ class SearchParameterUtilTest {
 
 	// Created by Claude Opus 4.7
 	@ParameterizedTest
-	@ValueSource(strings = {"Resource", "DomainResource", "resource", "RESOURCE", "domainresource", "DOMAINRESOURCE"})
+	@ValueSource(strings = {"Resource", "DomainResource", "CanonicalResource", "MetadataResource"})
 	void testIsAbstractResourceBase_returnsTrueForAbstractBases(String theBase) {
 		assertTrue(SearchParameterUtil.isAbstractResourceBase(theBase));
 	}
 
 	// Created by Claude Opus 4.7
+	// FHIR resource type codes are case-sensitive per the ResourceType valueset; wrong-case
+	// variants must not match.
 	@ParameterizedTest
-	@ValueSource(strings = {"Patient", "Observation", "Practitioner", "ValueSet", "StructureDefinition"})
-	void testIsAbstractResourceBase_returnsFalseForConcreteBases(String theBase) {
+	@ValueSource(strings = {
+		"Patient", "Observation", "Practitioner", "ValueSet", "StructureDefinition",
+		"resource", "RESOURCE", "domainresource", "DOMAINRESOURCE",
+		"canonicalresource", "CANONICALRESOURCE", "metadataresource", "METADATARESOURCE"
+	})
+	void testIsAbstractResourceBase_returnsFalseForConcreteOrMiscasedBases(String theBase) {
 		assertFalse(SearchParameterUtil.isAbstractResourceBase(theBase));
 	}
 
@@ -133,18 +139,51 @@ class SearchParameterUtilTest {
 	}
 
 	// Created by Claude Opus 4.7
-	@ParameterizedTest
-	@ValueSource(strings = {"Resource", "DomainResource", "resource", "DOMAINRESOURCE"})
-	void testExpandBaseAsStrings_withSingleAbstractBase_returnsAllConcreteTypes(String theAbstractBase) {
-		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of(theAbstractBase));
+	@Test
+	void testExpandBaseAsStrings_withResourceBase_returnsEveryConcreteType() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Resource"));
 		assertThat(result).containsExactlyInAnyOrderElementsOf(myCtx.getResourceTypes());
 	}
 
 	// Created by Claude Opus 4.7
 	@Test
-	void testExpandBaseAsStrings_withMixedConcreteAndAbstractBase_expandsToAllConcreteTypes() {
+	void testExpandBaseAsStrings_withDomainResourceBase_returnsOnlyDomainResourceDerivedTypes() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("DomainResource"));
+		// DomainResource-derived (common examples)
+		assertThat(result).contains("Patient", "Observation", "Practitioner", "Encounter");
+		// Non-DomainResource types (extend Resource directly)
+		assertThat(result).doesNotContain("Bundle", "Binary", "Parameters");
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testExpandBaseAsStrings_withCanonicalResourceBase_returnsOnlyCanonicalResourceDerivedTypes() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("CanonicalResource"));
+		// CanonicalResource-derived
+		assertThat(result).contains("StructureDefinition", "ValueSet", "CodeSystem", "SearchParameter");
+		// Not CanonicalResource-derived (plain DomainResource)
+		assertThat(result).doesNotContain("Patient", "Observation", "Bundle");
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testExpandBaseAsStrings_withMetadataResourceBase_returnsOnlyMetadataResourceDerivedTypes() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("MetadataResource"));
+		// MetadataResource-derived
+		assertThat(result).contains("Library", "Measure", "PlanDefinition", "ActivityDefinition");
+		// CanonicalResource but not MetadataResource (no status/date metadata block)
+		assertThat(result).doesNotContain("StructureDefinition");
+		// Not CanonicalResource at all
+		assertThat(result).doesNotContain("Patient", "Bundle");
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testExpandBaseAsStrings_withMixedConcreteAndAbstractBase_unionsConcreteAndExpandedTypes() {
 		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Patient", "DomainResource"));
-		assertThat(result).containsExactlyInAnyOrderElementsOf(myCtx.getResourceTypes());
+		// Patient is preserved, DomainResource expands to all DomainResource-derived concrete types
+		assertThat(result).contains("Patient", "Observation", "Practitioner");
+		assertThat(result).doesNotContain("Bundle", "Binary");
 	}
 
 	// Created by Claude Opus 4.7

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/util/SearchParameterUtilTest.java
@@ -14,11 +14,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -108,6 +110,55 @@ class SearchParameterUtilTest {
 
 		// Verify
 		assertEquals(expected, actual);
+	}
+
+	// Created by Claude Opus 4.7
+	@ParameterizedTest
+	@ValueSource(strings = {"Resource", "DomainResource", "resource", "RESOURCE", "domainresource", "DOMAINRESOURCE"})
+	void testIsAbstractResourceBase_returnsTrueForAbstractBases(String theBase) {
+		assertTrue(SearchParameterUtil.isAbstractResourceBase(theBase));
+	}
+
+	// Created by Claude Opus 4.7
+	@ParameterizedTest
+	@ValueSource(strings = {"Patient", "Observation", "Practitioner", "ValueSet", "StructureDefinition"})
+	void testIsAbstractResourceBase_returnsFalseForConcreteBases(String theBase) {
+		assertFalse(SearchParameterUtil.isAbstractResourceBase(theBase));
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testIsAbstractResourceBase_returnsFalseForEmptyString() {
+		assertFalse(SearchParameterUtil.isAbstractResourceBase(""));
+	}
+
+	// Created by Claude Opus 4.7
+	@ParameterizedTest
+	@ValueSource(strings = {"Resource", "DomainResource", "resource", "DOMAINRESOURCE"})
+	void testExpandBaseAsStrings_withSingleAbstractBase_returnsAllConcreteTypes(String theAbstractBase) {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of(theAbstractBase));
+		assertThat(result).containsExactlyInAnyOrderElementsOf(myCtx.getResourceTypes());
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testExpandBaseAsStrings_withMixedConcreteAndAbstractBase_expandsToAllConcreteTypes() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Patient", "DomainResource"));
+		assertThat(result).containsExactlyInAnyOrderElementsOf(myCtx.getResourceTypes());
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testExpandBaseAsStrings_withOnlyConcreteBases_returnsInputUnchanged() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of("Patient", "Observation"));
+		assertThat(result).containsExactly("Patient", "Observation");
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void testExpandBaseAsStrings_withEmptyList_returnsEmpty() {
+		List<String> result = SearchParameterUtil.expandBaseAsStrings(myCtx, List.of());
+		assertThat(result).isEmpty();
 	}
 
 }

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCache.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCache.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.rest.server.util.ResourceSearchParams;
+import ca.uhn.fhir.util.SearchParameterUtil;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.Validate;
@@ -126,9 +127,7 @@ public class ReadOnlySearchParamCache {
 						nextCanonical.getBase());
 
 				Collection<String> base = nextCanonical.getBase();
-				if (base.contains("Resource") || base.contains("DomainResource")) {
-					base = resourceNames;
-				}
+				base = SearchParameterUtil.expandBaseAsStrings(theFhirContext, base);
 
 				// Add it to our return value if permitted by the pattern parameters
 				for (String nextResourceName : base) {

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCache.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCache.java
@@ -127,7 +127,7 @@ public class ReadOnlySearchParamCache {
 						nextCanonical.getBase());
 
 				Collection<String> base = nextCanonical.getBase();
-				base = SearchParameterUtil.expandBaseAsStrings(theFhirContext, base);
+				base = SearchParameterUtil.expandBaseWhenNeeded(theFhirContext, base);
 
 				// Add it to our return value if permitted by the pattern parameters
 				for (String nextResourceName : base) {

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImpl.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImpl.java
@@ -461,16 +461,7 @@ public class SearchParamRegistryImpl
 	}
 
 	private @Nonnull Set<String> expandBaseList(Collection<String> nextBase) {
-		Set<String> expandedBases = new HashSet<>();
-		for (String base : nextBase) {
-			if ("Resource".equals(base) || "DomainResource".equals(base)) {
-				expandedBases.addAll(myFhirContext.getResourceTypes());
-				break;
-			} else {
-				expandedBases.add(base);
-			}
-		}
-		return expandedBases;
+		return new HashSet<>(SearchParameterUtil.expandBaseAsStrings(myFhirContext, nextBase));
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImpl.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImpl.java
@@ -461,7 +461,7 @@ public class SearchParamRegistryImpl
 	}
 
 	private @Nonnull Set<String> expandBaseList(Collection<String> nextBase) {
-		return new HashSet<>(SearchParameterUtil.expandBaseAsStrings(myFhirContext, nextBase));
+		return new HashSet<>(SearchParameterUtil.expandBaseWhenNeeded(myFhirContext, nextBase));
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCacheTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCacheTest.java
@@ -1,11 +1,14 @@
 package ca.uhn.fhir.jpa.searchparam.registry;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.util.ResourceSearchParams;
 import org.junit.jupiter.api.Test;
 
 import static ca.uhn.fhir.jpa.searchparam.registry.ReadOnlySearchParamCache.searchParamMatchesAtLeastOnePattern;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReadOnlySearchParamCacheTest {
@@ -26,6 +29,25 @@ public class ReadOnlySearchParamCacheTest {
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet("aaa"), "Patient", "name"));
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet(":name"), "Patient", "name"));
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet("Patient:"), "Patient", "name"));
+	}
+
+	// Created by Claude Opus 4.7
+	@Test
+	void fromFhirContext_builtInAbstractBaseSearchParameter_isRegisteredUnderEveryConcreteResourceType() {
+		// The FHIR R4 core spec ships SearchParameters such as "_id" with base=[Resource].
+		// fromFhirContext must delegate to SearchParameterUtil.expandBaseAsStrings so the SP
+		// lands under every concrete resource type rather than under the literal "Resource" key.
+		FhirContext ctx = FhirContext.forR4Cached();
+		SearchParameterCanonicalizer canonicalizer = new SearchParameterCanonicalizer(ctx);
+
+		ReadOnlySearchParamCache cache = ReadOnlySearchParamCache.fromFhirContext(ctx, canonicalizer);
+
+		ResourceSearchParams patientParams = cache.getSearchParamMap("Patient");
+		ResourceSearchParams observationParams = cache.getSearchParamMap("Observation");
+		ResourceSearchParams practitionerParams = cache.getSearchParamMap("Practitioner");
+		assertNotNull(patientParams.get("_id"));
+		assertNotNull(observationParams.get("_id"));
+		assertNotNull(practitionerParams.get("_id"));
 	}
 
 }

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCacheTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/ReadOnlySearchParamCacheTest.java
@@ -1,8 +1,9 @@
 package ca.uhn.fhir.jpa.searchparam.registry;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.server.util.ResourceSearchParams;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static ca.uhn.fhir.jpa.searchparam.registry.ReadOnlySearchParamCache.searchParamMatchesAtLeastOnePattern;
 import static com.google.common.collect.Sets.newHashSet;
@@ -13,42 +14,52 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReadOnlySearchParamCacheTest {
 
-	@Test
-	void testSearchParamMatchesAtLeastOnePattern() {
-		assertTrue(searchParamMatchesAtLeastOnePattern(newHashSet("*"), "Patient", "name"));
-		assertTrue(searchParamMatchesAtLeastOnePattern(newHashSet("Patient:name"), "Patient", "name"));
-		assertTrue(searchParamMatchesAtLeastOnePattern(newHashSet("Patient:*"), "Patient", "name"));
-		assertTrue(searchParamMatchesAtLeastOnePattern(newHashSet("*:name"), "Patient", "name"));
-		assertFalse(searchParamMatchesAtLeastOnePattern(newHashSet("Patient:foo"), "Patient", "name"));
-		assertFalse(searchParamMatchesAtLeastOnePattern(newHashSet("Foo:name"), "Patient", "name"));
+	@ParameterizedTest
+	@CsvSource({
+		"'*',           Patient, name",
+		"'Patient:name', Patient, name",
+		"'Patient:*',   Patient, name",
+		"'*:name',      Patient, name",
+	})
+	void searchParamMatchesAtLeastOnePattern_matches(String thePattern, String theResourceType, String theParamName) {
+		assertTrue(searchParamMatchesAtLeastOnePattern(newHashSet(thePattern), theResourceType, theParamName));
 	}
 
+	@ParameterizedTest
+	@CsvSource({
+		"'Patient:foo', Patient, name",
+		"'Foo:name',    Patient, name",
+	})
+	void searchParamMatchesAtLeastOnePattern_noMatch(String thePattern, String theResourceType, String theParamName) {
+		assertFalse(searchParamMatchesAtLeastOnePattern(newHashSet(thePattern), theResourceType, theParamName));
+	}
 
-	@Test
-	void testSearchParamMatchesAtLeastOnePattern_InvalidPattern() {
-		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet("aaa"), "Patient", "name"));
-		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet(":name"), "Patient", "name"));
-		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet("Patient:"), "Patient", "name"));
+	@ParameterizedTest
+	@ValueSource(strings = {"aaa", ":name", "Patient:"})
+	void searchParamMatchesAtLeastOnePattern_invalidPattern_throwsException(String thePattern) {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> searchParamMatchesAtLeastOnePattern(newHashSet(thePattern), "Patient", "name"));
 	}
 
 	// Created by Claude Opus 4.7
-	@Test
-	void fromFhirContext_builtInAbstractBaseSearchParameter_isRegisteredUnderEveryConcreteResourceType() {
-		// The FHIR R4 core spec ships SearchParameters such as "_id" with base=[Resource].
-		// fromFhirContext must delegate to SearchParameterUtil.expandBaseAsStrings so the SP
-		// lands under every concrete resource type rather than under the literal "Resource" key.
+	@ParameterizedTest
+	@CsvSource({
+		// _id has base=[Resource] — applies to every resource type
+		"_id,   Patient",
+		"_id,   Observation",
+		"_id,   Practitioner",
+		// _text has base=[DomainResource] — applies to every DomainResource subtype
+		"_text, Patient",
+		"_text, Observation",
+		"_text, Practitioner",
+	})
+	void fromFhirContext_builtInAbstractBaseSearchParameter_isRegisteredUnderEveryConcreteResourceType(
+			String theSpCode, String theResourceType) {
 		FhirContext ctx = FhirContext.forR4Cached();
-		SearchParameterCanonicalizer canonicalizer = new SearchParameterCanonicalizer(ctx);
+		ReadOnlySearchParamCache cache = ReadOnlySearchParamCache.fromFhirContext(ctx, new SearchParameterCanonicalizer(ctx));
 
-		ReadOnlySearchParamCache cache = ReadOnlySearchParamCache.fromFhirContext(ctx, canonicalizer);
-
-		ResourceSearchParams patientParams = cache.getSearchParamMap("Patient");
-		ResourceSearchParams observationParams = cache.getSearchParamMap("Observation");
-		ResourceSearchParams practitionerParams = cache.getSearchParamMap("Practitioner");
-		assertNotNull(patientParams.get("_id"));
-		assertNotNull(observationParams.get("_id"));
-		assertNotNull(practitionerParams.get("_id"));
+		assertNotNull(cache.getSearchParamMap(theResourceType).get(theSpCode),
+				() -> theSpCode + " should be indexed under " + theResourceType);
 	}
 
 }
-

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImplTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImplTest.java
@@ -170,10 +170,10 @@ public class SearchParamRegistryImplTest {
 
 	// Created by Claude Opus 4.7
 	@Test
-	void handleInit_searchParameterWithDomainResourceBase_isRegisteredUnderEveryConcreteResourceType() {
+	void handleInit_searchParameterWithDomainResourceBase_isRegisteredUnderDomainResourceDerivedTypesOnly() {
 		// A client-defined SearchParameter with base=[DomainResource] must be expanded via
-		// SearchParameterUtil.expandBaseAsStrings so it is registered under every concrete
-		// resource type rather than only the literal "DomainResource" key.
+		// SearchParameterUtil.expandBaseAsStrings to every DomainResource-derived concrete type
+		// and *not* to types that extend Resource directly (Bundle, Binary, Parameters).
 		IdDt id = new IdDt("SearchParameter/abstract-base-sp");
 		SearchParameter abstractSp = new SearchParameter();
 		abstractSp.setCode("abstract-base-code");
@@ -185,9 +185,14 @@ public class SearchParamRegistryImplTest {
 
 		mySearchParamRegistry.handleInit(List.of(id));
 
+		// DomainResource-derived concrete types — SP should be registered.
 		assertNotNull(mySearchParamRegistry.getActiveSearchParams("Patient", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
 		assertNotNull(mySearchParamRegistry.getActiveSearchParams("Observation", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
 		assertNotNull(mySearchParamRegistry.getActiveSearchParams("Practitioner", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
+		// Types that extend Resource directly (not DomainResource) — SP should NOT be registered.
+		assertNull(mySearchParamRegistry.getActiveSearchParams("Bundle", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
+		assertNull(mySearchParamRegistry.getActiveSearchParams("Binary", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
+		assertNull(mySearchParamRegistry.getActiveSearchParams("Parameters", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImplTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/registry/SearchParamRegistryImplTest.java
@@ -168,6 +168,28 @@ public class SearchParamRegistryImplTest {
 		assertEquals(32, mySearchParamRegistry.getActiveSearchParams("Patient", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).size());
 	}
 
+	// Created by Claude Opus 4.7
+	@Test
+	void handleInit_searchParameterWithDomainResourceBase_isRegisteredUnderEveryConcreteResourceType() {
+		// A client-defined SearchParameter with base=[DomainResource] must be expanded via
+		// SearchParameterUtil.expandBaseAsStrings so it is registered under every concrete
+		// resource type rather than only the literal "DomainResource" key.
+		IdDt id = new IdDt("SearchParameter/abstract-base-sp");
+		SearchParameter abstractSp = new SearchParameter();
+		abstractSp.setCode("abstract-base-code");
+		abstractSp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		abstractSp.setType(Enumerations.SearchParamType.TOKEN);
+		abstractSp.setExpression("Patient.identifier");
+		abstractSp.addBase("DomainResource");
+		when(mySearchParamProvider.read(id)).thenReturn(abstractSp);
+
+		mySearchParamRegistry.handleInit(List.of(id));
+
+		assertNotNull(mySearchParamRegistry.getActiveSearchParams("Patient", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
+		assertNotNull(mySearchParamRegistry.getActiveSearchParams("Observation", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
+		assertNotNull(mySearchParamRegistry.getActiveSearchParams("Practitioner", ISearchParamRegistry.SearchParamLookupContextEnum.INDEX).get("abstract-base-code"));
+	}
+
 	@Test
 	public void testRefreshAfterExpiry() {
 		mySearchParamRegistry.requestRefresh();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -14,12 +14,12 @@ import ca.uhn.fhir.jpa.dao.data.INpmPackageDao;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionDao;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionResourceDao;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
-import ca.uhn.fhir.jpa.term.custom.CustomTerminologySet;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageEntity;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionEntity;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionResourceEntity;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.jpa.term.custom.CustomTerminologySet;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
@@ -1609,36 +1609,6 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 			assertThat(baseAfter).doesNotContain("Patient");
 			assertThat(baseAfter).doesNotContain("DomainResource");
 			assertThat(baseAfter).contains("Observation");
-		});
-	}
-
-	// Created by Claude Opus 4.7
-	/**
-	 * Persisting a SearchParameter with {@code base: ["DomainResource"]} must not crash during
-	 * reindex URL construction. Pre-fix, {@code BaseHapiFhirResourceDao.isCommonSearchParam}
-	 * only matched the literal {@code "resource"} string, so the reindex branch reached
-	 * {@code getResourceDefinition("DomainResource")} and threw {@code DataFormatException}
-	 * (HAPI-1684).
-	 */
-	@Test
-	public void installPackage_searchParameterWithDomainResourceBase_doesNotCrashDuringReindex() throws IOException {
-		String url = "http://example.org/SearchParameter/domain-resource-sp";
-
-		SearchParameter domainResourceSp = new SearchParameter();
-		domainResourceSp.setId("domain-resource-sp");
-		domainResourceSp.setUrl(url);
-		domainResourceSp.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		domainResourceSp.setCode("domain-resource-code");
-		domainResourceSp.addBase("DomainResource");
-		domainResourceSp.setType(Enumerations.SearchParamType.TOKEN);
-		domainResourceSp.setExpression("Patient.identifier");
-
-		installAsPackage("domain-resource-pkg", "0.0.1", domainResourceSp);
-
-		runInTransaction(() -> {
-			IBundleProvider search = mySearchParameterDao.search(
-				SearchParameterMap.newSynchronous("url", new UriParam(url)));
-			assertEquals(1, search.sizeOrThrowNpe());
 		});
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -41,8 +41,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.ConceptMap;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.ImplementationGuide;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.NamingSystem;
@@ -54,6 +56,7 @@ import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.hl7.fhir.utilities.npm.PackageGenerator;
 import org.hl7.fhir.utilities.npm.PackageServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +75,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1554,6 +1559,140 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 		assertEquals(Enumerations.PublicationStatus.ACTIVE, sp.getStatus());
 		assertEquals("2.2", sp.getVersion());
 
+	}
+
+	// Created by Claude Opus 4.7
+	/**
+	 * When an existing SearchParameter has an abstract base ({@code Resource} or
+	 * {@code DomainResource}) that overlaps the incoming SP's concrete base, the installer's
+	 * split path in {@code updateExistingSearchParameterBaseIfNecessary} must expand the
+	 * abstract base before subtracting. Pre-fix, raw string {@code removeAll} left the
+	 * abstract token in place and the existing SP was not narrowed.
+	 */
+	@Test
+	public void installPackage_existingSearchParameterHasAbstractBaseOverlappingIncoming_narrowsByExpansion() throws IOException {
+		// Perf-only override: the split rewrites the existing SP's base to every concrete
+		// type except the incoming's — the resulting reindex request spans ~150 URLs.
+		// Disabling the reindex flag avoids queueing that job while the split itself
+		// (the code under test) runs unchanged.
+		myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(false);
+
+		String sharedCode = "abstract-base-demo";
+		String existingId = "existing-sp";
+
+		SearchParameter existing = new SearchParameter();
+		existing.setId(existingId);
+		existing.setUrl("http://example.org/SearchParameter/existing-sp");
+		existing.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		existing.setCode(sharedCode);
+		existing.addBase("Patient");
+		existing.addBase("DomainResource");
+		existing.setType(Enumerations.SearchParamType.TOKEN);
+		existing.setExpression("Patient.identifier");
+		mySearchParameterDao.update(existing, new SystemRequestDetails());
+
+		SearchParameter incoming = new SearchParameter();
+		incoming.setId("incoming-sp");
+		incoming.setUrl("http://example.org/SearchParameter/incoming-sp");
+		incoming.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		incoming.setCode(sharedCode);
+		incoming.addBase("Patient");
+		incoming.setType(Enumerations.SearchParamType.TOKEN);
+		incoming.setExpression("Patient.identifier");
+
+		installAsPackage("abstract-base-pkg", "0.0.1", incoming);
+
+		runInTransaction(() -> {
+			SearchParameter narrowed = mySearchParameterDao.read(
+				new IdType("SearchParameter/" + existingId), new SystemRequestDetails());
+			List<String> baseAfter = narrowed.getBase().stream().map(CodeType::getCode).toList();
+			assertThat(baseAfter).doesNotContain("Patient");
+			assertThat(baseAfter).doesNotContain("DomainResource");
+			assertThat(baseAfter).contains("Observation");
+		});
+	}
+
+	// Created by Claude Opus 4.7
+	/**
+	 * When the incoming `SearchParameter`'s `base` is abstract ({@code Resource} or {@code DomainResource})
+	 * and collides on `code` with an existing `SearchParameter` whose `base` overlaps, the installer must take
+	 * the override path rather than the split path — expanded bases cancel to empty, so there is nothing to
+	 * narrow. The existing `SearchParameter` should be overwritten with the incoming's content in place.
+	 */
+	@Test
+	public void installPackage_incomingSearchParameterWithAbstractBase_overridesExistingSearchParameter() throws IOException {
+		// Reindex flag off to avoid queueing jobs for concrete type URLs built from the existing SP's
+		// indexed token set. The override path under test doesn't depend on the flag.
+		myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(false);
+
+		String sharedCode = "abstract-override-demo";
+		String existingId = "existing-sp-override";
+
+		// Existing SP includes `DomainResource` in its base so the installer's JPA lookup
+		// (which intersects on `base` tokens) actually finds this row when the incoming SP
+		// arrives with `base: [DomainResource]`.
+		SearchParameter existing = new SearchParameter();
+		existing.setId(existingId);
+		existing.setUrl("http://example.org/SearchParameter/existing-sp-override");
+		existing.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		existing.setCode(sharedCode);
+		existing.addBase("Patient");
+		existing.addBase("DomainResource");
+		existing.setType(Enumerations.SearchParamType.TOKEN);
+		existing.setExpression("Patient.identifier");
+		mySearchParameterDao.update(existing, new SystemRequestDetails());
+
+		SearchParameter incoming = new SearchParameter();
+		incoming.setId("incoming-sp-override");
+		incoming.setUrl("http://example.org/SearchParameter/incoming-sp-override");
+		incoming.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		incoming.setCode(sharedCode);
+		incoming.addBase("DomainResource");
+		incoming.setType(Enumerations.SearchParamType.TOKEN);
+		incoming.setExpression("Patient.identifier");
+
+		installAsPackage("abstract-override-pkg", "0.0.1", incoming);
+
+		runInTransaction(() -> {
+			SearchParameter overridden = mySearchParameterDao.read(
+				new IdType("SearchParameter/" + existingId), new SystemRequestDetails());
+			List<String> baseAfter = overridden.getBase().stream().map(CodeType::getCode).toList();
+			assertThat(baseAfter).containsExactly("DomainResource");
+
+			IBundleProvider byCode = mySearchParameterDao.search(
+				SearchParameterMap.newSynchronous("code", new TokenParam(sharedCode)));
+			assertEquals(1, byCode.sizeOrThrowNpe());
+		});
+	}
+
+	// Created by Claude Opus 4.7
+	private void installAsPackage(String theName, String theVersion, IBaseResource... theResources) throws IOException {
+		PackageInstallationSpec spec = new PackageInstallationSpec()
+			.setName(theName)
+			.setVersion(theVersion)
+			.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL)
+			.setPackageContents(buildPackage(theName, theVersion, theResources));
+		myPackageInstallerSvc.install(spec);
+	}
+
+	// Created by Claude Opus 4.7
+	private byte[] buildPackage(String theName, String theVersion, IBaseResource... theResources) throws IOException {
+		PackageGenerator manifest = new PackageGenerator();
+		manifest.name(theName);
+		manifest.version(theVersion);
+		manifest.description("test package");
+		manifest.fhirVersions(List.of(FhirVersionEnum.R4.getFhirVersionString()));
+
+		NpmPackage pkg = NpmPackage.empty(manifest);
+		for (IBaseResource resource : theResources) {
+			String type = resource.getClass().getSimpleName();
+			String filename = type + "-" + resource.getIdElement().getIdPart() + ".json";
+			String json = myFhirContext.newJsonParser().encodeResourceToString(resource);
+			pkg.addFile("package", filename, json.getBytes(StandardCharsets.UTF_8), type);
+		}
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		pkg.save(out);
+		return out.toByteArray();
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -1613,59 +1613,6 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 	}
 
 	// Created by Claude Opus 4.7
-	/**
-	 * When the incoming `SearchParameter`'s `base` is abstract ({@code Resource} or {@code DomainResource})
-	 * and collides on `code` with an existing `SearchParameter` whose `base` overlaps, the installer must take
-	 * the override path rather than the split path — expanded bases cancel to empty, so there is nothing to
-	 * narrow. The existing `SearchParameter` should be overwritten with the incoming's content in place.
-	 */
-	@Test
-	public void installPackage_incomingSearchParameterWithAbstractBase_overridesExistingSearchParameter() throws IOException {
-		// Reindex flag off to avoid queueing jobs for concrete type URLs built from the existing SP's
-		// indexed token set. The override path under test doesn't depend on the flag.
-		myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(false);
-
-		String sharedCode = "abstract-override-demo";
-		String existingId = "existing-sp-override";
-
-		// Existing SP includes `DomainResource` in its base so the installer's JPA lookup
-		// (which intersects on `base` tokens) actually finds this row when the incoming SP
-		// arrives with `base: [DomainResource]`.
-		SearchParameter existing = new SearchParameter();
-		existing.setId(existingId);
-		existing.setUrl("http://example.org/SearchParameter/existing-sp-override");
-		existing.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		existing.setCode(sharedCode);
-		existing.addBase("Patient");
-		existing.addBase("DomainResource");
-		existing.setType(Enumerations.SearchParamType.TOKEN);
-		existing.setExpression("Patient.identifier");
-		mySearchParameterDao.update(existing, new SystemRequestDetails());
-
-		SearchParameter incoming = new SearchParameter();
-		incoming.setId("incoming-sp-override");
-		incoming.setUrl("http://example.org/SearchParameter/incoming-sp-override");
-		incoming.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		incoming.setCode(sharedCode);
-		incoming.addBase("DomainResource");
-		incoming.setType(Enumerations.SearchParamType.TOKEN);
-		incoming.setExpression("Patient.identifier");
-
-		installAsPackage("abstract-override-pkg", "0.0.1", incoming);
-
-		runInTransaction(() -> {
-			SearchParameter overridden = mySearchParameterDao.read(
-				new IdType("SearchParameter/" + existingId), new SystemRequestDetails());
-			List<String> baseAfter = overridden.getBase().stream().map(CodeType::getCode).toList();
-			assertThat(baseAfter).containsExactly("DomainResource");
-
-			IBundleProvider byCode = mySearchParameterDao.search(
-				SearchParameterMap.newSynchronous("code", new TokenParam(sharedCode)));
-			assertEquals(1, byCode.sizeOrThrowNpe());
-		});
-	}
-
-	// Created by Claude Opus 4.7
 	private void installAsPackage(String theName, String theVersion, IBaseResource... theResources) throws IOException {
 		PackageInstallationSpec spec = new PackageInstallationSpec()
 			.setName(theName)

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -1588,7 +1588,7 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 		existing.addBase("Patient");
 		existing.addBase("DomainResource");
 		existing.setType(Enumerations.SearchParamType.TOKEN);
-		existing.setExpression("Patient.identifier");
+		existing.setExpression("DomainResource.text");
 		mySearchParameterDao.update(existing, new SystemRequestDetails());
 
 		SearchParameter incoming = new SearchParameter();
@@ -1598,7 +1598,7 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 		incoming.setCode(sharedCode);
 		incoming.addBase("Patient");
 		incoming.setType(Enumerations.SearchParamType.TOKEN);
-		incoming.setExpression("Patient.identifier");
+		incoming.setExpression("Patient.text");
 
 		installAsPackage("abstract-base-pkg", "0.0.1", incoming);
 
@@ -1609,6 +1609,36 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 			assertThat(baseAfter).doesNotContain("Patient");
 			assertThat(baseAfter).doesNotContain("DomainResource");
 			assertThat(baseAfter).contains("Observation");
+		});
+	}
+
+	// Created by Claude Opus 4.7
+	/**
+	 * Persisting a SearchParameter with {@code base: ["DomainResource"]} must not crash during
+	 * reindex URL construction. Pre-fix, {@code BaseHapiFhirResourceDao.isCommonSearchParam}
+	 * only matched the literal {@code "resource"} string, so the reindex branch reached
+	 * {@code getResourceDefinition("DomainResource")} and threw {@code DataFormatException}
+	 * (HAPI-1684).
+	 */
+	@Test
+	public void installPackage_searchParameterWithDomainResourceBase_doesNotCrashDuringReindex() throws IOException {
+		String url = "http://example.org/SearchParameter/domain-resource-sp";
+
+		SearchParameter domainResourceSp = new SearchParameter();
+		domainResourceSp.setId("domain-resource-sp");
+		domainResourceSp.setUrl(url);
+		domainResourceSp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		domainResourceSp.setCode("domain-resource-code");
+		domainResourceSp.addBase("DomainResource");
+		domainResourceSp.setType(Enumerations.SearchParamType.TOKEN);
+		domainResourceSp.setExpression("Patient.identifier");
+
+		installAsPackage("domain-resource-pkg", "0.0.1", domainResourceSp);
+
+		runInTransaction(() -> {
+			IBundleProvider search = mySearchParameterDao.search(
+				SearchParameterMap.newSynchronous("url", new UriParam(url)));
+			assertEquals(1, search.sizeOrThrowNpe());
 		});
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcR4Test.java
@@ -14,12 +14,12 @@ import ca.uhn.fhir.jpa.dao.data.INpmPackageDao;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionDao;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionResourceDao;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
-import ca.uhn.fhir.jpa.term.custom.CustomTerminologySet;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageEntity;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionEntity;
 import ca.uhn.fhir.jpa.model.entity.NpmPackageVersionResourceEntity;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.jpa.term.custom.CustomTerminologySet;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
@@ -41,8 +41,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.ConceptMap;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.ImplementationGuide;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.NamingSystem;
@@ -54,6 +56,7 @@ import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.hl7.fhir.utilities.npm.PackageGenerator;
 import org.hl7.fhir.utilities.npm.PackageServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +75,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1558,6 +1563,87 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 
 	}
 
+	// Created by Claude Opus 4.7
+	@Test
+	public void installPackage_existingSearchParameterHasAbstractBaseOverlappingIncoming_narrowsExistingByExpansion() throws IOException {
+		// setup
+		// avoid indexing while performing SP updates
+		myStorageSettings.setMarkResourcesForReindexingUponSearchParameterChange(false);
+
+		String sharedCode = "abstract-base-demo";
+		String existingId = "existing-sp";
+		String incomingId = "incoming-sp";
+
+		SearchParameter existing = new SearchParameter();
+		existing.setId(existingId);
+		existing.setUrl("http://example.org/SearchParameter/" + existingId);
+		existing.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		existing.setCode(sharedCode);
+		existing.addBase("Patient");
+		existing.addBase("DomainResource");
+		existing.setType(Enumerations.SearchParamType.TOKEN);
+		existing.setExpression("DomainResource.text");
+		mySearchParameterDao.update(existing, new SystemRequestDetails());
+
+		SearchParameter incoming = new SearchParameter();
+		incoming.setId(incomingId);
+		incoming.setUrl("http://example.org/SearchParameter/" + incomingId);
+		incoming.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		incoming.setCode(sharedCode);
+		incoming.addBase("Patient");
+		incoming.setType(Enumerations.SearchParamType.TOKEN);
+		incoming.setExpression("Patient.text");
+
+		// test
+		installAsPackage("abstract-base-pkg", "0.0.1", incoming);
+
+		// verify
+		// the package installer will match by code+base to find an existing resource
+		// verify the new SP takes control of the resource type (Patient) for the same code
+		runInTransaction(() -> {
+			SearchParameter narrowedSP = mySearchParameterDao.read(
+				new IdType("SearchParameter/" + existingId), new SystemRequestDetails());
+			List<String> narrowedBaseAfter = narrowedSP.getBase().stream().map(CodeType::getCode).toList();
+			assertThat(narrowedBaseAfter).doesNotContain("Patient")
+					.doesNotContain("DomainResource").contains("Observation");
+
+			SearchParameter incomingSP = mySearchParameterDao.read(
+				new IdType("SearchParameter/" + incomingId), new SystemRequestDetails());
+			List<String> incomingBaseAfter = incomingSP.getBase().stream().map(CodeType::getCode).toList();
+			assertThat(incomingBaseAfter).contains("Patient")
+					.doesNotContain("Observation").doesNotContain("DomainResource");
+		});
+	}
+
+	// Created by Claude Opus 4.7
+	private void installAsPackage(String theName, String theVersion, IBaseResource... theResources) throws IOException {
+		PackageInstallationSpec spec = new PackageInstallationSpec()
+			.setName(theName)
+			.setVersion(theVersion)
+			.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL)
+			.setPackageContents(buildPackage(theName, theVersion, theResources));
+		myPackageInstallerSvc.install(spec);
+	}
+
+	// Created by Claude Opus 4.7
+	private byte[] buildPackage(String theName, String theVersion, IBaseResource... theResources) throws IOException {
+		PackageGenerator manifest = new PackageGenerator();
+		manifest.name(theName);
+		manifest.version(theVersion);
+		manifest.description("test package");
+		manifest.fhirVersions(List.of(FhirVersionEnum.R4.getFhirVersionString()));
+
+		NpmPackage pkg = NpmPackage.empty(manifest);
+		for (IBaseResource resource : theResources) {
+			String type = resource.getClass().getSimpleName();
+			String filename = type + "-" + resource.getIdElement().getIdPart() + ".json";
+			String json = myFhirContext.newJsonParser().encodeResourceToString(resource);
+			pkg.addFile("package", filename, json.getBytes(StandardCharsets.UTF_8), type);
+		}
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		pkg.save(out);
+		return out.toByteArray();
+	}
 
 	@Test
 	public void testLoadContents() throws IOException {
@@ -1902,103 +1988,6 @@ public class PackageInstallerSvcR4Test extends BaseJpaR4Test {
 		IBundleProvider result = myCodeSystemDao.search(map, new SystemRequestDetails());
 		assertThat(result.sizeOrThrowNpe()).isEqualTo(1);
 		return (CodeSystem) result.getResources(0, 1).get(0);
-	}
-
-	/**
-	 * Control: {@code MULTI_VERSION} install of a fresh {@code (url, version)} pair succeeds.
-	 * Locks in current routing — flips red if a future change lands the new resource onto an
-	 * existing slot owned by a different resource.
-	 */
-	@Test
-	void install_multiVersionPackageWithFreshVersion_succeeds(@TempDir Path theTempDir) throws IOException {
-		String csUrl = "http://example.org/CodeSystem/duplicate-codes";
-		createCodeSystem(csUrl, "1");
-		createCodeSystem(csUrl, "2");
-		myTerminologyDeferredStorageSvc.saveAllDeferred();
-		runInTransaction(() -> {
-			TermCodeSystem termCodeSystem = myTermCodeSystemDao.findByCodeSystemUri(csUrl);
-			assertThat(termCodeSystem).isNotNull();
-			TermCodeSystemVersion versionOne = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(termCodeSystem.getPid(), "1");
-			TermCodeSystemVersion versionTwo = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(termCodeSystem.getPid(), "2");
-			assertThat(versionOne).isNotNull();
-			assertThat(versionTwo).isNotNull();
-			assertThat(versionOne.getResource().getId()).isNotEqualTo(versionTwo.getResource().getId());
-		});
-
-		String packageVersion = "3";
-		PackageInstallationSpec spec = buildPackageContainingCodeSystem(theTempDir, "duplicate.codesystem.test", csUrl, packageVersion)
-			.setVersionPolicy(PackageInstallationSpec.VersionPolicyEnum.MULTI_VERSION);
-
-		PackageInstallOutcomeJson outcome = myPackageInstallerSvc.install(spec);
-
-		assertThat(outcome.getResourcesInstalled().getOrDefault("CodeSystem", 0)).isEqualTo(1);
-		runInTransaction(() -> {
-			TermCodeSystem termCodeSystem = myTermCodeSystemDao.findByCodeSystemUri(csUrl);
-			assertThat(termCodeSystem).isNotNull();
-			assertThat(myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(termCodeSystem.getPid(), packageVersion)).isNotNull();
-		});
-	}
-
-	/**
-	 * Covers the {@code isUpdate} branch of {@code tryReleaseConflictingVersionRow}: a
-	 * {@code SINGLE_VERSION} install updates an existing resource into a slot owned by another
-	 * resource, and the conflict is released instead of throwing 848.
-	 */
-	@Test
-	void install_singleVersionPackageUpdatesResourceConflictingWithOlderVersionSlot_succeeds(@TempDir Path theTempDir)
-			throws IOException {
-		String csUrl = "http://example.org/CodeSystem/duplicate-codes";
-		String resourceAId = createCodeSystem(csUrl, "1").getIdElement().getIdPart();
-		createCodeSystem(csUrl, "2"); // higher PID — returned first by URL-only search
-		myTerminologyDeferredStorageSvc.saveAllDeferred();
-
-		PackageInstallationSpec spec = buildPackageContainingCodeSystem(theTempDir, "duplicate.codesystem.test", csUrl, "1")
-			.setVersionPolicy(PackageInstallationSpec.VersionPolicyEnum.SINGLE_VERSION);
-
-		PackageInstallOutcomeJson outcome = myPackageInstallerSvc.install(spec);
-
-		assertThat(outcome.getResourcesInstalled().getOrDefault("CodeSystem", 0)).isEqualTo(1);
-		runInTransaction(() -> {
-			TermCodeSystem tcs = myTermCodeSystemDao.findByCodeSystemUri(csUrl);
-			assertThat(tcs).isNotNull();
-			TermCodeSystemVersion slotForVersionOne =
-				myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(tcs.getPid(), "1");
-			assertThat(slotForVersionOne).isNotNull();
-			// Resource B was updated to version="1" and claimed A's slot.
-			assertThat(slotForVersionOne.getResource().getIdDt().getIdPart()).isNotEqualTo(resourceAId);
-		});
-	}
-
-	private CodeSystem createCodeSystem(String theUrl, String theVersion) {
-		CodeSystem codeSystem = new CodeSystem();
-		codeSystem.setUrl(theUrl);
-		codeSystem.setVersion(theVersion);
-		codeSystem.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		codeSystem.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
-		codeSystem.addConcept(new CodeSystem.ConceptDefinitionComponent(new CodeType("foo-" + theVersion)));
-		return (CodeSystem) myCodeSystemDao.create(codeSystem, mySrd).getResource();
-	}
-
-	private PackageInstallationSpec buildPackageContainingCodeSystem(Path theTempDir, String theIgName, String theUrl, String theVersion) throws IOException {
-		Path igDir = Files.createDirectory(theTempDir.resolve("ig-v" + theVersion));
-		ImplementationGuideCreator igCreator = new ImplementationGuideCreator(myFhirContext, theIgName, "1.0.0");
-		igCreator.setDirectory(igDir);
-
-		CodeSystem packagedCodeSystem = new CodeSystem();
-		packagedCodeSystem.setId("packaged-codesystem-v" + theVersion);
-		packagedCodeSystem.setUrl(theUrl);
-		packagedCodeSystem.setVersion(theVersion);
-		packagedCodeSystem.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		packagedCodeSystem.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
-		packagedCodeSystem.addConcept(new CodeSystem.ConceptDefinitionComponent(new CodeType("from-package")));
-		igCreator.addResourceToIG("codesystem", packagedCodeSystem);
-
-		Path tarball = igCreator.createTestIG();
-		return new PackageInstallationSpec()
-			.setName(igCreator.getPackageName())
-			.setVersion(igCreator.getPackageVersion())
-			.setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL)
-			.setPackageContents(Files.readAllBytes(tarball));
 	}
 
 }


### PR DESCRIPTION
Resolves #7801.

  ### What changed

  **Fix**

  - `PackageInstallerSvcImpl.updateExistingSearchParameterBaseIfNecessary` now expands abstract `base` tokens via `SearchParameterUtil.expandBaseAsStrings` before subtracting the incoming `base`, so the existing `SearchParameter` is
  correctly narrowed to the concrete resource types the new one doesn't cover.

  **New utilities in `SearchParameterUtil`**

  - `isAbstractResourceBase(String)` — case-insensitive check for `Resource` / `DomainResource`.
  - `expandBaseAsStrings(FhirContext, Collection<String>)` — returns all concrete resource types if any entry is abstract, else the input unchanged.

  **Refactor (consolidation, no behavior change)**

  - `ReadOnlySearchParamCache` and `SearchParamRegistryImpl` previously carried inline copies of the abstract-base expansion logic. Both now delegate to `SearchParameterUtil.expandBaseAsStrings` for a single source of truth.

  **Tests**

  - `SearchParameterUtilTest` — unit coverage for the two new utilities (abstract/concrete/case-variant/empty inputs).
  - `PackageInstallerSvcImplTest.SearchParameterInstallTest` — new nested class with five explicit tests for `Resource`/`DomainResource` scenarios on both sides of the split. `testCreateOrUpdate_withSearchParameter` left unchanged.
  - `PackageInstallerSvcR4Test.installPackage_existingSearchParameterHasAbstractBaseOverlappingIncoming_narrowsByExpansion` — real-JPA integration test that seeds an existing `SearchParameter` with mixed `[Patient, DomainResource]` base,
  installs a colliding `[Patient]` one, and asserts the existing is narrowed to all concrete types except `Patient`.
  - `ReadOnlySearchParamCacheTest` / `SearchParamRegistryImplTest` — regression tests for the delegation sites.

  ### Test plan

  - [ ] `mvn install -pl hapi-fhir-base -DskipTests -Dcheckstyle.skip=true`
  - [ ] `mvn test -pl hapi-fhir-jpaserver-base -Dtest='PackageInstallerSvcImplTest,SearchParameterUtilTest' -Dcheckstyle.skip=true`
  - [ ] `mvn test -pl hapi-fhir-jpaserver-searchparam -Dtest='ReadOnlySearchParamCacheTest,SearchParamRegistryImplTest' -Dcheckstyle.skip=true`
  - [ ] `mvn test -pl hapi-fhir-jpaserver-test-r4 -Dtest='PackageInstallerSvcR4Test#installPackage_existingSearchParameterHasAbstractBaseOverlappingIncoming_narrowsByExpansion' -Dcheckstyle.skip=true`

