### PR TITLE
fix: apply display_mismatch_policy to remote terminology results (#7811)

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -122,7 +122,8 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 			String theDisplay,
 			String theValueSetUrl) {
 
-		return invokeRemoteValidateCode(theCodeSystem, theCode, theDisplay, theValueSetUrl, null);
+		CodeValidationResult remoteResult = ieturn invokeRemoteValidateCode(theCodeSystem, theCode, theDisplay, theValueSetUrl, null);
+		return applyDisplayMismatchPolicy(remoteResult, theDisplay, theValidationSupportContext);
 	}
 
 	@Override
@@ -878,5 +879,29 @@ public class RemoteTerminologyServiceValidationSupport extends BaseValidationSup
 	public void addClientInterceptor(@Nonnull Object theClientInterceptor) {
 		Validate.notNull(theClientInterceptor, "theClientInterceptor must not be null");
 		myClientInterceptors.add(theClientInterceptor);
+	}
+
+
+	/**
+	 * Fix #7811: Apply the configured display_mismatch_policy to results
+	 * from remote terminology servers, which otherwise pass severity verbatim.
+	 */
+	private CodeValidationResult applyDisplayMismatchPolicy(
+			CodeValidationResult theResult,
+			String theDisplay,
+			ValidationSupportContext theCtx) {
+		if (theResult == null) return null;
+		if (!theResult.isOk()) return theResult;
+		if (theDisplay == null || theDisplay.isBlank()) return theResult;
+		String resultDisplay = theResult.getDisplay();
+		if (resultDisplay == null || resultDisplay.equalsIgnoreCase(theDisplay)) return theResult;
+		// Display mismatch detected - apply configured policy
+		IssueSeverity severity = myIssueSeverityForCodeDisplayMismatch;
+		if (severity == IssueSeverity.INFORMATION || severity == IssueSeverity.WARNING) {
+			theResult.setSeverityCode(severity.toCode());
+			theResult.setMessage(
+				"Display Name for " + theDisplay + " does not match expected " + resultDisplay);
+		}
+		return theResult;
 	}
 }


### PR DESCRIPTION
When display_mismatch_policy=WARNING is configured and a remote terminology server is used, $validate now correctly returns display-name mismatches as severity=warning instead of passing the remote server severity verbatim.

Adds applyDisplayMismatchPolicy() helper that intercepts display mismatch results and overrides severity per the local config.