### PR TITLE
GL-8640: Expose getResourceTypePolicies() on PatientIdPartitionInterceptor

### DIFF
--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -224,6 +224,17 @@ public class PatientIdPartitionInterceptor {
 		myResourceTypeToCompartmentPolicy = Map.copyOf(thePatientCompartmentOptionalResourceTypes);
 	}
 
+	/**
+	 * Returns an unmodifiable view of the resource type policies currently in effect.
+	 *
+	 * @see #setResourceTypePolicies(Map)
+	 * @since 8.8.0
+	 */
+	@Nonnull
+	public Map<String, ResourceCompartmentStoragePolicy> getResourceTypePolicies() {
+		return Collections.unmodifiableMap(myResourceTypeToCompartmentPolicy);
+	}
+
 	@Hook(Pointcut.STORAGE_PARTITION_IDENTIFY_CREATE)
 	public RequestPartitionId identifyForCreate(IBaseResource theResource, RequestDetails theRequestDetails) {
 		RuntimeResourceDefinition resourceDef = myFhirContext.getResourceDefinition(theResource);


### PR DESCRIPTION
WIP: Resolving GL-8640. Adds a public getter for the resource type policy map so CDR's wiring fix (https://gitlab.com/simpatico.ai/cdr/-/issues/8640) can verify configuration without duplicated state or reflection.