### PR TITLE
fix: widen atMost window in SubscriptionTopicPartitionR5IT to prevent CI flakiness

### DIFF
--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/SubscriptionTopicPartitionR5IT.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/SubscriptionTopicPartitionR5IT.java
@@ -105,8 +105,9 @@ class SubscriptionTopicPartitionR5IT extends BaseSubscriptionsR5Test {
 
 		// Hold the assertion window open long enough for any in-flight delivery to land,
 		// so the test body (not teardown) reports the failure if the partition guard is broken.
+		// atMost must be well above during to absorb CI scheduling and GC pauses.
 		await().during(300, TimeUnit.MILLISECONDS)
-				.atMost(500, TimeUnit.MILLISECONDS)
+				.atMost(5, TimeUnit.SECONDS)
 				.untilAsserted(() -> assertThat(getSystemProviderCount())
 						.as("Topic subscription in PART-2 must not fire when a Patient is created in PART-1")
 						.isZero());


### PR DESCRIPTION
## Summary

- `during(300ms).atMost(500ms)` left only 200ms of headroom for Awaitility to confirm stability
- Under CI load, poll intervals stretch beyond 200ms, causing the `atMost` deadline to fire before a confirming poll can run — even when `count` stays 0 throughout
- Increased `atMost` to `5s` so CI scheduling and GC pauses cannot exhaust the budget before the `during(300ms)` threshold is reached

## Test plan

- [ ] `SubscriptionTopicPartitionR5IT` passes locally
- [ ] No other test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)