### PR TITLE
Route rel_* HAPI PRs to matching CDR release branch

### DIFF
--- a/.github/workflows/cdr_check/hapi_cdr_branch_map.json
+++ b/.github/workflows/cdr_check/hapi_cdr_branch_map.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Maps HAPI release branches to their corresponding CDR release branch. Add an entry whenever a new HAPI rel_* branch is cut.",
+  "branches": {
+    "rel_8_8": "rel_pub_2026_02",
+    "rel_8_10": "rel_pub_2026_05"
+  }
+}

--- a/.github/workflows/cdr_check/trigger_and_poll_gitlab.py
+++ b/.github/workflows/cdr_check/trigger_and_poll_gitlab.py
@@ -29,9 +29,27 @@ def poll_for_pipeline_status(pipe_id):
     pipeline_status_json = resp.json()
     return pipeline_status_json
 
-if not target_cdr_branch:
-    print("Defaulting CDR branch to master as this is an automatic build.")
-    target_cdr_branch = "master"
+def resolve_cdr_branch(hapi_branch, explicit_cdr_branch):
+    if explicit_cdr_branch:
+        return explicit_cdr_branch
+    if hapi_branch and hapi_branch.startswith("rel_"):
+        mapping_path = os.path.join(
+            os.path.dirname(__file__), "hapi_cdr_branch_map.json"
+        )
+        with open(mapping_path) as f:
+            mapping = json.load(f).get("branches", {})
+        if hapi_branch not in mapping:
+            print(
+                f"ERROR: HAPI branch '{hapi_branch}' has no entry in "
+                f"hapi_cdr_branch_map.json. Add the corresponding CDR "
+                f"release branch and re-run."
+            )
+            sys.exit(1)
+        return mapping[hapi_branch]
+    print("Defaulting CDR branch to master (non-release HAPI branch).")
+    return "master"
+
+target_cdr_branch = resolve_cdr_branch(current_hapi_branch, target_cdr_branch)
 
 # Prepare data for Robogary request
 request_data = {


### PR DESCRIPTION
PRs targeting HAPI rel_* branches were always triggering CDR master builds because the trigger script silently defaulted CDR_BRANCH to master when empty. Replace the default with a resolver that consults a HAPI->CDR branch mapping file and fails loudly on unmapped rel_* branches; master, feature branches, and explicit workflow_dispatch inputs keep their previous behavior.