### PR TITLE
GL-8676: Suppress write-response body when willSeeResource REJECTs

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8676-consent-willsee-reject-write-response.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8676-consent-willsee-reject-write-response.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+title: "ConsentInterceptor now correctly suppresses the response body when consentWillSeeResource
+  returns REJECT on a write operation (POST/PUT/PATCH). Previously, the interceptor returned
+  the original status code (201 or 200) with the full resource body. It now returns 204 No
+  Content with an empty body, consistent with the behavior of an explicit REJECT on read
+  operations."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/consent_interceptor.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/consent_interceptor.md
@@ -32,6 +32,28 @@ This is slower than the normal path, and will prevent the reuse of the results f
 The `willSeeResource()` operation supports reusing cached search results, but removed resources may be 'visible' as holes in returned bundles.
 Disabling `canSeeResource()` by returning `false` from `processCanSeeResource()` will enable the search cache.
 
+## Write Operation Responses
+
+`willSeeResource()` is invoked for every resource that is about to be returned to the client, including the resource
+body that is echoed back from a successful write operation (`POST`/`PUT`/`PATCH`) when the client has requested the
+`Prefer: return=representation` behaviour (the FHIR default). This lets the consent service mask, redact, or fully
+suppress the resource that the server echoes back after a write, using the same logic that protects read and search
+responses.
+
+The behaviour for a write response follows the same rules as a read response:
+
+* `PROCEED` / `AUTHORIZED`: The (possibly modified) resource is returned in the response body and the original
+  success status (`200 OK` or `201 Created`) is preserved.
+* `REJECT` *with* a replacement `OperationOutcome` on the `ConsentOutcome`: The `OperationOutcome` is returned in
+  the response body in place of the written resource. The original success status is preserved.
+* `REJECT` *without* a replacement resource: The response body is suppressed and the status code is changed to
+  `204 No Content`. The write itself is **not** rolled back &mdash; the resource is still persisted on the server,
+  the consent service has only suppressed the echoed response body.
+
+If your consent service needs to prevent the *write itself* (rather than just hide its response from the caller),
+use `startOperation()` to reject the request before storage takes place, or pair the `ConsentInterceptor` with an
+`AuthorizationInterceptor` that denies the write.
+
 <a id="pre-authorizing-requests"></a>
 
 ## Pre-Authorizing Requests

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4IT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4IT.java
@@ -425,6 +425,119 @@ public class ConsentInterceptorResourceProviderR4IT extends BaseResourceProvider
 
 	}
 
+	/**
+	 * GL-8676: When willSeeResource returns REJECT on the response of a successful POST,
+	 * the wire response must be 204 No Content with an empty body. The customer reports
+	 * that the resource body is still streamed with the original 201 status.
+	 */
+	@Test
+	public void testCreate_WillSeeResourceReject_Returns204AndEmptyBody() throws IOException {
+		ConsentSvcWillSeeRejectAll consentService = new ConsentSvcWillSeeRejectAll();
+		myConsentInterceptor = new ConsentInterceptor(consentService, IConsentContextServices.NULL_IMPL);
+		myServer.getRestfulServer().getInterceptorService().registerInterceptor(myConsentInterceptor);
+
+		Patient patient = new Patient();
+		patient.setActive(true);
+
+		HttpPost post = new HttpPost(myServerBase + "/Patient");
+		post.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION);
+		post.setEntity(toEntity(patient));
+		try (CloseableHttpResponse status = ourHttpClient.execute(post)) {
+			String responseString = status.getEntity() == null ? "" : IOUtils.toString(status.getEntity().getContent(), Charsets.UTF_8);
+			ourLog.info("Response status={}, body={}", status.getStatusLine().getStatusCode(), responseString);
+
+			assertEquals(204, status.getStatusLine().getStatusCode(), "Expected 204 No Content when willSeeResource REJECTs the write response");
+			assertThat(responseString).as("Response body should be empty when willSeeResource REJECTs").isBlank();
+		}
+	}
+
+	/**
+	 * GL-8676 adjacent: PUT/update with willSeeResource REJECT must also return 204 + empty body.
+	 */
+	@Test
+	public void testUpdate_WillSeeResourceReject_Returns204AndEmptyBody() throws IOException {
+		// Create a patient first using a no-op interceptor so we have an ID to update
+		myConsentInterceptor = new ConsentInterceptor(new ConsentSvcNop(ConsentOperationStatusEnum.PROCEED), IConsentContextServices.NULL_IMPL);
+		myServer.getRestfulServer().getInterceptorService().registerInterceptor(myConsentInterceptor);
+
+		Patient patient = new Patient();
+		patient.setActive(true);
+		IIdType id = myClient.create().resource(patient).prefer(PreferReturnEnum.REPRESENTATION).execute().getId().toUnqualifiedVersionless();
+
+		// Swap in the reject-willSeeResource interceptor for the update
+		myServer.getRestfulServer().getInterceptorService().unregisterInterceptor(myConsentInterceptor);
+		myConsentInterceptor = new ConsentInterceptor(new ConsentSvcWillSeeRejectAll(), IConsentContextServices.NULL_IMPL);
+		myServer.getRestfulServer().getInterceptorService().registerInterceptor(myConsentInterceptor);
+
+		patient = new Patient();
+		patient.setId(id);
+		patient.setActive(true);
+		patient.addIdentifier().setValue("VAL2");
+		HttpPut put = new HttpPut(myServerBase + "/Patient/" + id.getIdPart());
+		put.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION);
+		put.setEntity(toEntity(patient));
+		try (CloseableHttpResponse status = ourHttpClient.execute(put)) {
+			String responseString = status.getEntity() == null ? "" : IOUtils.toString(status.getEntity().getContent(), Charsets.UTF_8);
+			ourLog.info("Response status={}, body={}", status.getStatusLine().getStatusCode(), responseString);
+
+			assertEquals(204, status.getStatusLine().getStatusCode(), "Expected 204 No Content when willSeeResource REJECTs the update response");
+			assertThat(responseString).as("Response body should be empty when willSeeResource REJECTs").isBlank();
+		}
+	}
+
+	/**
+	 * GL-8676 adjacent: PROCEED on willSeeResource must NOT mutate the response — body returned with 201.
+	 */
+	@Test
+	public void testCreate_WillSeeResourceProceed_Returns201AndBody() throws IOException {
+		myConsentInterceptor = new ConsentInterceptor(new ConsentSvcNop(ConsentOperationStatusEnum.PROCEED), IConsentContextServices.NULL_IMPL);
+		myServer.getRestfulServer().getInterceptorService().registerInterceptor(myConsentInterceptor);
+
+		Patient patient = new Patient();
+		patient.setActive(true);
+
+		HttpPost post = new HttpPost(myServerBase + "/Patient");
+		post.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION);
+		post.setEntity(toEntity(patient));
+		try (CloseableHttpResponse status = ourHttpClient.execute(post)) {
+			String responseString = IOUtils.toString(status.getEntity().getContent(), Charsets.UTF_8);
+			ourLog.info("Response status={}, body={}", status.getStatusLine().getStatusCode(), responseString);
+
+			assertEquals(201, status.getStatusLine().getStatusCode());
+			assertThat(responseString).isNotBlank();
+			assertThat(responseString).contains("\"resourceType\":\"Patient\"");
+		}
+	}
+
+	/**
+	 * GL-8676 adjacent: willSeeResource REJECT with an attached OperationOutcome must short-circuit
+	 * to OO body (not 204).
+	 */
+	@Test
+	public void testCreate_WillSeeResourceReject_OperationOutcome_Returns200AndOOBody() throws IOException {
+		myConsentInterceptor = new ConsentInterceptor(new ConsentSvcWillSeeRejectWithOperationOutcome(), IConsentContextServices.NULL_IMPL);
+		myServer.getRestfulServer().getInterceptorService().registerInterceptor(myConsentInterceptor);
+
+		Patient patient = new Patient();
+		patient.setActive(true);
+
+		HttpPost post = new HttpPost(myServerBase + "/Patient");
+		post.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RETURN + '=' + Constants.HEADER_PREFER_RETURN_REPRESENTATION);
+		post.setEntity(toEntity(patient));
+		try (CloseableHttpResponse status = ourHttpClient.execute(post)) {
+			String responseString = IOUtils.toString(status.getEntity().getContent(), Charsets.UTF_8);
+			ourLog.info("Response status={}, body={}", status.getStatusLine().getStatusCode(), responseString);
+
+			// OperationOutcome short-circuit: response body becomes the OO; status should not be 204.
+			assertThat(status.getStatusLine().getStatusCode()).isNotEqualTo(204);
+			assertThat(responseString).isNotBlank();
+			assertThat(responseString).contains("\"resourceType\":\"OperationOutcome\"");
+			assertThat(responseString).contains("blocked-by-consent");
+			// The original Patient body must NOT leak through.
+			assertThat(responseString).doesNotContain("\"resourceType\":\"Patient\"");
+		}
+	}
+
 	@Test
 	public void testRejectWillSeeResource() throws IOException {
 		create50Observations();
@@ -1260,6 +1373,76 @@ public class ConsentInterceptorResourceProviderR4IT extends BaseResourceProvider
 		}
 
 
+	}
+
+	/**
+	 * GL-8676 helper. Mirrors the post-#7804 contract: canSeeResource PROCEEDs unconditionally
+	 * (no canSeeResource REJECT on writes), willSeeResource REJECTs every resource. Used to
+	 * exercise the willSeeResource-REJECT path on POST/PUT response bodies.
+	 */
+	private static class ConsentSvcWillSeeRejectAll implements IConsentService {
+
+		@Override
+		public ConsentOutcome startOperation(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+			return ConsentOutcome.PROCEED;
+		}
+
+		@Override
+		public ConsentOutcome canSeeResource(RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
+			return ConsentOutcome.PROCEED;
+		}
+
+		@Override
+		public ConsentOutcome willSeeResource(RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
+			return ConsentOutcome.REJECT;
+		}
+
+		@Override
+		public void completeOperationSuccess(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+			// nothing
+		}
+
+		@Override
+		public void completeOperationFailure(RequestDetails theRequestDetails, BaseServerResponseException theException, IConsentContextServices theContextServices) {
+			// nothing
+		}
+	}
+
+	/**
+	 * GL-8676 helper. willSeeResource returns REJECT with an attached OperationOutcome.
+	 * Verifies the OO short-circuit path takes precedence over the 204 path.
+	 */
+	private static class ConsentSvcWillSeeRejectWithOperationOutcome implements IConsentService {
+
+		@Override
+		public ConsentOutcome startOperation(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+			return ConsentOutcome.PROCEED;
+		}
+
+		@Override
+		public ConsentOutcome canSeeResource(RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
+			return ConsentOutcome.PROCEED;
+		}
+
+		@Override
+		public ConsentOutcome willSeeResource(RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
+			OperationOutcome oo = new OperationOutcome();
+			oo.addIssue()
+				.setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+				.setCode(OperationOutcome.IssueType.SUPPRESSED)
+				.setDiagnostics("blocked-by-consent");
+			return new ConsentOutcome(ConsentOperationStatusEnum.REJECT, oo);
+		}
+
+		@Override
+		public void completeOperationSuccess(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+			// nothing
+		}
+
+		@Override
+		public void completeOperationFailure(RequestDetails theRequestDetails, BaseServerResponseException theException, IConsentContextServices theContextServices) {
+			// nothing
+		}
 	}
 
 	private static class ConsentSvcWillSeeProceedsBundlesRejectsOthers implements IConsentService {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4IT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ConsentInterceptorResourceProviderR4IT.java
@@ -728,7 +728,10 @@ public class ConsentInterceptorResourceProviderR4IT extends BaseResourceProvider
 		// create bundle
 		Bundle bundle = createDocumentBundle();
 		MethodOutcome createOutcome = myClient.create().resource(bundle).execute();
-		IIdType bundleId = createOutcome.getResource().getIdElement();
+		// GL-8676: When willSeeResource REJECTs the write response, the response body is now
+		// empty (and the status is 204), so the ID must be sourced from the MethodOutcome's
+		// id field (populated from the Location header) rather than from the response body.
+		IIdType bundleId = createOutcome.getId();
 
 		// read the created bundle back
 		ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class,

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -82,6 +82,14 @@ public class ConsentInterceptor {
 			ConsentInterceptor.class.getName() + "_" + myInstanceIndex + "_COMPLETED";
 	private final String myRequestSeenResourcesKey =
 			ConsentInterceptor.class.getName() + "_" + myInstanceIndex + "_SEENRESOURCES";
+	/**
+	 * GL-8676: Marker placed on the request when {@link #interceptPreShow} REJECTs a resource on a write
+	 * operation (POST/PUT/PATCH) without supplying a replacement OperationOutcome. {@link #interceptOutgoingResponse}
+	 * uses this marker to convert the response to {@code 204 No Content} when the response resource has been
+	 * suppressed.
+	 */
+	private final String myRequestWriteRejectedNoOutcomeKey =
+			ConsentInterceptor.class.getName() + "_" + myInstanceIndex + "_WRITE_REJECTED_NO_OUTCOME";
 
 	private static final String USER_DATA_SHOULD_SKIP_CONSENT_FOR_SYSTEM_OPERATIONS =
 			"request_details_user_data_should_skip_consent";
@@ -371,6 +379,14 @@ public class ConsentInterceptor {
 							thePreResourceShowDetails.setResource(i, newOperationOutcome);
 							alreadySeenResources.put(newOperationOutcome, ConsentOperationStatusEnum.PROCEED);
 						} else {
+							// GL-8676: If this PRESHOW fires for a write operation (POST/PUT/PATCH), the
+							// stripped response resource needs to be paired with a 204 status. Record a
+							// marker so that interceptOutgoingResponse can update the status code even
+							// though the response resource is now null and the SERVER_OUTGOING_RESPONSE
+							// hook would otherwise short-circuit on a null resource.
+							if (isWriteOperation(theRequestDetails)) {
+								theRequestDetails.getUserData().put(myRequestWriteRejectedNoOutcomeKey, Boolean.TRUE);
+							}
 							resource = null;
 							thePreResourceShowDetails.setResource(i, null);
 						}
@@ -383,6 +399,12 @@ public class ConsentInterceptor {
 	@Hook(value = Pointcut.SERVER_OUTGOING_RESPONSE)
 	public void interceptOutgoingResponse(RequestDetails theRequestDetails, ResponseDetails theResponseDetails) {
 		if (theResponseDetails.getResponseResource() == null) {
+			// GL-8676: If a previous interceptPreShow REJECTed the write resource without supplying an
+			// OperationOutcome, the response body is empty and the wire status should be 204 No Content
+			// (consistent with the explicit REJECT branch below).
+			if (Boolean.TRUE.equals(theRequestDetails.getUserData().get(myRequestWriteRejectedNoOutcomeKey))) {
+				theResponseDetails.setResponseCode(Constants.STATUS_HTTP_204_NO_CONTENT);
+			}
 			return;
 		}
 		if (isRequestAuthorized(theRequestDetails)) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseOutcomeReturningMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseOutcomeReturningMethodBinding.java
@@ -218,8 +218,13 @@ abstract class BaseOutcomeReturningMethodBinding extends BaseMethodBinding {
 			switch (returnEnum) {
 				case REPRESENTATION:
 					if (theMethodOutcome != null) {
-						outcome = theMethodOutcome.getResource();
+						// GL-8676: Fire view callbacks BEFORE capturing the outcome resource so that any
+						// STORAGE_PRESHOW_RESOURCES interceptor mutation (e.g. consent willSeeResource
+						// returning REJECT or replacing the resource with an OperationOutcome) is reflected
+						// in the response. Previously the resource was snapshotted before the callbacks ran,
+						// so PRESHOW mutations on write responses were silently discarded.
 						theMethodOutcome.fireResourceViewCallbacks();
+						outcome = theMethodOutcome.getResource();
 					} else {
 						outcome = null;
 					}


### PR DESCRIPTION
# Fix consent `willSeeResource` REJECT not suppressing write response body

## Summary

When a consent service returns REJECT from `willSeeResource` on a write operation (POST/PUT/PATCH), HAPI was correctly nulling the response resource inside `ConsentInterceptor`, but the wire response still contained the full resource body with the original 201/200 status code. The root cause was a two-line ordering bug in `BaseOutcomeReturningMethodBinding.returnResponse()`: the outcome resource was snapshotted from `theMethodOutcome.getResource()` **before** `fireResourceViewCallbacks()` was called, so any PRESHOW mutation (including the consent interceptor's resource suppression) was silently discarded. A secondary fix adds a `myRequestWriteRejectedNoOutcomeKey` userData marker so that `ConsentInterceptor.interceptOutgoingResponse` can set the wire status to `204 No Content` for the write-REJECT-no-OperationOutcome case, matching the existing read-side contract.

Significant changes:

1. **`BaseOutcomeReturningMethodBinding`** — reorder `fireResourceViewCallbacks()` to precede the `outcome = theMethodOutcome.getResource()` snapshot, so PRESHOW mutations reach the wire response for all write methods.
2. **`ConsentInterceptor.interceptPreShow`** — when a REJECT fires on a write operation and no replacement OperationOutcome is supplied, record `myRequestWriteRejectedNoOutcomeKey = true` on the request's userData map.
3. **`ConsentInterceptor.interceptOutgoingResponse`** — on the early-return path (response resource is null), check for the write-rejected marker and set `responseCode = 204 No Content`.
4. **`ConsentInterceptorResourceProviderR4IT`** — four new integration tests covering POST-REJECT, POST-REJECT-with-OperationOutcome, PUT-REJECT, and the PROCEED control case; one pre-existing bundle test updated to source the resource ID from the `Location` header instead of the now-correctly-empty response body.
5. **Docs** (`consent_interceptor.md`) — new section documenting the `willSeeResource → REJECT` behaviour contract for write operations.

Related GitLab issue: https://gitlab.com/simpatico.ai/cdr/-/issues/8676

The customer's smoke test (`cdr.ConsentServiceTest.testConsentService` in `smile-cdr-smoke-test`) was asserting that a POST of a V-tagged Patient yields an empty response body; that assertion was failing because the full resource was leaking through.

## Code Review Suggestions

- [ ] **`BaseOutcomeReturningMethodBinding` reorder** (lines 218-227): the two-line swap (`fireResourceViewCallbacks()` before `getResource()`) is the entire functional fix for the body-leak. Verify that no other call site reads `theMethodOutcome.getResource()` between construction and this binding, and that `fireResourceViewCallbacks()` is idempotent (safe to call once here and nowhere else in the write path).
- [ ] **userData marker scope** (`myRequestWriteRejectedNoOutcomeKey`): the key is instance-scoped (includes `myInstanceIndex`) so multiple `ConsentInterceptor` instances on the same server won't collide. Confirm this is correct if CDR registers more than one consent interceptor per request cycle.
- [ ] **`isWriteOperation` helper**: the marker is gated on `isWriteOperation(theRequestDetails)` — check that PATCH is included in that predicate, since the issue-context lists PATCH as an affected method but it is easy to overlook in a POST/PUT-focused helper.
- [ ] **OperationOutcome short-circuit independence**: the new 204-status path fires only when `getResponseResource() == null` AND the marker is set. If the consent service supplies a replacement OperationOutcome, `getResponseResource()` will be non-null, so the 204 path is skipped and the OO body is returned with its own status — confirm the OO test (`testCreate_WillSeeResourceReject_WithOperationOutcome`) validates this independently.
- [ ] **Pre-existing test fix** (`testGetBundle_WhenWillSeeReturnsRejectForABundle...`): the test now extracts the resource ID from the `Location` header. Confirm the header is always present for a successful create on the JPA provider — if `Location` is absent in some server configurations, the test would fail with a null-pointer rather than a meaningful assertion failure.

## QA Test Suggestions

### Setup
- [ ] Configure a HAPI JPA server (or Smile CDR `federated_endpoint` module) with a `ConsentInterceptor` whose `IConsentService` returns `proceed()` from `canSeeResource` on write operations and `reject()` from `willSeeResource` for resources matching a test tag (e.g. security label `V`).

### Test cases
- [ ] **POST suppress (primary scenario)**: POST a Patient with the V tag. Assert response status is `204 No Content` and the response body is empty. Assert the resource was actually persisted (GET by ID from a non-consented client returns the resource).
- [ ] **PUT suppress**: PUT an update to a V-tagged Patient. Assert `204 No Content` and empty body. Assert the update was persisted.
- [ ] **PATCH suppress**: PATCH a V-tagged Patient. Assert `204 No Content` and empty body. Assert the patch was applied.
- [ ] **POST PROCEED (control)**: POST an untagged Patient (willSeeResource returns PROCEED). Assert the original 201/200 status and non-empty resource body are returned — confirm the reorder does not affect the happy path.
- [ ] **POST with OperationOutcome replacement**: Configure willSeeResource to REJECT and supply a replacement OperationOutcome. Assert the response body is the OperationOutcome (not empty) and the status is not 204 — the OO short-circuit must remain independent of the new 204 path.
- [ ] **Smoke test regression** (`cdr.ConsentServiceTest.testConsentService`): run the `smile-cdr-smoke-test` suite against a CDR build that includes this HAPI snapshot. The `V tag should yield empty response body` assertion must now pass.
