### PR TITLE
GH-7847: Fix $everything _type filter leaking unfiltered resource types

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7847-everything-type-filter-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7847-everything-type-filter-fix.yaml
@@ -4,5 +4,5 @@ issue: 7847
 title: "Fixed a bug where the Patient $everything operation with a _type parameter would return
   linked resources of types not specified in _type. Forward-include expansion in
   IncludesIterator now respects the _type filter, so only resources matching the requested
-  types are included in the response bundle. The Patient anchor resource is always returned
-  regardless of the _type filter, as per the operation's documented contract."
+  types are included in the response bundle. When _type is specified, the Patient anchor
+  resource is also subject to the filter and is omitted unless Patient is listed in _type."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7847-everything-type-filter-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7847-everything-type-filter-fix.yaml
@@ -2,7 +2,7 @@
 type: fix
 issue: 7847
 title: "Fixed a bug where the Patient $everything operation with a _type parameter would return
-  linked resources of types not specified in _type. Forward-include expansion now respects
-  the _type filter, so only resources matching the requested types are included in the
-  response bundle. Additionally, when _type is specified and Patient is not among the listed
-  types, the Patient anchor resource is no longer unconditionally included in the response."
+  linked resources of types not specified in _type. Forward-include expansion in
+  IncludesIterator now respects the _type filter, so only resources matching the requested
+  types are included in the response bundle. The Patient anchor resource is always returned
+  regardless of the _type filter, as per the operation's documented contract."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7847-everything-type-filter-fix.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7847-everything-type-filter-fix.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 7847
+title: "Fixed a bug where the Patient $everything operation with a _type parameter would return
+  linked resources of types not specified in _type. Forward-include expansion now respects
+  the _type filter, so only resources matching the requested types are included in the
+  response bundle. Additionally, when _type is specified and Patient is not among the listed
+  types, the Patient anchor resource is no longer unconditionally included in the response."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
@@ -74,6 +74,7 @@ page.server_jpa.upgrading=Upgrade Guide
 page.server_jpa.diff=Diff Operation
 page.server_jpa.fhir_patch=FHIR Patch
 page.server_jpa.lastn=LastN Operation
+page.server_jpa.patient_everything=Patient $everything Operation
 page.server_jpa.elastic=Lucene/Elasticsearch Indexing
 page.server_jpa.terminology=Terminology
 page.server_jpa.packages=FHIR Package Registry

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/patient_everything.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/patient_everything.md
@@ -36,7 +36,7 @@ The following parameters are supported:
 
 # Filtering by Resource Type
 
-The `_type` parameter narrows the linked resources returned by the operation to only those whose resource type appears in the comma-separated list. The Patient resource itself is always included regardless of the `_type` value.
+The `_type` parameter narrows the returned resources to only those whose resource type appears in the comma-separated list. This filter applies to all returned resources, including the Patient anchor resource itself. If `Patient` is not listed in `_type`, the Patient anchor is omitted from the response. To include the Patient resource when using `_type`, add `Patient` to the type list explicitly.
 
 Example — return only Observations linked to Patient/123:
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/patient_everything.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/patient_everything.md
@@ -1,0 +1,51 @@
+# Patient $everything Operation
+
+The `$everything` operation is a FHIR-defined extended operation that retrieves all resources associated with a given Patient. The operation is defined in the [FHIR specification](http://hl7.org/fhir/operation-patient-everything.html).
+
+HAPI FHIR's JPA server provides a built-in implementation of this operation on both the instance level (`Patient/[id]/$everything`) and the type level (`Patient/$everything`).
+
+# Instance-Level Usage
+
+Retrieve all resources linked to a specific patient:
+
+```http
+GET http://fhir.example.com/baseR4/Patient/123/$everything
+```
+
+The response is a searchset Bundle containing the Patient resource itself along with all resources that reference it (Observations, Conditions, Encounters, etc.).
+
+# Type-Level Usage
+
+Retrieve resources linked to all patients on the server:
+
+```http
+GET http://fhir.example.com/baseR4/Patient/$everything
+```
+
+# Parameters
+
+The following parameters are supported:
+
+* `_count=[n]`: (*optional*) Page size for the returned Bundle. Defaults to server-configured page size.
+* `_offset=[n]`: (*optional*) Offset into the result set for paging.
+* `_since=[date]`: (*optional*) Only return resources updated after the given date/time (`_lastUpdated=ge[date]` equivalent).
+* `_type=[comma-separated resource types]`: (*optional*) Filter the linked resources to include only those of the specified resource type(s). See [Filtering by Resource Type](#filtering-by-resource-type) for details and known behavior.
+* `_sort=[parameter]`: (*optional*) Sort expression applied to results.
+* `_content=[text]`: (*optional*) Full-text content search filter.
+* `_mdm=true`: (*optional*) If MDM is enabled, expand the patient set to include all MDM-linked patients before performing the `$everything`. See [MDM Search Expansion](/docs/server_jpa_mdm/mdm_expansion.html) for details.
+
+# Filtering by Resource Type
+
+The `_type` parameter narrows the linked resources returned by the operation to only those whose resource type appears in the comma-separated list. The Patient resource itself is always included regardless of the `_type` value.
+
+Example — return only Observations linked to Patient/123:
+
+```http
+GET http://fhir.example.com/baseR4/Patient/123/$everything?_type=Observation
+```
+
+Example — return Observations and Conditions linked to Patient/123:
+
+```http
+GET http://fhir.example.com/baseR4/Patient/123/$everything?_type=Observation,Condition
+```

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaResourceProviderPatient.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaResourceProviderPatient.java
@@ -118,7 +118,7 @@ public abstract class BaseJpaResourceProviderPatient<T extends IBaseResource> ex
 					List<IPrimitiveType<String>> theTypes,
 			@Description(
 							shortDefinition =
-									"Filter the resources to return only resources matching the given _type filter. When _type is specified, only resources of the listed types are returned; the patient anchor resource itself is also subject to this filter and is omitted unless Patient is included in _type.")
+									"If set to true, expands the patient set to include all patients linked via MDM before returning results. Requires MDM to be enabled on the server.")
 					@OperationParam(name = Constants.PARAM_MDM, min = 0, max = 1, typeName = "boolean")
 					IPrimitiveType<Boolean> theMdmExpand,
 			@Sort SortSpec theSortSpec,
@@ -214,7 +214,7 @@ public abstract class BaseJpaResourceProviderPatient<T extends IBaseResource> ex
 					List<IIdType> theId,
 			@Description(
 							shortDefinition =
-									"Filter the resources to return only resources matching the given _type filter. When _type is specified, only resources of the listed types are returned; the patient anchor resource itself is also subject to this filter and is omitted unless Patient is included in _type.")
+									"If set to true, expands the patient set to include all patients linked via MDM before returning results. Requires MDM to be enabled on the server.")
 					@OperationParam(name = Constants.PARAM_MDM, min = 0, max = 1, typeName = "boolean")
 					IPrimitiveType<Boolean> theMdmExpand,
 			@Sort SortSpec theSortSpec,

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaResourceProviderPatient.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/BaseJpaResourceProviderPatient.java
@@ -109,7 +109,7 @@ public abstract class BaseJpaResourceProviderPatient<T extends IBaseResource> ex
 					List<IPrimitiveType<String>> theFilter,
 			@Description(
 							shortDefinition =
-									"Filter the resources to return only resources matching the given _type filter (note that this filter is applied only to results which link to the given patient, not to the patient itself or to supporting resources linked to by the matched resources)")
+									"Filter the resources to return only resources matching the given _type filter. When _type is specified, only resources of the listed types are returned; the patient anchor resource itself is also subject to this filter and is omitted unless Patient is included in _type.")
 					@OperationParam(
 							name = Constants.PARAM_TYPE,
 							min = 0,
@@ -118,7 +118,7 @@ public abstract class BaseJpaResourceProviderPatient<T extends IBaseResource> ex
 					List<IPrimitiveType<String>> theTypes,
 			@Description(
 							shortDefinition =
-									"Filter the resources to return only resources matching the given _type filter (note that this filter is applied only to results which link to the given patient, not to the patient itself or to supporting resources linked to by the matched resources)")
+									"Filter the resources to return only resources matching the given _type filter. When _type is specified, only resources of the listed types are returned; the patient anchor resource itself is also subject to this filter and is omitted unless Patient is included in _type.")
 					@OperationParam(name = Constants.PARAM_MDM, min = 0, max = 1, typeName = "boolean")
 					IPrimitiveType<Boolean> theMdmExpand,
 			@Sort SortSpec theSortSpec,
@@ -198,7 +198,7 @@ public abstract class BaseJpaResourceProviderPatient<T extends IBaseResource> ex
 					List<IPrimitiveType<String>> theFilter,
 			@Description(
 							shortDefinition =
-									"Filter the resources to return only resources matching the given _type filter (note that this filter is applied only to results which link to the given patient, not to the patient itself or to supporting resources linked to by the matched resources)")
+									"Filter the resources to return only resources matching the given _type filter. When _type is specified, only resources of the listed types are returned; the patient anchor resource itself is also subject to this filter and is omitted unless Patient is included in _type.")
 					@OperationParam(
 							name = Constants.PARAM_TYPE,
 							min = 0,
@@ -214,7 +214,7 @@ public abstract class BaseJpaResourceProviderPatient<T extends IBaseResource> ex
 					List<IIdType> theId,
 			@Description(
 							shortDefinition =
-									"Filter the resources to return only resources matching the given _type filter (note that this filter is applied only to results which link to the given patient, not to the patient itself or to supporting resources linked to by the matched resources)")
+									"Filter the resources to return only resources matching the given _type filter. When _type is specified, only resources of the listed types are returned; the patient anchor resource itself is also subject to this filter and is omitted unless Patient is included in _type.")
 					@OperationParam(name = Constants.PARAM_MDM, min = 0, max = 1, typeName = "boolean")
 					IPrimitiveType<Boolean> theMdmExpand,
 			@Sort SortSpec theSortSpec,

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -933,8 +933,6 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 						Msg.code(2841) + "Resource " + myParams.get(IAnyResource.SP_RES_ID) + " is not known.");
 			}
 
-			// add the target pids to our executors as the first
-			// results iterator to go through
 			theSearchQueryExecutors.add(new ResolvedSearchQueryExecutor(new ArrayList<>(targetPids)));
 		} else {
 			// For Everything queries, we make the query root by the ResourceLink table, since this query
@@ -2829,6 +2827,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 
 				if (myCurrentIterator == null) {
 					Set<Include> includes = new HashSet<>();
+					List<String> typeNames = new ArrayList<>();
 					if (myParams.containsKey(Constants.PARAM_TYPE)) {
 						for (List<IQueryParameterType> typeList : myParams.get(Constants.PARAM_TYPE)) {
 							for (IQueryParameterType type : typeList) {
@@ -2837,6 +2836,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 									String rt = resourceType.trim();
 									if (isNotBlank(rt)) {
 										includes.add(new Include(rt + ":*", true));
+										typeNames.add(rt);
 									}
 								}
 							}
@@ -2845,16 +2845,21 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 					if (includes.isEmpty()) {
 						includes.add(new Include("*", true));
 					}
-					Set<JpaPid> newPids = loadIncludes(
-							myContext,
-							myEntityManager,
-							myCurrentPids,
-							includes,
-							false,
-							getParams().getLastUpdated(),
-							mySearchUuid,
-							myRequest,
-							null);
+					SearchBuilderLoadIncludesParameters<JpaPid> loadParams =
+							new SearchBuilderLoadIncludesParameters<>();
+					loadParams.setFhirContext(myContext);
+					loadParams.setEntityManager(myEntityManager);
+					loadParams.setMatches(myCurrentPids);
+					loadParams.setIncludeFilters(includes);
+					loadParams.setReverseMode(false);
+					loadParams.setLastUpdated(getParams().getLastUpdated());
+					loadParams.setSearchIdOrDescription(mySearchUuid);
+					loadParams.setRequestDetails(myRequest);
+					loadParams.setMaxCount(null);
+					if (!typeNames.isEmpty()) {
+						loadParams.setDesiredResourceTypes(typeNames);
+					}
+					Set<JpaPid> newPids = loadIncludes(loadParams);
 					myCurrentIterator = newPids.iterator();
 				}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -933,7 +933,12 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 						Msg.code(2841) + "Resource " + myParams.get(IAnyResource.SP_RES_ID) + " is not known.");
 			}
 
-			theSearchQueryExecutors.add(new ResolvedSearchQueryExecutor(new ArrayList<>(targetPids)));
+			// When _type is specified and does not include the anchor type, omit the anchor from results
+			boolean typeFilterExcludesAnchor = myParams.get(Constants.PARAM_TYPE) != null
+					&& !extractTypeSourceResourcesFromParams().contains(myResourceName);
+			if (!typeFilterExcludesAnchor) {
+				theSearchQueryExecutors.add(new ResolvedSearchQueryExecutor(new ArrayList<>(targetPids)));
+			}
 		} else {
 			// For Everything queries, we make the query root by the ResourceLink table, since this query
 			// is basically a reverse-include search. For type/Everything (as opposed to instance/Everything)

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JpaPatientEverythingTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JpaPatientEverythingTest.java
@@ -1870,6 +1870,47 @@ public class JpaPatientEverythingTest extends BaseResourceProviderR4Test {
     }
 
 	@Test
+	void patientEverythingWithTypeFilter_shouldOnlyReturnResourcesOfRequestedType() {
+		// Create Patient
+		Patient patient = new Patient();
+		String patientId = myClient.create().resource(patient).execute().getId().toUnqualifiedVersionless().getValue();
+		Reference referenceToPatient = new Reference(patientId);
+
+		// Create Encounter referencing the Patient
+		Encounter encounter = new Encounter();
+		encounter.setSubject(referenceToPatient);
+		String encounterId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
+		Reference referenceToEncounter = new Reference(encounterId);
+
+		// Create Observation referencing both Patient (subject) and Encounter (encounter field)
+		Observation observation = new Observation();
+		observation.setSubject(referenceToPatient);
+		observation.setEncounter(referenceToEncounter);
+		String observationId = myClient.create().resource(observation).execute().getId().toUnqualifiedVersionless().getValue();
+
+		// Call $everything?_type=Observation on the Patient
+		Parameters parameters = new Parameters();
+		parameters.addParameter(Constants.PARAM_TYPE, "Observation");
+		Bundle response = myClient.operation()
+			.onInstance(patientId)
+			.named(JpaConstants.OPERATION_EVERYTHING)
+			.withParameters(parameters)
+			.returnResourceType(Bundle.class)
+			.execute();
+
+		Set<String> resultIds = new HashSet<>();
+		for (Bundle.BundleEntryComponent entry : response.getEntry()) {
+			resultIds.add(entry.getResource().getIdElement().toUnqualifiedVersionless().getValue());
+		}
+
+		// The Observation should be present
+		assertThat(resultIds).contains(observationId);
+		// The Encounter should NOT be in the result — it is not of the requested type
+		// This assertion FAILS on master because the bug causes Encounter to be leaked
+		assertThat(resultIds).doesNotContain(encounterId);
+	}
+
+	@Test
 	void testEverythingOperation_shouldReturn404ForNonExistentPatient() {
 		myStorageSettings.setResourceClientIdStrategy(JpaStorageSettings.ClientIdStrategyEnum.ANY);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JpaPatientEverythingTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JpaPatientEverythingTest.java
@@ -1903,9 +1903,9 @@ public class JpaPatientEverythingTest extends BaseResourceProviderR4Test {
             resultIds.add(entry.getResource().getIdElement().toUnqualifiedVersionless().getValue());
         }
 
-        assertThat(resultIds).contains(observationId);   // requested type is returned
-        assertThat(resultIds).contains(patientId);        // anchor always returned
-        // _type filter must exclude resources of other types even when they are linked via compartment
+        assertThat(resultIds).contains(observationId);       // requested type is returned
+        // _type filter applies to all resources including the anchor; Patient not in _type list
+        assertThat(resultIds).doesNotContain(patientId);
         assertThat(resultIds).doesNotContain(encounterId);
     }
 
@@ -1987,7 +1987,8 @@ public class JpaPatientEverythingTest extends BaseResourceProviderR4Test {
 
         assertThat(resultIds).contains(observationId);       // requested type, directly refs Patient
         assertThat(resultIds).contains(conditionId);         // requested type, directly refs Patient
-        assertThat(resultIds).contains(patientId);           // anchor always returned
+        // _type filter applies to all resources including the anchor; Patient not in _type list
+        assertThat(resultIds).doesNotContain(patientId);
         assertThat(resultIds).doesNotContain(encounterId);   // not in _type list even though Observation references it
     }
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JpaPatientEverythingTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JpaPatientEverythingTest.java
@@ -1869,46 +1869,127 @@ public class JpaPatientEverythingTest extends BaseResourceProviderR4Test {
         }
     }
 
-	@Test
-	void patientEverythingWithTypeFilter_shouldOnlyReturnResourcesOfRequestedType() {
-		// Create Patient
-		Patient patient = new Patient();
-		String patientId = myClient.create().resource(patient).execute().getId().toUnqualifiedVersionless().getValue();
-		Reference referenceToPatient = new Reference(patientId);
+    @Test
+    void patientEverythingWithTypeFilter_shouldOnlyReturnResourcesOfRequestedType() {
+        // Create Patient
+        Patient patient = new Patient();
+        String patientId = myClient.create().resource(patient).execute().getId().toUnqualifiedVersionless().getValue();
+        Reference referenceToPatient = new Reference(patientId);
 
-		// Create Encounter referencing the Patient
-		Encounter encounter = new Encounter();
-		encounter.setSubject(referenceToPatient);
-		String encounterId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
-		Reference referenceToEncounter = new Reference(encounterId);
+        // Create Encounter referencing the Patient
+        Encounter encounter = new Encounter();
+        encounter.setSubject(referenceToPatient);
+        String encounterId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
+        Reference referenceToEncounter = new Reference(encounterId);
 
-		// Create Observation referencing both Patient (subject) and Encounter (encounter field)
-		Observation observation = new Observation();
-		observation.setSubject(referenceToPatient);
-		observation.setEncounter(referenceToEncounter);
-		String observationId = myClient.create().resource(observation).execute().getId().toUnqualifiedVersionless().getValue();
+        // Create Observation referencing both Patient (subject) and Encounter (encounter field)
+        Observation observation = new Observation();
+        observation.setSubject(referenceToPatient);
+        observation.setEncounter(referenceToEncounter);
+        String observationId = myClient.create().resource(observation).execute().getId().toUnqualifiedVersionless().getValue();
 
-		// Call $everything?_type=Observation on the Patient
-		Parameters parameters = new Parameters();
-		parameters.addParameter(Constants.PARAM_TYPE, "Observation");
-		Bundle response = myClient.operation()
-			.onInstance(patientId)
-			.named(JpaConstants.OPERATION_EVERYTHING)
-			.withParameters(parameters)
-			.returnResourceType(Bundle.class)
-			.execute();
+        // Call $everything?_type=Observation on the Patient
+        Parameters parameters = new Parameters();
+        parameters.addParameter(Constants.PARAM_TYPE, "Observation");
+        Bundle response = myClient.operation()
+            .onInstance(patientId)
+            .named(JpaConstants.OPERATION_EVERYTHING)
+            .withParameters(parameters)
+            .returnResourceType(Bundle.class)
+            .execute();
 
-		Set<String> resultIds = new HashSet<>();
-		for (Bundle.BundleEntryComponent entry : response.getEntry()) {
-			resultIds.add(entry.getResource().getIdElement().toUnqualifiedVersionless().getValue());
-		}
+        Set<String> resultIds = new HashSet<>();
+        for (Bundle.BundleEntryComponent entry : response.getEntry()) {
+            resultIds.add(entry.getResource().getIdElement().toUnqualifiedVersionless().getValue());
+        }
 
-		// The Observation should be present
-		assertThat(resultIds).contains(observationId);
-		// The Encounter should NOT be in the result — it is not of the requested type
-		// This assertion FAILS on master because the bug causes Encounter to be leaked
-		assertThat(resultIds).doesNotContain(encounterId);
-	}
+        assertThat(resultIds).contains(observationId);   // requested type is returned
+        assertThat(resultIds).contains(patientId);        // anchor always returned
+        // _type filter must exclude resources of other types even when they are linked via compartment
+        assertThat(resultIds).doesNotContain(encounterId);
+    }
+
+    @Test
+    void patientEverythingWithTypeFilterPatient_anchorAlwaysIncluded() {
+        // Create Patient
+        Patient patient = new Patient();
+        String patientId = myClient.create().resource(patient).execute().getId().toUnqualifiedVersionless().getValue();
+        Reference referenceToPatient = new Reference(patientId);
+
+        // Create Encounter referencing the Patient
+        Encounter encounter = new Encounter();
+        encounter.setSubject(referenceToPatient);
+        String encounterId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
+
+        // Create Observation referencing the Patient
+        Observation observation = new Observation();
+        observation.setSubject(referenceToPatient);
+        String observationId = myClient.create().resource(observation).execute().getId().toUnqualifiedVersionless().getValue();
+
+        // Call $everything?_type=Patient — anchor type is in the requested list
+        Parameters parameters = new Parameters();
+        parameters.addParameter(Constants.PARAM_TYPE, "Patient");
+        Bundle response = myClient.operation()
+            .onInstance(patientId)
+            .named(JpaConstants.OPERATION_EVERYTHING)
+            .withParameters(parameters)
+            .returnResourceType(Bundle.class)
+            .execute();
+
+        Set<String> resultIds = new HashSet<>();
+        for (Bundle.BundleEntryComponent entry : response.getEntry()) {
+            resultIds.add(entry.getResource().getIdElement().toUnqualifiedVersionless().getValue());
+        }
+
+        assertThat(resultIds).contains(patientId);           // Patient is both anchor and requested type
+        assertThat(resultIds).doesNotContain(encounterId);   // Encounter not in _type list
+        assertThat(resultIds).doesNotContain(observationId); // Observation not in _type list
+    }
+
+    @Test
+    void patientEverythingWithMultiTypeFilter_onlyRequestedTypesReturned() {
+        // Create Patient
+        Patient patient = new Patient();
+        String patientId = myClient.create().resource(patient).execute().getId().toUnqualifiedVersionless().getValue();
+        Reference referenceToPatient = new Reference(patientId);
+
+        // Create Encounter referencing the Patient
+        Encounter encounter = new Encounter();
+        encounter.setSubject(referenceToPatient);
+        String encounterId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
+        Reference referenceToEncounter = new Reference(encounterId);
+
+        // Create Observation referencing both Patient and Encounter
+        Observation observation = new Observation();
+        observation.setSubject(referenceToPatient);
+        observation.setEncounter(referenceToEncounter);
+        String observationId = myClient.create().resource(observation).execute().getId().toUnqualifiedVersionless().getValue();
+
+        // Create Condition referencing the Patient directly
+        Condition condition = new Condition();
+        condition.setSubject(referenceToPatient);
+        String conditionId = myClient.create().resource(condition).execute().getId().toUnqualifiedVersionless().getValue();
+
+        // Call $everything?_type=Observation,Condition — Encounter not in the list
+        Parameters parameters = new Parameters();
+        parameters.addParameter(Constants.PARAM_TYPE, "Observation,Condition");
+        Bundle response = myClient.operation()
+            .onInstance(patientId)
+            .named(JpaConstants.OPERATION_EVERYTHING)
+            .withParameters(parameters)
+            .returnResourceType(Bundle.class)
+            .execute();
+
+        Set<String> resultIds = new HashSet<>();
+        for (Bundle.BundleEntryComponent entry : response.getEntry()) {
+            resultIds.add(entry.getResource().getIdElement().toUnqualifiedVersionless().getValue());
+        }
+
+        assertThat(resultIds).contains(observationId);       // requested type, directly refs Patient
+        assertThat(resultIds).contains(conditionId);         // requested type, directly refs Patient
+        assertThat(resultIds).contains(patientId);           // anchor always returned
+        assertThat(resultIds).doesNotContain(encounterId);   // not in _type list even though Observation references it
+    }
 
 	@Test
 	void testEverythingOperation_shouldReturn404ForNonExistentPatient() {


### PR DESCRIPTION
## Summary

This PR fixes `GET /Patient/{id}/$everything?_type=<type>` returning resources of types not requested via the `_type` parameter. When a client requested only Observations, the response also included Encounters and other resources transitively linked through Observation references.

**Key behavior change:** When `_type` is specified, the `_type` filter now applies to _all_ returned resources including the Patient anchor resource itself. **If `Patient` is not listed in `_type`, the Patient anchor is omitted from the response.** To include the Patient resource when using `_type`, add `Patient` to the type list explicitly (e.g., `_type=Observation,Patient`).

The root cause was in `IncludesIterator.fetchNext()` inside `SearchBuilder.java`: it constructed `Include("Observation:*", true)` entries and invoked `loadIncludes()` through a simple overload that did not pass `desiredResourceTypes`. As a result, forward-include expansion followed all outbound references from matching resources without any type filter. The existing `loadIncludesMatchAll()` SQL layer already supported an `AND target_resource_type IN (...)` predicate — it simply was not being invoked in this code path.

1. `IncludesIterator.fetchNext()` now constructs a `SearchBuilderLoadIncludesParameters` object and populates `desiredResourceTypes` from the parsed `_type` parameter values before calling `loadIncludes()`.
2. The Patient anchor is excluded from results when `_type` is specified and does not include `Patient`.
3. The `@OperationParam` description for the `_type` parameter in `BaseJpaResourceProviderPatient` is updated to document this behavior.
4. Three new tests cover the fixed behavior: single-type filter (`_type=Observation` — Patient and Encounter omitted), anchor-type filter (`_type=Patient` — only Patient returned), and multi-type filter (`_type=Observation,Condition` — Patient and Encounter omitted).
5. A new documentation page for the `$everything` operation is added under the JPA server docs.
6. A changelog YAML entry is included for the 8.12.0 release.

## Code Review Suggestions

- [ ] **`_type` filter scope change (Patient anchor)**: The Patient anchor resource is now subject to the `_type` filter. Previously it was always returned. Confirm this behavioral change is acceptable and well-documented.
- [ ] **`SearchBuilderLoadIncludesParameters` construction in `fetchNext()`**: Confirm that `desiredResourceTypes` is populated from the correct source (the `_type` parameter on the `$everything` operation request, not a search parameter). Verify the types are extracted as plain resource type strings (e.g., `"Observation"`) rather than canonical URLs or search token values.
- [ ] **Wildcard include scope**: `Include("Observation:*", true)` uses a wildcard over all Observation search parameters with `isRecurse=true`. Verify that setting `desiredResourceTypes` correctly constrains the SQL predicate without conflicting with recursive include logic for the allowed types.
- [ ] **Null / empty `_type` case**: When `_type` is absent entirely, `desiredResourceTypes` should be `null` or empty, preserving existing behavior (return all types including Patient anchor). Confirm this fallback is handled.
- [ ] **Documentation page**: The new `patient_everything.md` page should be cross-referenced or linked from the existing JPA server operation index so it is discoverable.

## QA Test Suggestions

### Setup
- [ ] Deploy a JPA R4 server with the patched build.
- [ ] Create a Patient resource and link at least one Observation, one Encounter (referenced from the Observation), and one Condition to that patient.

### Test Cases
- [ ] **Single-type filter — Observation only**: Call `GET /Patient/{id}/$everything?_type=Observation`. Confirm the response bundle contains only Observation resources — **the Patient anchor and Encounter should NOT be present**.
- [ ] **Anchor type included**: Call `GET /Patient/{id}/$everything?_type=Observation,Patient`. Confirm the bundle contains both the Patient resource and Observation resources, but not Encounter.
- [ ] **Anchor type only**: Call `GET /Patient/{id}/$everything?_type=Patient`. Confirm only the Patient resource is returned.
- [ ] **Multi-type filter**: Call `GET /Patient/{id}/$everything?_type=Observation,Condition`. Confirm the bundle contains Observation and Condition resources but not Patient or Encounter.
- [ ] **No `_type` filter (regression)**: Call `GET /Patient/{id}/$everything` without `_type`. Confirm all linked resources (Patient, Observation, Encounter, Condition) are still returned, validating no regression in the default case.
- [ ] **Paging with `_type` filter**: If the server supports paged `$everything`, call with `_count=1&_type=Observation` across multiple pages and confirm all pages respect the type filter.

Closes #7847

---
> **Superseded by #7853** — rebased onto `rel_8_10` to target the 8.10 release branch (post-feature-freeze).