### PR TITLE
7861: Run PartitionLookupSvcImpl.listPartitions in a transaction

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7861-partition-lookup-list-partitions-transaction.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7861-partition-lookup-list-partitions-transaction.yaml
@@ -1,4 +1,5 @@
 ---
 type: fix
 issue: 7861
-title: "Fixed `listPartitions` method on the partition lookup service, which could return wrong empty results in some cases."
+title: "Previously, `PartitionLookupSvcImpl.listPartitions` could return an empty list when invoked without 
+an active transaction bound to the partition-owning `EntityManager`. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7861-partition-lookup-list-partitions-transaction.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7861-partition-lookup-list-partitions-transaction.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 7861
+title: "Fixed `listPartitions` method on the partition lookup service, which could return wrong empty results in some cases."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/partition/PartitionLookupSvcImpl.java
@@ -214,8 +214,7 @@ public class PartitionLookupSvcImpl implements IPartitionLookupSvc {
 
 	@Override
 	public List<PartitionEntity> listPartitions() {
-		List<PartitionEntity> allPartitions = myPartitionDao.findAll();
-		return allPartitions;
+		return executeInTransaction(() -> myPartitionDao.findAll());
 	}
 
 	private void validatePartitionNameDoesntAlreadyExist(String theName) {


### PR DESCRIPTION
In `PartitionLookupSvcImpl.listPartitions()` wrap call in transaction to avoid executing for EntityManager bound in current thread.

Fixes #7861 