### PR TITLE
Gl 8681 bulk export patient eligibility

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7867-patient-type-export-failure.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7867-patient-type-export-failure.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 8767
+jira: SMILE-12021
+title: "A regression was introduced temporarily which caused Patient Type-level exports to fail if the implementing system had disabled Patient Search Parameters. This has been corrected."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkDataExportJobSchedulingHelperImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkDataExportJobSchedulingHelperImpl.java
@@ -190,6 +190,7 @@ public class BulkDataExportJobSchedulingHelperImpl implements IBulkDataExportJob
 					ourLog.info("Purging batch 2 bulk export binary: {}", binaryId);
 					IIdType id = myBulkExportHelperSvc.toId(binaryId);
 					getBinaryDao().delete(id, new SystemRequestDetails());
+					//Archive this instead.
 				}
 			}
 		} // else we can't know what the binary IDs are, so delete this job and move on

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkDataExportJobSchedulingHelperImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkDataExportJobSchedulingHelperImpl.java
@@ -190,7 +190,7 @@ public class BulkDataExportJobSchedulingHelperImpl implements IBulkDataExportJob
 					ourLog.info("Purging batch 2 bulk export binary: {}", binaryId);
 					IIdType id = myBulkExportHelperSvc.toId(binaryId);
 					getBinaryDao().delete(id, new SystemRequestDetails());
-					//Archive this instead.
+					// Archive this instead.
 				}
 			}
 		} // else we can't know what the binary IDs are, so delete this job and move on

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkDataExportJobSchedulingHelperImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkDataExportJobSchedulingHelperImpl.java
@@ -190,7 +190,6 @@ public class BulkDataExportJobSchedulingHelperImpl implements IBulkDataExportJob
 					ourLog.info("Purging batch 2 bulk export binary: {}", binaryId);
 					IIdType id = myBulkExportHelperSvc.toId(binaryId);
 					getBinaryDao().delete(id, new SystemRequestDetails());
-					// Archive this instead.
 				}
 			}
 		} // else we can't know what the binary IDs are, so delete this job and move on

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
@@ -174,10 +174,11 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 				SearchRuntimeDetails searchRuntime = new SearchRuntimeDetails(null, theJobId);
 
 				Logs.getBatchTroubleshootingLog()
-						.atDebug()
-						.setMessage("Executing query for bulk export job[{}] chunk[{}]: {}")
+						.atInfo()
+						.setMessage("Executing query for bulk export job[{}] chunk[{}]: {}{}")
 						.addArgument(theJobId)
 						.addArgument(theChunkId)
+						.addArgument(resourceType)
 						.addArgument(map.toNormalizedQueryString())
 						.log();
 
@@ -694,7 +695,7 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 				.collect(Collectors.toSet());
 		if (patientSearchParams.isEmpty()) {
 			String errorMessage = String.format(
-					"Resource type [%s] is not eligible for this type of export, as it contains no active search parameters.",
+					"Resource type [%s] is not eligible for this type of export, as it contains no active patient compartment search parameters.",
 					theResourceType);
 			throw new IllegalArgumentException(Msg.code(2817) + errorMessage);
 		}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
@@ -158,26 +158,46 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 		LinkedHashSet<JpaPid> pids = new LinkedHashSet<>();
 
 		Set<String> expandedPatientIds = getPatientSetForPatientExport(theParams);
-		List<SearchParameterMap> maps = myBulkExportHelperSvc.createSearchParameterMapsForResourceType(def, theParams, true);
+		List<SearchParameterMap> maps =
+				myBulkExportHelperSvc.createSearchParameterMapsForResourceType(def, theParams, true);
 
 		if (resourceType.equalsIgnoreCase("Patient")) {
-			//If we are in a patient-style export, and finding PIDs of patients, we don't need to bother with checking compartment membership, we can simply perform the searches.
+			// If we are in a patient-style export, and finding PIDs of patients, we don't need to bother with checking
+			// compartment membership, we can simply perform the searches.
 			for (SearchParameterMap map : maps) {
-				validateAndEvaluateSearch(theParams, resourceType, theJobId, theChunkId, null, map, expandedPatientIds, pids);
+				validateAndEvaluateSearch(
+						theParams, resourceType, theJobId, theChunkId, null, map, expandedPatientIds, pids);
 			}
 		} else {
 			Set<String> patientSearchParams = getPatientActiveSearchParamsForResourceType(theParams.getResourceType());
 			for (String patientSearchParam : patientSearchParams) {
 				for (SearchParameterMap map : maps) {
-					validateAndEvaluateSearch(theParams, resourceType, theJobId, theChunkId, patientSearchParam, map, expandedPatientIds, pids);
+					validateAndEvaluateSearch(
+							theParams,
+							resourceType,
+							theJobId,
+							theChunkId,
+							patientSearchParam,
+							map,
+							expandedPatientIds,
+							pids);
 				}
 			}
 		}
 		return pids;
 	}
 
-	//TODO GGG: fix up the API of this method for 8.12.0
-	private void validateAndEvaluateSearch(ExportPIDIteratorParameters theParams, String resourceType, String theJobId, String theChunkId, String patientSearchParam, SearchParameterMap map, Set<String> expandedPatientIds, LinkedHashSet<JpaPid> pids) throws IOException {
+	// TODO GGG: fix up the API of this method for 8.12.0
+	private void validateAndEvaluateSearch(
+			ExportPIDIteratorParameters theParams,
+			String resourceType,
+			String theJobId,
+			String theChunkId,
+			String patientSearchParam,
+			SearchParameterMap map,
+			Set<String> expandedPatientIds,
+			LinkedHashSet<JpaPid> pids)
+			throws IOException {
 		// Ensure users did not monkey with the patient compartment search parameter.
 		validateSearchParametersForPatient(map, theParams);
 
@@ -197,7 +217,7 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 				.log();
 
 		try (IResultIterator<JpaPid> resultIterator = searchBuilder.createQuery(
-			map, searchRuntime, new SystemRequestDetails(), theParams.getPartitionIdOrAllPartitions())) {
+				map, searchRuntime, new SystemRequestDetails(), theParams.getPartitionIdOrAllPartitions())) {
 			int pidCount = 0;
 			while (resultIterator.hasNext()) {
 				if (pidCount % 10000 == 0) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessor.java
@@ -158,50 +158,61 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 		LinkedHashSet<JpaPid> pids = new LinkedHashSet<>();
 
 		Set<String> expandedPatientIds = getPatientSetForPatientExport(theParams);
+		List<SearchParameterMap> maps = myBulkExportHelperSvc.createSearchParameterMapsForResourceType(def, theParams, true);
 
-		Set<String> patientSearchParams = getPatientActiveSearchParamsForResourceType(theParams.getResourceType());
-		for (String patientSearchParam : patientSearchParams) {
-			List<SearchParameterMap> maps =
-					myBulkExportHelperSvc.createSearchParameterMapsForResourceType(def, theParams, true);
+		if (resourceType.equalsIgnoreCase("Patient")) {
+			//If we are in a patient-style export, and finding PIDs of patients, we don't need to bother with checking compartment membership, we can simply perform the searches.
 			for (SearchParameterMap map : maps) {
-				// Ensure users did not monkey with the patient compartment search parameter.
-				validateSearchParametersForPatient(map, theParams);
-
-				ISearchBuilder<JpaPid> searchBuilder = getSearchBuilderForResourceType(theParams.getResourceType());
-
-				filterBySpecificPatient(expandedPatientIds, resourceType, patientSearchParam, map);
-
-				SearchRuntimeDetails searchRuntime = new SearchRuntimeDetails(null, theJobId);
-
-				Logs.getBatchTroubleshootingLog()
-						.atInfo()
-						.setMessage("Executing query for bulk export job[{}] chunk[{}]: {}{}")
-						.addArgument(theJobId)
-						.addArgument(theChunkId)
-						.addArgument(resourceType)
-						.addArgument(map.toNormalizedQueryString())
-						.log();
-
-				try (IResultIterator<JpaPid> resultIterator = searchBuilder.createQuery(
-						map, searchRuntime, new SystemRequestDetails(), theParams.getPartitionIdOrAllPartitions())) {
-					int pidCount = 0;
-					while (resultIterator.hasNext()) {
-						if (pidCount % 10000 == 0) {
-							Logs.getBatchTroubleshootingLog()
-									.atDebug()
-									.setMessage("Bulk export job[{}] chunk[{}] has loaded {} pids")
-									.addArgument(theJobId)
-									.addArgument(theChunkId)
-									.addArgument(pidCount)
-									.log();
-						}
-						pidCount++;
-						pids.add(resultIterator.next());
-					}
+				validateAndEvaluateSearch(theParams, resourceType, theJobId, theChunkId, null, map, expandedPatientIds, pids);
+			}
+		} else {
+			Set<String> patientSearchParams = getPatientActiveSearchParamsForResourceType(theParams.getResourceType());
+			for (String patientSearchParam : patientSearchParams) {
+				for (SearchParameterMap map : maps) {
+					validateAndEvaluateSearch(theParams, resourceType, theJobId, theChunkId, patientSearchParam, map, expandedPatientIds, pids);
 				}
 			}
 		}
 		return pids;
+	}
+
+	//TODO GGG: fix up the API of this method for 8.12.0
+	private void validateAndEvaluateSearch(ExportPIDIteratorParameters theParams, String resourceType, String theJobId, String theChunkId, String patientSearchParam, SearchParameterMap map, Set<String> expandedPatientIds, LinkedHashSet<JpaPid> pids) throws IOException {
+		// Ensure users did not monkey with the patient compartment search parameter.
+		validateSearchParametersForPatient(map, theParams);
+
+		ISearchBuilder<JpaPid> searchBuilder = getSearchBuilderForResourceType(theParams.getResourceType());
+
+		filterBySpecificPatient(expandedPatientIds, resourceType, patientSearchParam, map);
+
+		SearchRuntimeDetails searchRuntime = new SearchRuntimeDetails(null, theJobId);
+
+		Logs.getBatchTroubleshootingLog()
+				.atInfo()
+				.setMessage("Executing query for bulk export job[{}] chunk[{}]: {}{}")
+				.addArgument(theJobId)
+				.addArgument(theChunkId)
+				.addArgument(resourceType)
+				.addArgument(map.toNormalizedQueryString())
+				.log();
+
+		try (IResultIterator<JpaPid> resultIterator = searchBuilder.createQuery(
+			map, searchRuntime, new SystemRequestDetails(), theParams.getPartitionIdOrAllPartitions())) {
+			int pidCount = 0;
+			while (resultIterator.hasNext()) {
+				if (pidCount % 10000 == 0) {
+					Logs.getBatchTroubleshootingLog()
+							.atDebug()
+							.setMessage("Bulk export job[{}] chunk[{}] has loaded {} pids")
+							.addArgument(theJobId)
+							.addArgument(theChunkId)
+							.addArgument(pidCount)
+							.log();
+				}
+				pidCount++;
+				pids.add(resultIterator.next());
+			}
+		}
 	}
 
 	private void filterBySpecificPatient(
@@ -693,6 +704,7 @@ public class JpaBulkExportProcessor implements IBulkExportProcessor<JpaPid> {
 				.filter(s -> mySearchParamRegistry.hasActiveSearchParam(
 						theResourceType, s, ISearchParamRegistry.SearchParamLookupContextEnum.SEARCH))
 				.collect(Collectors.toSet());
+
 		if (patientSearchParams.isEmpty()) {
 			String errorMessage = String.format(
 					"Resource type [%s] is not eligible for this type of export, as it contains no active patient compartment search parameters.",

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
@@ -452,6 +452,62 @@ public class JpaBulkExportProcessorTest {
 		validatePartitionId(thePartitioned, resourceDaoServletRequestDetailsCaptor.getValue().getRequestPartitionId());
 	}
 
+	/**
+	 * Reproduction for GL-8681 / SMILE-12021 (Kaiser Permanente).
+	 *
+	 * <p>When a customer runs {@code Patient/$export} on a CDR persistence module that does NOT have
+	 * {@code auto_create_placeholder_reference_targets.enabled=true} (the default), and a Patient-compartment
+	 * search param such as {@code Patient._id} is not registered as ACTIVE for SEARCH lookups, the bulk export
+	 * job fails with {@code HAPI-2817: Resource type [Patient] is not eligible for this type of export, as it
+	 * contains no active search parameters.}
+	 *
+	 * <p>The bug is in {@link JpaBulkExportProcessor#getPatientActiveSearchParamsForResourceType(String)}: it
+	 * filters all candidate patient-compartment search params through {@code hasActiveSearchParam} and throws
+	 * if the filtered set is empty. For the {@code Patient} resource type itself, this filter is too strict —
+	 * the resource IS the patient, so it should always be eligible for {@code Patient/$export} regardless of
+	 * whether its compartment search params register as active.
+	 *
+	 * <p>The DESIRED behaviour asserted here is that the call returns a non-null iterator and does not throw
+	 * {@code IllegalArgumentException} containing the {@code HAPI-2817} marker.
+	 */
+	@Test
+	void getResourcePidIterator_patientExportWhenResourceTypeIsPatientWithNoActiveSearchParams_doesNotThrowHapi2817() {
+		// setup — mirror customer's _type=Patient,Encounter (this test exercises the Patient leg)
+		ExportPIDIteratorParameters theParameters = createExportParameters(BulkExportJobParameters.ExportStyle.PATIENT);
+		theParameters.setResourceType("Patient");
+		theParameters.setPartitionId(getPartitionIdFromParams(false));
+
+		SearchParameterMap map = new SearchParameterMap();
+		List<SearchParameterMap> maps = new ArrayList<>();
+		maps.add(map);
+
+		JpaPid pid = JpaPid.fromId(123L);
+		ListResultIterator resultIterator = new ListResultIterator(Collections.singletonList(pid));
+
+		ISearchBuilder<JpaPid> searchBuilder = mock(ISearchBuilder.class);
+
+		// THE BUG TRIGGER: customer's persistence module reports the Patient-compartment search param as
+		// inactive for SEARCH lookups (this is what happens when
+		// auto_create_placeholder_reference_targets.enabled=false and the param has not been promoted).
+		when(mySearchParamRegistry.hasActiveSearchParam(anyString(), anyString(), any()))
+			.thenReturn(false);
+
+		// downstream mocks — these will only be reached if the bug is fixed and the eligibility check passes
+		when(myBulkExportHelperService.createSearchParameterMapsForResourceType(any(RuntimeResourceDefinition.class), eq(theParameters), eq(true)))
+			.thenReturn(maps);
+		when(mySearchBuilderFactory.newSearchBuilder(eq(theParameters.getResourceType()), any()))
+			.thenReturn(searchBuilder);
+		when(searchBuilder.createQuery(any(), any(), any(), any()))
+			.thenReturn(resultIterator);
+
+		// DESIRED behaviour: Patient/$export must succeed even when the Patient-compartment search param
+		// is reported inactive. The export should not blow up with HAPI-2817 just because the resource
+		// being exported is itself the patient compartment root.
+		assertThat(myProcessor.getResourcePidIterator(theParameters))
+			.as("Patient/$export should succeed even when no Patient-compartment search params are reported active")
+			.isNotNull();
+	}
+
 	@Test
 	void testGetPatientSetForPatientExport_withoutMdm_returnsOriginalPatients() {
 		// Given - Parameters with MDM disabled

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
@@ -452,27 +452,8 @@ public class JpaBulkExportProcessorTest {
 		validatePartitionId(thePartitioned, resourceDaoServletRequestDetailsCaptor.getValue().getRequestPartitionId());
 	}
 
-	/**
-	 * Reproduction for GL-8681 / SMILE-12021 (Kaiser Permanente).
-	 *
-	 * <p>When a customer runs {@code Patient/$export} on a CDR persistence module that does NOT have
-	 * {@code auto_create_placeholder_reference_targets.enabled=true} (the default), and a Patient-compartment
-	 * search param such as {@code Patient._id} is not registered as ACTIVE for SEARCH lookups, the bulk export
-	 * job fails with {@code HAPI-2817: Resource type [Patient] is not eligible for this type of export, as it
-	 * contains no active search parameters.}
-	 *
-	 * <p>The bug is in {@link JpaBulkExportProcessor#getPatientActiveSearchParamsForResourceType(String)}: it
-	 * filters all candidate patient-compartment search params through {@code hasActiveSearchParam} and throws
-	 * if the filtered set is empty. For the {@code Patient} resource type itself, this filter is too strict —
-	 * the resource IS the patient, so it should always be eligible for {@code Patient/$export} regardless of
-	 * whether its compartment search params register as active.
-	 *
-	 * <p>The DESIRED behaviour asserted here is that the call returns a non-null iterator and does not throw
-	 * {@code IllegalArgumentException} containing the {@code HAPI-2817} marker.
-	 */
 	@Test
 	void getResourcePidIterator_patientExportWhenResourceTypeIsPatientWithNoActiveSearchParams_doesNotThrowHapi2817() {
-		// setup — mirror customer's _type=Patient,Encounter (this test exercises the Patient leg)
 		ExportPIDIteratorParameters theParameters = createExportParameters(BulkExportJobParameters.ExportStyle.PATIENT);
 		theParameters.setResourceType("Patient");
 		theParameters.setPartitionId(getPartitionIdFromParams(false));
@@ -486,13 +467,9 @@ public class JpaBulkExportProcessorTest {
 
 		ISearchBuilder<JpaPid> searchBuilder = mock(ISearchBuilder.class);
 
-		// THE BUG TRIGGER: customer's persistence module reports the Patient-compartment search param as
-		// inactive for SEARCH lookups (this is what happens when
-		// auto_create_placeholder_reference_targets.enabled=false and the param has not been promoted).
 		when(mySearchParamRegistry.hasActiveSearchParam(anyString(), anyString(), any()))
 			.thenReturn(false);
 
-		// downstream mocks — these will only be reached if the bug is fixed and the eligibility check passes
 		when(myBulkExportHelperService.createSearchParameterMapsForResourceType(any(RuntimeResourceDefinition.class), eq(theParameters), eq(true)))
 			.thenReturn(maps);
 		when(mySearchBuilderFactory.newSearchBuilder(eq(theParameters.getResourceType()), any()))
@@ -500,9 +477,6 @@ public class JpaBulkExportProcessorTest {
 		when(searchBuilder.createQuery(any(), any(), any(), any()))
 			.thenReturn(resultIterator);
 
-		// DESIRED behaviour: Patient/$export must succeed even when the Patient-compartment search param
-		// is reported inactive. The export should not blow up with HAPI-2817 just because the resource
-		// being exported is itself the patient compartment root.
 		assertThat(myProcessor.getResourcePidIterator(theParameters))
 			.as("Patient/$export should succeed even when no Patient-compartment search params are reported active")
 			.isNotNull();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/JpaBulkExportProcessorTest.java
@@ -64,6 +64,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -480,6 +481,56 @@ public class JpaBulkExportProcessorTest {
 		assertThat(myProcessor.getResourcePidIterator(theParameters))
 			.as("Patient/$export should succeed even when no Patient-compartment search params are reported active")
 			.isNotNull();
+	}
+
+	@ParameterizedTest(name = "Patient/$export succeeds when patient compartment search params active = {0}")
+	@ValueSource(booleans = {true, false})
+	@SuppressWarnings("unchecked")
+	void getResourcePidIterator_patientExportForPatientResource_succeedsRegardlessOfPatientSearchParamActiveState(boolean thePatientSearchParamsActive) {
+		// Setup - Patient/$export over the Patient resource type itself
+		ExportPIDIteratorParameters parameters = createExportParameters(BulkExportJobParameters.ExportStyle.PATIENT);
+		parameters.setResourceType("Patient");
+		parameters.setPartitionId(getPartitionIdFromParams(false));
+
+		SearchParameterMap map = new SearchParameterMap();
+		List<SearchParameterMap> maps = Collections.singletonList(map);
+
+		JpaPid pid1 = JpaPid.fromId(123L);
+		JpaPid pid2 = JpaPid.fromId(456L);
+		ListResultIterator resultIterator = new ListResultIterator(Arrays.asList(pid1, pid2));
+
+		ISearchBuilder<JpaPid> searchBuilder = mock(ISearchBuilder.class);
+
+		// The key behaviour under test: with the fix in place, the Patient branch of
+		// getResourcePidIterator no longer consults getPatientActiveSearchParamsForResourceType,
+		// so the export must complete in both states. lenient() because the stubbed value is
+		// expected to be ignored when resourceType is Patient.
+		lenient().when(mySearchParamRegistry.hasActiveSearchParam(anyString(), anyString(), any()))
+			.thenReturn(thePatientSearchParamsActive);
+
+		when(myBulkExportHelperService.createSearchParameterMapsForResourceType(any(RuntimeResourceDefinition.class), eq(parameters), eq(true)))
+			.thenReturn(maps);
+		when(mySearchBuilderFactory.newSearchBuilder(eq("Patient"), any()))
+			.thenReturn(searchBuilder);
+		when(searchBuilder.createQuery(any(), any(), any(), any()))
+			.thenReturn(resultIterator);
+
+		// Test
+		Iterator<JpaPid> pidIterator = myProcessor.getResourcePidIterator(parameters);
+
+		// Verify - HAPI-2817 must not be thrown and the search must execute exactly once
+		// (no per-search-param fan-out for the Patient compartment root).
+		assertThat(pidIterator)
+			.as("Patient/$export should succeed regardless of patient search param active state (was: %s)", thePatientSearchParamsActive)
+			.isNotNull()
+			.toIterable()
+			.containsExactly(pid1, pid2);
+
+		verify(searchBuilder, times(1)).createQuery(
+			eq(map),
+			any(SearchRuntimeDetails.class),
+			nullable(RequestDetails.class),
+			eq(getPartitionIdFromParams(false)));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
@@ -1220,29 +1220,6 @@ public class BulkDataExportTest extends BaseResourceProviderR4Test {
 	}
 
 	@Test
-	public void testPatientTypeBulkExport() {
-		// Create some resources
-		Patient patient = new Patient();
-		patient.setId("P1");
-		patient.setActive(true);
-		myClient.update().resource(patient).execute();
-
-		Encounter encounter = new Encounter();
-		encounter.setSubject(new Reference("Patient/P1"));
-		String encId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
-		Encounter encounter2 = new Encounter();
-		String encId2 = myClient.create().resource(encounter2).execute().getId().toUnqualifiedVersionless().getValue();
-
-		// set the export options
-		BulkExportJobParameters options = new BulkExportJobParameters();
-		options.setExportStyle(BulkExportJobParameters.ExportStyle.PATIENT);
-
-		options.setResourceTypes(List.of("Patient", "Encounter"));
-		options.setOutputFormat(Constants.CT_FHIR_NDJSON);
-		verifyBulkExportResults(options, List.of("Patient/P1", encId), List.of(encId2));
-	}
-
-	@Test
 	public void testSystemBulkExport() {
 		List<String> expectedIds = new ArrayList<>();
 		for (int i = 0; i < 20; i++) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportTest.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
 import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
@@ -15,6 +16,8 @@ import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.searchparam.registry.ReadOnlySearchParamCache;
+import ca.uhn.fhir.jpa.searchparam.registry.RuntimeSearchParamCache;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -24,6 +27,7 @@ import ca.uhn.fhir.rest.client.apache.ResourceEntity;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.test.utilities.HttpClientExtension;
 import ca.uhn.fhir.util.Batch2JobDefinitionConstants;
 import ca.uhn.fhir.util.JsonUtil;
@@ -1213,6 +1217,29 @@ public class BulkDataExportTest extends BaseResourceProviderR4Test {
 		}
 
 		verifyBulkExportResults(options, expectedContainedIds, Collections.emptyList());
+	}
+
+	@Test
+	public void testPatientTypeBulkExport() {
+		// Create some resources
+		Patient patient = new Patient();
+		patient.setId("P1");
+		patient.setActive(true);
+		myClient.update().resource(patient).execute();
+
+		Encounter encounter = new Encounter();
+		encounter.setSubject(new Reference("Patient/P1"));
+		String encId = myClient.create().resource(encounter).execute().getId().toUnqualifiedVersionless().getValue();
+		Encounter encounter2 = new Encounter();
+		String encId2 = myClient.create().resource(encounter2).execute().getId().toUnqualifiedVersionless().getValue();
+
+		// set the export options
+		BulkExportJobParameters options = new BulkExportJobParameters();
+		options.setExportStyle(BulkExportJobParameters.ExportStyle.PATIENT);
+
+		options.setResourceTypes(List.of("Patient", "Encounter"));
+		options.setOutputFormat(Constants.CT_FHIR_NDJSON);
+		verifyBulkExportResults(options, List.of("Patient/P1", encId), List.of(encId2));
 	}
 
 	@Test


### PR DESCRIPTION
Fixed a bug in the JpaBulkExportProcessor in which a Patient type-level export (e.g. Patient/$export) would fail if there were no search parameters enabled for Patient Resource type. In HAPI-FHIR this does not occur, but downstream systems can limit which searchparameters are supported. 


Bulk export should work regardless  of whether the SPs are loaded. 