### PR TITLE
Fix package install failure HAPI-0521 when attempting to install resource with ID length > 64

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7865-fix-package-install-skips-resource-with-id-over-64-chars.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_8_0/7865-fix-package-install-skips-resource-with-id-over-64-chars.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7865
+title: "Previously, attempting to install resources whose FHIR ID exceeded 64 characters during package install 
+operation would throw HAPI-0521 (invalid FHIR ID), particularly when resource status validation was disabled. 
+This has been fixed by skipping installation of these invalid resources."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -902,6 +902,13 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 			return false;
 		}
 
+		if (hasInvalidId(theResource)) {
+			ourLog.warn(
+					"Skipping resource with ID {} longer than 64 characters, which makes an invalid FHIR ID.",
+					theResource.getIdElement().getIdPart());
+			return false;
+		}
+
 		if (!isValidResourceStatusForPackageUpload(theResource)) {
 			ourLog.warn(
 					"Failed to validate resource of type {} with ID {} - Error: Resource status not accepted value.",
@@ -911,6 +918,11 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		}
 
 		return true;
+	}
+
+	private boolean hasInvalidId(IBaseResource theResource) {
+		IIdType resourceId = theResource.getIdElement();
+		return resourceId.hasIdPart() && resourceId.getIdPart().length() > 64;
 	}
 
 	private boolean isEmbeddedValueSet(IBaseResource theResource) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImpl.java
@@ -902,7 +902,7 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 			return false;
 		}
 
-		if (hasInvalidId(theResource)) {
+		if (!hasValidId(theResource)) {
 			ourLog.warn(
 					"Skipping resource with ID {} longer than 64 characters, which makes an invalid FHIR ID.",
 					theResource.getIdElement().getIdPart());
@@ -920,9 +920,9 @@ public class PackageInstallerSvcImpl implements IPackageInstallerSvc {
 		return true;
 	}
 
-	private boolean hasInvalidId(IBaseResource theResource) {
+	private boolean hasValidId(IBaseResource theResource) {
 		IIdType resourceId = theResource.getIdElement();
-		return resourceId.hasIdPart() && resourceId.getIdPart().length() > 64;
+		return !resourceId.hasIdPart() || resourceId.isIdPartValid();
 	}
 
 	private boolean isEmbeddedValueSet(IBaseResource theResource) {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplTest.java
@@ -267,6 +267,27 @@ public class PackageInstallerSvcImplTest {
 			Exception actualExceptionThrown = assertThrows(Exception.class, () -> mySvc.validForUpload(spR4));
 			assertEquals(notAnUnprocessableEntityException, actualExceptionThrown);
 		}
+
+		// Created by claude-sonnet-4-6
+		// Regression test for HAPI-0521: resources with IDs > 64 chars must be rejected before status validation,
+		// so they are skipped even when validateResourceStatusForPackageUpload is disabled.
+		public static Stream<Arguments> parametersIdLengthValidation() {
+			return Stream.of(
+				arguments("a".repeat(65), false),   // over limit → rejected
+				arguments("a".repeat(64), true),    // exactly at limit → accepted
+				arguments(null, true)               // no ID → accepted
+			);
+		}
+
+		@ParameterizedTest
+		@MethodSource("parametersIdLengthValidation")
+		void testValidForUpload_idLengthCheck(String theId, boolean theExpected) {
+			Patient patient = new Patient();
+			if (theId != null) {
+				patient.setId(theId);
+			}
+			assertEquals(theExpected, mySvc.validForUpload(patient));
+		}
 	}
 
 
@@ -694,11 +715,19 @@ public class PackageInstallerSvcImplTest {
 		deviceWithUrl.setStatus(Device.FHIRDeviceStatus.ACTIVE);
 		deviceWithUrl.addIdentifier().setSystem("urn:sys").setValue("device-with-url");
 
+		// A device with a url element present but blank — resourceHasPopulatedUrl must return false,
+		// falling through to identifier-based matching.
+		Device deviceWithBlankUrl = new Device();
+		deviceWithBlankUrl.setStatus(Device.FHIRDeviceStatus.ACTIVE);
+		deviceWithBlankUrl.addIdentifier().setSystem("urn:sys").setValue("device-blank-url");
+		deviceWithBlankUrl.setUrl("");
+
 		return Stream.of(
 			arguments(csWithUrl, "url", "?url=http%3A//example.com/cs"),
 			arguments(deviceWithUrlNotPopulated, "identifier", "?identifier=urn%3Asys%7Cdevice-no-url"),
 			arguments(ptWithIdentifier, "identifier", "?identifier=urn%3Asys%7Cpt-id"),
-			arguments(deviceWithUrl, "url", "?url=http%3A//10.0.0.1/fhir")
+			arguments(deviceWithUrl, "url", "?url=http%3A//10.0.0.1/fhir"),
+			arguments(deviceWithBlankUrl, "identifier", "?identifier=urn%3Asys%7Cdevice-blank-url")
 		);
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
@@ -76,6 +76,11 @@ public class PackageInstallerSvcImplCreateTest extends BaseJpaR4Test {
 	@Autowired
 	private PackageInstallerSvcImpl mySvc;
 
+	@AfterEach
+	void resetStorageSettings() {
+		myStorageSettings.setValidateResourceStatusForPackageUpload(new JpaStorageSettings().isValidateResourceStatusForPackageUpload());
+	}
+
 	@Test
 	void createNamingSystem() throws IOException {
 		final NamingSystem namingSystem = new NamingSystem();
@@ -450,11 +455,6 @@ public class PackageInstallerSvcImplCreateTest extends BaseJpaR4Test {
 			.as("Should update the same resource").isEqualTo(firstId);
 		assertThat(installedDevice.getDeviceName().get(0).getName())
 			.as("Should have updated content").isEqualTo("Updated Device");
-	}
-
-	@AfterEach
-	void resetStorageSettings() {
-		myStorageSettings.setValidateResourceStatusForPackageUpload(new JpaStorageSettings().isValidateResourceStatusForPackageUpload());
 	}
 
 	// Created by claude-sonnet-4-6

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/packages/PackageInstallerSvcImplCreateTest.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.packages;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.implementationguide.ImplementationGuideCreator;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.data.ITermValueSetDao;
 import ca.uhn.fhir.jpa.entity.TermValueSet;
@@ -26,6 +27,7 @@ import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.npm.PackageGenerator;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -448,6 +450,82 @@ public class PackageInstallerSvcImplCreateTest extends BaseJpaR4Test {
 			.as("Should update the same resource").isEqualTo(firstId);
 		assertThat(installedDevice.getDeviceName().get(0).getName())
 			.as("Should have updated content").isEqualTo("Updated Device");
+	}
+
+	@AfterEach
+	void resetStorageSettings() {
+		myStorageSettings.setValidateResourceStatusForPackageUpload(new JpaStorageSettings().isValidateResourceStatusForPackageUpload());
+	}
+
+	// Created by claude-sonnet-4-6
+	// Regression for HAPI-0521: resources with IDs > 64 chars must be skipped during install
+	// (even when status validation is disabled) to prevent HAPI-0521 on DB insert.
+	// Boundary: exactly 64-char IDs are valid and must be installed normally.
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void install_resourceWithIdOver64Chars_isSkippedDoesNotThrowHapi0521(boolean theStatusValidationEnabled) throws IOException {
+		myStorageSettings.setValidateResourceStatusForPackageUpload(theStatusValidationEnabled);
+
+		ValueSet vs = new ValueSet();
+		vs.setId("ValueSet/" + "a".repeat(65));
+		vs.setUrl("http://example.org/vs-long-id");
+		vs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		install(vs);
+
+		IBundleProvider results = myValueSetDao.search(SearchParameterMap.newSynchronous(), REQUEST_DETAILS);
+		assertThat(results.getAllResources()).isEmpty();
+	}
+
+	// Created by claude-sonnet-4-6
+	@Test
+	void install_resourceWithIdExactly64Chars_isInstalled() throws IOException {
+		// Boundary: exactly 64-char ID is valid per FHIR spec and must not be rejected.
+		ValueSet vs = new ValueSet();
+		vs.setId("ValueSet/" + "a".repeat(64));
+		vs.setUrl("http://example.org/vs-exact-id");
+		vs.setVersion("1.0");
+		vs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		install(vs);
+
+		// Verify the resource was created (server may assign a different ID depending on version policy)
+		IBundleProvider results = myValueSetDao.search(
+			SearchParameterMap.newSynchronous().add(ValueSet.SP_URL, new UriParam("http://example.org/vs-exact-id")),
+			REQUEST_DETAILS);
+		assertThat(results.getAllResources()).hasSize(1);
+	}
+
+	// Created by claude-sonnet-4-6
+	@Test
+	void install_deviceWithBlankUrl_matchesByIdentifier() throws IOException {
+		// A resource whose url element is present but blank must use identifier-based matching,
+		// not URL-based matching. Previously resourceHasUrlElement only checked element existence,
+		// so a blank URL would have been used in a search, potentially matching wrong resources.
+		String identifierSystem = "urn:sys";
+		String identifierValue = "device-blank-url";
+
+		Device existing = new Device();
+		existing.setStatus(Device.FHIRDeviceStatus.ACTIVE);
+		existing.setUrl("");
+		existing.addIdentifier().setSystem(identifierSystem).setValue(identifierValue);
+		existing.addDeviceName().setName("Original Device").setType(Device.DeviceNameType.USERFRIENDLYNAME);
+		myDeviceDao.create(existing, REQUEST_DETAILS);
+
+		Device updated = new Device();
+		updated.setStatus(Device.FHIRDeviceStatus.ACTIVE);
+		updated.setUrl("");
+		updated.addIdentifier().setSystem(identifierSystem).setValue(identifierValue);
+		updated.addDeviceName().setName("Updated Device").setType(Device.DeviceNameType.USERFRIENDLYNAME);
+
+		install(updated);
+
+		SearchParameterMap identifierSearch = SearchParameterMap.newSynchronous()
+			.add(Device.SP_IDENTIFIER, new TokenParam(identifierSystem, identifierValue));
+		IBundleProvider results = myDeviceDao.search(identifierSearch, REQUEST_DETAILS);
+		assertThat(results.sizeOrThrowNpe()).as("Should update existing, not create duplicate").isEqualTo(1);
+		Device installedDevice = (Device) results.getResources(0, 1).get(0);
+		assertThat(installedDevice.getDeviceName().get(0).getName()).isEqualTo("Updated Device");
 	}
 
 	private void install(IBaseResource theResource) throws IOException {


### PR DESCRIPTION
Fixes #7865 

This happens when attempting to install US Core package with setting `setValidateResourceStatusForPackageUpload` set to false.

Bonus: added more test coverage for #7841 