### PR TITLE
Change datetimepicker format to use data attribute

### DIFF
--- a/hapi-fhir-testpage-overlay/src/main/webapp/js/RestfulTester.js
+++ b/hapi-fhir-testpage-overlay/src/main/webapp/js/RestfulTester.js
@@ -380,7 +380,7 @@ function addSearchControlDate(theSearchParamName, theContainerRowNum, theRowNum,
 	);
 
 	dateTimePicker.datetimepicker({
-		format: "YYYY-MM-DD",
+		format: input.attr('data-bs-toggledate-format'),
 		showTodayButton: true
 	});
 


### PR DESCRIPTION
The fhir testpage generates date/datetime input fields for search parameters depending on their name. It stores the format in the data-bs-toggledate-format attribute, but the datepicker is always initialized with a date without time.

This change corrects that, so that the datepicker respects the date format from the input field. This allows to enter dates with time.