### PR TITLE
Use better query plan in MSSQL DBPM

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7879-improve-query-in-mssql-dbpm.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_10_0/7879-improve-query-in-mssql-dbpm.yaml
@@ -1,0 +1,4 @@
+---
+type: perf
+issue: 7879
+title: "In MSSQL/SQL Server, when running in DB Partition Mode the query for fetching resource bodies during a search is inefficient because MSSQL does not properly support tuples. This query has been reworked for better performance."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -194,6 +194,7 @@ import ca.uhn.fhir.jpa.term.api.ITermConceptMappingSvc;
 import ca.uhn.fhir.jpa.term.api.ITermReadSvc;
 import ca.uhn.fhir.jpa.term.api.ITermReindexingSvc;
 import ca.uhn.fhir.jpa.term.config.TermCodeSystemConfig;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import ca.uhn.fhir.jpa.util.JpaHapiTransactionService;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.jpa.util.PartitionedIdModeVerificationSvc;
@@ -1142,11 +1143,17 @@ public class JpaConfig {
 	}
 
 	@Bean
+	public DialectSvc dialectSvc(HibernatePropertiesProvider theHibernatePropertiesProvider) {
+		return new DialectSvc(theHibernatePropertiesProvider);
+	}
+
+	@Bean
 	public PartitionedIdModeVerificationSvc partitionedIdModeVerificationSvc(
 			PartitionSettings thePartitionSettings,
 			HibernatePropertiesProvider theHibernatePropertiesProvider,
-			PlatformTransactionManager theTxManager) {
-		return new PartitionedIdModeVerificationSvc(thePartitionSettings, theHibernatePropertiesProvider, theTxManager);
+			PlatformTransactionManager theTxManager,
+			DialectSvc theDialectSvc) {
+		return new PartitionedIdModeVerificationSvc(thePartitionSettings, theHibernatePropertiesProvider, theTxManager, theDialectSvc);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/JpaConfig.java
@@ -1153,7 +1153,8 @@ public class JpaConfig {
 			HibernatePropertiesProvider theHibernatePropertiesProvider,
 			PlatformTransactionManager theTxManager,
 			DialectSvc theDialectSvc) {
-		return new PartitionedIdModeVerificationSvc(thePartitionSettings, theHibernatePropertiesProvider, theTxManager, theDialectSvc);
+		return new PartitionedIdModeVerificationSvc(
+				thePartitionSettings, theHibernatePropertiesProvider, theTxManager, theDialectSvc);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/SearchConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/SearchConfig.java
@@ -51,6 +51,7 @@ import ca.uhn.fhir.jpa.search.builder.tasks.SearchTask;
 import ca.uhn.fhir.jpa.search.builder.tasks.SearchTaskParameters;
 import ca.uhn.fhir.jpa.search.cache.ISearchCacheSvc;
 import ca.uhn.fhir.jpa.search.cache.ISearchResultCacheSvc;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import ca.uhn.fhir.rest.server.IPagingProvider;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.util.IMetaTagSorter;
@@ -67,6 +68,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class SearchConfig {
 	public static final String SEARCH_TASK = "searchTask";
 	public static final String CONTINUE_TASK = "continueTask";
+
+	@Autowired
+	private DialectSvc myDialectSvc;
 
 	@Autowired
 	private JpaStorageSettings myStorageSettings;
@@ -200,7 +204,8 @@ public class SearchConfig {
 				myIdHelperService,
 				myResourceHistoryTableDao,
 				myBatchResourceLoader,
-				theResourceType);
+				theResourceType,
+				myDialectSvc);
 	}
 
 	@Bean(name = SEARCH_TASK)

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -49,6 +49,7 @@ import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.BaseResourceIndexedSearchParam;
 import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTable;
 import ca.uhn.fhir.jpa.model.entity.ResourceLink;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.search.SearchBuilderLoadIncludesParameters;
 import ca.uhn.fhir.jpa.model.search.SearchRuntimeDetails;
 import ca.uhn.fhir.jpa.model.search.StorageProcessingMessage;
@@ -74,6 +75,7 @@ import ca.uhn.fhir.jpa.searchparam.util.PerformanceTracingLogger;
 import ca.uhn.fhir.jpa.util.BaseIterator;
 import ca.uhn.fhir.jpa.util.CartesianProductUtil;
 import ca.uhn.fhir.jpa.util.CurrentThreadCaptureQueriesListener;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import ca.uhn.fhir.jpa.util.QueryChunker;
 import ca.uhn.fhir.jpa.util.ScrollableResultsIterator;
 import ca.uhn.fhir.jpa.util.SqlQueryList;
@@ -110,9 +112,12 @@ import ca.uhn.fhir.util.StopWatch;
 import ca.uhn.fhir.util.StringUtil;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Multimaps;
 import com.healthmarketscience.sqlbuilder.ComboCondition;
 import com.healthmarketscience.sqlbuilder.Condition;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
@@ -128,6 +133,9 @@ import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
@@ -163,6 +171,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static ca.uhn.fhir.jpa.dao.index.IdHelperService.EMPTY_PREDICATE_ARRAY;
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.NO_MORE;
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.UNDESIRED_RESOURCE_LINKAGES_FOR_EVERYTHING_ON_PATIENT_INSTANCE;
 import static ca.uhn.fhir.jpa.search.builder.QueryStack.LOCATION_POSITION;
@@ -209,6 +218,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 	protected final IInterceptorBroadcaster myInterceptorBroadcaster;
 	protected final IResourceTagDao myResourceTagDao;
 	private final PerformanceTracingLogger myPerformanceTracingLogger;
+	private final DialectSvc myDialectSvc;
 	private String myResourceName;
 	private final Class<? extends IBaseResource> myResourceType;
 	private final HapiFhirLocalContainerEntityManagerFactoryBean myEntityManagerFactory;
@@ -274,7 +284,8 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 			IIdHelperService theIdHelperService,
 			IResourceHistoryTableDao theResourceHistoryTagDao,
 			BatchResourceLoader theBatchResourceLoader,
-			Class<? extends IBaseResource> theResourceType) {
+			Class<? extends IBaseResource> theResourceType,
+			DialectSvc theDialectSvc) {
 		myResourceName = theResourceName;
 		myResourceType = theResourceType;
 		myStorageSettings = theStorageSettings;
@@ -291,6 +302,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 		myIdHelperService = theIdHelperService;
 		myResourceHistoryTableDao = theResourceHistoryTagDao;
 		myBatchResourceLoader = theBatchResourceLoader;
+		myDialectSvc = theDialectSvc;
 
 		mySearchProperties = new SearchQueryProperties();
 		myPerformanceTracingLogger = new PerformanceTracingLogger(theInterceptorBroadcaster);
@@ -1377,8 +1389,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 		}
 
 		// Load the resource bodies
-		List<ResourceHistoryTable> resourceSearchViewList =
-				myResourceHistoryTableDao.findCurrentVersionsByResourcePidsAndFetchResourceTable(versionlessPids);
+		List<ResourceHistoryTable> resourceSearchViewList = loadCurrentResourceVersions(versionlessPids);
 
 		/*
 		 * If we have specific versions to load, replace the history entries with the
@@ -1457,6 +1468,59 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 			}
 			theResourceListToPopulate.set(index, next.resource());
 		}
+	}
+
+	private List<ResourceHistoryTable> loadCurrentResourceVersions(List<JpaPid> theResourcePids) {
+		List<ResourceHistoryTable> resourceSearchViewList;
+
+		if (myPartitionSettings.isDatabasePartitionMode() && myDialectSvc.isMssql()) {
+			resourceSearchViewList = loadCurrentResourceVersionsForMsSqlDbpm(theResourcePids);
+		} else {
+			resourceSearchViewList = myResourceHistoryTableDao.findCurrentVersionsByResourcePidsAndFetchResourceTable(theResourcePids);
+		}
+		return resourceSearchViewList;
+	}
+
+	// FIXME: document why
+	@VisibleForTesting
+	public List<ResourceHistoryTable> loadCurrentResourceVersionsForMsSqlDbpm(List<JpaPid> theResourcePids) {
+		Validate.isTrue(myPartitionSettings.isDatabasePartitionMode(), "This method should only be called in DBPM");
+		List<ResourceHistoryTable> resourceSearchViewList;
+
+		// Split the resource PIDs into partitions for efficient querying. We use a tree
+		// for the partition IDs to make the SQL consistent for tests.
+		Multimap<Integer, Long> partitionIdToPid = MultimapBuilder.treeKeys().arrayListValues().build();
+		for (JpaPid pid : theResourcePids) {
+			// The SearchBuilder pads the list with entries that will never match
+			// a real resource in order to create predictable numbers of parameters,
+			// but there is no reason to do that here
+			if (!JpaConstants.NO_MORE.equals(pid)) {
+				partitionIdToPid.put(pid.getPartitionId(), pid.getId());
+			}
+		}
+
+		CriteriaBuilder cb = myEntityManager.getCriteriaBuilder();
+		CriteriaQuery<ResourceHistoryTable> cq = cb.createQuery(ResourceHistoryTable.class);
+		Root<ResourceHistoryTable> from = cq.from(ResourceHistoryTable.class);
+
+		Join<?, ?> resourceTable = (Join<?, ?>) from.fetch("myResourceTable", JoinType.LEFT);
+		List<Predicate> partitionAndPidPredicates = new ArrayList<>(partitionIdToPid.keySet().size());
+		for (Map.Entry<Integer, Collection<Long>> entry : partitionIdToPid.asMap().entrySet()) {
+			Integer partitionId = entry.getKey();
+			Collection<Long> pids = entry.getValue();
+
+			Predicate partitionIdPredicate = cb.equal(resourceTable.get("myPartitionIdValue"), partitionId);
+			Predicate pidPredicate = resourceTable.get("myResourceId").in(pids);
+			partitionAndPidPredicates.add(cb.and(partitionIdPredicate, pidPredicate));
+		}
+
+		Predicate currentVersionPredicate = cb.equal(resourceTable.get("myVersion"), from.get("myResourceVersion"));
+
+		cq.where(currentVersionPredicate, cb.or(partitionAndPidPredicates.toArray(EMPTY_PREDICATE_ARRAY)));
+
+		TypedQuery<ResourceHistoryTable> query = myEntityManager.createQuery(cq);
+		resourceSearchViewList = query.getResultList();
+		return resourceSearchViewList;
 	}
 
 	@SuppressWarnings("OptionalIsPresent")

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -1496,8 +1496,10 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 		for (JpaPid pid : theResourcePids) {
 			// The SearchBuilder pads the list with entries that will never match
 			// a real resource in order to create predictable numbers of parameters,
-			// but there is no reason to do that here
-			if (!JpaConstants.NO_MORE.equals(pid)) {
+			// so we'll put appropriate values here for that too
+			if (JpaConstants.NO_MORE.equals(pid)) {
+				partitionIdToPid.put(-1, -1L);
+			} else {
 				partitionIdToPid.put(pid.getPartitionId(), pid.getId());
 			}
 		}
@@ -1506,7 +1508,7 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 		CriteriaQuery<ResourceHistoryTable> cq = cb.createQuery(ResourceHistoryTable.class);
 		Root<ResourceHistoryTable> from = cq.from(ResourceHistoryTable.class);
 
-		Join<?, ?> resourceTable = (Join<?, ?>) from.fetch("myResourceTable", JoinType.LEFT);
+		Join<?, ?> resourceTable = (Join<?, ?>) from.fetch("myResourceTable", JoinType.INNER);
 		List<Predicate> partitionAndPidPredicates =
 				new ArrayList<>(partitionIdToPid.keySet().size());
 		for (Map.Entry<Integer, Collection<Long>> entry :

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/SearchBuilder.java
@@ -49,7 +49,6 @@ import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.BaseResourceIndexedSearchParam;
 import ca.uhn.fhir.jpa.model.entity.ResourceHistoryTable;
 import ca.uhn.fhir.jpa.model.entity.ResourceLink;
-import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.jpa.model.search.SearchBuilderLoadIncludesParameters;
 import ca.uhn.fhir.jpa.model.search.SearchRuntimeDetails;
 import ca.uhn.fhir.jpa.model.search.StorageProcessingMessage;
@@ -112,12 +111,10 @@ import ca.uhn.fhir.util.StopWatch;
 import ca.uhn.fhir.util.StringUtil;
 import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
-import com.google.common.collect.Multimaps;
 import com.healthmarketscience.sqlbuilder.ComboCondition;
 import com.healthmarketscience.sqlbuilder.Condition;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
@@ -133,7 +130,6 @@ import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Fetch;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
@@ -1476,12 +1472,18 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 		if (myPartitionSettings.isDatabasePartitionMode() && myDialectSvc.isMssql()) {
 			resourceSearchViewList = loadCurrentResourceVersionsForMsSqlDbpm(theResourcePids);
 		} else {
-			resourceSearchViewList = myResourceHistoryTableDao.findCurrentVersionsByResourcePidsAndFetchResourceTable(theResourcePids);
+			resourceSearchViewList =
+					myResourceHistoryTableDao.findCurrentVersionsByResourcePidsAndFetchResourceTable(theResourcePids);
 		}
 		return resourceSearchViewList;
 	}
 
-	// FIXME: document why
+	/**
+	 * In Database Partition Mode, when loading resource bodies for most databases we issue
+	 * SQL like <code>WHERE (PARITION_ID,RES_ID) IN (1,2), (1,3)</code> but this syntax is
+	 * not supported by MSSQL / SQL Server. So for that specific platform, we rework the
+	 * call to issue SQL like <code>WHERE PARTITION = 1 AND RES_ID IN (2, 3)</code>
+	 */
 	@VisibleForTesting
 	public List<ResourceHistoryTable> loadCurrentResourceVersionsForMsSqlDbpm(List<JpaPid> theResourcePids) {
 		Validate.isTrue(myPartitionSettings.isDatabasePartitionMode(), "This method should only be called in DBPM");
@@ -1489,7 +1491,8 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 
 		// Split the resource PIDs into partitions for efficient querying. We use a tree
 		// for the partition IDs to make the SQL consistent for tests.
-		Multimap<Integer, Long> partitionIdToPid = MultimapBuilder.treeKeys().arrayListValues().build();
+		Multimap<Integer, Long> partitionIdToPid =
+				MultimapBuilder.treeKeys().arrayListValues().build();
 		for (JpaPid pid : theResourcePids) {
 			// The SearchBuilder pads the list with entries that will never match
 			// a real resource in order to create predictable numbers of parameters,
@@ -1504,8 +1507,10 @@ public class SearchBuilder implements ISearchBuilder<JpaPid> {
 		Root<ResourceHistoryTable> from = cq.from(ResourceHistoryTable.class);
 
 		Join<?, ?> resourceTable = (Join<?, ?>) from.fetch("myResourceTable", JoinType.LEFT);
-		List<Predicate> partitionAndPidPredicates = new ArrayList<>(partitionIdToPid.keySet().size());
-		for (Map.Entry<Integer, Collection<Long>> entry : partitionIdToPid.asMap().entrySet()) {
+		List<Predicate> partitionAndPidPredicates =
+				new ArrayList<>(partitionIdToPid.keySet().size());
+		for (Map.Entry<Integer, Collection<Long>> entry :
+				partitionIdToPid.asMap().entrySet()) {
 			Integer partitionId = entry.getKey();
 			Collection<Long> pids = entry.getValue();
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryExecutor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryExecutor.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.jpa.search.builder.sql;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.search.builder.ISearchQueryExecutor;
 import ca.uhn.fhir.jpa.util.ScrollableResultsIterator;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
@@ -41,9 +42,10 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static ca.uhn.fhir.jpa.model.util.JpaConstants.NO_MORE;
+
 public class SearchQueryExecutor implements ISearchQueryExecutor {
 
-	private static final JpaPid NO_MORE = JpaPid.fromId(-1L);
 	private static final SearchQueryExecutor NO_VALUE_EXECUTOR = new SearchQueryExecutor();
 	private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 	private static final Logger ourLog = LoggerFactory.getLogger(SearchQueryExecutor.class);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryExecutor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/sql/SearchQueryExecutor.java
@@ -22,7 +22,6 @@ package ca.uhn.fhir.jpa.search.builder.sql;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
-import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.search.builder.ISearchQueryExecutor;
 import ca.uhn.fhir.jpa.util.ScrollableResultsIterator;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
@@ -13,8 +13,10 @@ import java.util.Optional;
 
 public class DialectSvc {
 	private static final Logger ourLog = LoggerFactory.getLogger(DialectSvc.class);
+
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private static boolean ourForceMsSqlMode = false;
+
 	private final Optional<DriverTypeEnum> myDriverType;
 
 	public DialectSvc(HibernatePropertiesProvider theHibernatePropertiesProvider) {
@@ -25,7 +27,6 @@ public class DialectSvc {
 		} else {
 			myDriverType = Optional.of(((IHapiFhirDialect) dialect).getDriverType());
 		}
-
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
@@ -1,0 +1,55 @@
+package ca.uhn.fhir.jpa.util;
+
+import ca.uhn.fhir.jpa.config.HibernatePropertiesProvider;
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import ca.uhn.fhir.jpa.model.dialect.IHapiFhirDialect;
+import graphql.VisibleForTesting;
+import jakarta.annotation.Nonnull;
+import org.hibernate.dialect.Dialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class DialectSvc {
+	private static final Logger ourLog = LoggerFactory.getLogger(DialectSvc.class);
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	private static boolean ourForceMsSqlMode = false;
+	private final Optional<DriverTypeEnum> myDriverType;
+
+	public DialectSvc(HibernatePropertiesProvider theHibernatePropertiesProvider) {
+		Dialect dialect = theHibernatePropertiesProvider.getDialect();
+		if (!(dialect instanceof IHapiFhirDialect)) {
+			ourLog.warn("Dialect is not a HAPI FHIR dialect: {}", dialect);
+			myDriverType = Optional.empty();
+		} else {
+			myDriverType = Optional.of(((IHapiFhirDialect) dialect).getDriverType());
+		}
+
+	}
+
+	/**
+	 * This will be empty if a dialect is not a HAPI FHIR dialect. This shouldn't generally happen but
+	 * is possible.
+	 */
+	@Nonnull
+	public Optional<DriverTypeEnum> getDriverType() {
+		return myDriverType;
+	}
+
+	public boolean isMssql() {
+		if (ourForceMsSqlMode) {
+			return true;
+		}
+		return getDriverType().orElse(null) == DriverTypeEnum.MSSQL_2012;
+	}
+
+	/**
+	 * For unit testing only
+	 */
+	@VisibleForTesting
+	public static void setForceMsSqlMode(boolean theForceMsSqlMode) {
+		ourLog.warn("Forcing MS SQL mode: {}", theForceMsSqlMode);
+		ourForceMsSqlMode = theForceMsSqlMode;
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
@@ -3,7 +3,7 @@ package ca.uhn.fhir.jpa.util;
 import ca.uhn.fhir.jpa.config.HibernatePropertiesProvider;
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 import ca.uhn.fhir.jpa.model.dialect.IHapiFhirDialect;
-import graphql.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import org.hibernate.dialect.Dialect;
 import org.slf4j.Logger;
@@ -14,9 +14,9 @@ import java.util.Optional;
 public class DialectSvc {
 	private static final Logger ourLog = LoggerFactory.getLogger(DialectSvc.class);
 
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private static boolean ourForceMsSqlMode = false;
 
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private final Optional<DriverTypeEnum> myDriverType;
 
 	public DialectSvc(HibernatePropertiesProvider theHibernatePropertiesProvider) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/PartitionedIdModeVerificationSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/PartitionedIdModeVerificationSvc.java
@@ -25,10 +25,8 @@ import ca.uhn.fhir.jpa.config.HibernatePropertiesProvider;
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 import ca.uhn.fhir.jpa.migrate.JdbcUtils;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
-import ca.uhn.fhir.jpa.model.dialect.IHapiFhirDialect;
 import ca.uhn.fhir.system.HapiSystemProperties;
 import org.apache.commons.collections4.SetUtils;
-import org.hibernate.dialect.Dialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -37,6 +35,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.sql.DataSource;
@@ -54,6 +53,7 @@ public class PartitionedIdModeVerificationSvc {
 	private final PartitionSettings myPartitionSettings;
 	private final HibernatePropertiesProvider myHibernatePropertiesProvider;
 	private final PlatformTransactionManager myTxManager;
+	private final DialectSvc myDialectSvc;
 
 	/**
 	 * Constructor
@@ -61,10 +61,12 @@ public class PartitionedIdModeVerificationSvc {
 	public PartitionedIdModeVerificationSvc(
 			PartitionSettings thePartitionSettings,
 			HibernatePropertiesProvider theHibernatePropertiesProvider,
-			PlatformTransactionManager theTxManager) {
+			PlatformTransactionManager theTxManager,
+			DialectSvc theDialectSvc) {
 		myPartitionSettings = thePartitionSettings;
 		myHibernatePropertiesProvider = theHibernatePropertiesProvider;
 		myTxManager = theTxManager;
+		myDialectSvc = theDialectSvc;
 	}
 
 	@EventListener(classes = {ContextRefreshedEvent.class})
@@ -73,16 +75,15 @@ public class PartitionedIdModeVerificationSvc {
 		DataSource dataSource = myHibernatePropertiesProvider.getDataSource();
 		boolean expectDatabasePartitionMode = myPartitionSettings.isDatabasePartitionMode();
 
-		Dialect dialect = myHibernatePropertiesProvider.getDialect();
-		if (!(dialect instanceof IHapiFhirDialect)) {
-			ourLog.warn("Dialect is not a HAPI FHIR dialect: {}", dialect);
+		Optional<DriverTypeEnum> driverType = myDialectSvc.getDriverType();
+		if (driverType.isEmpty()) {
+			ourLog.warn("Database schema check skipped because dialect is not a HAPI FHIR dialect");
 			return;
 		}
 
-		DriverTypeEnum driverType = ((IHapiFhirDialect) dialect).getDriverType();
 		TransactionTemplate transactionTemplate = new TransactionTemplate(myTxManager);
 		DriverTypeEnum.ConnectionProperties cp =
-				new DriverTypeEnum.ConnectionProperties(dataSource, transactionTemplate, driverType);
+				new DriverTypeEnum.ConnectionProperties(dataSource, transactionTemplate, driverType.orElseThrow());
 		verifySchemaIsAppropriateForDatabasePartitionMode(cp, expectDatabasePartitionMode);
 	}
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.rest.api.Constants;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -60,6 +61,7 @@ import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.OptimisticLock;
+import org.hibernate.annotations.processing.Exclude;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.IdentifierBridgeRef;
@@ -153,6 +155,14 @@ public class ResourceTable extends BaseHasResource<JpaPid> implements Serializab
 			projectable = Projectable.YES,
 			valueBridge = @ValueBridgeRef(type = JpaPidValueBridge.class))
 	private JpaPid myPid;
+
+	/**
+	 * This is only here to support SearchBuilder#loadCurrentResourceVersionsForMsSqlDbpm
+	 */
+	@SuppressWarnings("unused")
+	@Basic(fetch = FetchType.LAZY)
+	@Column(name = "RES_ID", nullable = false, insertable = false, updatable = false)
+	private Integer myResourceId;
 
 	@Column(name = PartitionablePartitionId.PARTITION_ID, nullable = true, insertable = false, updatable = false)
 	private Integer myPartitionIdValue;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -161,7 +161,7 @@ public class ResourceTable extends BaseHasResource<JpaPid> implements Serializab
 	@SuppressWarnings("unused")
 	@Basic(fetch = FetchType.LAZY)
 	@Column(name = "RES_ID", nullable = false, insertable = false, updatable = false)
-	private Integer myResourceId;
+	private Long myResourceId;
 
 	@Column(name = PartitionablePartitionId.PARTITION_ID, nullable = true, insertable = false, updatable = false)
 	private Integer myPartitionIdValue;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceTable.java
@@ -61,7 +61,6 @@ import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.OptimisticLock;
-import org.hibernate.annotations.processing.Exclude;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.IdentifierBridgeRef;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/util/PartitionedIdModeVerificationSvcTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/util/PartitionedIdModeVerificationSvcTest.java
@@ -64,7 +64,7 @@ class PartitionedIdModeVerificationSvcTest {
 
 		PartitionSettings partitionedSettings = new PartitionSettings();
 		partitionedSettings.setDatabasePartitionMode(thePartitionedIdModeForSettings);
-		PartitionedIdModeVerificationSvc svc = new PartitionedIdModeVerificationSvc(partitionedSettings, myHibernatePropertiesProvider, txManager);
+		PartitionedIdModeVerificationSvc svc = new PartitionedIdModeVerificationSvc(partitionedSettings, myHibernatePropertiesProvider, txManager, new DialectSvc(myHibernatePropertiesProvider));
 
 		if (thePartitionedIdModeForSchema == thePartitionedIdModeForSettings) {
 			assertDoesNotThrow(svc::verifyPartitionedIdMode);
@@ -87,7 +87,7 @@ class PartitionedIdModeVerificationSvcTest {
 		when(myHibernatePropertiesProvider.getDialect()).thenReturn(new HapiFhirH2Dialect());
 
 		PartitionSettings partitionedSettings = new PartitionSettings();
-		PartitionedIdModeVerificationSvc svc = new PartitionedIdModeVerificationSvc(partitionedSettings, myHibernatePropertiesProvider, txManager);
+		PartitionedIdModeVerificationSvc svc = new PartitionedIdModeVerificationSvc(partitionedSettings, myHibernatePropertiesProvider, txManager, new DialectSvc(myHibernatePropertiesProvider));
 
 		assertDoesNotThrow(svc::verifyPartitionedIdMode);
 	}

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/DbpmEnabledTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/DbpmEnabledTest.java
@@ -10,16 +10,13 @@ import ca.uhn.fhir.jpa.provider.TerminologyUploaderProvider;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.term.api.ITermLoaderSvc;
 import ca.uhn.fhir.jpa.util.DialectSvc;
-import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.util.ClasspathUtil;
-import net.sourceforge.plantuml.klimt.creole.Sea;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r5.model.Attachment;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.UriType;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,13 +54,6 @@ public class DbpmEnabledTest extends BaseDbpmResourceProviderR5Test {
 
 		registerPartitionInterceptorAndCreatePartitions();
 		initResourceTypeCacheFromConfig();
-	}
-
-	@AfterEach
-	@Override
-	public void after() throws Exception {
-		DialectSvc.setForceMsSqlMode(false);
-		super.after();
 	}
 
 	@Test
@@ -107,37 +97,39 @@ public class DbpmEnabledTest extends BaseDbpmResourceProviderR5Test {
 	@Test
 	void testSearch_MsSqlResourceLoading() {
 		DialectSvc.setForceMsSqlMode(true);
+		try {
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(1));
+			createPatient(withId("A1"), withFamily("A1"));
+			createPatient(withId("B1"), withFamily("B1"));
+			createPatient(withId("C1"), withFamily("C1"));
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(2));
+			createPatient(withId("A2"), withFamily("A2"));
+			createPatient(withId("B2"), withFamily("B2"));
+			createPatient(withId("C2"), withFamily("C2"));
 
-		myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(1));
-		createPatient(withId("A1"), withFamily("A1"));
-		createPatient(withId("B1"), withFamily("B1"));
-		createPatient(withId("C1"), withFamily("C1"));
-		myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(2));
-		createPatient(withId("A2"), withFamily("A2"));
-		createPatient(withId("B2"), withFamily("B2"));
-		createPatient(withId("C2"), withFamily("C2"));
+			logAllResources();
 
-		logAllResources();
+			// Test
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionIds(1, 2));
+			myCaptureQueriesListener.clear();
+			List<String> actual = toUnqualifiedVersionlessIdValues(myPatientDao.search(SearchParameterMap.newSynchronous(), newSrd()));
 
-		// Test
-		myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionIds(1, 2));
-		myCaptureQueriesListener.clear();
-		List<String> actual = toUnqualifiedVersionlessIdValues(myPatientDao.search(SearchParameterMap.newSynchronous(), newSrd()));
-
-		// Verify
-		myCaptureQueriesListener.logSelectQueries();
-		assertThat(actual).containsExactlyInAnyOrder("Patient/A1", "Patient/B1", "Patient/C1", "Patient/A2", "Patient/B2", "Patient/C2");
-		String fetchByPidSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(1).getSql(false, false);
-		assertThat(fetchByPidSql).contains(
-				" from HFJ_RES_VER rht1_0 ",
-				" left join HFJ_RESOURCE mrt1_0 ",
-				// The HFJ_RESOURCE table is identified as mrt1_0 so make sure that's the table
-				// we're selecting on, and not the HFJ_RES_VER one
-				" where mrt1_0.RES_VER=rht1_0.RES_VER and (mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?) or mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?))"
+			// Verify
+			myCaptureQueriesListener.logSelectQueries();
+			assertThat(actual).containsExactlyInAnyOrder("Patient/A1", "Patient/B1", "Patient/C1", "Patient/A2", "Patient/B2", "Patient/C2");
+			String fetchByPidSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(1).getSql(false, false);
+			assertThat(fetchByPidSql).contains(
+				// If the variable names in this fragment ever change, make sure they are equivalently changed
+				// below. We'll be functionally correct if we do a WHERE on the HFJ_RES_VER table and tests will pass,
+				// but it's slower at scale than if we do a WHERE on the HFJ_RESOURCE table
+				" from HFJ_RES_VER rht1_0 join HFJ_RESOURCE mrt1_0",
+				" where mrt1_0.RES_VER=rht1_0.RES_VER and (mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?,?) or mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?) or mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?))"
 			);
-		assertEquals(1, StringUtils.countMatches(fetchByPidSql.toUpperCase(Locale.US), "JOIN"));
-		assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
-
+			assertEquals(1, StringUtils.countMatches(fetchByPidSql.toUpperCase(Locale.US), "JOIN"));
+			assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+		} finally {
+			DialectSvc.setForceMsSqlMode(false);
+		}
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/DbpmEnabledTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/DbpmEnabledTest.java
@@ -7,21 +7,31 @@ import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.provider.TerminologyUploaderProvider;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.term.api.ITermLoaderSvc;
+import ca.uhn.fhir.jpa.util.DialectSvc;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.util.ClasspathUtil;
+import net.sourceforge.plantuml.klimt.creole.Sea;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r5.model.Attachment;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.UriType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.List;
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -47,6 +57,13 @@ public class DbpmEnabledTest extends BaseDbpmResourceProviderR5Test {
 
 		registerPartitionInterceptorAndCreatePartitions();
 		initResourceTypeCacheFromConfig();
+	}
+
+	@AfterEach
+	@Override
+	public void after() throws Exception {
+		DialectSvc.setForceMsSqlMode(false);
+		super.after();
 	}
 
 	@Test
@@ -82,6 +99,48 @@ public class DbpmEnabledTest extends BaseDbpmResourceProviderR5Test {
 		runInTransaction(() -> assertThatThrownBy(() -> myIdHelperService.resolveResourceIdentityPid(RequestPartitionId.fromPartitionId(2), "Patient", "A", ResolveIdentityMode.includeDeleted().cacheOk())))
 			.isInstanceOf(ResourceNotFoundException.class);
 	}
+
+
+	/**
+	 * @see ca.uhn.fhir.jpa.search.builder.SearchBuilder#loadCurrentResourceVersionsForMsSqlDbpm(List)
+	 */
+	@Test
+	void testSearch_MsSqlResourceLoading() {
+		DialectSvc.setForceMsSqlMode(true);
+
+		myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(1));
+		createPatient(withId("A1"), withFamily("A1"));
+		createPatient(withId("B1"), withFamily("B1"));
+		createPatient(withId("C1"), withFamily("C1"));
+		myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(2));
+		createPatient(withId("A2"), withFamily("A2"));
+		createPatient(withId("B2"), withFamily("B2"));
+		createPatient(withId("C2"), withFamily("C2"));
+
+		logAllResources();
+
+		// Test
+		myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionIds(1, 2));
+		myCaptureQueriesListener.clear();
+		List<String> actual = toUnqualifiedVersionlessIdValues(myPatientDao.search(SearchParameterMap.newSynchronous(), newSrd()));
+
+		// Verify
+		myCaptureQueriesListener.logSelectQueries();
+		assertThat(actual).containsExactlyInAnyOrder("Patient/A1", "Patient/B1", "Patient/C1", "Patient/A2", "Patient/B2", "Patient/C2");
+		String fetchByPidSql = myCaptureQueriesListener.getSelectQueriesForCurrentThread().get(1).getSql(false, false);
+		assertThat(fetchByPidSql).contains(
+				" from HFJ_RES_VER rht1_0 ",
+				" left join HFJ_RESOURCE mrt1_0 ",
+				// The HFJ_RESOURCE table is identified as mrt1_0 so make sure that's the table
+				// we're selecting on, and not the HFJ_RES_VER one
+				" where mrt1_0.RES_VER=rht1_0.RES_VER and (mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?) or mrt1_0.PARTITION_ID=? and mrt1_0.RES_ID in (?,?,?))"
+			);
+		assertEquals(1, StringUtils.countMatches(fetchByPidSql.toUpperCase(Locale.US), "JOIN"));
+		assertEquals(2, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+
+	}
+
+
 
 
 	@Nested

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -105,6 +105,7 @@ import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionLoader;
 import ca.uhn.fhir.jpa.subscription.match.registry.SubscriptionRegistry;
 import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
 import ca.uhn.fhir.jpa.util.CircularQueueCaptureQueriesListener;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.mdm.dao.IMdmLinkDao;
 import ca.uhn.fhir.parser.IParser;
@@ -487,6 +488,8 @@ public abstract class BaseJpaTest extends BaseTest {
 
 		PartitionSettings defaultPartConfig = new PartitionSettings();
 		BeanUtils.copyProperties(defaultPartConfig, myPartitionSettings);
+
+		DialectSvc.setForceMsSqlMode(false);
 	}
 
 	@AfterEach

--- a/pom.xml
+++ b/pom.xml
@@ -1571,7 +1571,7 @@
 			<dependency>
 				<groupId>com.microsoft.sqlserver</groupId>
 				<artifactId>mssql-jdbc</artifactId>
-				<version>12.4.3.jre11</version>
+				<version>13.4.0.jre11</version>
 			</dependency>
 			<dependency>
 				<!--


### PR DESCRIPTION
In MSSQL/SQL Server, when running in DB Partition Mode the query for fetching resource bodies during a search is inefficient because MSSQL does not properly support tuples. This query has been reworked for better performance.