### PR TITLE
[7897] fix history count cache stale after write

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7897-fix-history-count-cache-stale-after-write.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7897-fix-history-count-cache-stale-after-write.yaml
@@ -1,0 +1,10 @@
+---
+type: fix
+issue: 7897
+jira: SMILE-11997
+title: "Fixed the bug where a `_history` query immediately following a resource update could
+  return a stale total and omit older versions for up to 60 seconds. The HISTORY_COUNT
+  memory cache was populated by reads but never invalidated by writes, so a primed total
+  of 1 caused the next history page to be sized to a single row and return only the newest
+  version. Resource create/update/delete now invalidate the affected instance, type, and
+  system level HISTORY_COUNT cache entries after the transaction commits."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7897-fix-history-count-cache-stale-after-write.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7897-fix-history-count-cache-stale-after-write.yaml
@@ -6,5 +6,5 @@ title: "Fixed the bug where a `_history` query immediately following a resource 
   return a stale total and omit older versions for up to 60 seconds. The HISTORY_COUNT
   memory cache was populated by reads but never invalidated by writes, so a primed total
   of 1 caused the next history page to be sized to a single row and return only the newest
-  version. Resource create/update/delete now invalidate the affected instance, type, and
+  version. Resource create/update/delete now invalidates the affected instance, type, and
   system level HISTORY_COUNT cache entries after the transaction commits."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -3208,6 +3208,39 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 	}
 
+	@Override
+	protected void postPersist(ResourceTable theEntity, T theResource, RequestDetails theRequestDetails) {
+		super.postPersist(theEntity, theResource, theRequestDetails);
+		invalidateHistoryCountCacheAfterCommit(theEntity);
+	}
+
+	@Override
+	protected void postUpdate(ResourceTable theEntity, T theResource, RequestDetails theRequestDetails) {
+		super.postUpdate(theEntity, theResource, theRequestDetails);
+		invalidateHistoryCountCacheAfterCommit(theEntity);
+	}
+
+	@Override
+	protected void postDelete(ResourceTable theEntity) {
+		super.postDelete(theEntity);
+		invalidateHistoryCountCacheAfterCommit(theEntity);
+	}
+
+	/**
+	 * Invalidates the {@link MemoryCacheService.CacheEnum#HISTORY_COUNT} entries that the
+	 * given resource write affects, scheduled to run after the surrounding transaction commits.
+	 */
+	private void invalidateHistoryCountCacheAfterCommit(ResourceTable theEntity) {
+		myMemoryCacheService.invalidateKeyAfterCommit(
+				MemoryCacheService.CacheEnum.HISTORY_COUNT,
+				MemoryCacheService.HistoryCountKey.forInstance(theEntity.getPersistentId()));
+		myMemoryCacheService.invalidateKeyAfterCommit(
+				MemoryCacheService.CacheEnum.HISTORY_COUNT,
+				MemoryCacheService.HistoryCountKey.forType(theEntity.getResourceType()));
+		myMemoryCacheService.invalidateKeyAfterCommit(
+				MemoryCacheService.CacheEnum.HISTORY_COUNT, MemoryCacheService.HistoryCountKey.forSystem());
+	}
+
 	/**
 	 * Method return type for {@link #reindexCorrectCurrentVersion(ResourceTable, ReindexParameters.ReindexSearchParametersEnum)}
 	 */

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -3208,6 +3208,11 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 		}
 	}
 
+	@VisibleForTesting
+	public void setMemoryCacheService(MemoryCacheService theMemoryCacheService) {
+		myMemoryCacheService = theMemoryCacheService;
+	}
+
 	@Override
 	protected void postPersist(ResourceTable theEntity, T theResource, RequestDetails theRequestDetails) {
 		super.postPersist(theEntity, theResource, theRequestDetails);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/JpaHistoryR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/JpaHistoryR4Test.java
@@ -281,7 +281,7 @@ public class JpaHistoryR4Test extends BaseJpaR4SystemTest {
 	}
 
 	@Test
-	public void testInstanceHistory_CacheInvalidatedAfterUpdate() {
+	void testInstanceHistory_AfterUpdate_CacheInvalidated() {
 		IIdType pid = createPatient();
 
 		// Prime the cache: total=1, single entry [v1]
@@ -301,7 +301,7 @@ public class JpaHistoryR4Test extends BaseJpaR4SystemTest {
 	}
 
 	@Test
-	public void testTypeHistory_CacheInvalidatedAfterUpdate() {
+	void testTypeHistory_AfterUpdate_CacheInvalidated() {
 		IIdType pid = createPatient();
 
 		// Prime the type-level cache
@@ -320,7 +320,7 @@ public class JpaHistoryR4Test extends BaseJpaR4SystemTest {
 	}
 
 	@Test
-	public void testSystemHistory_CacheInvalidatedAfterAnyWrite() {
+	void testSystemHistory_AfterAnyWrite_CacheInvalidated() {
 		createPatient();
 
 		// Prime the system-level cache (total=1)
@@ -341,7 +341,7 @@ public class JpaHistoryR4Test extends BaseJpaR4SystemTest {
 	}
 
 	@Test
-	public void testInstanceHistory_CacheInvalidatedAfterDelete() {
+	void testInstanceHistory_AfterDelete_CacheInvalidated() {
 		IIdType pid = createPatient();
 
 		// Prime the cache (total=1)

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/JpaHistoryR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/JpaHistoryR4Test.java
@@ -3,11 +3,14 @@ package ca.uhn.fhir.jpa.dao.r4;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.model.HistoryCountModeEnum;
+import ca.uhn.fhir.rest.param.HistorySearchDateRangeParam;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.util.BundleBuilder;
 import ca.uhn.fhir.util.StopWatch;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -275,6 +278,103 @@ public class JpaHistoryR4Test extends BaseJpaR4SystemTest {
 		// count(*) once, for a total of 21
 		assertEquals(20 + 1, myCaptureQueriesListener.countSelectQueries());
 
+	}
+
+	@Test
+	public void testInstanceHistory_CacheInvalidatedAfterUpdate() {
+		IIdType pid = createPatient();
+
+		// Prime the cache: total=1, single entry [v1]
+		IBundleProvider history = myPatientDao.history(pid, new HistorySearchDateRangeParam(), mySrd);
+		assertEquals(1, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(1);
+
+		// Update -> v2
+		updatePatientById(pid);
+
+		// Second read within the 60s TTL must show both versions, not just v2
+		myCaptureQueriesListener.clear();
+		history = myPatientDao.history(pid, new HistorySearchDateRangeParam(), mySrd);
+		assertEquals(2, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(2);
+		assertCountQueryIssued();
+	}
+
+	@Test
+	public void testTypeHistory_CacheInvalidatedAfterUpdate() {
+		IIdType pid = createPatient();
+
+		// Prime the type-level cache
+		IBundleProvider history = myPatientDao.history(null, null, null, mySrd);
+		assertEquals(1, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(1);
+
+		// Update -> v2
+		updatePatientById(pid);
+
+		myCaptureQueriesListener.clear();
+		history = myPatientDao.history(null, null, null, mySrd);
+		assertEquals(2, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(2);
+		assertCountQueryIssued();
+	}
+
+	@Test
+	public void testSystemHistory_CacheInvalidatedAfterAnyWrite() {
+		createPatient();
+
+		// Prime the system-level cache (total=1)
+		IBundleProvider history = mySystemDao.history(null, null, null, mySrd);
+		assertEquals(1, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(1);
+
+		// Write a different resource type -> system count must move to 2
+		Observation o = new Observation();
+		o.setStatus(Observation.ObservationStatus.FINAL);
+		myObservationDao.create(o, mySrd);
+
+		myCaptureQueriesListener.clear();
+		history = mySystemDao.history(null, null, null, mySrd);
+		assertEquals(2, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(2);
+		assertCountQueryIssued();
+	}
+
+	@Test
+	public void testInstanceHistory_CacheInvalidatedAfterDelete() {
+		IIdType pid = createPatient();
+
+		// Prime the cache (total=1)
+		IBundleProvider history = myPatientDao.history(pid, new HistorySearchDateRangeParam(), mySrd);
+		assertEquals(1, history.sizeOrThrowNpe());
+
+		// Delete creates a deletion-marker row in HFJ_RES_VER -> total should be 2
+		myPatientDao.delete(pid, mySrd);
+
+		myCaptureQueriesListener.clear();
+		history = myPatientDao.history(pid, new HistorySearchDateRangeParam(), mySrd);
+		assertEquals(2, history.sizeOrThrowNpe());
+		assertThat(history.getResources(0, 10)).hasSize(2);
+		assertCountQueryIssued();
+	}
+
+	private IIdType createPatient() {
+		Patient p = new Patient();
+		p.setActive(true);
+		return myPatientDao.create(p, mySrd).getId().toUnqualifiedVersionless();
+	}
+
+	private void updatePatientById(IIdType pid) {
+		Patient updated = new Patient();
+		updated.setId(pid);
+		updated.setActive(false);
+		myPatientDao.update(updated, mySrd);
+	}
+
+	private void assertCountQueryIssued() {
+		assertThat(myCaptureQueriesListener.getSelectQueries())
+				.as("post-write read must re-issue count(*) because the cache was invalidated")
+				.anyMatch(q -> q.getSql(false, false).toLowerCase(Locale.ROOT).startsWith("select count"));
 	}
 
 	private void create20Patients() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/stresstest/GiantTransactionPerfTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/stresstest/GiantTransactionPerfTest.java
@@ -45,6 +45,7 @@ import ca.uhn.fhir.jpa.searchparam.matcher.InMemoryResourceMatcher;
 import ca.uhn.fhir.jpa.searchparam.registry.SearchParamRegistryImpl;
 import ca.uhn.fhir.jpa.searchparam.registry.SearchParameterCanonicalizer;
 import ca.uhn.fhir.jpa.sp.SearchParamPresenceSvcImpl;
+import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
@@ -163,6 +164,8 @@ public class GiantTransactionPerfTest {
 	private IMetaTagSorter myMetaTagSorter;
 	@Mock
 	private IResourceTypeCacheSvc myResourceTypeCacheSvc;
+	@Mock
+	private MemoryCacheService myMemoryCacheService;
 
 	@AfterEach
 	public void afterEach() {
@@ -293,6 +296,7 @@ public class GiantTransactionPerfTest {
 		myEobDao.setResourceHistoryCalculator(myResourceHistoryCalculator);
 		myEobDao.setResourceTypeCacheSvc(myResourceTypeCacheSvc);
 		myEobDao.setInterceptorBroadcasterForUnitTest(myInterceptorSvc);
+		myEobDao.setMemoryCacheService(myMemoryCacheService);
 		myEobDao.start();
 
 		myDaoRegistry.setResourceDaos(Lists.newArrayList(myEobDao));

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/util/MemoryCacheService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/util/MemoryCacheService.java
@@ -20,6 +20,7 @@
 package ca.uhn.fhir.jpa.util;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
@@ -205,6 +206,20 @@ public class MemoryCacheService {
 
 	public void invalidateAllCaches() {
 		myCaches.values().forEach(Cache::invalidateAll);
+	}
+
+	/**
+	 * Schedules a {@code Cache#invalidate(Object)} for the given key to run when the current
+	 * database transaction successfully commits, or executes immediately if no transaction is
+	 * active.
+	 */
+	public <K> void invalidateKeyAfterCommit(CacheEnum theCache, K theKey) {
+		if (!theCache.getKeyType().isAssignableFrom(theKey.getClass())) {
+			throw new IllegalArgumentException(Msg.code(2929) + "Key type " + theKey.getClass()
+					+ " doesn't match expected " + theCache.getKeyType() + " for cache " + theCache);
+		}
+		HapiTransactionService.executeAfterCommitOrExecuteNowIfNoTransactionIsActive(
+				() -> getCache(theCache).invalidate(theKey));
 	}
 
 	private <K, T> Cache<K, T> getCache(CacheEnum theCache) {


### PR DESCRIPTION
### Issue
Run a `_history` query against a Resource, then immediately update the Resource and run the `_history` query again (within 60 seconds), the new version shows up, but not version 1.

### Cause
The HISTORY_COUNT memory cache (60-second TTL) is populated by history reads but never invalidated on writes. When a stale total of 1 sits in the cache, `PersistedJpaBundleProvider.size()` returns 1, the page builder requests rows [0, 1), `HistoryBuilder.fetchEntities` runs `setMaxResults(1)` sorted by myUpdated DESC, and the database — which now correctly contains v1+v2 — returns only the newest row (v2). v1 is silently dropped from the page until the cache entry expires.

### Fix
Invalidate the affected HISTORY_COUNT cache entries whenever the underlying history changes.

Closes #7897 