### PR TITLE
Set the CodeSystemVersion for all concepts during ICD-10 upload

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7903-fix-icd-10-import.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7903-fix-icd-10-import.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7903
+title: "Previously, the ICD-10 import failed with a NullPointerException.
+  This fixes this exception as well as a longer standing problem
+  where child concepts are not properly associated with the CodeSystemVersion."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/icd10/Icd10Loader.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/icd10/Icd10Loader.java
@@ -80,6 +80,7 @@ public class Icd10Loader {
 			boolean rootConcept = getChildrenByTagName(aClass, "SuperClass").isEmpty();
 			TermConcept termConcept = rootConcept ? codeSystemVersion.addConcept() : new TermConcept();
 			termConcept.setCode(code);
+			termConcept.setCodeSystemVersion(codeSystemVersion);
 
 			// Preferred label and other properties
 			for (Element rubric : getChildrenByTagName(aClass, "Rubric")) {

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/term/icd10/Icd10LoaderTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/term/icd10/Icd10LoaderTest.java
@@ -40,6 +40,11 @@ public class Icd10LoaderTest {
 		assertThat(properties).hasSize(2);
 		assertEquals("Include fruit", chapterA.getStringProperty("inclusion"));
 		assertEquals("Things that are not fruit", chapterA.getStringProperty("exclusion"));
+		TermConcept chapterA3 = chapterA.getChildCodes().stream()
+			.flatMap(concept -> concept.getChildCodes().stream())
+			.filter(concept -> "A3".equals(concept.getCode()))
+			.findFirst().orElseThrow();
+		assertEquals("Banana is a fruit.", chapterA3.getStringProperty("text"));
 
 		assertThat(toTree(rootConcepts)).isEqualTo("""
 						A "Fruit"

--- a/hapi-fhir-jpaserver-test-utilities/src/test/resources/icd/icd10-dummy-test-en.xml
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/resources/icd/icd10-dummy-test-en.xml
@@ -44,6 +44,11 @@
 		<Rubric kind="preferred">
 			<Label xml:lang="en" xml:space="default">Bananas</Label>
 		</Rubric>
+		<Rubric id="id-icd10_20190322-1587556953274-8" kind="text">
+			<Label xml:lang="en" xml:space="default">
+				<Para>Banana is a fruit.</Para>
+			</Label>
+		</Rubric>
 	</Class>
 	<Class code="B1-B2" kind="block">
 		<SuperClass code="B"/>


### PR DESCRIPTION
The ICD-10 upload does not work atm due to a NullPointerException for child concepts which also have "Rubric" other than "preferred" (which is the case for the international ICD-10 ClaML file).
Additionally, it led to further problems when storing the code system as it is expected that all concepts are associated with the CodeSystemVersion and this is not implicitly set for child concepts (see #6417).

The ICD-10 test has been adjusted to demonstrate the NullPointerException before the fix and the working solution after the fix.

Fixes #6417