### PR TITLE
Fix remote terminology property handling for Snowstorm

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7904-fix-snowstorm-as-remote-terminology-service.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7904-fix-snowstorm-as-remote-terminology-service.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 7904
+title: "Previously, using Snowstorm as a remote terminology service did not work when looking up codes
+  because Snowstorm uses valueString instead of valueCode for property names which is what hapi-fhir expected.
+  This fix adds handling for valueString and therefore allows using Snowstorm for remote lookups."

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -450,34 +450,43 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 		}
 
 		List<Base> values = property.getValues();
-		ParametersParameterComponent firstPart = (ParametersParameterComponent) values.get(0);
-		String propertyName = ((CodeType) firstPart.getValue()).getValue();
+		if (values.get(0) instanceof ParametersParameterComponent firstPart
+				&& values.get(1) instanceof ParametersParameterComponent secondPart) {
 
-		ParametersParameterComponent secondPart = (ParametersParameterComponent) values.get(1);
-		Type value = secondPart.getValue();
+			String propertyName = firstPart.getValue() instanceof CodeType c
+					? c.getValue()
+					: firstPart.getValue() instanceof StringType s ? s.getValue() : null;
+			if (propertyName == null) {
+				return null;
+			}
 
-		if (value != null) {
-			return createConceptPropertyR4(propertyName, value);
-		}
+			Type value = secondPart.getValue();
 
-		String groupName = secondPart.getName();
-		if (!"subproperty".equals(groupName)) {
+			if (value != null) {
+				return createConceptPropertyR4(propertyName, value);
+			}
+
+			String groupName = secondPart.getName();
+			if (!"subproperty".equals(groupName)) {
+				return null;
+			}
+
+			// handle property group (a property containing sub-properties)
+			GroupConceptProperty groupConceptProperty = new GroupConceptProperty(propertyName);
+
+			// we already retrieved the property name (group name) as first element, next will be the sub-properties.
+			// there is no dedicated value for a property group as it is an aggregate
+			for (int i = 1; i < values.size(); i++) {
+				ParametersParameterComponent nextPart = (ParametersParameterComponent) values.get(i);
+				BaseConceptProperty subProperty = createConceptPropertyR4(nextPart);
+				if (subProperty != null) {
+					groupConceptProperty.addSubProperty(subProperty);
+				}
+			}
+			return groupConceptProperty;
+		} else {
 			return null;
 		}
-
-		// handle property group (a property containing sub-properties)
-		GroupConceptProperty groupConceptProperty = new GroupConceptProperty(propertyName);
-
-		// we already retrieved the property name (group name) as first element, next will be the sub-properties.
-		// there is no dedicated value for a property group as it is an aggregate
-		for (int i = 1; i < values.size(); i++) {
-			ParametersParameterComponent nextPart = (ParametersParameterComponent) values.get(i);
-			BaseConceptProperty subProperty = createConceptPropertyR4(nextPart);
-			if (subProperty != null) {
-				groupConceptProperty.addSubProperty(subProperty);
-			}
-		}
-		return groupConceptProperty;
 	}
 
 	private static BaseConceptProperty createConceptPropertyR4(final String theName, final Type theValue) {

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/RemoteTerminologyLookupCodeWithResponseFileR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/RemoteTerminologyLookupCodeWithResponseFileR4Test.java
@@ -29,6 +29,7 @@ import java.util.List;
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.OPERATION_LOOKUP;
 import static ca.uhn.fhir.test.utilities.validation.IValidationProviders.CODE;
 import static ca.uhn.fhir.test.utilities.validation.IValidationProviders.CODE_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -109,5 +110,31 @@ public class RemoteTerminologyLookupCodeWithResponseFileR4Test {
 		String expected = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(returnParams);
 
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	void lookupCode_withSimplifiedSnowstormOutput_convertsCorrectly() {
+		String outputFile = "/terminology/CodeSystem-lookup-output-simplified-snowstorm.json";
+		myCodeSystemProvider.addTerminologyResponse(OPERATION_LOOKUP, CODE_SYSTEM, CODE, ourCtx, outputFile);
+
+		LookupCodeRequest request = new LookupCodeRequest(CODE_SYSTEM, CODE, null, null);
+
+		// test
+		IValidationSupport.LookupCodeResult outcome = mySvc.lookupCode(null, request);
+		assertNotNull(outcome);
+		assertThat(outcome.getCodeSystemDisplayName()).isEqualTo("International Edition");
+		assertThat(outcome.getProperties()).anySatisfy(property -> {
+			assertThat(property.getPropertyName()).isEqualTo("effectiveTime");
+			assertThat(property.getType()).isEqualTo("string");
+			assertThat(((IValidationSupport.StringConceptProperty)property).getValue()).isEqualTo("20231001");
+		}).anySatisfy(property -> {
+			assertThat(property.getPropertyName()).isEqualTo("moduleId");
+			assertThat(property.getType()).isEqualTo("code");
+			assertThat(((IValidationSupport.CodeConceptProperty)property).getValue()).isEqualTo("900000000000207008");
+		}).anySatisfy(property -> {
+			assertThat(property.getPropertyName()).isEqualTo("parent");
+			assertThat(property.getType()).isEqualTo("code");
+			assertThat(((IValidationSupport.CodeConceptProperty)property).getValue()).isEqualTo("12345");
+		}).hasSize(3);
 	}
 }

--- a/hapi-fhir-validation/src/test/resources/terminology/CodeSystem-lookup-output-simplified-snowstorm.json
+++ b/hapi-fhir-validation/src/test/resources/terminology/CodeSystem-lookup-output-simplified-snowstorm.json
@@ -1,0 +1,64 @@
+{
+	"resourceType": "Parameters",
+	"parameter": [
+		{
+			"name": "code",
+			"valueString": "1234"
+		},
+		{
+			"name": "name",
+			"valueString": "International Edition"
+		},
+		{
+			"name": "system",
+			"valueString": "http://snomed.info/sct"
+		},
+		{
+			"name": "version",
+			"valueString": "http://snomed.info/sct/900000000000207008/version/20250801"
+		},
+		{
+			"name": "inactive",
+			"valueBoolean": false
+		},
+		{
+			"name": "property",
+			"part": [
+				{
+					"name": "code",
+					"valueString": "effectiveTime"
+				},
+				{
+					"name": "valueString",
+					"valueString": "20231001"
+				}
+			]
+		},
+		{
+			"name": "property",
+			"part": [
+				{
+					"name": "code",
+					"valueString": "moduleId"
+				},
+				{
+					"name": "value",
+					"valueCode": "900000000000207008"
+				}
+			]
+		},
+		{
+			"name": "property",
+			"part": [
+				{
+					"name": "code",
+					"valueString": "parent"
+				},
+				{
+					"name": "value",
+					"valueCode": "12345"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Snowstorm returns properties where the `code` part uses `valueString` instead of `valueCode` (which is what was expected in hapi-fhir). This commit changes the behavior to also allow `valueString` and therefore allows the usage of Snowstorm as a remote terminology server in hapi-fhir.

Fixes #7212 