### PR TITLE
Replace pointcut SVG diagrams with mermaid snippets

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/client.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/client.md
@@ -1,0 +1,28 @@
+```mermaid
+flowchart TB
+{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd}}
+    App(["Your application"]):::app
+    MethodCalled["Client Method<br/>Called"]:::step
+    Encode["Resource<br/>encoded as JSON"]:::step
+    RequestCreated["HTTP Request<br/>Created"]:::step
+    RequestSent["HTTP Request<br/>Sent"]:::step
+    ResponseReceived["HTTP Response<br/>Received"]:::step
+    Parsed["Response<br/>Parsed"]:::step
+
+    RequestHook["Java Hook:<br/>CLIENT_REQUEST"]:::javahook
+    ResponseHook["Java Hook:<br/>CLIENT_RESPONSE"]:::javahook
+
+    App e1@-- "client.update()<br/>&nbsp;&nbsp;.resource(myPatient)<br/>&nbsp;&nbsp;.execute();" --> MethodCalled
+    MethodCalled e2@--> Encode
+    Encode e3@--> RequestCreated
+    RequestCreated -.-> RequestHook
+    RequestHook e4@--> RequestSent
+    RequestSent e5@--> ResponseReceived
+    ResponseReceived -.-> ResponseHook
+    ResponseHook e6@--> Parsed
+    Parsed e7@--> MethodCalled
+    MethodCalled e8@-- "return" --> App
+
+    click RequestHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#CLIENT_REQUEST" "Open CLIENT_REQUEST pointcut docs"
+    click ResponseHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#CLIENT_RESPONSE" "Open CLIENT_RESPONSE pointcut docs"
+```

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/client.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/client.md
@@ -1,6 +1,5 @@
 ```mermaid
 flowchart TB
-{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd}}
     App(["Your application"]):::app
     MethodCalled["Client Method<br/>Called"]:::step
     Encode["Resource<br/>encoded as JSON"]:::step
@@ -12,16 +11,16 @@ flowchart TB
     RequestHook["Java Hook:<br/>CLIENT_REQUEST"]:::javahook
     ResponseHook["Java Hook:<br/>CLIENT_RESPONSE"]:::javahook
 
-    App e1@-- "client.update()<br/>&nbsp;&nbsp;.resource(myPatient)<br/>&nbsp;&nbsp;.execute();" --> MethodCalled
-    MethodCalled e2@--> Encode
-    Encode e3@--> RequestCreated
-    RequestCreated -.-> RequestHook
-    RequestHook e4@--> RequestSent
-    RequestSent e5@--> ResponseReceived
-    ResponseReceived -.-> ResponseHook
-    ResponseHook e6@--> Parsed
-    Parsed e7@--> MethodCalled
-    MethodCalled e8@-- "return" --> App
+    App -- "client.update()<br/>&nbsp;&nbsp;.resource(myPatient)<br/>&nbsp;&nbsp;.execute();" --> MethodCalled
+    MethodCalled --> Encode
+    Encode --> RequestCreated
+    RequestCreated --> RequestHook
+    RequestHook --> RequestSent
+    RequestSent --> ResponseReceived
+    ResponseReceived --> ResponseHook
+    ResponseHook --> Parsed
+    Parsed --> MethodCalled
+    MethodCalled -- "return" --> App
 
     click RequestHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#CLIENT_REQUEST" "Open CLIENT_REQUEST pointcut docs"
     click ResponseHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#CLIENT_RESPONSE" "Open CLIENT_RESPONSE pointcut docs"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/persistence.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/persistence.md
@@ -1,6 +1,5 @@
 ```mermaid
 flowchart TB
-{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd}}
     Client(["HTTP<br/>Client"]):::app
 
     subgraph PlainServer["Plain Server"]
@@ -30,27 +29,27 @@ flowchart TB
         TxnCommit["Database transaction<br/>committed"]:::step
     end
 
-    Client e1@-- "PUT /Patient/123<br/>Content-Type: application/json" --> Receive
-    Receive e2@--> TxnOpen
-    TxnOpen e3@--> Decide
+    Client -- "PUT /Patient/123<br/>Content-Type: application/json" --> Receive
+    Receive --> TxnOpen
+    TxnOpen --> Decide
 
-    Decide e4@-- "Read" --> CacheCheck
-    CacheCheck -.-> PreCheckHook
-    PreCheckHook e5@--> Search
-    Search -.-> PreSearchHook
-    PreSearchHook e6@--> Loaded
+    Decide -- "Read" --> CacheCheck
+    CacheCheck --> PreCheckHook
+    PreCheckHook --> Search
+    Search --> PreSearchHook
+    PreSearchHook --> Loaded
 
-    Decide e7@-- "Write" --> FetchExisting
-    FetchExisting -.-> PreStorageHook
-    PreStorageHook e8@--> EntityUpdated
-    EntityUpdated -.-> PreCommitHook
-    PreCommitHook e9@--> Loaded
+    Decide -- "Write" --> FetchExisting
+    FetchExisting --> PreStorageHook
+    PreStorageHook --> EntityUpdated
+    EntityUpdated --> PreCommitHook
+    PreCommitHook --> Loaded
 
-    Loaded -.-> PreAccessHook
-    PreAccessHook e10@--> TxnCommit
-    TxnCommit e11@--> Response
-    Response -.-> PreShowHook
-    PreShowHook e12@--> Client
+    Loaded --> PreAccessHook
+    PreAccessHook --> TxnCommit
+    TxnCommit --> Response
+    Response --> PreShowHook
+    PreShowHook --> Client
 
     click PreShowHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#STORAGE_PRESHOW_RESOURCES" "Open STORAGE_PRESHOW_RESOURCES pointcut docs"
     click PreCheckHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#STORAGE_PRECHECK_FOR_CACHED_SEARCH" "Open STORAGE_PRECHECK_FOR_CACHED_SEARCH pointcut docs"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/persistence.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/persistence.md
@@ -1,0 +1,61 @@
+```mermaid
+flowchart TB
+{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd}}
+    Client(["HTTP<br/>Client"]):::app
+
+    subgraph PlainServer["Plain Server"]
+        direction TB
+        Receive["Server Receives<br/>HTTP Request"]:::step
+        Response["Response<br/>Prepared"]:::step
+        PreShowHook["Java Hook:<br/>STORAGE_PRESHOW_RESOURCES"]:::javahook
+    end
+
+    subgraph JPAStorage["JPA Server / Storage"]
+        direction TB
+        TxnOpen["Database transaction<br/>opened"]:::step
+        Decide{"Read or<br/>Write?"}
+
+        CacheCheck["Check for cached<br/>search results<br/>(search op only)"]:::step
+        PreCheckHook["Java Hook:<br/>STORAGE_PRECHECK_FOR_CACHED_SEARCH"]:::javahook
+        Search["Read / Search /<br/>History Performed"]:::step
+        PreSearchHook["Java Hook:<br/>STORAGE_PRESEARCH_REGISTERED"]:::javahook
+
+        FetchExisting["Existing database entity<br/>to modify (if any) fetched"]:::step
+        PreStorageHook["Java Hook:<br/>STORAGE_PRESTORAGE_RESOURCE_CREATED<br/>STORAGE_PRESTORAGE_RESOURCE_UPDATED<br/>STORAGE_PRESTORAGE_RESOURCE_DELETED<br/>STORAGE_PRESTORAGE_CLIENT_ASSIGNED_ID"]:::javahook
+        EntityUpdated["Database entity<br/>updated"]:::step
+        PreCommitHook["Java Hook:<br/>STORAGE_PRECOMMIT_RESOURCE_CREATED<br/>STORAGE_PRECOMMIT_RESOURCE_UPDATED<br/>STORAGE_PRECOMMIT_RESOURCE_DELETED"]:::javahook
+
+        Loaded["Resource(s) to<br/>return loaded"]:::step
+        PreAccessHook["Java Hook:<br/>STORAGE_PREACCESS_RESOURCES"]:::javahook
+        TxnCommit["Database transaction<br/>committed"]:::step
+    end
+
+    Client e1@-- "PUT /Patient/123<br/>Content-Type: application/json" --> Receive
+    Receive e2@--> TxnOpen
+    TxnOpen e3@--> Decide
+
+    Decide e4@-- "Read" --> CacheCheck
+    CacheCheck -.-> PreCheckHook
+    PreCheckHook e5@--> Search
+    Search -.-> PreSearchHook
+    PreSearchHook e6@--> Loaded
+
+    Decide e7@-- "Write" --> FetchExisting
+    FetchExisting -.-> PreStorageHook
+    PreStorageHook e8@--> EntityUpdated
+    EntityUpdated -.-> PreCommitHook
+    PreCommitHook e9@--> Loaded
+
+    Loaded -.-> PreAccessHook
+    PreAccessHook e10@--> TxnCommit
+    TxnCommit e11@--> Response
+    Response -.-> PreShowHook
+    PreShowHook e12@--> Client
+
+    click PreShowHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#STORAGE_PRESHOW_RESOURCES" "Open STORAGE_PRESHOW_RESOURCES pointcut docs"
+    click PreCheckHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#STORAGE_PRECHECK_FOR_CACHED_SEARCH" "Open STORAGE_PRECHECK_FOR_CACHED_SEARCH pointcut docs"
+    click PreSearchHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#STORAGE_PRESEARCH_REGISTERED" "Open STORAGE_PRESEARCH_REGISTERED pointcut docs"
+    click PreStorageHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html" "Open HAPI Pointcut docs (STORAGE_PRESTORAGE_RESOURCE_* family)"
+    click PreCommitHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html" "Open HAPI Pointcut docs (STORAGE_PRECOMMIT_RESOURCE_* family)"
+    click PreAccessHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#STORAGE_PREACCESS_RESOURCES" "Open STORAGE_PREACCESS_RESOURCES pointcut docs"
+```

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/server.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/server.md
@@ -1,0 +1,62 @@
+```mermaid
+flowchart TB
+{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd}}
+    Client(["HTTP<br/>Client"]):::app
+    Receive["Server Receives<br/>HTTP Request"]:::step
+    MapURL["Server Maps Request<br/>URL into Operation"]:::step
+    LocateHandler["Server Locates<br/>appropriate handler<br/>method"]:::step
+    Process["Server Processes<br/>Operation"]:::step
+    Response["Response<br/>Prepared"]:::step
+    Sent["HTTP Response<br/>Sent"]:::step
+    ExceptionTranslated["Exception Translated<br/>into OperationOutcome"]:::step
+
+    PreProcHook["Java Hook:<br/>SERVER_INCOMING_REQUEST_PRE_PROCESSED"]:::javahook
+    PreHandlerSelectedHook["Java Hook:<br/>SERVER_INCOMING_REQUEST_PRE_HANDLER_SELECTED"]:::javahook
+    PostProcHook["Java Hook:<br/>SERVER_INCOMING_REQUEST_POST_PROCESSED"]:::javahook
+    PreHandledHook["Java Hook:<br/>SERVER_INCOMING_REQUEST_PRE_HANDLED"]:::javahook
+    OutgoingHook["Java Hook:<br/>SERVER_OUTGOING_RESPONSE<br/>SERVER_OUTGOING_GRAPHQL_RESPONSE"]:::javahook
+    WriterCreatedHook["Java Hook:<br/>SERVER_OUTGOING_WRITER_CREATED"]:::javahook
+    CompletedNormallyHook["Java Hook:<br/>SERVER_PROCESSING_COMPLETED_NORMALLY"]:::javahook
+    CompletedHook["Java Hook:<br/>SERVER_PROCESSING_COMPLETED"]:::javahook
+
+    HandleExceptionHook["Java Hook:<br/>SERVER_HANDLE_EXCEPTION"]:::javahook
+    PreProcExceptionHook["Java Hook:<br/>SERVER_PRE_PROCESS_OUTGOING_EXCEPTION"]:::javahook
+    OutcomeHook["Java Hook:<br/>SERVER_OUTGOING_FAILURE_OPERATIONOUTCOME"]:::javahook
+
+    Client e1@-- "PUT /Patient/123<br/>Content-Type: application/json" --> Receive
+    Receive -.-> PreProcHook
+    PreProcHook e2@--> MapURL
+    MapURL -.-> PreHandlerSelectedHook
+    PreHandlerSelectedHook e3@--> LocateHandler
+    LocateHandler -.-> PostProcHook
+    PostProcHook e4@--> PreHandledHook
+    PreHandledHook e5@--> Process
+
+    Process e6@-- "normal" --> Response
+    Response -.-> OutgoingHook
+    OutgoingHook e7@--> WriterCreatedHook
+    WriterCreatedHook e8@--> Sent
+
+    Process e9@-- "exception" --> HandleExceptionHook
+    HandleExceptionHook e10@--> PreProcExceptionHook
+    PreProcExceptionHook e11@--> ExceptionTranslated
+    ExceptionTranslated -.-> OutcomeHook
+    OutcomeHook e12@--> Sent
+
+    Sent e13@-- "normal" --> CompletedNormallyHook
+    CompletedNormallyHook e14@--> CompletedHook
+    Sent e15@-- "exception" --> CompletedHook
+    CompletedHook e16@--> Client
+
+    click PreProcHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_INCOMING_REQUEST_PRE_PROCESSED" "Open SERVER_INCOMING_REQUEST_PRE_PROCESSED pointcut docs"
+    click PreHandlerSelectedHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_INCOMING_REQUEST_PRE_HANDLER_SELECTED" "Open SERVER_INCOMING_REQUEST_PRE_HANDLER_SELECTED pointcut docs"
+    click PostProcHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_INCOMING_REQUEST_POST_PROCESSED" "Open SERVER_INCOMING_REQUEST_POST_PROCESSED pointcut docs"
+    click PreHandledHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_INCOMING_REQUEST_PRE_HANDLED" "Open SERVER_INCOMING_REQUEST_PRE_HANDLED pointcut docs"
+    click OutgoingHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html" "Open HAPI Pointcut docs (SERVER_OUTGOING_RESPONSE / SERVER_OUTGOING_GRAPHQL_RESPONSE)"
+    click WriterCreatedHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_OUTGOING_WRITER_CREATED" "Open SERVER_OUTGOING_WRITER_CREATED pointcut docs"
+    click CompletedNormallyHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_PROCESSING_COMPLETED_NORMALLY" "Open SERVER_PROCESSING_COMPLETED_NORMALLY pointcut docs"
+    click CompletedHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_PROCESSING_COMPLETED" "Open SERVER_PROCESSING_COMPLETED pointcut docs"
+    click HandleExceptionHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_HANDLE_EXCEPTION" "Open SERVER_HANDLE_EXCEPTION pointcut docs"
+    click PreProcExceptionHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_PRE_PROCESS_OUTGOING_EXCEPTION" "Open SERVER_PRE_PROCESS_OUTGOING_EXCEPTION pointcut docs"
+    click OutcomeHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_OUTGOING_FAILURE_OPERATIONOUTCOME" "Open SERVER_OUTGOING_FAILURE_OPERATIONOUTCOME pointcut docs"
+```

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/server.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/server.md
@@ -1,6 +1,5 @@
 ```mermaid
 flowchart TB
-{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd}}
     Client(["HTTP<br/>Client"]):::app
     Receive["Server Receives<br/>HTTP Request"]:::step
     MapURL["Server Maps Request<br/>URL into Operation"]:::step
@@ -23,30 +22,30 @@ flowchart TB
     PreProcExceptionHook["Java Hook:<br/>SERVER_PRE_PROCESS_OUTGOING_EXCEPTION"]:::javahook
     OutcomeHook["Java Hook:<br/>SERVER_OUTGOING_FAILURE_OPERATIONOUTCOME"]:::javahook
 
-    Client e1@-- "PUT /Patient/123<br/>Content-Type: application/json" --> Receive
-    Receive -.-> PreProcHook
-    PreProcHook e2@--> MapURL
-    MapURL -.-> PreHandlerSelectedHook
-    PreHandlerSelectedHook e3@--> LocateHandler
-    LocateHandler -.-> PostProcHook
-    PostProcHook e4@--> PreHandledHook
-    PreHandledHook e5@--> Process
+    Client -- "PUT /Patient/123<br/>Content-Type: application/json" --> Receive
+    Receive --> PreProcHook
+    PreProcHook --> MapURL
+    MapURL --> PreHandlerSelectedHook
+    PreHandlerSelectedHook --> LocateHandler
+    LocateHandler --> PostProcHook
+    PostProcHook --> PreHandledHook
+    PreHandledHook --> Process
 
-    Process e6@-- "normal" --> Response
-    Response -.-> OutgoingHook
-    OutgoingHook e7@--> WriterCreatedHook
-    WriterCreatedHook e8@--> Sent
+    Process -- "normal" --> Response
+    Response --> OutgoingHook
+    OutgoingHook --> WriterCreatedHook
+    WriterCreatedHook --> Sent
 
-    Process e9@-- "exception" --> HandleExceptionHook
-    HandleExceptionHook e10@--> PreProcExceptionHook
-    PreProcExceptionHook e11@--> ExceptionTranslated
-    ExceptionTranslated -.-> OutcomeHook
-    OutcomeHook e12@--> Sent
+    Process -- "exception" --> HandleExceptionHook
+    HandleExceptionHook --> PreProcExceptionHook
+    PreProcExceptionHook --> ExceptionTranslated
+    ExceptionTranslated --> OutcomeHook
+    OutcomeHook --> Sent
 
-    Sent e13@-- "normal" --> CompletedNormallyHook
-    CompletedNormallyHook e14@--> CompletedHook
-    Sent e15@-- "exception" --> CompletedHook
-    CompletedHook e16@--> Client
+    Sent -- "normal" --> CompletedNormallyHook
+    CompletedNormallyHook --> CompletedHook
+    Sent -- "exception" --> CompletedHook
+    CompletedHook --> Client
 
     click PreProcHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_INCOMING_REQUEST_PRE_PROCESSED" "Open SERVER_INCOMING_REQUEST_PRE_PROCESSED pointcut docs"
     click PreHandlerSelectedHook "/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html#SERVER_INCOMING_REQUEST_PRE_HANDLER_SELECTED" "Open SERVER_INCOMING_REQUEST_PRE_HANDLER_SELECTED pointcut docs"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd
@@ -1,0 +1,4 @@
+classDef app fill:#c3f7c8,stroke:#3a414a
+classDef step fill:#cfe4ff,stroke:#3a414a
+classDef jshook fill:#fff3d9,stroke:#3a414a
+classDef javahook fill:#dfe3e8,stroke:#3a414a

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/mermaid_palette.mmd
@@ -1,4 +1,0 @@
-classDef app fill:#c3f7c8,stroke:#3a414a
-classDef step fill:#cfe4ff,stroke:#3a414a
-classDef jshook fill:#fff3d9,stroke:#3a414a
-classDef javahook fill:#dfe3e8,stroke:#3a414a

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/client_pointcuts.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/client_pointcuts.md
@@ -2,8 +2,7 @@
 
 The following diagram shows the request processing pipeline for processing a client request.
 
-<a href="/hapi-fhir/docs/images/interceptors-client-pipeline.svg" target="_blank">Expand</a>
-<img src="/hapi-fhir/docs/images/interceptors-client-pipeline.svg" alt="Client Pipeline"/>
+{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/client.md}}
 
 See the [Pointcut](/apidocs/hapi-fhir-base/ca/uhn/fhir/interceptor/api/Pointcut.html) JavaDoc for details about these pointcuts, what arguments are allowed etc.
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/server_pointcuts.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/interceptors/server_pointcuts.md
@@ -2,13 +2,11 @@
 
 The following diagram shows the request processing pipeline for processing a server request. You may click on the diagram to enlarge it.
 
-<a href="server_pointcuts/interceptors-server-pipeline.svg" target="_blank">Expand</a>
-<img src="server_pointcuts/interceptors-server-pipeline.svg" alt="Server Pipeline"/>
+{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/server.md}}
 
 # Storage / JPA Server Pointcuts
 
 The following diagram shows the request processing pipeline for processing a server request. You may click on the diagram to enlarge it.
 
-<a href="server_pointcuts/interceptors-server-jpa-pipeline.svg" target="_blank">Expand</a>
-<img src="server_pointcuts/interceptors-server-jpa-pipeline.svg" alt="Server Pipeline"/>
+{{snippet:file:hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/_snippets/diagrams/pointcuts/persistence.md}}
 


### PR DESCRIPTION
The three pointcut SVGs on interceptors/client_pointcuts.md and interceptors/server_pointcuts.md (Client Pipeline, Plain Server Pipeline, JPA Server Pipeline) are replaced with mermaid recreations stored centrally under
hapi-fhir-docs/.../_snippets/diagrams/pointcuts/{client,server, persistence}.md and included via the existing {{snippet:file:...}} directive. Adds a shared mermaid_palette.mmd under _snippets/ that each diagram includes for the app/step/javahook classDefs.

The mermaid replicas mirror the source SVGs:

- client.md: round-trip flow for a FHIR client call from app through encode/request/sent/received/parsed and back, with CLIENT_REQUEST before the HTTP send and CLIENT_RESPONSE after the HTTP receive.

- server.md: full plain-server lifecycle with all 10 SERVER_* happy-path pointcuts plus the 3-hook exception branch (HANDLE_ EXCEPTION, PRE_PROCESS_OUTGOING_EXCEPTION, OUTGOING_FAILURE_ OPERATIONOUTCOME), with the normal/exception split at ServerProcessesOperation and a second decision at HTTPResponseSent where PROCESSING_COMPLETED_NORMALLY fires only on the normal path before both paths converge at PROCESSING_COMPLETED.

- persistence.md: plain-server + JPA-storage subgraphs with a Read/Write fan-out off the transaction-opened node, the PRESEARCH_REGISTERED / PRECHECK_FOR_CACHED_SEARCH hooks on the read branch, the PRESTORAGE_RESOURCE_* + CLIENT_ASSIGNED_ID and PRECOMMIT_RESOURCE_* families on the write branch, merging at Resource(s) to return loaded with PREACCESS_RESOURCES, commit, and PRESHOW_RESOURCES on the way out to the client.

The original SVG files (interceptors-client-pipeline.svg, interceptors-server-pipeline.svg, interceptors-server-jpa-pipeline. svg) are left in place; future PRs can delete them.
