### PR TITLE
Add raw post ability to fhir client

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -767,7 +767,7 @@ public abstract class BaseParser implements IParser {
 	@SuppressWarnings("cast")
 	@Override
 	public <T extends IBaseResource> T parseResource(Class<T> theResourceType, String theMessageString) {
-		Validate.notBlank(theMessageString, "theMessageString must not be null or blank");
+		Validate.notNull(theMessageString, "theMessageString must not be null");
 		StringReader reader = new StringReader(theMessageString);
 		return parseResource(theResourceType, reader);
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -767,6 +767,7 @@ public abstract class BaseParser implements IParser {
 	@SuppressWarnings("cast")
 	@Override
 	public <T extends IBaseResource> T parseResource(Class<T> theResourceType, String theMessageString) {
+		Validate.notBlank(theMessageString, "theMessageString must not be null or blank");
 		StringReader reader = new StringReader(theMessageString);
 		return parseResource(theResourceType, reader);
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IRawHttp.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IRawHttp.java
@@ -36,6 +36,15 @@ public interface IRawHttp {
 	 * @param theUrl The URL to send the GET request to. Can be absolute or relative
 	 *               to the client's base URL.
 	 * @return A builder for configuring and executing the HTTP GET request
+	 * @since 8.6.0
 	 */
 	IClientHttpExecutable<IClientHttpExecutable<?, IEntityResult>, IEntityResult> get(String theUrl);
+
+	/**
+	 * Creates a POST request to the specified URL.
+	 *
+	 * @since 8.12.0
+	 */
+	IClientHttpExecutable<IClientHttpExecutable<?, IEntityResult>, IEntityResult> post(
+			String theUrl, RawRequestEntity theRequest);
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/RawRequestEntity.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/RawRequestEntity.java
@@ -1,0 +1,26 @@
+package ca.uhn.fhir.rest.gclient;
+
+public class RawRequestEntity {
+	private final String myContentType;
+	private final byte[] myBytes;
+
+	/**
+	 * Constructor
+	 *
+	 * @param theContentType The "Content-Type" header value of the request (e.g. "application/json")
+	 * @param theBytes       The bytes to use as the request body payload
+	 * @since 8.12.0
+	 */
+	public RawRequestEntity(String theContentType, byte[] theBytes) {
+		myContentType = theContentType;
+		myBytes = theBytes;
+	}
+
+	public String getContentType() {
+		return myContentType;
+	}
+
+	public byte[] getBytes() {
+		return myBytes;
+	}
+}

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/GenericClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/GenericClient.java
@@ -61,6 +61,7 @@ import ca.uhn.fhir.rest.client.method.DeleteMethodBinding;
 import ca.uhn.fhir.rest.client.method.HistoryMethodBinding;
 import ca.uhn.fhir.rest.client.method.HttpDeleteClientInvocation;
 import ca.uhn.fhir.rest.client.method.HttpGetClientInvocation;
+import ca.uhn.fhir.rest.client.method.HttpRawClientInvocation;
 import ca.uhn.fhir.rest.client.method.HttpSimpleClientInvocation;
 import ca.uhn.fhir.rest.client.method.IClientResponseHandler;
 import ca.uhn.fhir.rest.client.method.MethodUtil;
@@ -126,6 +127,7 @@ import ca.uhn.fhir.rest.gclient.IUpdateWithQuery;
 import ca.uhn.fhir.rest.gclient.IUpdateWithQueryTyped;
 import ca.uhn.fhir.rest.gclient.IValidate;
 import ca.uhn.fhir.rest.gclient.IValidateUntyped;
+import ca.uhn.fhir.rest.gclient.RawRequestEntity;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -483,12 +485,18 @@ public class GenericClient extends BaseClient implements IGenericClient {
 
 		@Override
 		public IClientHttpExecutable<IClientHttpExecutable<?, IEntityResult>, IEntityResult> get(String theUrl) {
-			return new RawGetEntityResultInternal(theUrl);
+			return new RawGetEntityResultInternal<>(theUrl);
+		}
+
+		@Override
+		public IClientHttpExecutable<IClientHttpExecutable<?, IEntityResult>, IEntityResult> post(
+				String theUrl, RawRequestEntity theRequest) {
+			return new RawPostEntityResultInternal<>(theUrl, theRequest);
 		}
 	}
 
-	class RawGetEntityResultInternal<T extends IClientHttpExecutable<?, EntityResult>>
-			extends BaseClientHttpExecutable<T, EntityResult> {
+	class RawGetEntityResultInternal<T extends IClientHttpExecutable<?, IEntityResult>>
+			extends BaseClientHttpExecutable<T, IEntityResult> {
 		final String myUrl;
 
 		public RawGetEntityResultInternal(String theUrl) {
@@ -496,7 +504,7 @@ public class GenericClient extends BaseClient implements IGenericClient {
 		}
 
 		@Override
-		public EntityResult execute() {
+		public IEntityResult execute() {
 			IClientResponseHandler<EntityResult> binding = new EntityResultResponseHandler();
 			HttpGetClientInvocation invocation = new HttpGetClientInvocation(myContext, myUrl);
 			return invokeClient(
@@ -514,7 +522,37 @@ public class GenericClient extends BaseClient implements IGenericClient {
 		}
 	}
 
-	private abstract class BaseClientHttpExecutable<T extends IClientHttpExecutable<?, Y>, Y>
+	class RawPostEntityResultInternal<T extends IClientHttpExecutable<?, IEntityResult>>
+			extends BaseClientHttpExecutable<T, IEntityResult> {
+		private final String myUrl;
+		private final RawRequestEntity myRequest;
+
+		public RawPostEntityResultInternal(String theUrl, RawRequestEntity theRequest) {
+			myUrl = theUrl;
+			myRequest = theRequest;
+		}
+
+		@Override
+		public IEntityResult execute() {
+			IClientResponseHandler<EntityResult> binding = new EntityResultResponseHandler();
+			HttpRawClientInvocation invocation = new HttpRawClientInvocation(myContext, myUrl, myRequest);
+
+			return invokeClient(
+					myContext,
+					binding,
+					invocation,
+					null,
+					null,
+					false,
+					null,
+					null,
+					null,
+					myCustomAcceptHeaderValue,
+					myCustomHeaderValues);
+		}
+	}
+
+	private abstract static class BaseClientHttpExecutable<T extends IClientHttpExecutable<?, Y>, Y>
 			implements IClientHttpExecutable<T, Y> {
 		CacheControlDirective myCacheControlDirective;
 		Map<String, List<String>> myCustomHeaderValues = new HashMap<>();
@@ -767,7 +805,7 @@ public class GenericClient extends BaseClient implements IGenericClient {
 				String nextKey = nextEntry.getKey();
 				List<IQueryParameterType> nextValues = nextEntry.getValue();
 				for (IQueryParameterType nextValue : nextValues) {
-					String value = nextValue.getValueAsQueryToken(myContext);
+					String value = nextValue.getValueAsQueryToken();
 					String qualifier = nextValue.getQueryParameterQualifier();
 					if (isNotBlank(qualifier)) {
 						nextKey = nextKey + qualifier;
@@ -1424,8 +1462,7 @@ public class GenericClient extends BaseClient implements IGenericClient {
 		}
 
 		private void addParam(String theName, IQueryParameterType theValue) {
-			IPrimitiveType<?> stringType =
-					ParametersUtil.createString(myContext, theValue.getValueAsQueryToken(myContext));
+			IPrimitiveType<?> stringType = ParametersUtil.createString(myContext, theValue.getValueAsQueryToken());
 			addParam(theName, stringType);
 		}
 
@@ -2206,11 +2243,11 @@ public class GenericClient extends BaseClient implements IGenericClient {
 			Map<String, List<String>> params = getParamMap();
 
 			for (TokenParam next : myTags) {
-				addParam(params, Constants.PARAM_TAG, next.getValueAsQueryToken(myContext));
+				addParam(params, Constants.PARAM_TAG, next.getValueAsQueryToken());
 			}
 
 			for (TokenParam next : mySecurity) {
-				addParam(params, Constants.PARAM_SECURITY, next.getValueAsQueryToken(myContext));
+				addParam(params, Constants.PARAM_SECURITY, next.getValueAsQueryToken());
 			}
 
 			for (Collection<String> profileUris : myProfiles) {
@@ -2281,7 +2318,7 @@ public class GenericClient extends BaseClient implements IGenericClient {
 
 			if (myLastUpdated != null) {
 				for (DateParam next : myLastUpdated.getValuesAsQueryTokens()) {
-					addParam(params, Constants.PARAM_LASTUPDATED, next.getValueAsQueryToken(myContext));
+					addParam(params, Constants.PARAM_LASTUPDATED, next.getValueAsQueryToken());
 				}
 			}
 

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HttpRawClientInvocation.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/method/HttpRawClientInvocation.java
@@ -22,23 +22,27 @@ package ca.uhn.fhir.rest.client.method;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.client.api.IHttpClient;
 import ca.uhn.fhir.rest.client.api.IHttpRequest;
-import ca.uhn.fhir.rest.client.api.UrlSourceEnum;
 import ca.uhn.fhir.rest.client.impl.BaseHttpClientInvocation;
+import ca.uhn.fhir.rest.gclient.RawRequestEntity;
+import org.hl7.fhir.instance.model.api.IBaseBinary;
 
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.commons.lang3.ObjectUtils.getIfNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 public class HttpRawClientInvocation extends BaseHttpClientInvocation {
 
 	private final String myUrl;
-	private UrlSourceEnum myUrlSource = UrlSourceEnum.EXPLICIT;
-	private RequestTypeEnum myRequestType;
+	private final RawRequestEntity myRequestEntity;
 
-	public HttpRawClientInvocation(FhirContext theContext, String theUrlPath, RequestTypeEnum theRequestType) {
+	public HttpRawClientInvocation(FhirContext theContext, String theUrlPath, RawRequestEntity theRequestEntity) {
 		super(theContext);
 		myUrl = theUrlPath;
-		myRequestType = theRequestType;
+		myRequestEntity = theRequestEntity;
 	}
 
 	@Override
@@ -47,12 +51,30 @@ public class HttpRawClientInvocation extends BaseHttpClientInvocation {
 			Map<String, List<String>> theExtraParams,
 			EncodingEnum theEncoding,
 			Boolean thePrettyPrint) {
-		IHttpRequest retVal = createHttpRequest(myUrl, theEncoding, myRequestType);
-		retVal.setUrlSource(myUrlSource);
-		return retVal;
-	}
 
-	public void setUrlSource(UrlSourceEnum theUrlSource) {
-		myUrlSource = theUrlSource;
+		StringBuilder urlBuilder = new StringBuilder();
+
+		String url = getIfNull(myUrl, "");
+
+		if (!url.startsWith("http://") && !url.startsWith("https://")) {
+			urlBuilder.append(theUrlBase);
+			if (!theUrlBase.endsWith("/") && !url.startsWith("/")) {
+				urlBuilder.append('/');
+			}
+		}
+
+		if (isNotBlank(url)) {
+			urlBuilder.append(url);
+		}
+
+		IHttpClient httpClient =
+				getRestfulClientFactory().getHttpClient(urlBuilder, null, null, RequestTypeEnum.POST, getHeaders());
+
+		IBaseBinary binary =
+				(IBaseBinary) getContext().getResourceDefinition("Binary").newInstance();
+		binary.setContentType(myRequestEntity.getContentType());
+		binary.setContent(myRequestEntity.getBytes());
+
+		return httpClient.createBinaryRequest(getContext(), binary);
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7956-raw-http-post-from-client.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7956-raw-http-post-from-client.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 7956
+title: "The FHIR GenericClient `IRawHttp` interface now has an additional method `post()` which can be used to send a raw (potentially non-FHIR payload) HTTP POST through the client, leveraging interceptors and other functionality from the client."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/NDJsonParserTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/NDJsonParserTest.java
@@ -12,23 +12,23 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NDJsonParserTest {
-	private static FhirContext ourCtx = FhirContext.forR4();
+	private final FhirContext myCtx = FhirContext.forR4Cached();
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(NDJsonParserTest.class);
 
 	private String toNDJson(IBaseResource bundle) throws DataFormatException {
-		IParser p = ourCtx.newNDJsonParser();
+		IParser p = myCtx.newNDJsonParser();
 		return p.encodeResourceToString(bundle);
 	}
 
 	private IBaseResource fromNDJson(String ndjson) throws DataFormatException {
-		IParser p = ourCtx.newNDJsonParser();
+		IParser p = myCtx.newNDJsonParser();
 		return p.parseResource(ndjson);
 	} 
 
 	private boolean fhirResourcesEqual(IBaseResource expected, IBaseResource actual) {
 		// I would prefer to use, e.g., EqualsBuilder to do this instead.
-		String encoded_expected = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(expected);
-		String encoded_actual = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(actual);
+		String encoded_expected = myCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(expected);
+		String encoded_actual = myCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(actual);
 
 		ourLog.info("Expected: {}", encoded_expected);
  		ourLog.info("Actual  : {}", encoded_actual);
@@ -38,7 +38,7 @@ public class NDJsonParserTest {
 
 	@Test
 	public void testSinglePatientEncodeDecode() {
-		BundleBuilder myBuilder = new BundleBuilder(ourCtx);
+		BundleBuilder myBuilder = new BundleBuilder(myCtx);
 
 		Patient p = new Patient();
 		p.setId("Patient/P1");
@@ -51,7 +51,7 @@ public class NDJsonParserTest {
 
 	@Test
 	public void testEmptyBundleEncodeDecode() {
-		BundleBuilder myBuilder = new BundleBuilder(ourCtx);
+		BundleBuilder myBuilder = new BundleBuilder(myCtx);
 
 		myBuilder.setType("collection");
 		IBaseResource myBundle = myBuilder.getBundle();
@@ -62,7 +62,7 @@ public class NDJsonParserTest {
 
 	@Test
 	public void testThreePatientEncodeDecode() {
-		BundleBuilder myBuilder = new BundleBuilder(ourCtx);
+		BundleBuilder myBuilder = new BundleBuilder(myCtx);
 
 		Patient p = new Patient();
 		p.setId("Patient/P1");
@@ -82,7 +82,7 @@ public class NDJsonParserTest {
 
 	@Test
 	public void testHasNewlinesEncodeDecode() {
-		BundleBuilder myBuilder = new BundleBuilder(ourCtx);
+		BundleBuilder myBuilder = new BundleBuilder(myCtx);
 
 		Patient p = new Patient();
 		p.setId("Patient/P1");
@@ -105,14 +105,14 @@ public class NDJsonParserTest {
 
 	@Test
 	public void testOnlyDecodesBundles() {
-		BundleBuilder myBuilder = new BundleBuilder(ourCtx);
+		BundleBuilder myBuilder = new BundleBuilder(myCtx);
 
 		Patient p = new Patient();
 		p.setId("Patient/P1");
 		myBuilder.addCollectionEntry(p);
 		IBaseResource myBundle = myBuilder.getBundle();
  		String myBundleJson = toNDJson(myBundle);
-		IParser parser = ourCtx.newNDJsonParser();
+		IParser parser = myCtx.newNDJsonParser();
 		assertThatExceptionOfType(DataFormatException.class).isThrownBy(() -> {
 			parser.parseResource(Patient.class, myBundleJson);
 		});

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/client/GenericClientR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/client/GenericClientR4Test.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.rest.client.impl.GenericClient;
 import ca.uhn.fhir.rest.client.interceptor.CookieInterceptor;
 import ca.uhn.fhir.rest.client.interceptor.UserInfoInterceptor;
 import ca.uhn.fhir.rest.gclient.IEntityResult;
+import ca.uhn.fhir.rest.gclient.RawRequestEntity;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.StringParam;
@@ -187,6 +188,76 @@ public class GenericClientR4Test extends BaseGenericClientR4Test {
 			assertEquals(400, e.getStatusCode());
 			assertEquals("HTTP 400 Bad Request", e.getMessage());
 		}
+	}
+
+	@Test
+	void testRawPostRequestWith200Response() throws IOException {
+		// given
+		Header header = new BasicHeader("custom-header", "custom-value");
+		Header[] headers = new Header[1];
+		headers[0] = header;
+		String responseBody = """
+			 { "jobId": "blahblah" }
+			 """;
+		ArgumentCaptor<HttpUriRequest> capt = prepareClientForResponse(
+			 Constants.CT_JSON,
+			 ()->new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8)),
+			 new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"),
+			 headers
+		);
+		IGenericClient client = ourCtx.newRestfulGenericClient("http://example.com/fhir");
+
+		String requestContentType = Constants.CT_OCTET_STREAM;
+		byte[] bytes = new byte[] { 1, 2, 3, 4};
+
+		// when
+		IEntityResult result = client.rawHttpRequest().post("someurl?param1=value1", new RawRequestEntity(requestContentType, bytes))
+			 .withAdditionalHeader("custom-request-header", "custom-type")
+			 .accept("application/custom-accept")
+			 .execute();
+
+		// then
+		HttpPost httpUriRequest = (HttpPost) capt.getAllValues().get(0);
+		assertEquals("http://example.com/fhir/someurl?param1=value1", UrlUtil.unescape(httpUriRequest.getURI().toString()));
+		String response = new String(result.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+		assertEquals(responseBody, response);
+		assertEquals("application/json", result.getMimeType());
+		assertEquals(200, result.getStatusCode());
+		assertEquals("custom-value", result.getHeaders().get("custom-header").get(0));
+		assertEquals("custom-type", capt.getValue().getHeaders("custom-request-header")[0].getValue());
+		assertEquals("application/custom-accept", capt.getValue().getHeaders("accept")[0].getValue());
+		assertEquals(requestContentType, httpUriRequest.getFirstHeader("Content-Type").getValue());
+		assertEquals(4, IOUtils.toByteArray(httpUriRequest.getEntity().getContent()).length);
+	}
+
+	@Test
+	void testRawPostRequestWith400Response() throws IOException {
+		// given
+		Header header = new BasicHeader("custom-header", "custom-value");
+		Header[] headers = new Header[1];
+		headers[0] = header;
+		String responseBody = """
+			 { "jobId": "blahblah" }
+			 """;
+		ArgumentCaptor<HttpUriRequest> capt = prepareClientForResponse(
+			 Constants.CT_JSON,
+			 ()->new ByteArrayInputStream(new byte[0]),
+			 new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 400, "Bad Request"),
+			 headers
+		);
+		IGenericClient client = ourCtx.newRestfulGenericClient("http://example.com/fhir");
+
+		// when
+		try {
+			client.rawHttpRequest()
+				 .post("someurl?param1=value1", new RawRequestEntity(Constants.CT_TEXT, "".getBytes(StandardCharsets.UTF_8)))
+				 .accept("application/custom-accept")
+				 .execute();
+		} catch (InvalidRequestException e) {
+			assertEquals(400, e.getStatusCode());
+			assertEquals("HTTP 400 Bad Request", e.getMessage());
+		}
+
 	}
 
 


### PR DESCRIPTION
The FHIR GenericClient `IRawHttp` interface now has an additional method `post()` which can be used to send a raw (potentially non-FHIR payload) HTTP POST through the client, leveraging interceptors and other functionality from the client.