### PR TITLE
Refactor bulk modify servlet into reusable component

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiToStringBuilder.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/HapiToStringBuilder.java
@@ -1,0 +1,25 @@
+package ca.uhn.fhir.util;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * Added functionality to {@link ToStringBuilder}
+ *
+ * @since 8.12.0
+ */
+public class HapiToStringBuilder extends ToStringBuilder {
+
+	public HapiToStringBuilder(Object theObject, ToStringStyle theStyle) {
+		super(theObject, theStyle);
+	}
+
+	/**
+	 * Performs an {@link #append(String, int)} if {@literal theValue != 0}
+	 */
+	public void appendIfNonZero(String theFieldName, int theValue) {
+		if (theValue != 0) {
+			append(theFieldName, theValue);
+		}
+	}
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
@@ -458,14 +458,6 @@ public class ParametersUtil {
 		addParameterToParameters(theCtx, theParameters, theName, value);
 	}
 
-	public static void addParameterToParametersUrl(
-			FhirContext theCtx, IBaseParameters theParameters, String theName, String theValue) {
-		IPrimitiveType<String> value = (IPrimitiveType<String>)
-				Objects.requireNonNull(theCtx.getElementDefinition("url")).newInstance();
-		value.setValue(theValue);
-		addParameterToParameters(theCtx, theParameters, theName, value);
-	}
-
 	/**
 	 * Add a parameter with no value (typically because we'll be adding sub-parameters)
 	 */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ParametersUtil.java
@@ -458,6 +458,14 @@ public class ParametersUtil {
 		addParameterToParameters(theCtx, theParameters, theName, value);
 	}
 
+	public static void addParameterToParametersUrl(
+			FhirContext theCtx, IBaseParameters theParameters, String theName, String theValue) {
+		IPrimitiveType<String> value = (IPrimitiveType<String>)
+				Objects.requireNonNull(theCtx.getElementDefinition("url")).newInstance();
+		value.setValue(theValue);
+		addParameterToParameters(theCtx, theParameters, theName, value);
+	}
+
 	/**
 	 * Add a parameter with no value (typically because we'll be adding sub-parameters)
 	 */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -649,13 +649,14 @@ public class UrlUtil {
 			return new CanonicalUrlParts(theUrl, Optional.ofNullable(theVersion));
 		} else {
 			String url = theUrl.substring(0, pipeIdx);
-			String versionId = theVersion;
+			String versionId = theUrl.substring(pipeIdx + 1);
 			if (isBlank(versionId)) {
-				versionId = theUrl.substring(pipeIdx + 1);
+				return new CanonicalUrlParts(url, Optional.ofNullable(theVersion));
+			} else if (isNotBlank(theVersion) && !versionId.equals(theVersion)) {
+				throw new InvalidRequestException(Msg.code(2952) + "Version in URL[" + sanitizeUrlPart(theUrl)
+						+ " does not match expected version: " + theVersion);
 			}
-			if (isBlank(versionId)) {
-				return new CanonicalUrlParts(url, Optional.empty());
-			}
+
 			return new CanonicalUrlParts(url, Optional.of(versionId));
 		}
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/UrlUtil.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
@@ -623,6 +624,42 @@ public class UrlUtil {
 		return candidates;
 	}
 
+	/**
+	 * Parses a versioned or unversioned canonical URL (e.g. <code>http://foo</code> or <code>http://foo|123</code>)
+	 * into its constituent parts.
+	 *
+	 * @since 8.12.0
+	 */
+	public static CanonicalUrlParts parseCanonicalUrl(String theUrl) {
+		return parseCanonicalUrl(theUrl, null);
+	}
+
+	/**
+	 * Parses a versioned or unversioned canonical URL (e.g. <code>http://foo</code> or <code>http://foo|123</code>)
+	 * into its constituent parts. An optional version ID can also be provided, for scenarios where the version can be
+	 * provided either in the URL or in a separate parameter. If both are provided, the version from the parameter
+	 * takes precedence.
+	 *
+	 * @since 8.12.0
+	 */
+	@Nonnull
+	public static CanonicalUrlParts parseCanonicalUrl(@Nonnull String theUrl, @Nullable String theVersion) {
+		int pipeIdx = theUrl.indexOf('|');
+		if (pipeIdx == -1) {
+			return new CanonicalUrlParts(theUrl, Optional.ofNullable(theVersion));
+		} else {
+			String url = theUrl.substring(0, pipeIdx);
+			String versionId = theVersion;
+			if (isBlank(versionId)) {
+				versionId = theUrl.substring(pipeIdx + 1);
+			}
+			if (isBlank(versionId)) {
+				return new CanonicalUrlParts(url, Optional.empty());
+			}
+			return new CanonicalUrlParts(url, Optional.of(versionId));
+		}
+	}
+
 	private static void throwInvalidRequestExceptionForNotValidUri(String theUri, Exception theCause) {
 		throw new InvalidRequestException(
 				Msg.code(2419) + String.format("Provided URI is not valid: %s", theUri), theCause);
@@ -666,4 +703,6 @@ public class UrlUtil {
 			myVersionId = theVersionId;
 		}
 	}
+
+	public record CanonicalUrlParts(String url, Optional<String> versionId) {}
 }

--- a/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
+++ b/hapi-fhir-converter/src/main/java/ca/uhn/hapi/converters/canonical/VersionCanonicalizer.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.model.dstu2.composite.CodingDt;
 import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_10_40;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_10_50;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_14_40;
@@ -102,7 +103,8 @@ public class VersionCanonicalizer {
 		this(FhirContext.forCached(theTargetVersion));
 	}
 
-	public VersionCanonicalizer(FhirContext theTargetContext) {
+	public VersionCanonicalizer(@Nonnull FhirContext theTargetContext) {
+		Validate.notNull(theTargetContext, "theTargetContext must not be null");
 		myContext = theTargetContext;
 		FhirVersionEnum targetVersion = theTargetContext.getVersion().getVersion();
 		switch (targetVersion) {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7957-add-async-polling-class.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7957-add-async-polling-class.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 7957
+title: "A new experimental class called `AsyncRequestUtil` provides utilities
+  for operation providers which provide async batch2 job kickoff and status
+  polling."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7957-add-urlutil-canonical-url-parsing.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7957-add-urlutil-canonical-url-parsing.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 7957
+title: "A new method on the `UrlUtil` class provides the ability to
+   parse a canonical URL into the URL and version components."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/util/DialectSvc.java
@@ -69,7 +69,9 @@ public class DialectSvc {
 	 */
 	@VisibleForTesting
 	public static void setForceMsSqlMode(boolean theForceMsSqlMode) {
-		ourLog.warn("Forcing MS SQL mode: {}", theForceMsSqlMode);
+		if (theForceMsSqlMode) {
+			ourLog.warn("Forcing MS SQL mode");
+		}
 		ourForceMsSqlMode = theForceMsSqlMode;
 	}
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -225,12 +225,12 @@ public class RestfulServerUtils {
 				.getServerAddressStrategy()
 				.determineServerBase(servletContext, servletRequest);
 
-		StringBuilder pollUrlBuilder = new StringBuilder(baseUrl);
+		StringBuilder urlBuilder = new StringBuilder(baseUrl);
 		if (!baseUrl.endsWith("/")) {
-			pollUrlBuilder.append("/");
+			urlBuilder.append("/");
 		}
-		pollUrlBuilder.append(theRelativeUrl);
-		return pollUrlBuilder.toString();
+		urlBuilder.append(theRelativeUrl);
+		return urlBuilder.toString();
 	}
 
 	public static String createLinkSelf(String theServerBase, RequestDetails theRequest) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -55,8 +55,10 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBaseBinary;
@@ -198,6 +200,37 @@ public class RestfulServerUtils {
 
 			parser.setEncodeElements(newElements);
 		}
+	}
+
+	/**
+	 * Given a relative URL (e.g. <code>ValueSet/123/$expand</code>), creates a fully qualified URL by appending the relative URL to the server base.
+	 *
+	 * @param theRequestDetails The ServletRequestDetails object containing the server context and request details
+	 * @param theRelativeUrl The relative URL to append to the server base. Must not start with "/".
+	 * @return The fully qualified URL
+	 * @since 8.12.0
+	 */
+	@Nonnull
+	public static String createFullyQualifiedUrlFromRelativeUrl(
+			ServletRequestDetails theRequestDetails, String theRelativeUrl) {
+		Validate.notNull(theRequestDetails, "The ServletRequestDetails object must not be null");
+		Validate.notBlank(theRelativeUrl, "The relative URL must not be blank");
+		Validate.isTrue(!theRelativeUrl.startsWith("/"), "The relative URL must not start with '/'");
+
+		ServletContext servletContext =
+				(ServletContext) theRequestDetails.getServletAttribute(RestfulServer.SERVLET_CONTEXT_ATTRIBUTE);
+		HttpServletRequest servletRequest = theRequestDetails.getServletRequest();
+		String baseUrl = theRequestDetails
+				.getServer()
+				.getServerAddressStrategy()
+				.determineServerBase(servletContext, servletRequest);
+
+		StringBuilder pollUrlBuilder = new StringBuilder(baseUrl);
+		if (!baseUrl.endsWith("/")) {
+			pollUrlBuilder.append("/");
+		}
+		pollUrlBuilder.append(theRelativeUrl);
+		return pollUrlBuilder.toString();
 	}
 
 	public static String createLinkSelf(String theServerBase, RequestDetails theRequest) {

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyOrRewriteProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyOrRewriteProvider.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrl;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
 import ca.uhn.fhir.batch2.model.StatusEnum;
+import ca.uhn.fhir.batch2.util.AsyncRequestUtil;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
@@ -35,33 +36,21 @@ import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.IDaoRegistry;
 import ca.uhn.fhir.jpa.batch.models.Batch2JobStartResponse;
-import ca.uhn.fhir.jpa.dao.BaseTransactionProcessor;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
-import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.parser.IParser;
-import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
 import ca.uhn.fhir.rest.server.util.ServletRequestUtil;
 import ca.uhn.fhir.util.BundleBuilder;
-import ca.uhn.fhir.util.CanonicalBundleEntry;
 import ca.uhn.fhir.util.JsonUtil;
-import ca.uhn.fhir.util.OperationOutcomeUtil;
 import ca.uhn.fhir.util.UrlUtil;
 import ca.uhn.fhir.util.ValidateUtil;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import jakarta.annotation.Nonnull;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
@@ -72,16 +61,15 @@ import org.hl7.fhir.r4.model.IdType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static ca.uhn.fhir.rest.server.provider.ProviderConstants.ALL_PARTITIONS_TENANT_NAME;
 import static org.apache.commons.lang3.ObjectUtils.getIfNull;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trim;
 
@@ -195,35 +183,13 @@ public abstract class BaseBulkModifyOrRewriteProvider {
 
 		Batch2JobStartResponse outcome = myJobCoordinator.startInstance(theRequestDetails, startRequest);
 
-		String jobInstanceId = outcome.getInstanceId();
+		String relativeUrl = createPollingRelativeUrl(outcome.getInstanceId());
+		String operationName = getOperationName();
 
-		String pollUrl = createPollUrl(theRequestDetails, jobInstanceId);
-
-		// Create an OperationOutcome to return
-		IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(myContext);
-		String message =
-				getOperationName() + " job has been accepted. Poll for status at the following URL: " + pollUrl;
-		String severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
-		String code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
-		OperationOutcomeUtil.addIssue(myContext, oo, severity, message, null, code);
-		postProcessResponseOperationOutcome(oo, theRequestDetails);
-
-		// Provide a response
-		Multimap<String, String> additionalHeaders = ImmutableMultimap.<String, String>builder()
-				.put(Constants.HEADER_CONTENT_LOCATION, pollUrl)
-				.build();
-
-		RestfulServerUtils.streamResponseAsResource(
-				theRequestDetails.getServer(),
-				oo,
-				Set.of(),
-				HttpServletResponse.SC_ACCEPTED,
-				additionalHeaders,
-				false,
-				false,
-				theRequestDetails,
-				null,
-				null);
+		Consumer<IBaseOperationOutcome> operationOutcomePostProcessor =
+				oo -> postProcessResponseOperationOutcome(oo, theRequestDetails);
+		AsyncRequestUtil.handleAsynchronousOperationStartRequest(
+				theRequestDetails, relativeUrl, operationName, operationOutcomePostProcessor);
 	}
 
 	/**
@@ -272,211 +238,118 @@ public abstract class BaseBulkModifyOrRewriteProvider {
 	}
 
 	@Nonnull
-	private String createPollUrl(ServletRequestDetails theRequestDetails, String jobInstanceId) {
-		ServletContext servletContext =
-				(ServletContext) theRequestDetails.getServletAttribute(RestfulServer.SERVLET_CONTEXT_ATTRIBUTE);
-		HttpServletRequest servletRequest = theRequestDetails.getServletRequest();
-		String baseUrl = theRequestDetails
-				.getServer()
-				.getServerAddressStrategy()
-				.determineServerBase(servletContext, servletRequest);
-
-		StringBuilder pollUrlBuilder = new StringBuilder(baseUrl);
-		if (!baseUrl.endsWith("/")) {
-			pollUrlBuilder.append("/");
-		}
-		pollUrlBuilder.append(getOperationPollForStatusStatus());
-		pollUrlBuilder.append('?');
-		pollUrlBuilder.append(JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_JOB_ID);
-		pollUrlBuilder.append('=');
-		pollUrlBuilder.append(jobInstanceId);
-		return pollUrlBuilder.toString();
+	private String createPollingRelativeUrl(String jobInstanceId) {
+		return getOperationPollForStatusStatus()
+				+ '?'
+				+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_JOB_ID
+				+ '='
+				+ jobInstanceId;
 	}
 
 	/**
 	 * Subclasses should call this method to poll for job status
 	 */
 	protected void pollForJobStatus(
-			ServletRequestDetails theRequestDetails, IPrimitiveType<String> theJobId, IPrimitiveType<String> theReturn)
+			ServletRequestDetails theRequestDetails,
+			IPrimitiveType<String> theJobInstanceId,
+			IPrimitiveType<String> theReturn)
 			throws IOException {
-		ValidateUtil.isTrueOrThrowInvalidRequest(theJobId != null && theJobId.hasValue(), "Missing job id");
+		ValidateUtil.isTrueOrThrowInvalidRequest(
+				theJobInstanceId != null && theJobInstanceId.hasValue(), "Missing job id");
 
 		String returnValue = null;
 		if (theReturn != null) {
 			returnValue = theReturn.getValueAsString();
 		}
 
-		JobInstance instance;
-		try {
-			instance = myJobCoordinator.getInstance(theJobId.getValue());
-		} catch (ResourceNotFoundException e) {
-			throw new ResourceNotFoundException(
-					Msg.code(2787) + "Invalid/unknown job ID: " + UrlUtil.sanitizeUrlPart(theJobId.getValue()));
-		}
+		IJobCoordinator jobCoordinator = myJobCoordinator;
+		String jobId = getJobId();
+		String operationName = getOperationName();
 
-		ValidateUtil.isTrueOrThrowInvalidRequest(
-				instance.getJobDefinitionId().equals(getJobId()),
-				"Job ID does not correspond to a " + getOperationName() + " job");
+		JobInstance instance = AsyncRequestUtil.getJobInstance(theJobInstanceId, jobCoordinator, jobId, operationName);
 
-		int status = HttpStatus.SC_INTERNAL_SERVER_ERROR;
-		List<String> messages = new ArrayList<>();
-		String severity = "";
-		String code = "";
-		String progressMessage = null;
-		String returnString = null;
-		IBaseBundle returnBundle = null;
-		boolean respondUsingBundle = false;
-		switch (instance.getStatus()) {
-			case QUEUED -> {
-				status = HttpStatus.SC_ACCEPTED;
-				messages.add(getOperationName() + " job has not yet started");
-				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
-				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
-			}
-			case IN_PROGRESS -> {
-				status = HttpStatus.SC_ACCEPTED;
-				messages.add(getOperationName() + " job has started and is in progress");
-				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
-				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
-			}
-			case FINALIZE -> {
-				status = HttpStatus.SC_ACCEPTED;
-				messages.add(getOperationName() + " job has started and is being finalized");
-				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
-				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
-			}
-			case ERRORED, FAILED, COMPLETED -> {
-				if (instance.getStatus() == StatusEnum.COMPLETED) {
-					status = HttpStatus.SC_OK;
-					progressMessage = getOperationName() + " job has completed successfully";
-					severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
-					code = OperationOutcomeUtil.OO_ISSUE_CODE_SUCCESS;
-				} else {
-					status = HttpStatus.SC_INTERNAL_SERVER_ERROR;
-					progressMessage = getOperationName() + " job has failed with error: " + instance.getErrorMessage();
-					severity = OperationOutcomeUtil.OO_SEVERITY_ERROR;
-					code = OperationOutcomeUtil.OO_ISSUE_CODE_PROCESSING;
-				}
-
-				String reportText = instance.getReport();
-				if (isBlank(reportText)) {
-					messages.add(progressMessage);
-				} else {
-					BulkModifyResourcesResultsJson results =
-							JsonUtil.deserialize(reportText, BulkModifyResourcesResultsJson.class);
+		if (instance.getStatus().isEnded()) {
+			if (isNotBlank(instance.getReport())) {
+				if (JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_DRYRUN_CHANGES.equals(returnValue)) {
 					BaseBulkModifyJobParameters jobParameters =
 							instance.getParameters(BaseBulkModifyJobParameters.DeserializingImpl.class);
 					boolean isDryRunCollectChanges = jobParameters.isDryRun()
 							&& jobParameters.getDryRunMode() == BaseBulkModifyJobParameters.DryRunMode.COLLECT_CHANGED;
-
-					if (JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_REPORT.equals(returnValue)) {
-						returnString = results.getReport();
-					} else if (JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_DRYRUN_CHANGES.equals(
-							returnValue)) {
-						if (!isDryRunCollectChanges) {
-							throw new InvalidRequestException(
-									Msg.code(2815) + "Changes response can only be provided for "
-											+ JpaConstants.OPERATION_BULK_PATCH_PARAM_DRY_RUN + " jobs with "
-											+ JpaConstants.OPERATION_BULK_PATCH_PARAM_DRY_RUN_MODE + "="
-											+ JpaConstants.OPERATION_BULK_PATCH_PARAM_DRY_RUN_MODE_COLLECT_CHANGES);
-						}
-
-						returnBundle = createChangesBundle(results);
+					if (!isDryRunCollectChanges) {
+						throw new InvalidRequestException(Msg.code(2815) + "Changes response can only be provided for "
+								+ JpaConstants.OPERATION_BULK_PATCH_PARAM_DRY_RUN + " jobs with "
+								+ JpaConstants.OPERATION_BULK_PATCH_PARAM_DRY_RUN_MODE + "="
+								+ JpaConstants.OPERATION_BULK_PATCH_PARAM_DRY_RUN_MODE_COLLECT_CHANGES);
 					}
-					messages.add(results.getReport());
-					messages.add("Access raw text report at URL: "
-							+ createPollUrl(theRequestDetails, instance.getInstanceId()) + "&"
-							+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN + "="
-							+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_REPORT);
-					if (isDryRunCollectChanges) {
-						messages.add("Access collected dry-run changes at URL: "
-								+ createPollUrl(theRequestDetails, instance.getInstanceId()) + "&"
-								+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN + "="
-								+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_DRYRUN_CHANGES);
-					}
+
+					BulkModifyResourcesResultsJson results =
+							JsonUtil.deserialize(instance.getReport(), BulkModifyResourcesResultsJson.class);
+					IBaseBundle returnBundle = createChangesBundle(results);
+					int status = instance.getStatus() == StatusEnum.COMPLETED
+							? HttpStatus.SC_OK
+							: HttpStatus.SC_INTERNAL_SERVER_ERROR;
+					RestfulServerUtils.streamResponseAsResource(
+							theRequestDetails.getServer(),
+							returnBundle,
+							Set.of(),
+							status,
+							null,
+							false,
+							false,
+							theRequestDetails,
+							null,
+							null);
+					return;
 				}
-				respondUsingBundle = true;
-			}
-			case CANCELLED -> {
-				status = HttpStatus.SC_OK;
-				messages.add(getOperationName() + " job has been cancelled");
-				severity = OperationOutcomeUtil.OO_SEVERITY_WARN;
-				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
-				respondUsingBundle = true;
 			}
 		}
 
-		ImmutableMultimap.Builder<String, String> additionalHeaders = ImmutableMultimap.builder();
-		if (progressMessage != null) {
-			additionalHeaders.put(Constants.HEADER_X_PROGRESS, progressMessage);
-		} else if (!messages.isEmpty()) {
-			additionalHeaders.put(Constants.HEADER_X_PROGRESS, messages.get(0));
+		handleAsyncJobPollForStatusResponse(theRequestDetails, instance, operationName, returnValue);
+	}
+
+	private void handleAsyncJobPollForStatusResponse(
+			ServletRequestDetails theRequestDetails,
+			JobInstance theJobInstance,
+			String theOperationName,
+			String theReturnParameterValue)
+			throws IOException {
+		Function<JobInstance, AsyncRequestUtil.CompletedJobPollResponse> createCompletionPollResponse =
+				theInstance -> createCompletedJobPollResponse(theRequestDetails, theInstance, theReturnParameterValue);
+		AsyncRequestUtil.handleAsyncJobPollForStatusResponse(
+				theRequestDetails, theJobInstance, theOperationName, createCompletionPollResponse);
+	}
+
+	private AsyncRequestUtil.CompletedJobPollResponse createCompletedJobPollResponse(
+			ServletRequestDetails theRequestDetails, JobInstance theInstance, String theReturnParameterValue) {
+		BulkModifyResourcesResultsJson results =
+				JsonUtil.deserialize(theInstance.getReport(), BulkModifyResourcesResultsJson.class);
+		BaseBulkModifyJobParameters jobParameters =
+				theInstance.getParameters(BaseBulkModifyJobParameters.DeserializingImpl.class);
+		boolean isDryRunCollectChanges = jobParameters.isDryRun()
+				&& jobParameters.getDryRunMode() == BaseBulkModifyJobParameters.DryRunMode.COLLECT_CHANGED;
+
+		if (JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_REPORT.equals(theReturnParameterValue)) {
+			return new AsyncRequestUtil.CompletedJobPollResponse(results.getReport(), null);
 		}
 
-		if (returnBundle != null) {
-			RestfulServerUtils.streamResponseAsResource(
-					theRequestDetails.getServer(),
-					returnBundle,
-					Set.of(),
-					status,
-					additionalHeaders.build(),
-					false,
-					false,
-					theRequestDetails,
-					null,
-					null);
-			return;
+		List<String> messages = new ArrayList<>();
+		messages.add(results.getReport());
+		String relativeUrl1 = createPollingRelativeUrl(theInstance.getInstanceId());
+
+		messages.add("Access raw text report at URL: "
+				+ RestfulServerUtils.createFullyQualifiedUrlFromRelativeUrl(theRequestDetails, relativeUrl1) + "&"
+				+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN + "="
+				+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_REPORT);
+		if (isDryRunCollectChanges) {
+			String relativeUrl = createPollingRelativeUrl(theInstance.getInstanceId());
+
+			messages.add("Access collected dry-run changes at URL: "
+					+ RestfulServerUtils.createFullyQualifiedUrlFromRelativeUrl(theRequestDetails, relativeUrl) + "&"
+					+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN + "="
+					+ JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_RETURN_VALUE_DRYRUN_CHANGES);
 		}
 
-		if (returnString != null) {
-			writeResponseWithStringBody(theRequestDetails.getServletResponse(), additionalHeaders, returnString);
-			return;
-		}
-
-		IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(myContext);
-		for (String message : messages) {
-			OperationOutcomeUtil.addIssue(myContext, oo, severity, message, null, code);
-		}
-
-		IBaseResource responseResource;
-		if (respondUsingBundle) {
-			BundleBuilder bundleBuilder = new BundleBuilder(myContext);
-			bundleBuilder.setType(BundleTypeEnum.BATCH_RESPONSE.getCode());
-
-			CanonicalBundleEntry entry = new CanonicalBundleEntry();
-			entry.setResponseStatus(BaseTransactionProcessor.toStatusString(status));
-			entry.setResponseOutcome(oo);
-			bundleBuilder.addEntry(entry);
-
-			responseResource = bundleBuilder.getBundle();
-		} else {
-			responseResource = oo;
-		}
-
-		/*
-		 * According to the Asynchronous Interaction Request Pattern at
-		 * https://hl7.org/fhir/async-bundle.html,
-		 * if the job has completed (either successfully or unsuccessfully/prematurely), the response
-		 * should use an HTTP 200 status and should indicate the actual status in a Bundle
-		 * resource.
-		 */
-		if (respondUsingBundle) {
-			status = HttpStatus.SC_OK;
-		}
-
-		Multimap<String, String> additionalHeaders1 = additionalHeaders.build();
-
-		RestfulServerUtils.streamResponseAsResource(
-				theRequestDetails.getServer(),
-				responseResource,
-				Set.of(),
-				status,
-				additionalHeaders1,
-				false,
-				false,
-				theRequestDetails,
-				null,
-				null);
+		return new AsyncRequestUtil.CompletedJobPollResponse(null, messages);
 	}
 
 	private IBaseBundle createChangesBundle(BulkModifyResourcesResultsJson theResultsJson) {
@@ -491,24 +364,6 @@ public abstract class BaseBulkModifyOrRewriteProvider {
 			bundleBuilder.addTransactionDeleteEntry(id.getResourceType(), id.getIdPart());
 		}
 		return bundleBuilder.getBundle();
-	}
-
-	private void writeResponseWithStringBody(
-			HttpServletResponse theServletResponse,
-			ImmutableMultimap.Builder<String, String> theAdditionalHeaders,
-			String theResponseString)
-			throws IOException {
-		theServletResponse.setStatus(HttpStatus.SC_OK);
-		theServletResponse.setContentType(Constants.CT_TEXT);
-		theServletResponse.setCharacterEncoding(Constants.CHARSET_NAME_UTF8);
-
-		for (Map.Entry<String, String> next : theAdditionalHeaders.build().entries()) {
-			theServletResponse.addHeader(next.getKey(), next.getValue());
-		}
-
-		try (PrintWriter writer = theServletResponse.getWriter()) {
-			writer.write(theResponseString);
-		}
 	}
 
 	@Nonnull

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyOrRewriteProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/bulkmodify/framework/base/BaseBulkModifyOrRewriteProvider.java
@@ -266,7 +266,7 @@ public abstract class BaseBulkModifyOrRewriteProvider {
 		String jobId = getJobId();
 		String operationName = getOperationName();
 
-		JobInstance instance = AsyncRequestUtil.getJobInstance(theJobInstanceId, jobCoordinator, jobId, operationName);
+		JobInstance instance = AsyncRequestUtil.getJobInstance(jobCoordinator, jobId, theJobInstanceId, operationName);
 
 		if (instance.getStatus().isEnded()) {
 			if (isNotBlank(instance.getReport())) {

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/bulkmodify/patch/BulkPatchProviderTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/bulkmodify/patch/BulkPatchProviderTest.java
@@ -190,6 +190,8 @@ public class BulkPatchProviderTest {
 		instance.setErrorMessage(theParams.errorMessage());
 		instance.setReport(theParams.reportMessage());
 		instance.setParameters(new BulkPatchJobParameters());
+		instance.setCurrentGatedStepId("current-gated-step");
+		instance.setProgress(0.51);
 		when(myJobCoordinator.getInstance(eq("MY-INSTANCE-ID"))).thenReturn(instance);
 
 		// Test
@@ -431,8 +433,8 @@ public class BulkPatchProviderTest {
 
 		return Stream.of(
 			new PollForStatusTest(StatusEnum.QUEUED, HttpStatus.Code.ACCEPTED.getCode(), theOperation + " job has not yet started"),
-			new PollForStatusTest(StatusEnum.IN_PROGRESS, HttpStatus.Code.ACCEPTED.getCode(), theOperation + " job has started and is in progress"),
-			new PollForStatusTest(StatusEnum.FINALIZE, HttpStatus.Code.ACCEPTED.getCode(), theOperation + " job has started and is being finalized"),
+			new PollForStatusTest(StatusEnum.IN_PROGRESS, HttpStatus.Code.ACCEPTED.getCode(), theOperation + " job has started and is in progress Current step: current-gated-step. Overall progress: 51%."),
+			new PollForStatusTest(StatusEnum.FINALIZE, HttpStatus.Code.ACCEPTED.getCode(), theOperation + " job has completed main processing and is being finalized"),
 			new PollForStatusTest(StatusEnum.CANCELLED, null, null, HttpStatus.Code.OK.getCode(), theOperation + " job has been cancelled", theOperation + " job has been cancelled", true),
 			new PollForStatusTest(StatusEnum.FAILED, "This is an error message", null, HttpStatus.Code.INTERNAL_SERVER_ERROR.getCode(), theOperation + " job has failed with error: This is an error message", theOperation + " job has failed with error: This is an error message", true),
 			new PollForStatusTest(StatusEnum.COMPLETED, null, null, HttpStatus.Code.OK.getCode(), theOperation + " job has completed successfully", theOperation + " job has completed successfully", true),

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/bulkmodify/patchrewrite/BulkPatchRewriteProviderTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/bulkmodify/patchrewrite/BulkPatchRewriteProviderTest.java
@@ -41,6 +41,7 @@ import static ca.uhn.fhir.batch2.jobs.bulkmodify.patch.BulkPatchProviderTest.val
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.OPERATION_BULK_PATCH_REWRITE_STATUS;
 import static ca.uhn.fhir.jpa.model.util.JpaConstants.OPERATION_BULK_PATCH_STATUS_PARAM_JOB_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -134,6 +135,8 @@ class BulkPatchRewriteProviderTest {
 		instance.setJobDefinitionId(BulkPatchRewriteJobAppCtx.JOB_ID);
 		instance.setErrorMessage(theParams.errorMessage());
 		instance.setReport(theParams.reportMessage());
+		instance.setCurrentGatedStepId("current-gated-step");
+		instance.setProgress(0.51);
 		when(myJobCoordinator.getInstance(eq("MY-INSTANCE-ID"))).thenReturn(instance);
 
 		// Test

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -67,6 +67,11 @@
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-el</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- OpenTelemetry -->
 		<dependency>

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/util/AsyncRequestUtil.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/util/AsyncRequestUtil.java
@@ -1,0 +1,281 @@
+package ca.uhn.fhir.batch2.util;
+
+import ca.uhn.fhir.batch2.api.IJobCoordinator;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.StatusEnum;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.dao.BaseTransactionProcessor;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.server.RestfulServerUtils;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import ca.uhn.fhir.util.BundleBuilder;
+import ca.uhn.fhir.util.CanonicalBundleEntry;
+import ca.uhn.fhir.util.DatatypeUtil;
+import ca.uhn.fhir.util.OperationOutcomeUtil;
+import ca.uhn.fhir.util.UrlUtil;
+import ca.uhn.fhir.util.ValidateUtil;
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * This class is currently considered an internal HAPI FHIR API and is subject to change. Use with caution!
+ */
+public class AsyncRequestUtil {
+
+	private AsyncRequestUtil() {
+		// non-instantiable
+	}
+
+	/**
+	 * <p>
+	 * This method is currently considered an internal HAPI FHIR API and is subject to change. Use with caution!
+	 * </p>
+	 */
+	@Beta
+	public static void handleAsynchronousOperationStartRequest(
+			ServletRequestDetails theRequestDetails,
+			String theRelativeUrl,
+			String theOperationName,
+			@Nullable Consumer<IBaseOperationOutcome> theOperationOutcomePostProcessor)
+			throws IOException {
+		String pollUrl = RestfulServerUtils.createFullyQualifiedUrlFromRelativeUrl(theRequestDetails, theRelativeUrl);
+		FhirContext fhirContext = theRequestDetails.getServer().getFhirContext();
+
+		// Create an OperationOutcome to return
+		IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(fhirContext);
+		String message = theOperationName + " job has been accepted. Poll for status at the following URL: " + pollUrl;
+		String severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
+		String code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
+		OperationOutcomeUtil.addIssue(fhirContext, oo, severity, message, null, code);
+
+		if (theOperationOutcomePostProcessor != null) {
+			theOperationOutcomePostProcessor.accept(oo);
+		}
+
+		// Provide a response
+		Multimap<String, String> additionalHeaders = ImmutableMultimap.<String, String>builder()
+				.put(Constants.HEADER_CONTENT_LOCATION, pollUrl)
+				.build();
+
+		RestfulServerUtils.streamResponseAsResource(
+				theRequestDetails.getServer(),
+				oo,
+				Set.of(),
+				HttpServletResponse.SC_ACCEPTED,
+				additionalHeaders,
+				false,
+				false,
+				theRequestDetails,
+				null,
+				null);
+	}
+
+	@Nonnull
+	public static JobInstance getJobInstance(
+			IPrimitiveType<String> theJobInstanceId,
+			IJobCoordinator jobCoordinator,
+			String jobId,
+			String operationName) {
+		JobInstance instance;
+		try {
+			instance = jobCoordinator.getInstance(DatatypeUtil.toStringValue(theJobInstanceId));
+		} catch (ResourceNotFoundException e) {
+			throw new ResourceNotFoundException(
+					Msg.code(2787) + "Invalid/unknown job ID: " + UrlUtil.sanitizeUrlPart(theJobInstanceId.getValue()));
+		}
+
+		ValidateUtil.isTrueOrThrowInvalidRequest(
+				instance.getJobDefinitionId().equals(jobId),
+				"Job ID does not correspond to a " + operationName + " job");
+		return instance;
+	}
+
+	/**
+	 * Writes a response with a <code>text/plain</code> string as the response body and
+	 * an HTTP 200 status code.
+	 */
+	private static void writeResponseWithStringBody(HttpServletResponse theServletResponse, String theResponseString)
+			throws IOException {
+		theServletResponse.setStatus(HttpStatus.SC_OK);
+		theServletResponse.setContentType(Constants.CT_TEXT);
+		theServletResponse.setCharacterEncoding(Constants.CHARSET_NAME_UTF8);
+
+		try (PrintWriter writer = theServletResponse.getWriter()) {
+			writer.write(theResponseString);
+		}
+	}
+
+	/**
+	 * Creates the HTTP response for an asynchronous job poll request.
+	 * <p>
+	 * This method is currently considered an internal HAPI FHIR API and is subject to change. Use with caution!
+	 * </p>
+	 *
+	 * @param theRequestDetails               The request details associated with the poll request
+	 * @param theJobInstance                  The Batch2 Job Instance being polled
+	 * @param theOperationName                A descriptive name for the operation being polled. This isn't used for anything programmatic or machine processed, it is just used in messages returned to the client. The operation name of the operation which kicked off the job is generally appropriate.
+	 * @param theCompletedJobResponseProvider A function that provides details for the completed job. This function will be called
+	 *                                        when a client polls for the status of a job and the job is completed. It can supply
+	 *                                        additional messages that will be returned with the response, or even supply an entire
+	 *                                        report to return instead of the standard OperationOutcome.
+	 * @see CompletedJobPollResponse
+	 */
+	@Beta
+	public static void handleAsyncJobPollForStatusResponse(
+			ServletRequestDetails theRequestDetails,
+			JobInstance theJobInstance,
+			String theOperationName,
+			Function<JobInstance, CompletedJobPollResponse> theCompletedJobResponseProvider)
+			throws IOException {
+		int status = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+		List<String> messages = new ArrayList<>();
+		String severity = "";
+		String code = "";
+		String progressMessage = null;
+		boolean respondUsingBundle = false;
+		switch (theJobInstance.getStatus()) {
+			case QUEUED -> {
+				status = HttpStatus.SC_ACCEPTED;
+				messages.add(theOperationName + " job has not yet started");
+				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
+				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
+			}
+			case IN_PROGRESS -> {
+				status = HttpStatus.SC_ACCEPTED;
+				String message = theOperationName + " job has started and is in progress.";
+				if (theJobInstance.getCurrentGatedStepId() != null) {
+					message += " Current step: " + theJobInstance.getCurrentGatedStepId() + ".";
+				}
+				messages.add(message);
+				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
+				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
+			}
+			case FINALIZE -> {
+				status = HttpStatus.SC_ACCEPTED;
+				messages.add(theOperationName + " job has started and is being finalized");
+				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
+				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
+			}
+				//noinspection deprecation
+			case ERRORED, FAILED, COMPLETED -> {
+				if (theJobInstance.getStatus() == StatusEnum.COMPLETED) {
+					status = HttpStatus.SC_OK;
+					progressMessage = theOperationName + " job has completed successfully";
+					severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
+					code = OperationOutcomeUtil.OO_ISSUE_CODE_SUCCESS;
+				} else {
+					progressMessage =
+							theOperationName + " job has failed with error: " + theJobInstance.getErrorMessage();
+					severity = OperationOutcomeUtil.OO_SEVERITY_ERROR;
+					code = OperationOutcomeUtil.OO_ISSUE_CODE_PROCESSING;
+				}
+
+				String reportText = theJobInstance.getReport();
+				if (isBlank(reportText)) {
+					messages.add(progressMessage);
+				} else {
+					CompletedJobPollResponse completedJobPollResponse =
+							theCompletedJobResponseProvider.apply(theJobInstance);
+					if (completedJobPollResponse.rawBody() != null) {
+						writeResponseWithStringBody(
+								theRequestDetails.getServletResponse(), completedJobPollResponse.rawBody());
+						return;
+					}
+					if (completedJobPollResponse.messages() != null) {
+						messages.addAll(completedJobPollResponse.messages());
+					}
+				}
+				respondUsingBundle = true;
+			}
+			case CANCELLED -> {
+				status = HttpStatus.SC_OK;
+				messages.add(theOperationName + " job has been cancelled");
+				severity = OperationOutcomeUtil.OO_SEVERITY_WARN;
+				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
+				respondUsingBundle = true;
+			}
+		}
+
+		ImmutableMultimap.Builder<String, String> additionalHeaders = ImmutableMultimap.builder();
+		if (progressMessage != null) {
+			additionalHeaders.put(Constants.HEADER_X_PROGRESS, progressMessage);
+		} else if (!messages.isEmpty()) {
+			additionalHeaders.put(Constants.HEADER_X_PROGRESS, messages.get(0));
+		}
+
+		FhirContext fhirContext = theRequestDetails.getServer().getFhirContext();
+		IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(fhirContext);
+		for (String message : messages) {
+			OperationOutcomeUtil.addIssue(fhirContext, oo, severity, message, null, code);
+		}
+
+		IBaseResource responseResource;
+		if (respondUsingBundle) {
+			BundleBuilder bundleBuilder = new BundleBuilder(fhirContext);
+			bundleBuilder.setType(BundleTypeEnum.BATCH_RESPONSE.getCode());
+
+			CanonicalBundleEntry entry = new CanonicalBundleEntry();
+			entry.setResponseStatus(BaseTransactionProcessor.toStatusString(status));
+			entry.setResponseOutcome(oo);
+			bundleBuilder.addEntry(entry);
+
+			responseResource = bundleBuilder.getBundle();
+		} else {
+			responseResource = oo;
+		}
+
+		/*
+		 * According to the Asynchronous Interaction Request Pattern at
+		 * https://hl7.org/fhir/async-bundle.html,
+		 * if the job has completed (either successfully or unsuccessfully/prematurely), the response
+		 * should use an HTTP 200 status and should indicate the actual status in a Bundle
+		 * resource.
+		 */
+		if (respondUsingBundle) {
+			status = HttpStatus.SC_OK;
+		}
+
+		Multimap<String, String> additionalHeaders1 = additionalHeaders.build();
+
+		RestfulServerUtils.streamResponseAsResource(
+				theRequestDetails.getServer(),
+				responseResource,
+				Set.of(),
+				status,
+				additionalHeaders1,
+				false,
+				false,
+				theRequestDetails,
+				null,
+				null);
+	}
+
+	/**
+	 * This object is created and returned by a lambda passed to {@link #handleAsyncJobPollForStatusResponse}
+	 * @param rawBody
+	 * @param messages
+	 * @see #handleAsyncJobPollForStatusResponse(ServletRequestDetails, JobInstance, String, Function)
+	 */
+	public record CompletedJobPollResponse(@Nullable String rawBody, List<String> messages) {}
+}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/util/AsyncRequestUtil.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/util/AsyncRequestUtil.java
@@ -93,21 +93,21 @@ public class AsyncRequestUtil {
 
 	@Nonnull
 	public static JobInstance getJobInstance(
+			IJobCoordinator theJobCoordinator,
+			String theJobDefinitionId,
 			IPrimitiveType<String> theJobInstanceId,
-			IJobCoordinator jobCoordinator,
-			String jobId,
-			String operationName) {
+			String theOperationName) {
 		JobInstance instance;
 		try {
-			instance = jobCoordinator.getInstance(DatatypeUtil.toStringValue(theJobInstanceId));
+			instance = theJobCoordinator.getInstance(DatatypeUtil.toStringValue(theJobInstanceId));
 		} catch (ResourceNotFoundException e) {
 			throw new ResourceNotFoundException(
 					Msg.code(2787) + "Invalid/unknown job ID: " + UrlUtil.sanitizeUrlPart(theJobInstanceId.getValue()));
 		}
 
 		ValidateUtil.isTrueOrThrowInvalidRequest(
-				instance.getJobDefinitionId().equals(jobId),
-				"Job ID does not correspond to a " + operationName + " job");
+				instance.getJobDefinitionId().equals(theJobDefinitionId),
+				"Job ID does not correspond to a " + theOperationName + " job");
 		return instance;
 	}
 
@@ -167,13 +167,16 @@ public class AsyncRequestUtil {
 				if (theJobInstance.getCurrentGatedStepId() != null) {
 					message += " Current step: " + theJobInstance.getCurrentGatedStepId() + ".";
 				}
+				if (theJobInstance.getProgress() > 0) {
+					message += " Overall progress: " + ((int) (100.0 * theJobInstance.getProgress()) + "%.");
+				}
 				messages.add(message);
 				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
 				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
 			}
 			case FINALIZE -> {
 				status = HttpStatus.SC_ACCEPTED;
-				messages.add(theOperationName + " job has started and is being finalized");
+				messages.add(theOperationName + " job has completed main processing and is being finalized");
 				severity = OperationOutcomeUtil.OO_SEVERITY_INFO;
 				code = OperationOutcomeUtil.OO_ISSUE_CODE_INFORMATIONAL;
 			}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/util/AsyncRequestUtil.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/util/AsyncRequestUtil.java
@@ -163,7 +163,7 @@ public class AsyncRequestUtil {
 			}
 			case IN_PROGRESS -> {
 				status = HttpStatus.SC_ACCEPTED;
-				String message = theOperationName + " job has started and is in progress.";
+				String message = theOperationName + " job has started and is in progress";
 				if (theJobInstance.getCurrentGatedStepId() != null) {
 					message += " Current step: " + theJobInstance.getCurrentGatedStepId() + ".";
 				}

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -213,4 +214,30 @@ public class UrlUtilTest {
 		assertThat(map.containsKey("key")).isTrue();
 		assertThat(map.get("key")).contains("nice day");
 	}
+
+	@ParameterizedTest
+	@CsvSource(textBlock = """
+		# Input URL    ,  Input Version , Expected URL   , Expected Version
+		http://foo     ,                , http://foo     , null
+		http://foo|    ,                , http://foo     , null
+		http://foo|123 ,                , http://foo     , 123
+		http://foo     , 123            , http://foo     , 123
+		http://foo|456 , 123            , http://foo     , 123
+		""")
+	void testParseCanonicalUrl(String theInputUrl, String theInputVersionId, String theExpectedUrl, String theExpectedVersionId) {
+		UrlUtil.CanonicalUrlParts parts;
+		if (isNotBlank(theExpectedUrl)) {
+			parts = UrlUtil.parseCanonicalUrl(theInputUrl, theInputVersionId);
+		} else {
+			parts = UrlUtil.parseCanonicalUrl(theInputUrl);
+		}
+		assertEquals(theExpectedUrl, parts.url());
+		if ("null".equals(theExpectedVersionId)) {
+			assertFalse(parts.versionId().isPresent());
+		} else {
+			assertEquals(theExpectedVersionId, parts.versionId().orElseThrow());
+		}
+	}
+
+
 }

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/UrlUtilTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -222,11 +223,16 @@ public class UrlUtilTest {
 		http://foo|    ,                , http://foo     , null
 		http://foo|123 ,                , http://foo     , 123
 		http://foo     , 123            , http://foo     , 123
-		http://foo|456 , 123            , http://foo     , 123
+		http://foo|456 , 123            , http://foo     , FAIL
 		""")
 	void testParseCanonicalUrl(String theInputUrl, String theInputVersionId, String theExpectedUrl, String theExpectedVersionId) {
 		UrlUtil.CanonicalUrlParts parts;
-		if (isNotBlank(theExpectedUrl)) {
+		if ("FAIL".equals(theExpectedVersionId)) {
+			assertThatThrownBy(() -> UrlUtil.parseCanonicalUrl(theInputUrl, theInputVersionId))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining("Version in URL[http://foo|456 does not match expected version: 123");
+			return;
+		} else if (isNotBlank(theExpectedUrl)) {
 			parts = UrlUtil.parseCanonicalUrl(theInputUrl, theInputVersionId);
 		} else {
 			parts = UrlUtil.parseCanonicalUrl(theInputUrl);

--- a/pom.xml
+++ b/pom.xml
@@ -1441,7 +1441,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-csv</artifactId>
-				<version>1.10.0</version>
+				<version>1.14.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.aspectj</groupId>


### PR DESCRIPTION
This PR refactors the `BaseBulkModifyOrRewriteProvider` servlet, which is used to submit Bulk Modify jobs and poll for status, into some reusable components that can be leveraged by other similar providers.