### PR TITLE
Add unqualified path name support to FhirPatch

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7958-support-untyped-expressions-in-fhirpath.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/7958-support-untyped-expressions-in-fhirpath.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 7958
+title: "The FHIR Patch engine now supports untyped path expressions (e.g. `code` instead of the typed equivalent `Observation.code`). Previously only typed expressions were supported."

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/patch/FhirPatch.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/patch/FhirPatch.java
@@ -163,6 +163,8 @@ public class FhirPatch {
 	private void handleAddOperation(@Nullable IBaseResource theResource, IBase theParameters, PatchOutcome theOutcome) {
 
 		String path = ParametersUtil.getParameterPartValueAsString(myContext, theParameters, PARAMETER_PATH);
+		path = defaultString(path);
+		path = prefixResourceTypeToPathIfneeded(path, theResource);
 		String elementName = ParametersUtil.getParameterPartValueAsString(myContext, theParameters, PARAMETER_NAME);
 
 		String containingPath = defaultString(path);
@@ -192,6 +194,7 @@ public class FhirPatch {
 
 		String path = ParametersUtil.getParameterPartValueAsString(myContext, theParameters, PARAMETER_PATH);
 		path = defaultString(path);
+		path = prefixResourceTypeToPathIfneeded(path, theResource);
 
 		int lastDot = path.lastIndexOf(".");
 		if (lastDot == -1) {
@@ -242,6 +245,7 @@ public class FhirPatch {
 			@Nullable IBaseResource theResource, IBase theParameters, PatchOutcome theOutcome) {
 		String path = ParametersUtil.getParameterPartValueAsString(myContext, theParameters, PARAMETER_PATH);
 		path = defaultString(path);
+		path = prefixResourceTypeToPathIfneeded(path, theResource);
 
 		boolean allowMultiDelete = ParametersUtil.getParameterPartValueAsBoolean(
 						myContext, theParameters, PARAMETER_ALLOW_MULTIPLE_MATCHES)
@@ -306,6 +310,7 @@ public class FhirPatch {
 		String path = ParametersUtil.getParameterPartValueAsString(myContext, theParameters, PARAMETER_PATH);
 		path = defaultString(path);
 		path = normalizeExtensionFunctionSyntax(path);
+		path = prefixResourceTypeToPathIfneeded(path, theResource);
 
 		// TODO
 		/*
@@ -345,6 +350,13 @@ public class FhirPatch {
 
 		// replace the value
 		replaceValuesByPath(cd, theParameters, fhirPath, parsedFhirPath, theOutcome);
+	}
+
+	private String prefixResourceTypeToPathIfneeded(String thePath, IBaseResource theResource) {
+		if (isNotBlank(thePath) && Character.isLowerCase(thePath.charAt(0))) {
+			return myContext.getResourceType(theResource) + "." + thePath;
+		}
+		return thePath;
 	}
 
 	private void replaceValuesByPath(

--- a/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/patch/FhirPatchTest.java
+++ b/hapi-fhir-storage/src/test/java/ca/uhn/fhir/jpa/patch/FhirPatchTest.java
@@ -13,6 +13,7 @@ import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.EpisodeOfCare;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Group;
@@ -23,6 +24,7 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Specimen;
 import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.r5.model.Encounter;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeEach;
@@ -717,6 +719,89 @@ public class FhirPatchTest implements ITestDataBuilder {
 		// Verify
 		assertThat(input.getDeceased()).isInstanceOf(BooleanType.class);
 		assertThat(((BooleanType) input.getDeceased()).getValue()).isTrue();
+	}
+
+	@Test
+	void testReplace_UnqualifiedPath() {
+		ValueSet valueSet = new ValueSet();
+		valueSet.setStatus(Enumerations.PublicationStatus.DRAFT);
+
+		// Path has no resource type prefix
+		FhirPatchBuilder patchBuilder = new FhirPatchBuilder(myFhirContext);
+		patchBuilder
+			.replace()
+			.path("status")
+			.value(new CodeType("active"));
+		IBaseParameters patchDocument = patchBuilder.build();
+
+		// Test
+		myPatch.apply(valueSet, patchDocument);
+
+		// Verify
+		assertEquals(Enumerations.PublicationStatus.ACTIVE, valueSet.getStatus());
+
+	}
+
+	@Test
+	void testInsert_UnqualifiedPath() {
+		ValueSet valueSet = new ValueSet();
+		valueSet.setStatus(Enumerations.PublicationStatus.DRAFT);
+
+		// Path has no resource type prefix
+		FhirPatchBuilder patchBuilder = new FhirPatchBuilder(myFhirContext);
+		patchBuilder
+			.insert()
+			.path("identifier")
+			.index(0)
+			.value(new Identifier().setSystem("http://system").setValue("value-new"));
+		IBaseParameters patchDocument = patchBuilder.build();
+
+		// Test
+		myPatch.apply(valueSet, patchDocument);
+
+		// Verify
+		assertEquals("http://system", valueSet.getIdentifier().get(0).getSystem());
+	}
+
+	@Test
+	void testAdd_UnqualifiedPath() {
+		Observation obs = new Observation();
+		obs.getCode().setText("foo");
+
+		// Path has no resource type prefix
+		FhirPatchBuilder patchBuilder = new FhirPatchBuilder(myFhirContext);
+		patchBuilder
+			.add()
+			.path("code")
+			.name("coding")
+			.value(new Coding().setSystem("http://system").setCode("code-new"));
+		IBaseParameters patchDocument = patchBuilder.build();
+
+		// Test
+		myPatch.apply(obs, patchDocument);
+
+		// Verify
+		assertEquals("http://system", obs.getCode().getCodingFirstRep().getSystem());
+		assertEquals("foo", obs.getCode().getText());
+	}
+
+	@Test
+	void testDelete_UnqualifiedPath() {
+		Observation obs = new Observation();
+		obs.getCode().addCoding().setSystem("http://system").setCode("code-old");
+
+		// Path has no resource type prefix
+		FhirPatchBuilder patchBuilder = new FhirPatchBuilder(myFhirContext);
+		patchBuilder
+			.delete()
+			.path("code.coding");
+		IBaseParameters patchDocument = patchBuilder.build();
+
+		// Test
+		myPatch.apply(obs, patchDocument);
+
+		// Verify
+		assertEquals(null, obs.getCode().getCodingFirstRep().getSystem());
 	}
 
 	/**


### PR DESCRIPTION
The FHIR Patch engine now supports untyped path expressions (e.g. `code` instead of the typed equivalent `Observation.code`). Previously only typed expressions were supported.