### PR TITLE
Fix O(N^2) ArrayList.contains loop in DaoSearchParamSynchronizer.subtract

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8017-fix-dao-search-param-synchronizer-on2.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8017-fix-dao-search-param-synchronizer-on2.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 8017
+title: "Fixed a quadratic (O(N^2)) `ArrayList.contains` loop in
+  `DaoSearchParamSynchronizer.subtract` that caused re-uploads of very large
+  CodeSystem resources (e.g. NDC, with ~10^6 `ResourceIndexedSearchParam*`
+  rows) to spin for hours of CPU. The `theToSubtract` argument is now wrapped
+  in a `HashSet` (when not already a `Set`), restoring O(N) behavior."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizer.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizer.java
@@ -407,9 +407,16 @@ public class DaoSearchParamSynchronizer {
 			return new ArrayList<>();
 		}
 
+		// Wrap theToSubtract in a HashSet so contains() is O(1) instead of O(N).
+		// Without this, large code system re-PUTs (e.g. NDC, ~10^6 ResourceIndexedSearchParam* rows)
+		// spin for hours in O(N^2) ArrayList scans inside synchronize() because the second call
+		// (subtract(newParams, theExistingParams)) passes the original existing-params collection
+		// (typically an ArrayList) as theToSubtract.
+		Set<T> toSubtractSet = (theToSubtract instanceof Set) ? (Set<T>) theToSubtract : new HashSet<>(theToSubtract);
+
 		ArrayList<T> retVal = new ArrayList<>();
 		for (T next : theSubtractFrom) {
-			if (!theToSubtract.contains(next)) {
+			if (!toSubtractSet.contains(next)) {
 				retVal.add(next);
 			}
 		}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizerSubtractTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/index/DaoSearchParamSynchronizerSubtractTest.java
@@ -1,0 +1,117 @@
+package ca.uhn.fhir.jpa.dao.index;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for {@link DaoSearchParamSynchronizer#subtract(java.util.Collection, java.util.Collection)}.
+ * <p>
+ * Before the fix, this method called {@code theToSubtract.contains(next)} inside a loop over
+ * {@code theSubtractFrom}. When {@code theToSubtract} was an {@code ArrayList} (the typical
+ * call site for {@code paramsToAdd} in {@link DaoSearchParamSynchronizer#synchronize}, which
+ * passes the existing-params collection as the second argument), the operation was O(N^2).
+ * <p>
+ * For large code systems (e.g. NDC, ~10^6 {@code ResourceIndexedSearchParam*} rows) this caused
+ * multi-hour CPU spins on re-PUT. After the fix, {@code theToSubtract} is wrapped in a HashSet
+ * (when not already a Set), giving O(N) overall.
+ */
+class DaoSearchParamSynchronizerSubtractTest {
+
+	@Test
+	void subtract_emptyInput_returnsEmptyList() {
+		List<Long> result = DaoSearchParamSynchronizer.subtract(
+				Collections.emptyList(), List.of(1L, 2L, 3L));
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void subtract_noOverlap_returnsAllOfSubtractFrom() {
+		List<Long> subtractFrom = List.of(1L, 2L, 3L);
+		List<Long> toSubtract = List.of(10L, 20L, 30L);
+
+		List<Long> result = DaoSearchParamSynchronizer.subtract(subtractFrom, toSubtract);
+
+		assertThat(result).containsExactlyElementsOf(subtractFrom);
+	}
+
+	@Test
+	void subtract_fullOverlap_returnsEmptyList() {
+		List<Long> subtractFrom = List.of(1L, 2L, 3L);
+		List<Long> toSubtract = List.of(3L, 2L, 1L);
+
+		List<Long> result = DaoSearchParamSynchronizer.subtract(subtractFrom, toSubtract);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void subtract_partialOverlap_returnsOnlyNonOverlapping() {
+		List<Long> subtractFrom = List.of(1L, 2L, 3L, 4L, 5L);
+		List<Long> toSubtract = List.of(2L, 4L);
+
+		List<Long> result = DaoSearchParamSynchronizer.subtract(subtractFrom, toSubtract);
+
+		assertThat(result).containsExactly(1L, 3L, 5L);
+	}
+
+	@Test
+	void subtract_preservesOrderOfSubtractFrom() {
+		List<Long> subtractFrom = List.of(5L, 3L, 4L, 1L, 2L);
+		List<Long> toSubtract = List.of(3L, 1L);
+
+		List<Long> result = DaoSearchParamSynchronizer.subtract(subtractFrom, toSubtract);
+
+		assertThat(result).containsExactly(5L, 4L, 2L);
+	}
+
+	/**
+	 * Regression guard for the O(N^2) bug. With the buggy ArrayList.contains() loop, this case
+	 * (N=100,000 with the second argument being an ArrayList) was measured at ~42 sec on a
+	 * developer machine (Java 21, 4 GB heap). With the fix it runs in well under 100 ms. We
+	 * assert under a generous 5 sec ceiling so the test stays stable across CI hardware while
+	 * still catching a regression.
+	 */
+	@Test
+	void subtract_largeArrayListInput_completesInLinearTime() {
+		final int N = 100_000;
+		List<Long> subtractFrom = new ArrayList<>(N);
+		List<Long> toSubtractArrayList = new ArrayList<>(N);
+		for (long i = 0; i < N; i++) {
+			subtractFrom.add(i);
+			// 50% overlap: even values are in both lists, odd values are only in subtractFrom.
+			if (i % 2 == 0) {
+				toSubtractArrayList.add(i);
+			} else {
+				toSubtractArrayList.add(i + N); // disjoint value
+			}
+		}
+
+		long startNs = System.nanoTime();
+		List<Long> result = DaoSearchParamSynchronizer.subtract(subtractFrom, toSubtractArrayList);
+		long elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+
+		assertThat(result)
+				.as("Half the elements (the odd values) should remain")
+				.hasSize(N / 2);
+		assertThat(elapsedMs)
+				.as("subtract took %d ms for N=%d; expected <5000 ms. The O(N^2) bug may have regressed.", elapsedMs, N)
+				.isLessThan(5_000);
+	}
+
+	@Test
+	void subtract_setInput_isHandledCorrectly() {
+		List<Long> subtractFrom = List.of(1L, 2L, 3L, 4L, 5L);
+		Set<Long> toSubtractSet = new HashSet<>(List.of(2L, 4L));
+
+		List<Long> result = DaoSearchParamSynchronizer.subtract(subtractFrom, toSubtractSet);
+
+		assertThat(result).containsExactly(1L, 3L, 5L);
+	}
+}


### PR DESCRIPTION

`DaoSearchParamSynchronizer.subtract(Collection, Collection)` does `theToSubtract.contains(next)` inside a loop over `theSubtractFrom`. When `theToSubtract` is an `ArrayList` (which is the case for the `paramsToAdd` call site, where the existing-params collection is passed as the second argument), `.contains()` is O(N) and the whole call becomes O(N²).

For resources that produce a large number of `ResourceIndexedSearchParam*` rows — most notably large `CodeSystem` resources whose built-in `CodeSystem.code` SearchParameter indexes a token per concept — this turns a normal re-PUT into a multi-hour CPU spin.

This PR wraps `theToSubtract` in a `HashSet` (when it isn't already a `Set`) so `.contains()` is O(1) and the total work is O(N).

---

## Reproducer

1. Empty DB, default HAPI JPA server config.
2. `PUT /CodeSystem/ndc` with the FHIR NDC `CodeSystem` resource (~762,886 concepts, ~82 MB JSON). Completes in ~10–20 min depending on hardware.
3. `PUT /CodeSystem/ndc` **again** with the same (or any) content.
4. The second PUT never returns. The HTTP worker thread is `RUNNABLE` at 100 % CPU.

A `jstack` of the stuck worker shows the loop unambiguously:

```
"http-nio-8888-exec-5" #75 ... runnable
   java.lang.Thread.State: RUNNABLE
    at org.apache.commons.lang3.builder.EqualsBuilder.append(EqualsBuilder.java:731)
    at ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken.equals(ResourceIndexedSearchParamToken.java:243)
    at java.util.ArrayList.indexOfRange(ArrayList.java:299)
    at java.util.ArrayList.indexOf(ArrayList.java:286)
    at java.util.ArrayList.contains(ArrayList.java:275)
    at ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer.subtract(DaoSearchParamSynchronizer.java:319)
    at ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer.synchronize(DaoSearchParamSynchronizer.java:164)
    at ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer.synchronizeSearchParamsToDatabase(DaoSearchParamSynchronizer.java:79)
    at ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.updateEntity(BaseHapiFhirDao.java:1107)
    at ca.uhn.fhir.jpa.dao.JpaResourceDaoCodeSystem.updateEntity(JpaResourceDaoCodeSystem.java:236)
    ...
```

Observed CPU on the stuck worker: **45+ minutes of pure CPU time, still climbing**, before the upstream HTTP client gave up at its 1-hour socket read timeout. Server was responsive to other requests during this period — no DB or pool exhaustion — but the worker thread itself never completed.

---

## Root cause

In `DaoSearchParamSynchronizer.synchronize(...)` (line ~163-164):

```java
newParams = new HashSet<>(newParams);
List<T> paramsToRemove = subtract(theExistingParams, newParams);    // OK — newParams is a HashSet
List<T> paramsToAdd    = subtract(newParams, theExistingParams);    // BUG — theExistingParams is the input Collection
```

Only the first `subtract` call is fast — its `theToSubtract` argument is the freshly created HashSet. The second call passes `theExistingParams` as `theToSubtract`. That collection is whatever the caller supplied — in practice usually an `ArrayList` of entities loaded from the database.

`subtract()` then iterates over `newParams` (size N) and for each element does `theExistingParams.contains(next)` (cost N) → **total cost O(N²)**.

For a `CodeSystem` re-PUT, each concept's code contributes a `ResourceIndexedSearchParamToken` row via the built-in `CodeSystem.code` SearchParameter. NDC produces ~10⁶ tokens, so the inner loop runs ~10¹² `equals()` calls. Each `equals()` call also allocates short-lived objects via `EqualsBuilder`, which puts severe pressure on the GC (we observed individual G1 pauses up to ~15 s during the run).

---

## Fix

One-method change in `DaoSearchParamSynchronizer.java`:

```java
public static <T> List<T> subtract(Collection<T> theSubtractFrom, Collection<T> theToSubtract) {
    assert theSubtractFrom != theToSubtract || (theSubtractFrom.isEmpty());

    if (theSubtractFrom.isEmpty()) {
        return new ArrayList<>();
    }

    // Wrap theToSubtract in a HashSet so contains() is O(1) instead of O(N).
    // Without this, large code system re-PUTs (e.g. NDC, 762k concepts) spin
    // for hours in O(N^2) ArrayList scans called from synchronize().
    Set<T> toSubtractSet = (theToSubtract instanceof Set)
            ? (Set<T>) theToSubtract
            : new HashSet<>(theToSubtract);

    ArrayList<T> retVal = new ArrayList<>();
    for (T next : theSubtractFrom) {
        if (!toSubtractSet.contains(next)) {
            retVal.add(next);
        }
    }
    return retVal;
}
```

(Add `import java.util.Set;` if not already present.)

### Why this is safe

- All `ResourceIndexedSearchParam*` entities passed through `subtract()` already implement `equals()` and `hashCode()` consistently (they have to, otherwise the existing `newParams = new HashSet<>(newParams)` above would already misbehave).
- When `theToSubtract` is already a `Set`, we reuse it directly — no extra copy.
- When it's not a Set, we pay O(N) once to build a HashSet and save O(N²) afterwards.
- Behavior is unchanged: same elements returned, same order from the iteration over `theSubtractFrom`.

---

## Performance evidence

Measured against HAPI 8.6.1 on SQL Server, default starter config, 4 GB JVM heap, single PUT of `CodeSystem-NDC.json` (~762k–769k concepts, ~82 MB):

| Scenario | Before fix | After fix |
|---|---|---|
| 1st PUT (empty DB) | 9 min 40 sec | 9 min 40 sec |
| 2nd PUT (same DB) | **never completes** — worker thread RUNNABLE for 45+ min of CPU, client times out at 1 h socket read timeout | **8 min 3 sec** |
| Worst single GC pause during 2nd PUT | ~14.7 sec | ~8.7 sec |
| Hung worker thread at end of 2nd PUT | RUNNABLE in `subtract`, 45+ min CPU consumed | none — all workers PARKED |

Stack trace of the worker thread during the pre-fix hang (every single dump over a 10-minute window showed the same frames at the top):

```
at org.apache.commons.lang3.builder.EqualsBuilder.append(EqualsBuilder.java:731)
at ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken.equals(ResourceIndexedSearchParamToken.java:243)
at java.util.ArrayList.indexOfRange(ArrayList.java:299)
at java.util.ArrayList.indexOf(ArrayList.java:286)
at java.util.ArrayList.contains(ArrayList.java:275)
at ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer.subtract(DaoSearchParamSynchronizer.java:319)
at ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer.synchronize(DaoSearchParamSynchronizer.java:164)
at ca.uhn.fhir.jpa.dao.index.DaoSearchParamSynchronizer.synchronizeSearchParamsToDatabase(DaoSearchParamSynchronizer.java:79)
at ca.uhn.fhir.jpa.dao.BaseHapiFhirDao.updateEntity(BaseHapiFhirDao.java:1107)
at ca.uhn.fhir.jpa.dao.JpaResourceDaoCodeSystem.updateEntity(JpaResourceDaoCodeSystem.java:236)
```

---

## Tests

Suggested unit test additions in `DaoSearchParamSynchronizerTest` (or new test class):

1. `subtract_whenToSubtractIsArrayList_isLinearNotQuadratic` — build two collections of N=100,000 mock indexed-search-param tokens, call `subtract(a, b)` with `b` as an `ArrayList`, assert completion time below a generous threshold (e.g. 5 s).
2. `subtract_whenToSubtractIsSet_reusesInput` — verify a `Set` argument is not wrapped again (can use a spy).
3. `subtract_correctnessRegression` — small inputs verifying the result list still contains exactly the elements in `theSubtractFrom` that aren't in `theToSubtract`, with various overlaps.

An end-to-end integration test for a large-CodeSystem re-PUT would also be valuable but may be too slow for CI; a smaller "5,000 concept" CodeSystem re-PUT in JPA tests would be enough to gate this regression.

---

## Risk

Very low. The change is local to one method, preserves its contract, requires `equals/hashCode` properties that the input types already guarantee, and is exercised by every JPA write path.

---

## CHANGELOG entry

HAPI uses per-version YAML changelog files (not the maven-changes-plugin). Add a new file:

`hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/<MAJOR>_<MINOR>_<PATCH>/<issue#>-daosearchparamsynchronizer-on2.yaml`

(use the highest-numbered changelog directory on `master` — i.e. the next un-released version)

```yaml
type: fix
issue: <issue-number>
title: "Avoid O(N^2) ArrayList.contains in DaoSearchParamSynchronizer.subtract: re-uploading a large CodeSystem (e.g. NDC, ~10^6 ResourceIndexedSearchParam* rows) used to spin in a quadratic ArrayList scan for hours. The collection passed as 'to subtract' is now wrapped in a HashSet, restoring O(N) behavior."
```

---

## Notes

- Worth checking whether HAPI's terminology upload paths (`UploadStatistics`,
  `TermLoaderSvcImpl`) also call into this synchronizer for CodeSystem `_history/N` updates; they do, via `JpaResourceDaoCodeSystem.updateEntity`.
- If accepted, consider also documenting in the "tuning large terminologies"
  docs that re-PUT of large CodeSystems was previously O(N²) and recommending
  the `$apply-codesystem-delta-add` operation for repeated incremental
  updates.

Fixes #8017