### PR TITLE
Update org.hl7.fhir.core to 6.9.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1014,7 +1014,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.9.4.1</fhir_core_version>
+		<fhir_core_version>6.9.4.2</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<spotless.exclude.pattern>**/test/**/*.java</spotless.exclude.pattern>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>


### PR DESCRIPTION
Note: this will fail the 'Compile against CDR' check, as this change targets an older HAPI release and the check targets a master branch which has moved on to a more recent HAPI release/build.

However, the relevant change (https://github.com/hapifhir/org.hl7.fhir.core/commit/109c88837c032ef399b2eb87ddde86692065cf41) is already in the HAPI master branch via an update to org.hl7.fhir.core 6.9.9 (https://github.com/hapifhir/org.hl7.fhir.core/commit/e08982d2b6f6dcd6c670a762d9cf999179fbe4ed), so its impacts have been tested in HAPI (https://github.com/hapifhir/hapi-fhir/pull/7962).