### PR TITLE
Resolve "Unqualified _id chained search on multi-target reference parameter silently returns zero results"

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8025-fix-unqualified-id-chained-searches-on-multi-target-reference-parameter.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8025-fix-unqualified-id-chained-searches-on-multi-target-reference-parameter.yaml
@@ -1,7 +1,7 @@
 ---
 type: fix
 issue: 8025
-title: "Fixed: Unqualified _id chained searches on a multi-target reference parameter 
+title: "Fixed:  Unqualified _id chained searches on a multi-target reference parameter 
    (e.g. DiagnosticReport?based-on._id=sr-1) silently returned zero results when the SearchParameter declared 
    more than one target type. The per-target-type subqueries were OR'd together on a shared SearchQueryBuilder, 
    and the first iteration whose target type didn't contain the id called setMatchNothing(), short-circuiting 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8025-fix-unqualified-id-chained-searches-on-multi-target-reference-parameter.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8025-fix-unqualified-id-chained-searches-on-multi-target-reference-parameter.yaml
@@ -1,0 +1,9 @@
+---
+type: fix
+issue: 8025
+title: "Fixed: Unqualified _id chained searches on a multi-target reference parameter 
+   (e.g. DiagnosticReport?based-on._id=sr-1) silently returned zero results when the SearchParameter declared 
+   more than one target type. The per-target-type subqueries were OR'd together on a shared SearchQueryBuilder, 
+   and the first iteration whose target type didn't contain the id called setMatchNothing(), short-circuiting 
+   the entire query — even when a sibling iteration would have matched. Empty per-branch lookups now emit 
+   a branch-local always-false condition instead, leaving the surrounding OR intact."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8025-fix-unqualified-id-chained-searches-on-multi-target-reference-parameter.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8025-fix-unqualified-id-chained-searches-on-multi-target-reference-parameter.yaml
@@ -3,7 +3,4 @@ type: fix
 issue: 8025
 title: "Fixed:  Unqualified _id chained searches on a multi-target reference parameter 
    (e.g. DiagnosticReport?based-on._id=sr-1) silently returned zero results when the SearchParameter declared 
-   more than one target type. The per-target-type subqueries were OR'd together on a shared SearchQueryBuilder, 
-   and the first iteration whose target type didn't contain the id called setMatchNothing(), short-circuiting 
-   the entire query — even when a sibling iteration would have matched. Empty per-branch lookups now emit 
-   a branch-local always-false condition instead, leaving the surrounding OR intact."
+   more than one target type."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
@@ -122,7 +122,8 @@ public class ResourceIdPredicateBuilder extends BasePredicateBuilder {
 		}
 
 		if (allOrPids != null && allOrPids.isEmpty()) {
-			// During unqualified chain resolution, e.g. ?based-on._idx=x, do not drop out early and instead evaluate all target types
+			// During unqualified chain resolution, e.g. ?based-on._idx=x, do not drop out early and instead evaluate
+			// all target types
 			if (theSourceJoinColumn != null) {
 				SearchFilterParser.CompareOperation operation = defaultIfNull(theOperation, defaultOperation);
 				return new CustomCondition(

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
@@ -122,33 +122,13 @@ public class ResourceIdPredicateBuilder extends BasePredicateBuilder {
 		}
 
 		if (allOrPids != null && allOrPids.isEmpty()) {
-			/*
-			 * If we are being invoked as a child predicate (i.e. our caller is joining
-			 * us back via theSourceJoinColumn), we are by construction in an OR
-			 * position — for example, the unqualified chain "?based-on._id=x" iterates
-			 * every target type of the based-on SearchParameter and OR's the per-type
-			 * subqueries together.
-			 *
-			 * In that context, calling setMatchNothing() would taint the SHARED
-			 * SearchQueryBuilder and short-circuit the entire outer query — even
-			 * though sibling OR branches may still resolve. Instead, produce an
-			 * always-false condition for this branch only (and the symmetric
-			 * always-true for `ne`, since "id NOT IN {}" is trivially satisfied by
-			 * every row).
-			 */
+			// During unqualified chain resolution, e.g. ?based-on._idx=x, do not drop out early and instead evaluate all target types
 			if (theSourceJoinColumn != null) {
 				SearchFilterParser.CompareOperation operation = defaultIfNull(theOperation, defaultOperation);
 				return new CustomCondition(
 						operation == SearchFilterParser.CompareOperation.ne ? "(NULL IS NULL)" : "(NULL IS NOT NULL)");
 			}
-
-			/*
-			 * Top-level call (no source-join column): the empty set is an AND-position
-			 * guarantee that nothing can match, so the existing setMatchNothing()
-			 * short-circuit is correct and desirable.
-			 */
 			setMatchNothing();
-
 		} else if (allOrPids != null) {
 
 			SearchFilterParser.CompareOperation operation = defaultIfNull(theOperation, defaultOperation);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
@@ -33,6 +33,7 @@ import ca.uhn.fhir.rest.api.SearchIncludeDeletedEnum;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.TokenParamModifier;
 import com.healthmarketscience.sqlbuilder.Condition;
+import com.healthmarketscience.sqlbuilder.CustomCondition;
 import com.healthmarketscience.sqlbuilder.dbspec.basic.DbColumn;
 import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -121,7 +122,30 @@ public class ResourceIdPredicateBuilder extends BasePredicateBuilder {
 		}
 
 		if (allOrPids != null && allOrPids.isEmpty()) {
+			/*
+			 * If we are being invoked as a child predicate (i.e. our caller is joining
+			 * us back via theSourceJoinColumn), we are by construction in an OR
+			 * position — for example, the unqualified chain "?based-on._id=x" iterates
+			 * every target type of the based-on SearchParameter and OR's the per-type
+			 * subqueries together.
+			 *
+			 * In that context, calling setMatchNothing() would taint the SHARED
+			 * SearchQueryBuilder and short-circuit the entire outer query — even
+			 * though sibling OR branches may still resolve. Instead, produce an
+			 * always-false condition for this branch only (and the symmetric
+			 * always-true for `ne`, since "id NOT IN {}" is trivially satisfied by
+			 * every row).
+			 */
+			if (theSourceJoinColumn != null) {
+				SearchFilterParser.CompareOperation operation = defaultIfNull(theOperation, defaultOperation);
+				return new CustomCondition(operation == SearchFilterParser.CompareOperation.ne ? "(NULL IS NULL)" : "(NULL IS NOT NULL)");
+			}
 
+			/*
+			 * Top-level call (no source-join column): the empty set is an AND-position
+			 * guarantee that nothing can match, so the existing setMatchNothing()
+			 * short-circuit is correct and desirable.
+			 */
 			setMatchNothing();
 
 		} else if (allOrPids != null) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceIdPredicateBuilder.java
@@ -138,7 +138,8 @@ public class ResourceIdPredicateBuilder extends BasePredicateBuilder {
 			 */
 			if (theSourceJoinColumn != null) {
 				SearchFilterParser.CompareOperation operation = defaultIfNull(theOperation, defaultOperation);
-				return new CustomCondition(operation == SearchFilterParser.CompareOperation.ne ? "(NULL IS NULL)" : "(NULL IS NOT NULL)");
+				return new CustomCondition(
+						operation == SearchFilterParser.CompareOperation.ne ? "(NULL IS NULL)" : "(NULL IS NOT NULL)");
 			}
 
 			/*

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/ChainingR4SearchTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/ChainingR4SearchTest.java
@@ -1964,6 +1964,84 @@ public class ChainingR4SearchTest extends BaseJpaR4Test {
 			.contains("HASH_EXACT");
 	}
 
+	@Test
+	// Created by claude-opus-4-7 for https://github.com/hapifhir/hapi-fhir/issues/8025
+	void test_unqualifiedChainedIdOnMultiTargetReference_returnsMatchingResource() {
+		// SearchParameter http://hl7.org/fhir/SearchParameter/DiagnosticReport-based-on declares
+		//   target = [ CarePlan, ImmunizationRecommendation, MedicationRequest, NutritionOrder, ServiceRequest ]
+		// The customer's DiagnosticReport references a ServiceRequest with FHIR id "sr-1".
+		createResource("ServiceRequest", withId("sr-1"));
+		createResource("DiagnosticReport", withId("dr-1"),
+			withReference("basedOn", "ServiceRequest/sr-1"));
+
+		// Sanity: the qualified form works. resourceTypes contains only ServiceRequest,
+		// so the iteration in ResourceLinkPredicateBuilder runs once, resolveResourceIdentities
+		// returns a non-empty PID set, and setMatchNothing() is never called.
+		SearchParameterMap qualified = SearchParameterMap.newSynchronous();
+		qualified.add(DiagnosticReport.SP_BASED_ON, new ReferenceParam("ServiceRequest", "_id", "sr-1"));
+		IBundleProvider qualifiedResult = myDiagnosticReportDao.search(qualified, newSrd());
+		assertThat(toUnqualifiedVersionlessIdValues(qualifiedResult))
+			.as("qualified chain (sanity)")
+			.containsExactly("DiagnosticReport/dr-1");
+
+		// The unqualified form must return the same resource. Today, it does not.
+		// resourceTypes contains all 5 SP targets. The first iteration (CarePlan) builds
+		// IIdHelperService.resolveResourceIdentities([CarePlan/sr-1]), which returns empty,
+		// triggers setMatchNothing() on the shared SearchQueryBuilder, and the entire query
+		// is short-circuited to "no rows" — even though the ServiceRequest iteration would
+		// have built a perfectly correct subquery on its turn.
+		SearchParameterMap unqualified = SearchParameterMap.newSynchronous();
+		unqualified.add(DiagnosticReport.SP_BASED_ON, new ReferenceParam(null, "_id", "sr-1"));
+		IBundleProvider unqualifiedResult = myDiagnosticReportDao.search(unqualified, newSrd());
+		assertThat(toUnqualifiedVersionlessIdValues(unqualifiedResult))
+			.as("unqualified chain — fails today, must return the same DR as the qualified form")
+			.containsExactly("DiagnosticReport/dr-1");
+	}
+
+	@Test
+	// Created by claude-opus-4-7 for https://github.com/hapifhir/hapi-fhir/issues/8025
+	void test_unqualifiedChainedIdOnMultiTargetReference_returnsAllWhenIdAmbiguousAcrossTypes() {
+		// FHIR ids are unique within a resource type but may collide ACROSS types.
+		// An unqualified chained _id search on a multi-target reference must therefore
+		// return matches from every target type whose resource has that id.
+		//
+		// Today this case is doubly broken: setMatchNothing() fires on the first iteration
+		// whose target type doesn't have the id, even though TWO of the iterations would
+		// have produced correct subqueries. After the fix, both DRs must come back.
+		createResource("ServiceRequest", withId("shared-id"));
+		createResource("CarePlan",       withId("shared-id"));
+
+		createResource("DiagnosticReport", withId("dr-sr"),
+			withReference("basedOn", "ServiceRequest/shared-id"));
+		createResource("DiagnosticReport", withId("dr-cp"),
+			withReference("basedOn", "CarePlan/shared-id"));
+
+		SearchParameterMap map = SearchParameterMap.newSynchronous();
+		map.add(DiagnosticReport.SP_BASED_ON, new ReferenceParam(null, "_id", "shared-id"));
+		IBundleProvider result = myDiagnosticReportDao.search(map, newSrd());
+
+		assertThat(toUnqualifiedVersionlessIdValues(result))
+			.containsExactlyInAnyOrder("DiagnosticReport/dr-sr", "DiagnosticReport/dr-cp");
+	}
+
+	@Test
+	// Created by claude-opus-4-7 for https://github.com/hapifhir/hapi-fhir/issues/8025
+	void test_unqualifiedChainedIdOnMultiTargetReference_returnsEmptyWhenIdMatchesNoTargetType() {
+		// Regression guard. After fixing the OR-context handling in ResourceIdPredicateBuilder,
+		// we must still return an empty bundle when the id genuinely does not exist for any
+		// target type. The fix should change HOW we arrive at empty (per-iteration FALSE
+		// condition in the OR, rather than a global setMatchNothing), not WHETHER we do.
+		createResource("ServiceRequest", withId("sr-1"));
+		createResource("DiagnosticReport", withId("dr-1"),
+			withReference("basedOn", "ServiceRequest/sr-1"));
+
+		SearchParameterMap map = SearchParameterMap.newSynchronous();
+		map.add(DiagnosticReport.SP_BASED_ON, new ReferenceParam(null, "_id", "does-not-exist"));
+		IBundleProvider result = myDiagnosticReportDao.search(map, newSrd());
+
+		assertThat(toUnqualifiedVersionlessIdValues(result)).isEmpty();
+	}
+
 	private void countUnionStatementsInGeneratedQuery(String theUrl, int theExpectedNumberOfUnions) {
 		myCaptureQueriesListener.clear();
 		myTestDaoSearch.searchForIds(theUrl);


### PR DESCRIPTION

See HAPI-FHIR Issue #8025 for a detailed description of the purpose of this Pull Request.
