### PR TITLE
Improve batch2 gated job execution speed

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>8.11.11-SNAPSHOT</version>
+		 <version>8.11.12-SNAPSHOT</version>
 
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>8.11.11-SNAPSHOT</version>
+	<version>8.11.12-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-apache-http5/pom.xml
+++ b/hapi-fhir-client-apache-http5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8062-improve-batch2-speed.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8062-improve-batch2-speed.yaml
@@ -1,0 +1,4 @@
+---
+type: perf
+issue: 8062
+title: "The Batch2 maintenance job has been split into two separate steps that can be executed separately: The active job maintenance (handles advancing gated jobs) and the ended job maintenance (purges old files). The active job maintenance is now executed at a much higher frequency (every 5 seconds as opposed to every minute) so that active batch jobs can don't spend a lot of time waiting between steps."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8062-improve-batch2-speed.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8062-improve-batch2-speed.yaml
@@ -1,4 +1,4 @@
 ---
 type: perf
 issue: 8062
-title: "The Batch2 maintenance job has been split into two separate steps that can be executed separately: The active job maintenance (handles advancing gated jobs) and the ended job maintenance (purges old files). The active job maintenance is now executed at a much higher frequency (every 5 seconds as opposed to every minute) so that active batch jobs can don't spend a lot of time waiting between steps."
+title: "The Batch2 maintenance job has been split into two separate steps that can be executed separately: The active job maintenance (handles advancing gated jobs) and the ended job maintenance (purges old files). The active job maintenance is now executed at a much higher frequency (every 5 seconds as opposed to every minute) so that active batch jobs don't spend a lot of time waiting between steps."

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpa-hibernate-services/pom.xml
+++ b/hapi-fhir-jpa-hibernate-services/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImpl.java
@@ -375,13 +375,25 @@ public class JpaJobPersistenceImpl implements IJobPersistence {
 	}
 
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public List<JobInstance> fetchInstances(int thePageSize, int thePageIndex) {
 		// default sort is myCreateTime Asc
 		PageRequest pageRequest = PageRequest.of(thePageIndex, thePageSize, Sort.Direction.ASC, CREATE_TIME);
 		return myTransactionService
 				.withSystemRequestOnDefaultPartition()
+				.withPropagation(Propagation.REQUIRES_NEW)
 				.execute(() -> myJobInstanceRepository.findAll(pageRequest).stream()
+						.map(this::toInstance)
+						.collect(Collectors.toList()));
+	}
+
+	@Override
+	public List<JobInstance> fetchInstances(int thePageSize, int thePageIndex, Set<StatusEnum> theStatuses) {
+		// The repository query returns a stable sort
+		PageRequest pageRequest = PageRequest.of(thePageIndex, thePageSize);
+		return myTransactionService
+				.withSystemRequestOnDefaultPartition()
+				.withPropagation(Propagation.REQUIRES_NEW)
+				.execute(() -> myJobInstanceRepository.findAllWithStatuses(pageRequest, theStatuses).stream()
 						.map(this::toInstance)
 						.collect(Collectors.toList()));
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/TerminologyXmlUtil.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/TerminologyXmlUtil.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.base;
 
 import ca.uhn.fhir.batch2.api.AttachmentDetails;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep1ExpandDistributionIntoFilesStep.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep1ExpandDistributionIntoFilesStep.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.custom;
 
 import ca.uhn.fhir.batch2.api.IJobDataSink;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep2HandleConcepts.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep2HandleConcepts.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.custom;
 
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep3HandleProperties.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep3HandleProperties.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.custom;
 
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep4HandleHierarchy.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyStep4HandleHierarchy.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.custom;
 
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/icd10cm/ImportIcd10CmStep1ExpandDistributionIntoFilesStep.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/icd10cm/ImportIcd10CmStep1ExpandDistributionIntoFilesStep.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.icd.icd10cm;
 
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/icd10cm/ImportIcd10CmStep2HandleConcepts.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/icd10cm/ImportIcd10CmStep2HandleConcepts.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.jpa.batch2.jobs.term.icd.icd10cm;
 
 import ca.uhn.fhir.batch2.api.AttachmentDetails;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
@@ -111,7 +111,8 @@ public interface IBatch2JobInstanceRepository
 			"SELECT new ca.uhn.fhir.batch2.model.BatchInstanceStatusDTO(e.myId, e.myStatus, e.myStartTime, e.myEndTime) FROM Batch2JobInstanceEntity e WHERE e.myId = :id")
 	BatchInstanceStatusDTO fetchBatchInstanceStatus(@Param("id") String theInstanceId);
 
-	@Query("SELECT e FROM Batch2JobInstanceEntity e WHERE e.myStatus IN (:statuses) ORDER BY e.myCreateTime ASC, e.myId ASC")
+	@Query(
+			"SELECT e FROM Batch2JobInstanceEntity e WHERE e.myStatus IN (:statuses) ORDER BY e.myCreateTime ASC, e.myId ASC")
 	Collection<Batch2JobInstanceEntity> findAllWithStatuses(
 			PageRequest thePageRequest, @Param("statuses") Set<StatusEnum> theStatuses);
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
@@ -111,7 +111,7 @@ public interface IBatch2JobInstanceRepository
 			"SELECT new ca.uhn.fhir.batch2.model.BatchInstanceStatusDTO(e.myId, e.myStatus, e.myStartTime, e.myEndTime) FROM Batch2JobInstanceEntity e WHERE e.myId = :id")
 	BatchInstanceStatusDTO fetchBatchInstanceStatus(@Param("id") String theInstanceId);
 
-	@Query("SELECT e FROM Batch2JobInstanceEntity e WHERE e.myStatus IN (:statuses) ORDER BY e.myId")
+	@Query("SELECT e FROM Batch2JobInstanceEntity e WHERE e.myStatus IN (:statuses) ORDER BY e.myCreateTime ASC, e.myId ASC")
 	Collection<Batch2JobInstanceEntity> findAllWithStatuses(
 			PageRequest thePageRequest, @Param("statuses") Set<StatusEnum> theStatuses);
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/data/IBatch2JobInstanceRepository.java
@@ -23,12 +23,14 @@ import ca.uhn.fhir.batch2.model.BatchInstanceStatusDTO;
 import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.jpa.entity.Batch2JobInstanceEntity;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -108,4 +110,8 @@ public interface IBatch2JobInstanceRepository
 	@Query(
 			"SELECT new ca.uhn.fhir.batch2.model.BatchInstanceStatusDTO(e.myId, e.myStatus, e.myStartTime, e.myEndTime) FROM Batch2JobInstanceEntity e WHERE e.myId = :id")
 	BatchInstanceStatusDTO fetchBatchInstanceStatus(@Param("id") String theInstanceId);
+
+	@Query("SELECT e FROM Batch2JobInstanceEntity e WHERE e.myStatus IN (:statuses) ORDER BY e.myId")
+	Collection<Batch2JobInstanceEntity> findAllWithStatuses(
+			PageRequest thePageRequest, @Param("statuses") Set<StatusEnum> theStatuses);
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
@@ -420,7 +420,7 @@ public class ExpungeEverythingService implements IExpungeEverythingService {
 
 	/**
 	 * Deletes Batch2WorkChunkEntity and Batch2JobInstanceEntity while holding the maintenance
-	 * semaphore (via {@link IJobMaintenanceService#holdMaintenanceForExpunge()}) to prevent any
+	 * semaphore (via {@link IJobMaintenanceService#holdActiveJobMaintenanceForExpunge()}) to prevent any
 	 * concurrent maintenance pass from inserting or updating batch2 entities during deletion.
 	 *
 	 * <p>The semaphore hold prevents maintenance on the local JVM. In clustered deployments,
@@ -438,7 +438,7 @@ public class ExpungeEverythingService implements IExpungeEverythingService {
 		// Hold the maintenance semaphore while deleting batch2 entities.
 		// This prevents the local maintenance job from inserting/updating work chunks and job
 		// instances while we are deleting them, eliminating FK violations and deadlocks.
-		try (Closeable ignored = myJobMaintenanceService.holdMaintenanceForExpunge()) {
+		try (Closeable ignored = myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()) {
 			int outcome = 0;
 			int consecutiveFailures = 0;
 			while (true) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
@@ -420,7 +420,7 @@ public class ExpungeEverythingService implements IExpungeEverythingService {
 
 	/**
 	 * Deletes Batch2WorkChunkEntity and Batch2JobInstanceEntity while holding the maintenance
-	 * semaphore (via {@link IJobMaintenanceService#holdActiveJobMaintenanceForExpunge()}) to prevent any
+	 * semaphore (via {@link IJobMaintenanceService#holdJobMaintenanceForExpunge()}) to prevent any
 	 * concurrent maintenance pass from inserting or updating batch2 entities during deletion.
 	 *
 	 * <p>The semaphore hold prevents maintenance on the local JVM. In clustered deployments,
@@ -438,7 +438,7 @@ public class ExpungeEverythingService implements IExpungeEverythingService {
 		// Hold the maintenance semaphore while deleting batch2 entities.
 		// This prevents the local maintenance job from inserting/updating work chunks and job
 		// instances while we are deleting them, eliminating FK violations and deadlocks.
-		try (Closeable ignored = myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()) {
+		try (Closeable ignored = myJobMaintenanceService.holdJobMaintenanceForExpunge()) {
 			int outcome = 0;
 			int consecutiveFailures = 0;
 			while (true) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
@@ -52,7 +52,10 @@ import static org.apache.commons.lang3.StringUtils.left;
 @Entity
 @Table(
 		name = "BT2_JOB_INSTANCE",
-		indexes = {@Index(name = "IDX_BT2JI_CT", columnList = "CREATE_TIME")})
+		indexes = {
+			@Index(name = "IDX_BT2JI_CT", columnList = "CREATE_TIME"),
+			@Index(name = "IDX_BT2JI_STAT_CT", columnList = "STAT,ID")
+		})
 public class Batch2JobInstanceEntity implements Serializable {
 
 	public static final int STATUS_MAX_LENGTH = 20;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
@@ -54,7 +54,7 @@ import static org.apache.commons.lang3.StringUtils.left;
 		name = "BT2_JOB_INSTANCE",
 		indexes = {
 			@Index(name = "IDX_BT2JI_CT", columnList = "CREATE_TIME"),
-			@Index(name = "IDX_BT2JI_STAT_CT", columnList = "STAT,CREATE_TIME,ID")
+			@Index(name = "IDX_BT2JI_STAT_CT_ID", columnList = "STAT,CREATE_TIME,ID")
 		})
 public class Batch2JobInstanceEntity implements Serializable {
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/Batch2JobInstanceEntity.java
@@ -54,7 +54,7 @@ import static org.apache.commons.lang3.StringUtils.left;
 		name = "BT2_JOB_INSTANCE",
 		indexes = {
 			@Index(name = "IDX_BT2JI_CT", columnList = "CREATE_TIME"),
-			@Index(name = "IDX_BT2JI_STAT_CT", columnList = "STAT,ID")
+			@Index(name = "IDX_BT2JI_STAT_CT", columnList = "STAT,CREATE_TIME,ID")
 		})
 public class Batch2JobInstanceEntity implements Serializable {
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -183,9 +183,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.type(ColumnTypeEnum.INT);
 
 		version.onTable("BT2_JOB_INSTANCE")
-				.addIndex("20260610.10", "IDX_BT2JI_STAT_CT")
+				.addIndex("20260610.10", "IDX_BT2JI_STAT_CT_ID")
 				.unique(false)
-				.withColumns("STAT", "ID");
+				.withColumns("STAT", "CREATE_TIME", "ID");
 	}
 
 	protected void init8_10_0() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -181,6 +181,11 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 				.addColumn("20260601.30", "EXTRA_CHUNK_IDX")
 				.nullable()
 				.type(ColumnTypeEnum.INT);
+
+		version.onTable("BT2_JOB_INSTANCE")
+				.addIndex("20260610.10", "IDX_BT2JI_STAT_CT")
+				.unique(false)
+				.withColumns("STAT", "ID");
 	}
 
 	protected void init8_10_0() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermCodeSystemStorageSvcImpl.java
@@ -55,6 +55,7 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import ca.uhn.fhir.util.StopWatch;
 import ca.uhn.fhir.util.UrlUtil;
 import ca.uhn.fhir.util.ValidateUtil;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
@@ -210,8 +211,14 @@ public class TermCodeSystemStorageSvcImpl implements ITermCodeSystemStorageSvc {
 		Set<String> codes = findAllCodes(theAdditions);
 		if (!codes.isEmpty()) {
 			QueryChunker.chunk(codes, codesSubList -> {
+				StopWatch sw = new StopWatch();
 				List<TermConcept> conceptsSubList =
 						myConceptDao.findByCodeSystemAndCodeList(theCodeSystemVersion.getPid(), codesSubList);
+				ourLog.info(
+						"Handled prefetch on {} candidate codes and found {} existing in {}",
+						codesSubList.size(),
+						conceptsSubList.size(),
+						sw);
 
 				List<TermConcept.TermConceptPk> conceptIds =
 						conceptsSubList.stream().map(TermConcept::getPid).toList();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingServiceTest.java
@@ -38,7 +38,7 @@ class ExpungeEverythingServiceTest {
 	void testExpungeBatch2_acquiresAndReleasesMaintenanceHold() throws Exception {
 		// Setup
 		Closeable mockHold = mock(Closeable.class);
-		when(myJobMaintenanceService.holdMaintenanceForExpunge()).thenReturn(mockHold);
+		when(myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()).thenReturn(mockHold);
 
 		IHapiTransactionService.IExecutionBuilder mockBuilder = mock(IHapiTransactionService.IExecutionBuilder.class);
 		when(myTxService.withRequest(any())).thenReturn(mockBuilder);
@@ -50,7 +50,7 @@ class ExpungeEverythingServiceTest {
 		int result = myExpungeEverythingService.expungeBatch2Entities(null, RequestPartitionId.allPartitions());
 
 		// Verify hold was acquired and released
-		verify(myJobMaintenanceService).holdMaintenanceForExpunge();
+		verify(myJobMaintenanceService).holdActiveJobMaintenanceForExpunge();
 		verify(mockHold).close();
 		assertThat(result).isEqualTo(5);
 	}
@@ -59,7 +59,7 @@ class ExpungeEverythingServiceTest {
 	void testExpungeBatch2_retriesOnFkViolationThenSucceeds() throws Exception {
 		// Setup: first call throws FK violation, second call succeeds, third returns 0
 		Closeable mockHold = mock(Closeable.class);
-		when(myJobMaintenanceService.holdMaintenanceForExpunge()).thenReturn(mockHold);
+		when(myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()).thenReturn(mockHold);
 
 		IHapiTransactionService.IExecutionBuilder mockBuilder = mock(IHapiTransactionService.IExecutionBuilder.class);
 		when(myTxService.withRequest(any())).thenReturn(mockBuilder);
@@ -82,7 +82,7 @@ class ExpungeEverythingServiceTest {
 	void testExpungeBatch2_throwsAfterMaxRetries() throws Exception {
 		// Setup: always throw FK violation
 		Closeable mockHold = mock(Closeable.class);
-		when(myJobMaintenanceService.holdMaintenanceForExpunge()).thenReturn(mockHold);
+		when(myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()).thenReturn(mockHold);
 
 		IHapiTransactionService.IExecutionBuilder mockBuilder = mock(IHapiTransactionService.IExecutionBuilder.class);
 		when(myTxService.withRequest(any())).thenReturn(mockBuilder);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingServiceTest.java
@@ -38,7 +38,7 @@ class ExpungeEverythingServiceTest {
 	void testExpungeBatch2_acquiresAndReleasesMaintenanceHold() throws Exception {
 		// Setup
 		Closeable mockHold = mock(Closeable.class);
-		when(myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()).thenReturn(mockHold);
+		when(myJobMaintenanceService.holdJobMaintenanceForExpunge()).thenReturn(mockHold);
 
 		IHapiTransactionService.IExecutionBuilder mockBuilder = mock(IHapiTransactionService.IExecutionBuilder.class);
 		when(myTxService.withRequest(any())).thenReturn(mockBuilder);
@@ -50,7 +50,7 @@ class ExpungeEverythingServiceTest {
 		int result = myExpungeEverythingService.expungeBatch2Entities(null, RequestPartitionId.allPartitions());
 
 		// Verify hold was acquired and released
-		verify(myJobMaintenanceService).holdActiveJobMaintenanceForExpunge();
+		verify(myJobMaintenanceService).holdJobMaintenanceForExpunge();
 		verify(mockHold).close();
 		assertThat(result).isEqualTo(5);
 	}
@@ -59,7 +59,7 @@ class ExpungeEverythingServiceTest {
 	void testExpungeBatch2_retriesOnFkViolationThenSucceeds() throws Exception {
 		// Setup: first call throws FK violation, second call succeeds, third returns 0
 		Closeable mockHold = mock(Closeable.class);
-		when(myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()).thenReturn(mockHold);
+		when(myJobMaintenanceService.holdJobMaintenanceForExpunge()).thenReturn(mockHold);
 
 		IHapiTransactionService.IExecutionBuilder mockBuilder = mock(IHapiTransactionService.IExecutionBuilder.class);
 		when(myTxService.withRequest(any())).thenReturn(mockBuilder);
@@ -82,7 +82,7 @@ class ExpungeEverythingServiceTest {
 	void testExpungeBatch2_throwsAfterMaxRetries() throws Exception {
 		// Setup: always throw FK violation
 		Closeable mockHold = mock(Closeable.class);
-		when(myJobMaintenanceService.holdActiveJobMaintenanceForExpunge()).thenReturn(mockHold);
+		when(myJobMaintenanceService.holdJobMaintenanceForExpunge()).thenReturn(mockHold);
 
 		IHapiTransactionService.IExecutionBuilder mockBuilder = mock(IHapiTransactionService.IExecutionBuilder.class);
 		when(myTxService.withRequest(any())).thenReturn(mockBuilder);

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-ips/pom.xml
+++ b/hapi-fhir-jpaserver-ips/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-dstu2/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-dstu3/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu3/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
@@ -856,7 +856,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 
 		// waiting for the multitude of failures
 		await().until(() -> {
-			myJobMaintenanceService.runMaintenancePass();
+			myJobMaintenanceService.runActiveJobMaintenancePass();
 			JobInstance instance = myJobCoordinator.getInstance(instanceId);
 			ourLog.info("Attempt " + counter.get() + " for "
 				+ instance.getInstanceId() + ". Status: " + instance.getStatus());
@@ -1028,7 +1028,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 
 		// we want to control the maintenance runner ourselves in this case
 		// to prevent intermittent test failures
-		myJobMaintenanceService.enableMaintenancePass(false);
+		myJobMaintenanceService.enableMaintenance(false);
 
 		try {
 			IJobStepWorker<TestJobParameters, VoidModel, FirstStepOutput> firstStep = (step, sink) -> {
@@ -1064,7 +1064,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 			myBatch2JobHelper.awaitJobHasStatusWithForcedMaintenanceRuns(instanceId,
 				StatusEnum.CANCELLED);
 		} finally {
-			myJobMaintenanceService.enableMaintenancePass(true);
+			myJobMaintenanceService.enableMaintenance(true);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
@@ -293,7 +293,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 
 		try {
 			// run maintenance pass -> cleans up failed jobs/workchunks
-			myBatch2JobHelper.runMaintenancePass();
+			myBatch2JobHelper.runActiveJobMaintenancePass();
 
 			// create a fake work notification
 			JobWorkNotification notification = new JobWorkNotification();
@@ -411,7 +411,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 
 		myFirstStepLatch.setExpectedCount(1);
 		Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(new SystemRequestDetails(), request);
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		myFirstStepLatch.awaitExpected();
 
 		myBatch2JobHelper.awaitJobCompletion(startResponse.getInstanceId());
@@ -436,7 +436,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 		myFirstStepLatch.setExpectedCount(1);
 		myLastStepLatch.setExpectedCount(1);
 		String batchJobId = myJobCoordinator.startInstance(new SystemRequestDetails(), request).getInstanceId();
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		myFirstStepLatch.awaitExpected();
 		myBatch2JobHelper.assertFastTracking(batchJobId);
 
@@ -475,7 +475,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 			 * still being processed by the WorkChunkMessageHandler
 			 * (and thus, not available yet).
 			 */
-			myBatch2JobHelper.forceRunMaintenancePass();
+			myBatch2JobHelper.forceRunActiveJobMaintenancePass();
 		};
 
 		buildAndDefine3StepReductionJob(jobId, new IReductionStepHandler() {
@@ -661,7 +661,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 			Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(new SystemRequestDetails(), request);
 
 			String instanceId = startResponse.getInstanceId();
-			myBatch2JobHelper.runMaintenancePass();
+			myBatch2JobHelper.runActiveJobMaintenancePass();
 			myFirstStepLatch.awaitExpected();
 			assertNotNull(instanceId);
 
@@ -729,7 +729,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 				// which should cause multiple maintenance runs to run simultaneously
 				if (theDelayReductionStepBool && mySecondGate.getAndIncrement() == 1) {
 					ourLog.info("SECOND FORCED MAINTENANCE PASS FORCED");
-					myBatch2JobHelper.forceRunMaintenancePass();
+					myBatch2JobHelper.forceRunActiveJobMaintenancePass();
 				}
 			}
 
@@ -756,7 +756,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 		myFirstStepLatch.setExpectedCount(1);
 		Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(new SystemRequestDetails(), request);
 		String instanceId = startResponse.getInstanceId();
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		myFirstStepLatch.awaitExpected();
 		assertNotNull(instanceId);
 
@@ -987,7 +987,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 		myFirstStepLatch.setExpectedCount(1);
 		Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(new SystemRequestDetails(), request);
 		String instanceId = startResponse.getInstanceId();
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		myFirstStepLatch.awaitExpected();
 
 		myLastStepLatch.setExpectedCount(2);
@@ -1049,7 +1049,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 			myFirstStepLatch.setExpectedCount(1);
 			Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(new SystemRequestDetails(), request);
 			String instanceId = startResponse.getInstanceId();
-			myBatch2JobHelper.forceRunMaintenancePass();
+			myBatch2JobHelper.forceRunActiveJobMaintenancePass();
 			myFirstStepLatch.awaitExpected();
 
 			// validate

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2CoordinatorIT.java
@@ -293,7 +293,7 @@ public class Batch2CoordinatorIT extends BaseJpaR4Test {
 
 		try {
 			// run maintenance pass -> cleans up failed jobs/workchunks
-			myBatch2JobHelper.runActiveJobMaintenancePass();
+			myBatch2JobHelper.runEndedJobMaintenancePass();
 
 			// create a fake work notification
 			JobWorkNotification notification = new JobWorkNotification();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceDatabaseIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceDatabaseIT.java
@@ -111,9 +111,9 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void runMaintenancePass_noChunks_noChange() {
+	public void runActiveMaintenancePass_noChunks_noChange() {
 		assertInstanceCount(1);
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		assertInstanceCount(1);
 
 		assertInstanceStatus(StatusEnum.IN_PROGRESS);
@@ -121,35 +121,35 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 
 	@Test
-	public void runMaintenancePass_SingleQueuedChunk_noChange() {
+	public void runActiveMaintenancePass_SingleQueuedChunk_noChange() {
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
 			"chunk1, FIRST, QUEUED",
 			""
 		);
 
 		expectation.storeChunks();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		expectation.assertNotifications();
 
 		assertInstanceStatus(StatusEnum.IN_PROGRESS);
 	}
 
 	@Test
-	public void runMaintenancePass_SingleInProgressChunk_noChange() {
+	public void runActiveMaintenancePass_SingleInProgressChunk_noChange() {
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
 			"chunk1, FIRST, IN_PROGRESS",
 			""
 		);
 
 		expectation.storeChunks();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		expectation.assertNotifications();
 
 		assertInstanceStatus(StatusEnum.IN_PROGRESS);
 	}
 
 	@Test
-	public void runMaintenancePass_SingleCompleteChunk_notifiesAndChangesGatedStep() throws InterruptedException {
+	public void runActiveMaintenancePass_SingleCompleteChunk_notifiesAndChangesGatedStep() throws InterruptedException {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -164,7 +164,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 		expectation.storeChunks();
 		myChannelInterceptor.setExpectedCount(1);
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		myChannelInterceptor.awaitExpected();
 		expectation.assertNotifications();
 
@@ -173,7 +173,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void runMaintenancePass_DoubleCompleteChunk_notifiesAndChangesGatedStep() throws InterruptedException {
+	public void runActiveMaintenancePass_DoubleCompleteChunk_notifiesAndChangesGatedStep() throws InterruptedException {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -190,7 +190,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 		expectation.storeChunks();
 		myChannelInterceptor.setExpectedCount(2);
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		myChannelInterceptor.awaitExpected();
 		expectation.assertNotifications();
 
@@ -199,7 +199,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void runMaintenancePass_DoubleIncompleteChunk_noChange() {
+	public void runActiveMaintenancePass_DoubleIncompleteChunk_noChange() {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -213,7 +213,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 		);
 
 		expectation.storeChunks();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		expectation.assertNotifications();
 
 		assertInstanceStatus(StatusEnum.IN_PROGRESS);
@@ -221,7 +221,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 	}
 	
 	@Test
-	public void runMaintenancePass_allStepsComplete_jobCompletes() {
+	public void runActiveMaintenancePass_allStepsComplete_jobCompletes() {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -239,7 +239,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 		expectation.storeChunks();
 
 
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 
 
 		expectation.assertNotifications();
@@ -266,10 +266,10 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 		expectation.storeChunks();
 
-		myJobMaintenanceService.runMaintenancePass();
-		myJobMaintenanceService.runMaintenancePass();
-		myJobMaintenanceService.runMaintenancePass();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 
 		expectation.assertNotifications();
 
@@ -296,9 +296,9 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 		expectation.storeChunks();
 
-		myJobMaintenanceService.runMaintenancePass();
-		myJobMaintenanceService.runMaintenancePass();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 
 		expectation.assertNotifications();
 
@@ -308,7 +308,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 	// TODO MB Ken and Nathan created these.  Do we want to make them real?
 	@Test
 	@Disabled("future plans")
-	public void runMaintenancePass_MultipleStepsInProgress_CancelsInstance() {
+	public void runActiveMaintenancePass_MultipleStepsInProgress_CancelsInstance() {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -320,7 +320,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 		);
 
 		expectation.storeChunks();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		expectation.assertNotifications();
 
 		assertInstanceStatus(StatusEnum.FAILED);
@@ -329,7 +329,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 	@Test
 	@Disabled("future plans")
-	public void runMaintenancePass_MultipleOtherStepsInProgress_CancelsInstance() {
+	public void runActiveMaintenancePass_MultipleOtherStepsInProgress_CancelsInstance() {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -341,7 +341,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 		);
 
 		expectation.storeChunks();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		expectation.assertNotifications();
 
 		assertInstanceStatus(StatusEnum.FAILED);
@@ -350,7 +350,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 
 	@Test
 	@Disabled("future plans")
-	public void runMaintenancePass_MultipleStepsQueued_CancelsInstance() {
+	public void runActiveMaintenancePass_MultipleStepsQueued_CancelsInstance() {
 		assertCurrentGatedStep(FIRST);
 
 		WorkChunkExpectation expectation = new WorkChunkExpectation(
@@ -363,7 +363,7 @@ public class Batch2JobMaintenanceDatabaseIT extends BaseJpaR4Test {
 		);
 
 		expectation.storeChunks();
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		expectation.assertNotifications();
 
 		assertInstanceStatus(StatusEnum.FAILED);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceIT.java
@@ -178,7 +178,10 @@ public class Batch2JobMaintenanceIT extends BaseJpaR4Test {
 		myFirstStepLatch.setExpectedCount(1);
 		myLastStepLatch.setExpectedCount(1);
 		String batchJobId = myJobCoordinator.startInstance(new SystemRequestDetails(), request).getInstanceId();
-		myFirstStepLatch.awaitExpected();
+//		myJobMaintenanceService.runActiveJobMaintenancePass();
+
+		// FIXME: remove timing
+		myFirstStepLatch.awaitExpectedWithTimeout(10000000);
 
 		myBatch2JobHelper.assertFastTracking(batchJobId);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceIT.java
@@ -178,10 +178,7 @@ public class Batch2JobMaintenanceIT extends BaseJpaR4Test {
 		myFirstStepLatch.setExpectedCount(1);
 		myLastStepLatch.setExpectedCount(1);
 		String batchJobId = myJobCoordinator.startInstance(new SystemRequestDetails(), request).getInstanceId();
-//		myJobMaintenanceService.runActiveJobMaintenancePass();
-
-		// FIXME: remove timing
-		myFirstStepLatch.awaitExpectedWithTimeout(10000000);
+		myFirstStepLatch.awaitExpected();
 
 		myBatch2JobHelper.assertFastTracking(batchJobId);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceIT.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobMaintenanceIT.java
@@ -9,6 +9,7 @@ import ca.uhn.fhir.batch2.api.RunOutcome;
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.api.VoidModel;
 import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
+import ca.uhn.fhir.batch2.maintenance.ActiveJobInstanceProcessor;
 import ca.uhn.fhir.batch2.maintenance.JobMaintenanceServiceImpl;
 import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
@@ -48,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The on-enter actions are defined in
  * {@link ca.uhn.fhir.batch2.progress.JobInstanceStatusUpdater#handleStatusChange(JobInstance)}}
  * {@link ca.uhn.fhir.batch2.progress.InstanceProgress#updateStatus(JobInstance)}
- * {@link ca.uhn.fhir.batch2.maintenance.JobInstanceProcessor#cleanupInstance()}
+ * {@link ActiveJobInstanceProcessor#cleanupInstance()}
 
  * For chunks:
  *   {@link JpaJobPersistenceImpl#onWorkChunkCreate}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.batch2.api.RunOutcome;
 import ca.uhn.fhir.batch2.channel.BatchJobSender;
 import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
 import ca.uhn.fhir.batch2.jobs.imprt.NdJsonFileJson;
-import ca.uhn.fhir.batch2.maintenance.JobInstanceProcessor;
+import ca.uhn.fhir.batch2.maintenance.ActiveJobInstanceProcessor;
 import ca.uhn.fhir.batch2.model.BatchInstanceStatusDTO;
 import ca.uhn.fhir.batch2.model.BatchInstanceStepStatisticsDTO;
 import ca.uhn.fhir.batch2.model.BatchWorkChunkStatusDTO;
@@ -52,7 +52,6 @@ import com.google.common.collect.Iterators;
 import jakarta.annotation.Nonnull;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.time.DateUtils;
-import org.htmlunit.html.FrameWindow;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -66,7 +65,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ContextConfiguration;
@@ -146,7 +144,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 	@AfterEach
 	public void after() {
 		myJobDefinitionRegistry.removeJobDefinition(JOB_DEFINITION_ID, JOB_DEF_VER);
-		myMaintenanceService.enableMaintenancePass(true);
+		myMaintenanceService.enableMaintenance(true);
 
 		JpaJobPersistenceImpl proxy = ProxyUtil.getSingletonTarget(mySvc, JpaJobPersistenceImpl.class);
 		proxy.setMaxBytesPerAttachmentChunk(null);
@@ -334,7 +332,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 	public void testStartChunkOnlyWorksOnValidChunks(WorkChunkStatusEnum theStatus, boolean theShouldBeStartedByConsumer) {
 		// Setup
 		JobInstance instance = createInstance();
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
 
 		storeWorkChunk(JOB_DEFINITION_ID, FIRST_STEP_ID, instanceId, 0, CHUNK_DATA, false);
@@ -654,7 +652,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		// Now let's set the job so that it appears to have been created over an hour ago
 		runInTransaction(() -> {
 			Batch2JobInstanceEntity storedInstance = myJobInstanceRepository.findById(id).orElseThrow();
-			storedInstance.setCreateTime(DateUtils.addMilliseconds(new Date(), (int) (-1 - JobInstanceProcessor.CANCEL_BUILDING_THRESHOLD)));
+			storedInstance.setCreateTime(DateUtils.addMilliseconds(new Date(), (int) (-1 - ActiveJobInstanceProcessor.CANCEL_BUILDING_THRESHOLD)));
 			myJobInstanceRepository.save(storedInstance);
 		});
 
@@ -669,7 +667,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 			assertNotNull(storedInstance.getEndTime());
 
 			// Now let's set the end time far enough back that it will be purged
-			storedInstance.setEndTime(DateUtils.addMilliseconds(new Date(), (int) (-1 - JobInstanceProcessor.PURGE_THRESHOLD)));
+			storedInstance.setEndTime(DateUtils.addMilliseconds(new Date(), (int) (-1 - ActiveJobInstanceProcessor.PURGE_THRESHOLD)));
 			myJobInstanceRepository.save(storedInstance);
 		});
 
@@ -731,7 +729,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 			return Void.class;
 		}).when(myBatchSender).sendWorkChannelMessage(any(JobWorkNotification.class));
 		latch.setExpectedCount(1);
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
 
 		// execute & verify
@@ -760,7 +758,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		String expectedFirstChunkData = "IAmChunk1";
 		String expectedSecondChunkData = "IAmChunk2";
 		JobInstance instance = createInstance(true, isGatedExecution);
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
 		PointcutLatch latch = new PointcutLatch("senderlatch");
 		doAnswer(a -> {
@@ -1122,7 +1120,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 	public void testStoreAndFetchWorkChunk_withOrWithoutGatedExecutionwithData_createdAndTransitionToExpectedStatus(boolean theGatedExecution, WorkChunkStatusEnum theExpectedCreatedStatus, WorkChunkStatusEnum theExpectedTransitionStatus) throws InterruptedException {
 		// setup
 		JobInstance instance = createInstance(true, theGatedExecution);
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
 		PointcutLatch latch = new PointcutLatch("senderlatch");
 		doAnswer(a -> {
@@ -1158,7 +1156,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 	@Test
 	public void testMarkChunkAsCompleted_Success() throws InterruptedException {
 		boolean isGatedExecution = false;
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 		JobInstance instance = createInstance(true, isGatedExecution);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
 		String chunkId = storeWorkChunk(DEF_CHUNK_ID, STEP_CHUNK_ID, instanceId, SEQUENCE_NUMBER, CHUNK_DATA, isGatedExecution);
@@ -1212,7 +1210,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 			return Void.class;
 		}).when(myBatchSender).sendWorkChannelMessage(any(JobWorkNotification.class));
 		latch.setExpectedCount(1);
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 
 		JobInstance instance = createInstance(true, isGatedExecution);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
@@ -1270,7 +1268,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 	@Test
 	public void testMarkChunkAsCompleted_Fail() throws InterruptedException {
 		boolean isGatedExecution = false;
-		myMaintenanceService.enableMaintenancePass(false);
+		myMaintenanceService.enableMaintenance(false);
 		JobInstance instance = createInstance(true, isGatedExecution);
 		String instanceId = mySvc.storeNewInstance(newSrd(), instance);
 		String chunkId = storeWorkChunk(DEF_CHUNK_ID, STEP_CHUNK_ID, instanceId, SEQUENCE_NUMBER, null, isGatedExecution);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
@@ -319,8 +319,12 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 			.atZone(ZoneId.systemDefault())
 			.toInstant());
 
+		logAllBatch2JobInstances();
+
+		myCaptureQueriesListener.clear();
 		final List<JobInstance> jobInstancesByCutoff =
 			mySvc.fetchInstances(JOB_DEFINITION_ID, StatusEnum.getEndedStatuses(), cutoffDate, PageRequest.of(0, 2));
+		myCaptureQueriesListener.logSelectQueries();
 
 		assertThat(jobInstancesByCutoff.stream()
 			.map(JobInstance::getInstanceId)
@@ -672,7 +676,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		});
 
 		// The maintenance pass should now cancel the job since it's been building for too long
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runEndedJobMaintenancePass();
 
 		// Verify
 		runInTransaction(() -> {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/batch2/JpaJobPersistenceImplTest.java
@@ -651,7 +651,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		});
 
 		// An initial maintenance pass shouldn't modify the job since it's new
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 
 		// Now let's set the job so that it appears to have been created over an hour ago
 		runInTransaction(() -> {
@@ -661,7 +661,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		});
 
 		// The maintenance pass should now cancel the job since it's been building for too long
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 
 		// Verify
 		runInTransaction(() -> {
@@ -743,7 +743,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 
 		String id = storeWorkChunk(JOB_DEFINITION_ID, LAST_STEP_ID, instanceId, 0, null, theGatedExecution);
 		runInTransaction(() -> assertEquals(theExpectedStatusOnCreate, findChunkByIdOrThrow(id).getStatus()));
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> assertEquals(theExpectedStatusAfterTransition, findChunkByIdOrThrow(id).getStatus()));
 
 		WorkChunk chunk = mySvc.onWorkChunkDequeue(id).orElseThrow(IllegalArgumentException::new);
@@ -781,7 +781,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 			assertEquals(WorkChunkStatusEnum.GATE_WAITING, findChunkByIdOrThrow(secondChunkId).getStatus());
 		});
 
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> {
 			assertEquals(WorkChunkStatusEnum.QUEUED, findChunkByIdOrThrow(firstChunkId).getStatus());
 			// maintenance should not affect chunks in step 2
@@ -798,7 +798,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 			assertEquals(WorkChunkStatusEnum.GATE_WAITING, findChunkByIdOrThrow(secondChunkId).getStatus());
 		});
 
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> {
 			assertEquals(WorkChunkStatusEnum.COMPLETED, findChunkByIdOrThrow(firstChunkId).getStatus());
 			// now that all chunks for step 1 is COMPLETED, should enqueue chunks in step 2
@@ -1141,7 +1141,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		String id = storeWorkChunk(JOB_DEFINITION_ID, LAST_STEP_ID, instanceId, 0, CHUNK_DATA, theGatedExecution);
 		assertNotNull(id);
 		runInTransaction(() -> assertEquals(theExpectedCreatedStatus, findChunkByIdOrThrow(id).getStatus()));
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> assertEquals(theExpectedTransitionStatus, findChunkByIdOrThrow(id).getStatus()));
 
 		WorkChunk chunk = mySvc.onWorkChunkDequeue(id).orElseThrow(IllegalArgumentException::new);
@@ -1173,7 +1173,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		latch.setExpectedCount(1);
 
 		runInTransaction(() -> assertEquals(WorkChunkStatusEnum.READY, findChunkByIdOrThrow(chunkId).getStatus()));
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> assertEquals(WorkChunkStatusEnum.QUEUED, findChunkByIdOrThrow(chunkId).getStatus()));
 
 		WorkChunk chunk = mySvc.onWorkChunkDequeue(chunkId).orElseThrow(IllegalArgumentException::new);
@@ -1222,7 +1222,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		assertNotNull(chunkId);
 
 		runInTransaction(() -> assertEquals(WorkChunkStatusEnum.READY, findChunkByIdOrThrow(chunkId).getStatus()));
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> assertEquals(WorkChunkStatusEnum.QUEUED, findChunkByIdOrThrow(chunkId).getStatus()));
 
 		WorkChunk chunk = mySvc.onWorkChunkDequeue(chunkId).orElseThrow(IllegalArgumentException::new);
@@ -1285,7 +1285,7 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		latch.setExpectedCount(1);
 
 		runInTransaction(() -> assertEquals(WorkChunkStatusEnum.READY, findChunkByIdOrThrow(chunkId).getStatus()));
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 		runInTransaction(() -> assertEquals(WorkChunkStatusEnum.QUEUED, findChunkByIdOrThrow(chunkId).getStatus()));
 
 		WorkChunk chunk = mySvc.onWorkChunkDequeue(chunkId).orElseThrow(IllegalArgumentException::new);
@@ -1537,8 +1537,8 @@ public class JpaJobPersistenceImplTest extends BaseJpaR4Test {
 		}
 
 		@Override
-		public void runMaintenancePass() {
-			myBatch2JobHelper.forceRunMaintenancePass();
+		public void runActiveJobMaintenancePass() {
+			myBatch2JobHelper.forceRunActiveJobMaintenancePass();
 		}
 	}
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/imprt2/BulkImportR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/imprt2/BulkImportR4Test.java
@@ -97,7 +97,7 @@ public class BulkImportR4Test extends BaseJpaR4Test {
 
 		// Verify
 		await().atMost(120, TimeUnit.SECONDS).until(() -> {
-			myJobCleanerService.runMaintenancePass();
+			myJobCleanerService.runActiveJobMaintenancePass();
 			JobInstance instance = myJobCoordinator.getInstance(instanceId);
 			return instance.getStatus() == StatusEnum.FAILED;
 		});
@@ -147,7 +147,7 @@ public class BulkImportR4Test extends BaseJpaR4Test {
 		// Verify
 
 		await().atMost(120, TimeUnit.SECONDS).until(() -> {
-			myJobCleanerService.runMaintenancePass();
+			myJobCleanerService.runActiveJobMaintenancePass();
 			JobInstance instance = myJobCoordinator.getInstance(instanceId);
 			return instance.getStatus() == StatusEnum.COMPLETED;
 		});
@@ -210,7 +210,7 @@ public class BulkImportR4Test extends BaseJpaR4Test {
 			// Verify
 
 			await().until(() -> {
-				myJobCleanerService.runMaintenancePass();
+				myJobCleanerService.runActiveJobMaintenancePass();
 				JobInstance instance = myJobCoordinator.getInstance(instanceId);
 				StatusEnum status = instance.getStatus();
 				ourLog.info("Job status for instance[{}]: {}", instanceId, status);
@@ -292,7 +292,7 @@ public class BulkImportR4Test extends BaseJpaR4Test {
 		// Verify
 
 		await().until(() -> {
-			myJobCleanerService.runMaintenancePass();
+			myJobCleanerService.runActiveJobMaintenancePass();
 			JobInstance instance = myJobCoordinator.getInstance(instanceId);
 			return instance.getStatus() == StatusEnum.FAILED;
 		});
@@ -336,7 +336,7 @@ public class BulkImportR4Test extends BaseJpaR4Test {
 			// Verify
 
 			await().until(() -> {
-				myJobCleanerService.runMaintenancePass();
+				myJobCleanerService.runActiveJobMaintenancePass();
 				JobInstance instance = myJobCoordinator.getInstance(instanceId);
 				return instance.getStatus() == StatusEnum.FAILED;
 			});

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/imprt2/BulkImportWithPatientIdPartitioningTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/imprt2/BulkImportWithPatientIdPartitioningTest.java
@@ -84,7 +84,7 @@ public class BulkImportWithPatientIdPartitioningTest extends BaseJpaR4Test {
 
 		// Execute
 
-		Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(request);
+		Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(newSrd(), request);
 		String instanceId = startResponse.getInstanceId();
 		assertThat(instanceId).isNotBlank();
 		ourLog.info("Execution got ID: {}", instanceId);
@@ -92,7 +92,7 @@ public class BulkImportWithPatientIdPartitioningTest extends BaseJpaR4Test {
 		// Verify
 
 		await().atMost(120, TimeUnit.SECONDS).until(() -> {
-			myJobCleanerService.runMaintenancePass();
+			myJobCleanerService.runActiveJobMaintenancePass();
 			JobInstance instance = myJobCoordinator.getInstance(instanceId);
 			return instance.getStatus() == StatusEnum.COMPLETED;
 		});

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/AbstractGenericMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/AbstractGenericMergeR4Test.java
@@ -696,7 +696,7 @@ public abstract class AbstractGenericMergeR4Test<T extends IBaseResource> extend
 			// Wait for "query-ids" step to complete
 			await()
 					.until(() -> {
-						myBatch2JobHelper.runMaintenancePass();
+						myBatch2JobHelper.runActiveJobMaintenancePass();
 						String currentGatedStepId = myJobCoordinator.getInstance(jobId).getCurrentGatedStepId();
 						return !"query-ids".equals(currentGatedStepId);
 					});

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/MergeBatchTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/MergeBatchTest.java
@@ -119,7 +119,7 @@ public class MergeBatchTest extends BaseJpaR4Test {
 		myBatch2JobHelper.awaitJobFailure(jobStartResponse);
 
 		await().until(() -> {
-			myBatch2JobHelper.runMaintenancePass();
+			myBatch2JobHelper.runActiveJobMaintenancePass();
 			return myTaskDao.read(taskId, mySrd).getStatus().equals(Task.TaskStatus.FAILED);
 		});
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderCustomSearchParamR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderCustomSearchParamR4Test.java
@@ -231,7 +231,7 @@ public class ResourceProviderCustomSearchParamR4Test extends BaseResourceProvide
 		mySearchParameterDao.create(fooSp, mySrd);
 
 		runInTransaction(() -> {
-			myBatch2JobHelper.forceRunMaintenancePass();
+			myBatch2JobHelper.forceRunActiveJobMaintenancePass();
 
 			List<JobInstance> allJobs = myBatch2JobHelper.findJobsByDefinition(JOB_REINDEX);
 			assertEquals(1, allJobs.size());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4CodeSystemTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4CodeSystemTest.java
@@ -76,7 +76,7 @@ public class ResourceProviderR4CodeSystemTest extends BaseResourceProviderR4Test
 		// ensure all terms are loaded
 		await().atMost(5, TimeUnit.SECONDS)
 				.until(() -> {
-					myBatch2JobHelper.forceRunMaintenancePass();
+					myBatch2JobHelper.forceRunActiveJobMaintenancePass();
 					myITermDeferredStorageSvc.saveDeferred();
 					return myITermDeferredStorageSvc.isStorageQueueEmpty(true);
 				});

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesBatchTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/replacereferences/ReplaceReferencesBatchTest.java
@@ -98,7 +98,7 @@ public class ReplaceReferencesBatchTest extends BaseJpaR4Test {
 		myBatch2JobHelper.awaitJobFailure(jobStartResponse);
 
 		await().until(() -> {
-			myBatch2JobHelper.runMaintenancePass();
+			myBatch2JobHelper.runActiveJobMaintenancePass();
 			return myTaskDao.read(taskId, mySrd).getStatus().equals(Task.TaskStatus.FAILED);
 		});
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplR4Test.java
@@ -488,7 +488,7 @@ public class TerminologySvcImplR4Test extends BaseTermR4Test {
 		myCodeSystemDao.update(codeSystem, mySrd);
 
 		await().until(() -> {
-			myBatch2JobHelper.runMaintenancePass();
+			myBatch2JobHelper.runActiveJobMaintenancePass();
 			myTerminologyDeferredStorageSvc.saveAllDeferred();
 			myBatchJobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 			return myTerminologyDeferredStorageSvc.isStorageQueueEmpty(true);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
@@ -2260,7 +2260,7 @@ public class ValueSetExpansionR4Test extends BaseTermR4Test implements IValueSet
 
 		// Perform pre-expansion
 		await().until(() -> {
-			myBatch2JobHelper.runMaintenancePass();
+			myBatch2JobHelper.runActiveJobMaintenancePass();
 			myTerminologyDeferredStorageSvc.saveAllDeferred();
 			return myTerminologyDeferredStorageSvc.isStorageQueueEmpty(true);
 		});

--- a/hapi-fhir-jpaserver-test-r4b/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/pom.xml
+++ b/hapi-fhir-jpaserver-test-r5/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobFeaturesTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/Batch2JobFeaturesTest.java
@@ -76,9 +76,9 @@ public class Batch2JobFeaturesTest extends BaseJpaR5Test {
 		assertEquals(StatusEnum.BUILDING, myJobCoordinator.getBatchInstanceStatus(instanceId).status());
 
 
-		myJobMaintenanceService.forceMaintenancePass();
-		myJobMaintenanceService.forceMaintenancePass();
-		myJobMaintenanceService.forceMaintenancePass();
+		myJobMaintenanceService.forceActiveJobMaintenancePass();
+		myJobMaintenanceService.forceActiveJobMaintenancePass();
+		myJobMaintenanceService.forceActiveJobMaintenancePass();
 
 		// Job should still be in building status
 		assertEquals(StatusEnum.BUILDING, myJobCoordinator.getBatchInstanceStatus(instanceId).status());

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/bulkpatch/BulkPatchJobR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/bulkpatch/BulkPatchJobR5Test.java
@@ -108,9 +108,9 @@ public class BulkPatchJobR5Test extends BaseBulkPatchR5Test {
 		assertEquals("B1", actualPatientB.getIdentifier().get(0).getValue());
 		assertEquals("1", actualPatientB.getMeta().getVersionId());
 
-		myBatch2JobHelper.runMaintenancePass();
-		myBatch2JobHelper.runMaintenancePass();
-		myBatch2JobHelper.runMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
+		myBatch2JobHelper.runActiveJobMaintenancePass();
 
 		JobInstance instance = myJobCoordinator.getInstance(jobId);
 		ourLog.info("Instance: {}", instance);

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/ImportTerminologyTestHarnessApp.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/ImportTerminologyTestHarnessApp.java
@@ -60,7 +60,7 @@ public class ImportTerminologyTestHarnessApp {
 
 		while (true) {
 			Thread.sleep(1000);
-			appCtx.getBean(IJobMaintenanceService.class).forceMaintenancePass();
+			appCtx.getBean(IJobMaintenanceService.class).forceActiveJobMaintenancePass();
 		}
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaTest.java
@@ -41,6 +41,7 @@ import ca.uhn.fhir.jpa.config.r4.FhirContextR4Config;
 import ca.uhn.fhir.jpa.config.util.ResourceTypeUtil;
 import ca.uhn.fhir.jpa.dao.BaseHapiFhirDao;
 import ca.uhn.fhir.jpa.dao.IFulltextSearchSvc;
+import ca.uhn.fhir.jpa.dao.data.IBatch2JobInstanceRepository;
 import ca.uhn.fhir.jpa.dao.data.INpmPackageVersionDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTableDao;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryTagDao;
@@ -66,6 +67,8 @@ import ca.uhn.fhir.jpa.dao.data.ITermConceptParentChildLinkDao;
 import ca.uhn.fhir.jpa.dao.data.ITermConceptPropertyDao;
 import ca.uhn.fhir.jpa.dao.data.ITermValueSetConceptDao;
 import ca.uhn.fhir.jpa.dao.data.ITermValueSetDao;
+import ca.uhn.fhir.jpa.dao.mdm.MdmLinkDaoJpaImpl;
+import ca.uhn.fhir.jpa.entity.Batch2JobInstanceEntity;
 import ca.uhn.fhir.jpa.entity.MdmLink;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.entity.TermConceptDesignation;
@@ -337,6 +340,8 @@ public abstract class BaseJpaTest extends BaseTest {
 
 	@Autowired
 	protected ApplicationContext myApplicationContext;
+	@Autowired
+	protected IBatch2JobInstanceRepository myJobInstanceDao;
 
 	@TestConfiguration
 	public static class TestSearchParamConfig {
@@ -688,6 +693,12 @@ public abstract class BaseJpaTest extends BaseTest {
 	protected void logAllDateIndexes() {
 		runInTransaction(() -> {
 			ourLog.info("Date indexes:\n * {}", myResourceIndexedSearchParamDateDao.findAll().stream().map(ResourceIndexedSearchParamDate::toString).collect(Collectors.joining("\n * ")));
+		});
+	}
+
+	protected void logAllBatch2JobInstances() {
+		runInTransaction(() -> {
+			ourLog.info("Batch2 Job instances:\n * {}", myJobInstanceDao.findAll().stream().map(Batch2JobInstanceEntity::toString).collect(Collectors.joining("\n * ")));
 		});
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -366,6 +366,10 @@ public class Batch2JobHelper {
 		myJobMaintenanceService.runActiveJobMaintenancePass();
 	}
 
+	public void runEndedJobMaintenancePass() {
+		myJobMaintenanceService.runEndedJobMaintenancePass();
+	}
+
 	@VisibleForTesting
 	public void enableMaintenanceRunner(boolean theEnabled) {
 		myJobMaintenanceService.enableMaintenance(theEnabled);

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -160,7 +160,7 @@ public class Batch2JobHelper {
 		if (hasStatus(theInstanceId, theExpectedStatuses)) {
 			return true;
 		}
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 		return hasStatus(theInstanceId, theExpectedStatuses);
 	}
 
@@ -328,7 +328,7 @@ public class Batch2JobHelper {
 		HashMap<String, String> map = new HashMap<>();
 		Awaitility.await().atMost(DEFAULT_WAIT_DURATION)
 			.until(() -> {
-				myJobMaintenanceService.runMaintenancePass();
+				myJobMaintenanceService.runActiveJobMaintenancePass();
 
 				List<JobInstance> jobs = myJobCoordinator.getInstances(1000, 1);
 				// "All Jobs" assumes at least one job exists
@@ -355,12 +355,12 @@ public class Batch2JobHelper {
 	}
 
 	public void runMaintenancePass() {
-		myJobMaintenanceService.runMaintenancePass();
+		myJobMaintenanceService.runActiveJobMaintenancePass();
 	}
 
 	@VisibleForTesting
 	public void enableMaintenanceRunner(boolean theEnabled) {
-		myJobMaintenanceService.enableMaintenancePass(theEnabled);
+		myJobMaintenanceService.enableMaintenance(theEnabled);
 	}
 
 	/**
@@ -368,7 +368,7 @@ public class Batch2JobHelper {
 	 * the semaphore to release
 	 */
 	public void forceRunMaintenancePass() {
-		myJobMaintenanceService.forceMaintenancePass();
+		myJobMaintenanceService.forceActiveJobMaintenancePass();
 	}
 
 	public void cancelAllJobsAndAwaitCancellation() {

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -354,7 +354,15 @@ public class Batch2JobHelper {
 		}
 	}
 
+	/**
+	 * @deprecated Use {@link #runActiveJobMaintenancePass()} instead
+	 */
+	@Deprecated(since = "8.12.0", forRemoval = true)
 	public void runMaintenancePass() {
+		myJobMaintenanceService.runActiveJobMaintenancePass();
+	}
+
+	public void runActiveJobMaintenancePass() {
 		myJobMaintenanceService.runActiveJobMaintenancePass();
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/Batch2JobHelper.java
@@ -190,7 +190,7 @@ public class Batch2JobHelper {
 				.atMost(waitDuration)
 				.until(() -> {
 					counter.getAndIncrement();
-					forceRunMaintenancePass();
+					forceRunActiveJobMaintenancePass();
 					return hasStatus(theInstanceId, theStatusEnums);
 				});
 		} catch (ConditionTimeoutException ex) {
@@ -379,7 +379,7 @@ public class Batch2JobHelper {
 	 * Forces a run of the maintenance pass without waiting for
 	 * the semaphore to release
 	 */
-	public void forceRunMaintenancePass() {
+	public void forceRunActiveJobMaintenancePass() {
 		myJobMaintenanceService.forceActiveJobMaintenancePass();
 	}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/Batch2FastSchedulerConfig.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/Batch2FastSchedulerConfig.java
@@ -37,6 +37,6 @@ public class Batch2FastSchedulerConfig {
 
 	@PostConstruct
 	void fastScheduler() {
-		((JobMaintenanceServiceImpl)myJobMaintenanceService).setScheduledJobFrequencyMillis(200);
+		((JobMaintenanceServiceImpl)myJobMaintenanceService).setScheduledJobFrequencyMillis(200L);
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/test/Batch2JobHelperTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/test/Batch2JobHelperTest.java
@@ -49,7 +49,7 @@ class Batch2JobHelperTest {
 		when(myJobCoordinator.getInstance(JOB_ID)).thenReturn(ourIncompleteInstance, ourIncompleteInstance, ourIncompleteInstance, ourCompleteInstance);
 
 		myBatch2JobHelper.awaitJobCompletion(JOB_ID);
-		verify(myJobMaintenanceService, times(1)).runMaintenancePass();
+		verify(myJobMaintenanceService, times(1)).runActiveJobMaintenancePass();
 
 	}
 
@@ -108,7 +108,7 @@ class Batch2JobHelperTest {
 
 		// verify
 		verify(myJobCoordinator, atLeastOnce()).getInstances(1000, 1);
-		verify(myJobMaintenanceService, atLeastOnce()).runMaintenancePass();
+		verify(myJobMaintenanceService, atLeastOnce()).runActiveJobMaintenancePass();
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-repositories/pom.xml
+++ b/hapi-fhir-repositories/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>8.11.11-SNAPSHOT</version>
+			<version>8.11.12-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>8.11.11-SNAPSHOT</version>
+      <version>8.11.12-SNAPSHOT</version>
 
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/pom.xml
+++ b/hapi-fhir-storage-batch2-test-utilities/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/AbstractIJobPersistenceSpecificationTest.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/AbstractIJobPersistenceSpecificationTest.java
@@ -45,7 +45,6 @@ import ca.uhn.hapi.fhir.batch2.test.support.TestJobStep2InputType;
 import ca.uhn.hapi.fhir.batch2.test.support.TestJobStep3InputType;
 import ca.uhn.test.concurrency.PointcutLatch;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.mockito.ArgumentCaptor;
@@ -157,7 +156,7 @@ public abstract class AbstractIJobPersistenceSpecificationTest
 		myJobDefinitionRegistry.removeJobDefinition(JOB_DEFINITION_ID, JOB_DEF_VER);
 
 		// re-enable our runner after every test (just in case)
-		myMaintenanceService.enableMaintenancePass(true);
+		myMaintenanceService.enableMaintenance(true);
 
 		// clear invocations on the batch sender from previous jobs that might be
 		// kicking around
@@ -290,7 +289,7 @@ public abstract class AbstractIJobPersistenceSpecificationTest
 	}
 
 	public void enableMaintenanceRunner(boolean theToEnable) {
-		myMaintenanceService.enableMaintenancePass(theToEnable);
+		myMaintenanceService.enableMaintenance(theToEnable);
 	}
 
 	public PointcutLatch disableWorkChunkMessageHandler() {

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/AbstractIJobPersistenceSpecificationTest.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/AbstractIJobPersistenceSpecificationTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractIJobPersistenceSpecificationTest
 	}
 
 	@Override
-	public abstract void runMaintenancePass();
+	public abstract void runActiveJobMaintenancePass();
 
 	public TransactionTemplate newTxTemplate() {
 		TransactionTemplate retVal = new TransactionTemplate(getTxManager());

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IInstanceStateTransitions.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IInstanceStateTransitions.java
@@ -21,8 +21,7 @@ package ca.uhn.hapi.fhir.batch2.test;
 
 import ca.uhn.fhir.batch2.api.IJobPersistence;
 import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
-import ca.uhn.fhir.batch2.maintenance.JobChunkProgressAccumulator;
-import ca.uhn.fhir.batch2.maintenance.JobInstanceProcessor;
+import ca.uhn.fhir.batch2.maintenance.ActiveJobInstanceProcessor;
 import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.StatusEnum;
@@ -107,11 +106,10 @@ public interface IInstanceStateTransitions extends IWorkChunkCommon, WorkChunkTe
 
 		// when
 		getTestManager().runInTransaction(()-> {
-			new JobInstanceProcessor(
+			new ActiveJobInstanceProcessor(
 				getTestManager().getSvc(),
 				null,
 				instanceId1,
-				new JobChunkProgressAccumulator(),
 				null,
 				jobDefinitionRegistry,
 				interceptorService

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IJobMaintenanceActions.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IJobMaintenanceActions.java
@@ -57,7 +57,7 @@ public interface IJobMaintenanceActions extends IWorkChunkCommon, WorkChunkTestC
 		getTestManager().createChunksInStates(result);
 
 		// test
-		getTestManager().runMaintenancePass();
+		getTestManager().runActiveJobMaintenancePass();
 
 		// verify
 		getTestManager().verifyWorkChunkMessageHandlerCalled(sendLatch, numToTransition);
@@ -139,7 +139,7 @@ public interface IJobMaintenanceActions extends IWorkChunkCommon, WorkChunkTestC
 		getTestManager().createChunksInStates(state);
 
 		// test
-		getTestManager().runMaintenancePass();
+		getTestManager().runActiveJobMaintenancePass();
 
 		// verify
 		// nothing ever queued -> nothing ever sent to queue
@@ -194,7 +194,7 @@ public interface IJobMaintenanceActions extends IWorkChunkCommon, WorkChunkTestC
 		getTestManager().createChunksInStates(state);
 
 		// test
-		getTestManager().runMaintenancePass();
+		getTestManager().runActiveJobMaintenancePass();
 
 		// verify
 		getTestManager().verifyWorkChunkMessageHandlerCalled(sendingLatch, 2);
@@ -224,7 +224,7 @@ public interface IJobMaintenanceActions extends IWorkChunkCommon, WorkChunkTestC
 		// TEST run job maintenance - force transition
 		getTestManager().enableMaintenanceRunner(true);
 
-		getTestManager().runMaintenancePass();
+		getTestManager().runActiveJobMaintenancePass();
 
 		// verify
 		getTestManager().verifyWorkChunkMessageHandlerCalled(sendLatch, expectedTransitions);

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/ITestFixture.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/ITestFixture.java
@@ -51,7 +51,7 @@ public interface ITestFixture {
 
 	JobInstance freshFetchJobInstance(String theInstanceId);
 
-	void runMaintenancePass();
+	void runActiveJobMaintenancePass();
 
 	PlatformTransactionManager getTransactionManager();
 

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IWorkChunkStateTransitions.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IWorkChunkStateTransitions.java
@@ -95,7 +95,7 @@ public interface IWorkChunkStateTransitions extends IWorkChunkCommon, WorkChunkT
 		String jobInstanceId = getTestManager().createAndStoreJobInstance(jobDef);
 		String myChunkId = getTestManager().createChunk(jobInstanceId, false);
 
-		getTestManager().runMaintenancePass();
+		getTestManager().runActiveJobMaintenancePass();
 		// the worker has received the chunk, and marks it started.
 		WorkChunk chunk = getTestManager().getSvc().onWorkChunkDequeue(myChunkId).orElseThrow(IllegalArgumentException::new);
 

--- a/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IWorkChunkStorageTests.java
+++ b/hapi-fhir-storage-batch2-test-utilities/src/main/java/ca/uhn/hapi/fhir/batch2/test/IWorkChunkStorageTests.java
@@ -25,7 +25,6 @@ import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.batch2.model.WorkChunkCompletionEvent;
 import ca.uhn.fhir.batch2.model.WorkChunkErrorEvent;
 import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
-import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.hapi.fhir.batch2.test.support.JobMaintenanceStateInformation;
 import ca.uhn.test.concurrency.PointcutLatch;
@@ -100,7 +99,7 @@ public interface IWorkChunkStorageTests extends IWorkChunkCommon, WorkChunkTestC
 		getTestManager().runInTransaction(() -> assertEquals(WorkChunkStatusEnum.READY, getTestManager().freshFetchWorkChunk(id).getStatus()));
 
 		// test
-		getTestManager().runMaintenancePass();
+		getTestManager().runActiveJobMaintenancePass();
 
 		// verify it's in QUEUED now
 		stateInformation.verifyFinalStates(getTestManager().getSvc());

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/AttachmentMetadata.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/AttachmentMetadata.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server - Batch2 Task Processor
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package ca.uhn.fhir.batch2.api;
 
 import org.springframework.data.domain.Pageable;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/IJobMaintenanceService.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/IJobMaintenanceService.java
@@ -23,6 +23,23 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.io.Closeable;
 
+/**
+ * There are two kinds of maintenance work that is handled by this interface:
+ * <ul>
+ * <li>
+ *     <b>Active Maintenance</b> is performed by {@link ca.uhn.fhir.batch2.maintenance.ActiveJobInstanceProcessor}
+ *     on jobs in non-terminal states (QUEUED, BUILDING, IN_PROGRESS, FINALIZING, etc.).
+ *     This maintenance happens frequently so that jobs get updated status information,
+ *     gated jobs keep advancing, etc.
+ * </li>
+ * <li>
+ *     <b>Ended Job Maintenance</b> is performed by {@link ca.uhn.fhir.batch2.maintenance.EndedJobInstanceProcessor}
+ *     on jobs in terminal states (COMPLETED, CANCELLED, FAILED, etc.).
+ *     This maintenance happens less frequently than active maintenance and is used
+ *     to clean up old entries in the database.
+ * </li>
+ * </ul>
+ */
 public interface IJobMaintenanceService {
 
 	/**
@@ -36,7 +53,7 @@ public interface IJobMaintenanceService {
 	 * @return a {@link Closeable} that releases the maintenance semaphore when closed.
 	 *         The Closeable is idempotent — calling close() multiple times is safe.
 	 */
-	default Closeable holdMaintenanceForExpunge() {
+	default Closeable holdActiveJobMaintenanceForExpunge() {
 		// No-op default: implementations that support expunge coordination should override this.
 		return () -> {};
 	}
@@ -45,25 +62,33 @@ public interface IJobMaintenanceService {
 	 * Do not wait for the next scheduled time for maintenance. Trigger it immediately.
 	 * @return true if a request to run a maintenance pass was fired, false if there was already a trigger request in queue so we can just use that one
 	 */
-	boolean triggerMaintenancePass();
+	boolean triggerActiveJobMaintenancePass();
 
-	void runMaintenancePass();
+	/**
+	 * Runs a maintenance pass for active jobs (jobs in statuses QUEUED, BUILDING, IN_PROGRESS, etc.)
+	 */
+	void runActiveJobMaintenancePass();
+
+	/**
+	 * Runs a maintenance pass for ended jobs (jobs in statuses FAILED, COMPLETED, etc.)
+	 */
+	void runEndedJobMaintenancePass();
 
 	/**
 	 * Forces a second maintenance run.
 	 * Only to be used in tests to simulate a long running maintenance step.
 	 *
 	 * <p><b>Warning:</b> This method acquires the maintenance semaphore with an uninterruptible
-	 * blocking wait. Do not call this while {@link #holdMaintenanceForExpunge()} is held on the
+	 * blocking wait. Do not call this while {@link #holdActiveJobMaintenanceForExpunge()} is held on the
 	 * same thread — it will deadlock.
 	 */
 	@VisibleForTesting
-	void forceMaintenancePass();
+	void forceActiveJobMaintenancePass();
 
 	/**
 	 * This is only to be called in a testing environment
 	 * to ensure state changes are controlled.
 	 */
 	@VisibleForTesting
-	void enableMaintenancePass(boolean thetoEnable);
+	void enableMaintenance(boolean theEnable);
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/IJobMaintenanceService.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/IJobMaintenanceService.java
@@ -53,7 +53,7 @@ public interface IJobMaintenanceService {
 	 * @return a {@link Closeable} that releases the maintenance semaphore when closed.
 	 *         The Closeable is idempotent — calling close() multiple times is safe.
 	 */
-	default Closeable holdActiveJobMaintenanceForExpunge() {
+	default Closeable holdJobMaintenanceForExpunge() {
 		// No-op default: implementations that support expunge coordination should override this.
 		return () -> {};
 	}
@@ -79,7 +79,7 @@ public interface IJobMaintenanceService {
 	 * Only to be used in tests to simulate a long running maintenance step.
 	 *
 	 * <p><b>Warning:</b> This method acquires the maintenance semaphore with an uninterruptible
-	 * blocking wait. Do not call this while {@link #holdActiveJobMaintenanceForExpunge()} is held on the
+	 * blocking wait. Do not call this while {@link #holdJobMaintenanceForExpunge()} is held on the
 	 * same thread — it will deadlock.
 	 */
 	@VisibleForTesting

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/IJobPersistence.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/api/IJobPersistence.java
@@ -105,6 +105,12 @@ public interface IJobPersistence extends IWorkChunkPersistence {
 	// on implementations @Transactional(propagation = Propagation.REQUIRES_NEW)
 	List<JobInstance> fetchInstances(int thePageSize, int thePageIndex);
 
+	/**
+	 * Fetch all instances
+	 */
+	// on implementations @Transactional(propagation = Propagation.REQUIRES_NEW)
+	List<JobInstance> fetchInstances(int thePageSize, int thePageIndex, Set<StatusEnum> theStatuses);
+
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	void enqueueWorkChunkForProcessing(String theChunkId, Consumer<Integer> theCallback);
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/config/BaseBatch2Config.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/config/BaseBatch2Config.java
@@ -116,7 +116,6 @@ public abstract class BaseBatch2Config {
 			JobDefinitionRegistry theJobDefinitionRegistry,
 			JpaStorageSettings theStorageSettings,
 			BatchJobSender theBatchJobSender,
-			WorkChunkProcessor theExecutor,
 			IReductionStepExecutorService theReductionStepExecutorService) {
 		return new JobMaintenanceServiceImpl(
 				theSchedulerService,
@@ -124,7 +123,6 @@ public abstract class BaseBatch2Config {
 				theStorageSettings,
 				theJobDefinitionRegistry,
 				theBatchJobSender,
-				theExecutor,
 				theReductionStepExecutorService,
 				myInterceptorService);
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobStepExecutor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobStepExecutor.java
@@ -149,7 +149,7 @@ public class JobStepExecutor<PT extends IModelJson, IT extends IModelJson, OT ex
 			// wipmb 6.8 either delete fast-tracking, or narrow this call to just this instance and step
 			// This runs full maintenance for EVERY job as each chunk completes in a fast tracked job.  That's a LOT of
 			// work.
-			boolean success = myJobMaintenanceService.triggerMaintenancePass();
+			boolean success = myJobMaintenanceService.triggerActiveJobMaintenancePass();
 			if (!success) {
 				myJobPersistence.updateInstance(myInstance.getInstanceId(), instance -> {
 					instance.setFastTracking(false);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/ActiveJobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/ActiveJobInstanceProcessor.java
@@ -49,7 +49,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public class JobInstanceProcessor {
+/**
+ * This processor is invoked by {@link JobMaintenanceServiceImpl}
+ * and is responsible for ongoing maintenance of jobs that have not
+ * yet started and jobs that have started but have not yet finished.
+ * It handles advancing gated jobs to subsequent steps, as well as
+ * calculating progress for jobs that are in progress.
+ */
+public class ActiveJobInstanceProcessor {
 	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
 	public static final long PURGE_THRESHOLD = 7L * DateUtils.MILLIS_PER_DAY;
 	public static final long CANCEL_BUILDING_THRESHOLD = DateUtils.MILLIS_PER_HOUR;
@@ -65,29 +72,22 @@ public class JobInstanceProcessor {
 	private final String myInstanceId;
 	private final JobDefinitionRegistry myJobDefinitionegistry;
 
-	private long myPurgeThreshold = PURGE_THRESHOLD;
-
-	public JobInstanceProcessor(
+	public ActiveJobInstanceProcessor(
 			IJobPersistence theJobPersistence,
 			BatchJobSender theBatchJobSender,
 			String theInstanceId,
-			JobChunkProgressAccumulator theProgressAccumulator,
 			IReductionStepExecutorService theReductionStepExecutorService,
 			JobDefinitionRegistry theJobDefinitionRegistry,
 			@Nonnull IInterceptorService theInterceptorService) {
 		myJobPersistence = theJobPersistence;
 		myBatchJobSender = theBatchJobSender;
 		myInstanceId = theInstanceId;
-		myProgressAccumulator = theProgressAccumulator;
+		myProgressAccumulator = new JobChunkProgressAccumulator();
 		myReductionStepExecutorService = theReductionStepExecutorService;
 		myJobDefinitionegistry = theJobDefinitionRegistry;
 		myJobInstanceProgressCalculator = new JobInstanceProgressCalculator(
-				theJobPersistence, theProgressAccumulator, theJobDefinitionRegistry, theInterceptorService);
+				theJobPersistence, myProgressAccumulator, theJobDefinitionRegistry, theInterceptorService);
 		myJobInstanceStatusUpdater = new JobInstanceStatusUpdater(theJobDefinitionRegistry, theInterceptorService);
-	}
-
-	public void setPurgeThreshold(long thePurgeThreshold) {
-		myPurgeThreshold = thePurgeThreshold;
 	}
 
 	public void process() {
@@ -115,8 +115,21 @@ public class JobInstanceProcessor {
 
 		// move POLL_WAITING -> READY
 		processPollingChunks(theInstance.getInstanceId());
+
 		// determine job progress; delete CANCELED/COMPLETE/FAILED jobs that are no longer needed
-		cleanupInstance(theInstance);
+		switch (theInstance.getStatus()) {
+			case IN_PROGRESS:
+			case ERRORED:
+				myJobInstanceProgressCalculator.calculateAndStoreInstanceProgress(theInstance.getInstanceId());
+				break;
+			case QUEUED:
+			case FINALIZE:
+			case COMPLETED:
+			case FAILED:
+			case CANCELLED:
+				break;
+		}
+
 		// move gated jobs to the next step, if needed
 		// moves GATE_WAITING / QUEUED (legacy) chunks to:
 		// READY (for regular gated jobs)
@@ -165,7 +178,7 @@ public class JobInstanceProcessor {
 	private boolean handleCancellation(JobInstance theInstance) {
 		if (theInstance.isPendingCancellationRequest()) {
 			String errorMessage = buildCancelledMessage(theInstance);
-			ourLog.info("Job {} moving to CANCELLED", theInstance.getInstanceId());
+			ourLog.info("Job {} has cancellation requested, moving to CANCELLED", theInstance.getInstanceId());
 			return myJobPersistence.updateInstance(theInstance.getInstanceId(), instance -> {
 				boolean changed = myJobInstanceStatusUpdater.updateInstanceStatus(instance, StatusEnum.CANCELLED);
 				if (changed) {
@@ -183,49 +196,6 @@ public class JobInstanceProcessor {
 			msg += " while running step " + theInstance.getCurrentGatedStepId();
 		}
 		return msg;
-	}
-
-	private void cleanupInstance(JobInstance theInstance) {
-		switch (theInstance.getStatus()) {
-			case QUEUED:
-				// If we're still QUEUED, there are no stats to calculate
-				break;
-			case FINALIZE:
-				// If we're in FINALIZE, the reduction step is working, so we should stay out of the way until it
-				// marks the job as COMPLETED
-				return;
-			case IN_PROGRESS:
-			case ERRORED:
-				myJobInstanceProgressCalculator.calculateAndStoreInstanceProgress(theInstance.getInstanceId());
-				break;
-			case COMPLETED:
-			case FAILED:
-				if (purgeExpiredInstance(theInstance)) {
-					return;
-				}
-				break;
-			case CANCELLED:
-				purgeExpiredInstance(theInstance);
-				// wipmb For 6.8 - Are we deliberately not purging chunks for cancelled jobs?  This is a very
-				// complicated way to say that.
-				return;
-		}
-
-		if (theInstance.isFinished() && !theInstance.isWorkChunksPurged()) {
-			myJobPersistence.deleteChunksAndMarkInstanceAsChunksPurged(theInstance.getInstanceId());
-		}
-	}
-
-	private boolean purgeExpiredInstance(JobInstance theInstance) {
-		if (theInstance.getEndTime() != null) {
-			long cutoff = System.currentTimeMillis() - myPurgeThreshold;
-			if (theInstance.getEndTime().getTime() < cutoff) {
-				ourLog.info("Deleting old job instance {}", theInstance.getInstanceId());
-				myJobPersistence.deleteInstanceAndChunks(theInstance.getInstanceId());
-				return true;
-			}
-		}
-		return false;
 	}
 
 	private void triggerGatedExecutions(JobInstance theInstance, JobDefinition<?> theJobDefinition) {
@@ -418,7 +388,6 @@ public class JobInstanceProcessor {
 	 */
 	private void processPollingChunks(String theInstanceId) {
 		int updatedChunkCount = myJobPersistence.updatePollWaitingChunksForJobIfReady(theInstanceId);
-
 		ourLog.debug(
 				"Moved {} Work Chunks in POLL_WAITING to READY for Job Instance {}", updatedChunkCount, theInstanceId);
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/EndedJobInstanceProcessor.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/EndedJobInstanceProcessor.java
@@ -1,0 +1,100 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server - Batch2 Task Processor
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.batch2.maintenance;
+
+import ca.uhn.fhir.batch2.api.IJobPersistence;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.util.Logs;
+import ca.uhn.fhir.util.StopWatch;
+import org.apache.commons.lang3.time.DateUtils;
+import org.slf4j.Logger;
+
+/**
+ * This processor is invoked by {@link JobMaintenanceServiceImpl}
+ * and is responsible for cleaning up job instances that have ended.
+ * This includes deleting work chunks for failed or completed jobs, as well as
+ * eventually purging old job instances entirely.
+ * It is intended to be run less frequently.
+ */
+public class EndedJobInstanceProcessor {
+	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
+	public static final long PURGE_THRESHOLD = 7L * DateUtils.MILLIS_PER_DAY;
+
+	// 10k; we want to get as many as we can
+	private final IJobPersistence myJobPersistence;
+	private final String myInstanceId;
+
+	private long myPurgeThreshold = PURGE_THRESHOLD;
+
+	public EndedJobInstanceProcessor(IJobPersistence theJobPersistence, String theInstanceId) {
+		myJobPersistence = theJobPersistence;
+		myInstanceId = theInstanceId;
+	}
+
+	public void setPurgeThreshold(long thePurgeThreshold) {
+		myPurgeThreshold = thePurgeThreshold;
+	}
+
+	public void process() {
+		ourLog.debug("Starting job processing: {}", myInstanceId);
+		StopWatch stopWatch = new StopWatch();
+
+		JobInstance theInstance = myJobPersistence.fetchInstance(myInstanceId).orElse(null);
+		if (theInstance == null) {
+			return;
+		}
+
+		// determine job progress; delete CANCELED/COMPLETE/FAILED jobs that are no longer needed
+		cleanupInstance(theInstance);
+
+		ourLog.debug("Finished job processing: {} - {}", myInstanceId, stopWatch);
+	}
+
+	private void cleanupInstance(JobInstance theInstance) {
+		switch (theInstance.getStatus()) {
+			case QUEUED:
+			case FINALIZE:
+			case IN_PROGRESS:
+			case ERRORED:
+				break;
+			case COMPLETED:
+			case FAILED:
+			case CANCELLED:
+				purgeExpiredInstance(theInstance);
+				break;
+		}
+
+		if (theInstance.isFinished() && !theInstance.isWorkChunksPurged()) {
+			myJobPersistence.deleteChunksAndMarkInstanceAsChunksPurged(theInstance.getInstanceId());
+		}
+	}
+
+	private boolean purgeExpiredInstance(JobInstance theInstance) {
+		if (theInstance.getEndTime() != null) {
+			long cutoff = System.currentTimeMillis() - myPurgeThreshold;
+			if (theInstance.getEndTime().getTime() < cutoff) {
+				ourLog.info("Deleting old job instance {}", theInstance.getInstanceId());
+				myJobPersistence.deleteInstanceAndChunks(theInstance.getInstanceId());
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
@@ -433,8 +433,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 		@Override
 		public void execute(JobExecutionContext theContext) {
-			// FIXME: reduce
-			ourLog.info("Running Batch2 active job maintenance pass");
+			ourLog.trace("Running Batch2 active job maintenance pass");
 			myTarget.runActiveJobMaintenancePass();
 		}
 	}
@@ -445,6 +444,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 		@Override
 		public void execute(JobExecutionContext theContext) {
+			ourLog.trace("Running Batch2 ended job maintenance pass");
 			myTarget.runEndedJobMaintenancePass();
 		}
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
@@ -24,8 +24,9 @@ import ca.uhn.fhir.batch2.api.IJobPersistence;
 import ca.uhn.fhir.batch2.api.IReductionStepExecutorService;
 import ca.uhn.fhir.batch2.channel.BatchJobSender;
 import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
-import ca.uhn.fhir.batch2.coordinator.WorkChunkProcessor;
+import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.IInterceptorService;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
@@ -46,10 +47,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.Closeable;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * This class performs regular polls of the stored jobs in order to
@@ -81,31 +84,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * </p>
  */
 public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasScheduledJobs {
-	static final Logger ourLog = Logs.getBatchTroubleshootingLog();
-
 	public static final int INSTANCES_PER_PASS = 100;
-	public static final String SCHEDULED_JOB_ID = JobMaintenanceScheduledJob.class.getName();
+	public static final String ACTIVE_JOB_MAINTENANCE_SCHEDULED_JOB_ID = JobMaintenanceScheduledJob.class.getName();
+	public static final String ENDED_JOB_MAINTENANCE_SCHEDULED_JOB_ID = EndedJobMaintenanceScheduledJob.class.getName();
 	public static final int MAINTENANCE_TRIGGER_RUN_WITHOUT_SCHEDULER_TIMEOUT = 5;
+	static final Logger ourLog = Logs.getBatchTroubleshootingLog();
 	private static final long HOLD_MAINTENANCE_TIMEOUT_SECONDS = 300;
-
-	private long myFailedJobLifetimeOverride = -1;
-
 	private final IJobPersistence myJobPersistence;
 	private final ISchedulerService mySchedulerService;
 	private final JpaStorageSettings myStorageSettings;
 	private final JobDefinitionRegistry myJobDefinitionRegistry;
 	private final BatchJobSender myBatchJobSender;
-	private final WorkChunkProcessor myJobExecutorSvc;
 	private final IReductionStepExecutorService myReductionStepExecutorService;
 	private final IInterceptorService myInterceptorService;
-
-	private final Semaphore myRunMaintenanceSemaphore = new Semaphore(1);
-
-	private long myScheduledJobFrequencyMillis = DateUtils.MILLIS_PER_MINUTE;
+	private final Semaphore myRunActiveMaintenanceSemaphore = new Semaphore(1);
+	private final Semaphore myRunEndedMaintenanceSemaphore = new Semaphore(1);
+	private long myFailedJobLifetimeOverride = -1;
 	private Runnable myMaintenanceJobStartedCallback = () -> {};
 	private Runnable myMaintenanceJobFinishedCallback = () -> {};
 
 	private boolean myEnabledBool = true;
+	private Long myScheduledJobFrequencyMillis;
 
 	/**
 	 * Constructor
@@ -116,38 +115,54 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 			JpaStorageSettings theStorageSettings,
 			@Nonnull JobDefinitionRegistry theJobDefinitionRegistry,
 			@Nonnull BatchJobSender theBatchJobSender,
-			@Nonnull WorkChunkProcessor theExecutor,
 			@Nonnull IReductionStepExecutorService theReductionStepExecutorService,
 			@Nonnull IInterceptorService theInterceptorService) {
 		myStorageSettings = theStorageSettings;
 		myReductionStepExecutorService = theReductionStepExecutorService;
-		Validate.notNull(theSchedulerService);
-		Validate.notNull(theJobPersistence);
-		Validate.notNull(theJobDefinitionRegistry);
-		Validate.notNull(theBatchJobSender);
+		Validate.notNull(theSchedulerService, "theSchedulerService must not be null");
+		Validate.notNull(theJobPersistence, "theJobPersistence must not be null");
+		Validate.notNull(theJobDefinitionRegistry, "theJobDefinitionRegistry must not be null");
+		Validate.notNull(theBatchJobSender, "theBatchJobSender must not be null");
 
 		myJobPersistence = theJobPersistence;
 		mySchedulerService = theSchedulerService;
 		myJobDefinitionRegistry = theJobDefinitionRegistry;
 		myBatchJobSender = theBatchJobSender;
-		myJobExecutorSvc = theExecutor;
 		myInterceptorService = theInterceptorService;
 	}
 
 	@Override
 	public void scheduleJobs(ISchedulerService theSchedulerService) {
-		mySchedulerService.scheduleClusteredJob(myScheduledJobFrequencyMillis, buildJobDefinition());
+		long activeJobMaintenanceFrequency = 5 * DateUtils.MILLIS_PER_SECOND;
+		long endedJobMaintenanceFrequency = 5 * DateUtils.MILLIS_PER_MINUTE;
+		if (myScheduledJobFrequencyMillis != null) {
+			activeJobMaintenanceFrequency = myScheduledJobFrequencyMillis;
+			endedJobMaintenanceFrequency = myScheduledJobFrequencyMillis;
+		}
+		mySchedulerService.scheduleClusteredJob(activeJobMaintenanceFrequency, buildActiveJobDefinition());
+		mySchedulerService.scheduleClusteredJob(endedJobMaintenanceFrequency, buildEndedJobDefinition());
 	}
 
 	@Nonnull
-	private ScheduledJobDefinition buildJobDefinition() {
+	private ScheduledJobDefinition buildActiveJobDefinition() {
 		ScheduledJobDefinition jobDefinition = new ScheduledJobDefinition();
-		jobDefinition.setId(SCHEDULED_JOB_ID);
+		jobDefinition.setId(ACTIVE_JOB_MAINTENANCE_SCHEDULED_JOB_ID);
 		jobDefinition.setJobClass(JobMaintenanceScheduledJob.class);
 		return jobDefinition;
 	}
 
-	public void setScheduledJobFrequencyMillis(long theScheduledJobFrequencyMillis) {
+	@Nonnull
+	private ScheduledJobDefinition buildEndedJobDefinition() {
+		ScheduledJobDefinition jobDefinition = new ScheduledJobDefinition();
+		jobDefinition.setId(ENDED_JOB_MAINTENANCE_SCHEDULED_JOB_ID);
+		jobDefinition.setJobClass(EndedJobMaintenanceScheduledJob.class);
+		return jobDefinition;
+	}
+
+	public void setScheduledJobFrequencyMillis(Long theScheduledJobFrequencyMillis) {
+		Validate.isTrue(
+				myScheduledJobFrequencyMillis == null || myScheduledJobFrequencyMillis > 0,
+				"Scheduled job frequency must be greater than 0");
 		myScheduledJobFrequencyMillis = theScheduledJobFrequencyMillis;
 	}
 
@@ -155,20 +170,20 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 	 * @return true if a request to run a maintance pass was submitted
 	 */
 	@Override
-	public boolean triggerMaintenancePass() {
+	public boolean triggerActiveJobMaintenancePass() {
 		if (!myStorageSettings.isJobFastTrackingEnabled()) {
 			return false;
 		}
 		if (mySchedulerService.isClusteredSchedulingEnabled()) {
-			mySchedulerService.triggerClusteredJobImmediately(buildJobDefinition());
+			mySchedulerService.triggerClusteredJobImmediately(buildActiveJobDefinition());
 			return true;
 		} else {
 			// We are probably running a unit test
-			return runMaintenanceDirectlyWithTimeout();
+			return runActiveMaintenanceDirectlyWithTimeout();
 		}
 	}
 
-	private boolean runMaintenanceDirectlyWithTimeout() {
+	private boolean runActiveMaintenanceDirectlyWithTimeout() {
 		if (getQueueLength() > 0) {
 			ourLog.debug(
 					"There are already {} threads waiting to run a maintenance pass.  Ignoring request.",
@@ -181,14 +196,14 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 					"There is no clustered scheduling service.  Requesting semaphore to run maintenance pass directly.");
 			// Some unit test, esp. the Loinc terminology tests, depend on this maintenance pass being run shortly after
 			// it is requested
-			if (myRunMaintenanceSemaphore.tryAcquire(
+			if (myRunActiveMaintenanceSemaphore.tryAcquire(
 					MAINTENANCE_TRIGGER_RUN_WITHOUT_SCHEDULER_TIMEOUT, TimeUnit.MINUTES)) {
 				try {
 					ourLog.debug("Semaphore acquired.  Starting maintenance pass.");
-					doMaintenancePass();
+					doActiveMaintenancePass();
 				} finally {
 					ourLog.debug("Maintenance pass complete.  Releasing semaphore.");
-					myRunMaintenanceSemaphore.release();
+					myRunActiveMaintenanceSemaphore.release();
 				}
 			}
 			return true;
@@ -199,33 +214,33 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 	@VisibleForTesting
 	int getQueueLength() {
-		return myRunMaintenanceSemaphore.getQueueLength();
+		return myRunActiveMaintenanceSemaphore.getQueueLength() + myRunEndedMaintenanceSemaphore.getQueueLength();
 	}
 
 	@Override
 	@VisibleForTesting
-	public void forceMaintenancePass() {
+	public void forceActiveJobMaintenancePass() {
 		// to simulate a long running job!
 		ourLog.info("Forcing a maintenance pass run; semaphore at {}", getQueueLength());
-		myRunMaintenanceSemaphore.acquireUninterruptibly();
+		myRunActiveMaintenanceSemaphore.acquireUninterruptibly();
 		try {
-			doMaintenancePass();
+			doActiveMaintenancePass();
 		} finally {
-			myRunMaintenanceSemaphore.release();
+			myRunActiveMaintenanceSemaphore.release();
 		}
 	}
 
 	@Override
-	public void enableMaintenancePass(boolean theToEnable) {
+	public void enableMaintenance(boolean theToEnable) {
 		myEnabledBool = theToEnable;
 	}
 
 	// Created by claude-opus-4-6
 	@Override
-	public Closeable holdMaintenanceForExpunge() {
+	public Closeable holdActiveJobMaintenanceForExpunge() {
 		ourLog.info("Requesting hold on maintenance for expunge operation");
 		try {
-			if (!myRunMaintenanceSemaphore.tryAcquire(HOLD_MAINTENANCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+			if (!myRunActiveMaintenanceSemaphore.tryAcquire(HOLD_MAINTENANCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
 				throw new InternalErrorException(
 						Msg.code(2842) + "Timed out waiting to acquire maintenance hold for expunge after "
 								+ HOLD_MAINTENANCE_TIMEOUT_SECONDS + " seconds");
@@ -236,7 +251,138 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 					Msg.code(2843) + "Interrupted while waiting to acquire maintenance hold for expunge", e);
 		}
 		ourLog.info("Acquired hold on maintenance for expunge operation");
-		return new MaintenanceHold(myRunMaintenanceSemaphore);
+		return new MaintenanceHold(myRunActiveMaintenanceSemaphore);
+	}
+
+	@Override
+	public void runActiveJobMaintenancePass() {
+		if (!myEnabledBool) {
+			ourLog.error("Maintenance (Active Job) job is disabled! This will affect all batch2 jobs!");
+		}
+
+		if (!myRunActiveMaintenanceSemaphore.tryAcquire()) {
+			ourLog.debug("Another Active Job maintenance pass is already in progress.  Ignoring request.");
+			return;
+		}
+		try {
+			ourLog.debug("Active Maintenance pass starting.");
+			doActiveMaintenancePass();
+		} catch (Exception e) {
+			ourLog.error("Active Job Maintenance pass failed", e);
+		} finally {
+			myRunActiveMaintenanceSemaphore.release();
+		}
+	}
+
+	@Override
+	public void runEndedJobMaintenancePass() {
+		if (!myEnabledBool) {
+			ourLog.error("Maintenance (Ended Job) job is disabled! This will affect all batch2 jobs!");
+		}
+
+		if (!myRunEndedMaintenanceSemaphore.tryAcquire()) {
+			ourLog.debug("Another Ended Job maintenance pass is already in progress.  Ignoring request.");
+			return;
+		}
+		try {
+			ourLog.debug("Ended Job Maintenance pass starting.");
+			doEndedMaintenancePass();
+		} catch (Exception e) {
+			ourLog.error("Ended Job Maintenance pass failed", e);
+		} finally {
+			myRunEndedMaintenanceSemaphore.release();
+		}
+	}
+
+	private void doActiveMaintenancePass() {
+		myMaintenanceJobStartedCallback.run();
+
+		Set<StatusEnum> statuses = StatusEnum.getNotEndedStatuses();
+		Consumer<JobInstance> processorCallback = (instance) -> {
+			String instanceId = instance.getInstanceId();
+			ActiveJobInstanceProcessor jobInstanceProcessor = new ActiveJobInstanceProcessor(
+					myJobPersistence,
+					myBatchJobSender,
+					instanceId,
+					myReductionStepExecutorService,
+					myJobDefinitionRegistry,
+					myInterceptorService);
+			ourLog.debug(
+					"Triggering non-ended status maintenance process for instance {} in status {}",
+					instance.getInstanceId(),
+					instance.getStatus());
+			jobInstanceProcessor.process();
+		};
+
+		doMaintenancePass(statuses, processorCallback);
+
+		myMaintenanceJobFinishedCallback.run();
+	}
+
+	private void doEndedMaintenancePass() {
+		Set<StatusEnum> statuses = StatusEnum.getEndedStatuses();
+		Consumer<JobInstance> processorCallback = (instance) -> {
+			String instanceId = instance.getInstanceId();
+			EndedJobInstanceProcessor processor = new EndedJobInstanceProcessor(myJobPersistence, instanceId);
+			if (myFailedJobLifetimeOverride >= 0) {
+				processor.setPurgeThreshold(myFailedJobLifetimeOverride);
+			}
+			ourLog.debug(
+					"Triggering ended status maintenance process for instance {} in status {}",
+					instance.getInstanceId(),
+					instance.getStatus());
+			processor.process();
+		};
+		doMaintenancePass(statuses, processorCallback);
+	}
+
+	private void doMaintenancePass(Set<StatusEnum> statuses, Consumer<JobInstance> processorCallback) {
+		Set<String> processedInstanceIds = new HashSet<>();
+
+		for (int page = 0; ; page++) {
+
+			List<JobInstance> instances = myJobPersistence.fetchInstances(INSTANCES_PER_PASS, page, statuses);
+
+			for (JobInstance instance : instances) {
+				String instanceId = instance.getInstanceId();
+				Optional<JobDefinition<?>> jobDefinition = getJobDefinition(instance);
+
+				if (jobDefinition.isPresent() && processedInstanceIds.add(instanceId)) {
+					myJobDefinitionRegistry.setJobDefinition(instance);
+					processorCallback.accept(instance);
+				}
+			}
+
+			if (instances.size() < INSTANCES_PER_PASS) {
+				break;
+			}
+		}
+	}
+
+	@Nonnull
+	private Optional<JobDefinition<?>> getJobDefinition(JobInstance theInstance) {
+		Optional<JobDefinition<?>> jobDefinition = myJobDefinitionRegistry.getJobDefinition(
+				theInstance.getJobDefinitionId(), theInstance.getJobDefinitionVersion());
+		if (jobDefinition.isEmpty()) {
+			ourLog.warn(
+					"Job definition {} for instance {} is currently unavailable",
+					theInstance.getJobDefinitionId(),
+					theInstance.getInstanceId());
+		}
+		return jobDefinition;
+	}
+
+	@VisibleForTesting
+	public void setFailedJobLifetime(long theFailedJobLifetime) {
+		myFailedJobLifetimeOverride = theFailedJobLifetime;
+	}
+
+	public void setMaintenanceJobStartedCallback(Runnable theMaintenanceJobStartedCallback) {
+		myMaintenanceJobStartedCallback = theMaintenanceJobStartedCallback;
+	}
+
+	public void setMaintenanceJobFinishedCallback(Runnable theMaintenanceJobFinishedCallback) {
+		myMaintenanceJobFinishedCallback = theMaintenanceJobFinishedCallback;
 	}
 
 	// Created by claude-opus-4-6
@@ -257,99 +403,23 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 		}
 	}
 
-	@Override
-	public void runMaintenancePass() {
-		if (!myEnabledBool) {
-			ourLog.error("Maintenance job is disabled! This will affect all batch2 jobs!");
-		}
-
-		if (!myRunMaintenanceSemaphore.tryAcquire()) {
-			ourLog.debug("Another maintenance pass is already in progress.  Ignoring request.");
-			return;
-		}
-		try {
-			ourLog.debug("Maintenance pass starting.");
-			doMaintenancePass();
-		} catch (Exception e) {
-			ourLog.error("Maintenance pass failed", e);
-		} finally {
-			myRunMaintenanceSemaphore.release();
-		}
-	}
-
-	private void doMaintenancePass() {
-		myMaintenanceJobStartedCallback.run();
-		Set<String> processedInstanceIds = new HashSet<>();
-		JobChunkProgressAccumulator progressAccumulator = new JobChunkProgressAccumulator();
-		for (int page = 0; ; page++) {
-			List<JobInstance> instances = myJobPersistence.fetchInstances(INSTANCES_PER_PASS, page);
-
-			for (JobInstance instance : instances) {
-				String instanceId = instance.getInstanceId();
-				if (myJobDefinitionRegistry
-						.getJobDefinition(instance.getJobDefinitionId(), instance.getJobDefinitionVersion())
-						.isPresent()) {
-					if (processedInstanceIds.add(instanceId)) {
-						myJobDefinitionRegistry.setJobDefinition(instance);
-						JobInstanceProcessor jobInstanceProcessor =
-								createJobInstanceProcessor(instanceId, progressAccumulator);
-						ourLog.debug(
-								"Triggering maintenance process for instance {} in status {}",
-								instanceId,
-								instance.getStatus());
-						jobInstanceProcessor.process();
-					}
-				} else {
-					ourLog.warn(
-							"Job definition {} for instance {} is currently unavailable",
-							instance.getJobDefinitionId(),
-							instanceId);
-				}
-			}
-
-			if (instances.size() < INSTANCES_PER_PASS) {
-				break;
-			}
-		}
-		myMaintenanceJobFinishedCallback.run();
-	}
-
-	private JobInstanceProcessor createJobInstanceProcessor(
-			String theInstanceId, JobChunkProgressAccumulator theAccumulator) {
-		JobInstanceProcessor processor = new JobInstanceProcessor(
-				myJobPersistence,
-				myBatchJobSender,
-				theInstanceId,
-				theAccumulator,
-				myReductionStepExecutorService,
-				myJobDefinitionRegistry,
-				myInterceptorService);
-		if (myFailedJobLifetimeOverride >= 0) {
-			processor.setPurgeThreshold(myFailedJobLifetimeOverride);
-		}
-		return processor;
-	}
-
-	@VisibleForTesting
-	public void setFailedJobLifetime(long theFailedJobLifetime) {
-		myFailedJobLifetimeOverride = theFailedJobLifetime;
-	}
-
-	public void setMaintenanceJobStartedCallback(Runnable theMaintenanceJobStartedCallback) {
-		myMaintenanceJobStartedCallback = theMaintenanceJobStartedCallback;
-	}
-
-	public void setMaintenanceJobFinishedCallback(Runnable theMaintenanceJobFinishedCallback) {
-		myMaintenanceJobFinishedCallback = theMaintenanceJobFinishedCallback;
-	}
-
 	public static class JobMaintenanceScheduledJob implements HapiJob {
 		@Autowired
 		private IJobMaintenanceService myTarget;
 
 		@Override
 		public void execute(JobExecutionContext theContext) {
-			myTarget.runMaintenancePass();
+			myTarget.runActiveJobMaintenancePass();
+		}
+	}
+
+	public static class EndedJobMaintenanceScheduledJob implements HapiJob {
+		@Autowired
+		private IJobMaintenanceService myTarget;
+
+		@Override
+		public void execute(JobExecutionContext theContext) {
+			myTarget.runEndedJobMaintenancePass();
 		}
 	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
@@ -97,8 +97,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 	private final BatchJobSender myBatchJobSender;
 	private final IReductionStepExecutorService myReductionStepExecutorService;
 	private final IInterceptorService myInterceptorService;
-	private final Semaphore myRunActiveMaintenanceSemaphore = new Semaphore(1);
-	private final Semaphore myRunEndedMaintenanceSemaphore = new Semaphore(1);
+	private final Semaphore myRunMaintenanceSemaphore = new Semaphore(1);
 	private long myFailedJobLifetimeOverride = -1;
 	private Runnable myMaintenanceJobStartedCallback = () -> {};
 	private Runnable myMaintenanceJobFinishedCallback = () -> {};
@@ -161,7 +160,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 	public void setScheduledJobFrequencyMillis(Long theScheduledJobFrequencyMillis) {
 		Validate.isTrue(
-				myScheduledJobFrequencyMillis == null || myScheduledJobFrequencyMillis > 0,
+				theScheduledJobFrequencyMillis == null || theScheduledJobFrequencyMillis > 0,
 				"Scheduled job frequency must be greater than 0");
 		myScheduledJobFrequencyMillis = theScheduledJobFrequencyMillis;
 	}
@@ -196,14 +195,14 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 					"There is no clustered scheduling service.  Requesting semaphore to run maintenance pass directly.");
 			// Some unit test, esp. the Loinc terminology tests, depend on this maintenance pass being run shortly after
 			// it is requested
-			if (myRunActiveMaintenanceSemaphore.tryAcquire(
+			if (myRunMaintenanceSemaphore.tryAcquire(
 					MAINTENANCE_TRIGGER_RUN_WITHOUT_SCHEDULER_TIMEOUT, TimeUnit.MINUTES)) {
 				try {
 					ourLog.debug("Semaphore acquired.  Starting maintenance pass.");
 					doActiveMaintenancePass();
 				} finally {
 					ourLog.debug("Maintenance pass complete.  Releasing semaphore.");
-					myRunActiveMaintenanceSemaphore.release();
+					myRunMaintenanceSemaphore.release();
 				}
 			}
 			return true;
@@ -214,7 +213,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 	@VisibleForTesting
 	int getQueueLength() {
-		return myRunActiveMaintenanceSemaphore.getQueueLength() + myRunEndedMaintenanceSemaphore.getQueueLength();
+		return myRunMaintenanceSemaphore.getQueueLength();
 	}
 
 	@Override
@@ -222,11 +221,11 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 	public void forceActiveJobMaintenancePass() {
 		// to simulate a long running job!
 		ourLog.info("Forcing a maintenance pass run; semaphore at {}", getQueueLength());
-		myRunActiveMaintenanceSemaphore.acquireUninterruptibly();
+		myRunMaintenanceSemaphore.acquireUninterruptibly();
 		try {
 			doActiveMaintenancePass();
 		} finally {
-			myRunActiveMaintenanceSemaphore.release();
+			myRunMaintenanceSemaphore.release();
 		}
 	}
 
@@ -237,10 +236,10 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 	// Created by claude-opus-4-6
 	@Override
-	public Closeable holdActiveJobMaintenanceForExpunge() {
+	public Closeable holdJobMaintenanceForExpunge() {
 		ourLog.info("Requesting hold on maintenance for expunge operation");
 		try {
-			if (!myRunActiveMaintenanceSemaphore.tryAcquire(HOLD_MAINTENANCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+			if (!myRunMaintenanceSemaphore.tryAcquire(HOLD_MAINTENANCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
 				throw new InternalErrorException(
 						Msg.code(2842) + "Timed out waiting to acquire maintenance hold for expunge after "
 								+ HOLD_MAINTENANCE_TIMEOUT_SECONDS + " seconds");
@@ -250,8 +249,9 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 			throw new InternalErrorException(
 					Msg.code(2843) + "Interrupted while waiting to acquire maintenance hold for expunge", e);
 		}
+
 		ourLog.info("Acquired hold on maintenance for expunge operation");
-		return new MaintenanceHold(myRunActiveMaintenanceSemaphore);
+		return new MaintenanceHold(myRunMaintenanceSemaphore);
 	}
 
 	@Override
@@ -260,7 +260,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 			ourLog.error("Maintenance (Active Job) job is disabled! This will affect all batch2 jobs!");
 		}
 
-		if (!myRunActiveMaintenanceSemaphore.tryAcquire()) {
+		if (!myRunMaintenanceSemaphore.tryAcquire()) {
 			ourLog.debug("Another Active Job maintenance pass is already in progress.  Ignoring request.");
 			return;
 		}
@@ -270,7 +270,7 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 		} catch (Exception e) {
 			ourLog.error("Active Job Maintenance pass failed", e);
 		} finally {
-			myRunActiveMaintenanceSemaphore.release();
+			myRunMaintenanceSemaphore.release();
 		}
 	}
 
@@ -280,17 +280,29 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 			ourLog.error("Maintenance (Ended Job) job is disabled! This will affect all batch2 jobs!");
 		}
 
-		if (!myRunEndedMaintenanceSemaphore.tryAcquire()) {
-			ourLog.debug("Another Ended Job maintenance pass is already in progress.  Ignoring request.");
+		try {
+			/*
+			 * In case the active maintenance worker is really busy, we'll wait a little while
+			 * just to avoid too much risk of the less frequent but still important Ended Job
+			 * maintenance pass
+			 */
+			if (!myRunMaintenanceSemaphore.tryAcquire(10, TimeUnit.SECONDS)) {
+				ourLog.debug("Another Ended Job maintenance pass is already in progress.  Ignoring request.");
+				return;
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			ourLog.debug("Waiting for maintenance semaphore was interrupted, aborting");
 			return;
 		}
+
 		try {
 			ourLog.debug("Ended Job Maintenance pass starting.");
 			doEndedMaintenancePass();
 		} catch (Exception e) {
 			ourLog.error("Ended Job Maintenance pass failed", e);
 		} finally {
-			myRunEndedMaintenanceSemaphore.release();
+			myRunMaintenanceSemaphore.release();
 		}
 	}
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImpl.java
@@ -138,6 +138,11 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 			activeJobMaintenanceFrequency = myScheduledJobFrequencyMillis;
 			endedJobMaintenanceFrequency = myScheduledJobFrequencyMillis;
 		}
+		ourLog.atInfo()
+				.setMessage("Scheduling Batch2 maintenance with frequency: Active={}ms, Ended={}ms")
+				.addArgument(activeJobMaintenanceFrequency)
+				.addArgument(endedJobMaintenanceFrequency)
+				.log();
 		mySchedulerService.scheduleClusteredJob(activeJobMaintenanceFrequency, buildActiveJobDefinition());
 		mySchedulerService.scheduleClusteredJob(endedJobMaintenanceFrequency, buildEndedJobDefinition());
 	}
@@ -260,10 +265,17 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 			ourLog.error("Maintenance (Active Job) job is disabled! This will affect all batch2 jobs!");
 		}
 
-		if (!myRunMaintenanceSemaphore.tryAcquire()) {
-			ourLog.debug("Another Active Job maintenance pass is already in progress.  Ignoring request.");
+		try {
+			if (!myRunMaintenanceSemaphore.tryAcquire(5, TimeUnit.SECONDS)) {
+				ourLog.debug("Another Active Job maintenance pass is already in progress.  Ignoring request.");
+				return;
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			ourLog.debug("Waiting for active job maintenance semaphore was interrupted, aborting");
 			return;
 		}
+
 		try {
 			ourLog.debug("Active Maintenance pass starting.");
 			doActiveMaintenancePass();
@@ -421,6 +433,8 @@ public class JobMaintenanceServiceImpl implements IJobMaintenanceService, IHasSc
 
 		@Override
 		public void execute(JobExecutionContext theContext) {
+			// FIXME: reduce
+			ourLog.info("Running Batch2 active job maintenance pass");
 			myTarget.runActiveJobMaintenancePass();
 		}
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/package-info.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/package-info.java
@@ -40,8 +40,8 @@
  *
  * </p><p>
  *
- * Once a minute, Quartz runs the  {@link ca.uhn.fhir.batch2.api.IJobMaintenanceService#runMaintenancePass() maintenance pass}.
- * This loop inspects every job, and dispatches to {@link ca.uhn.fhir.batch2.maintenance.JobInstanceProcessor#process() the JobInstanceProcessor}.
+ * Once a minute, Quartz runs the  {@link ca.uhn.fhir.batch2.api.IJobMaintenanceService#runActiveJobMaintenancePass() maintenance pass}.
+ * This loop inspects every job, and dispatches to {@link ca.uhn.fhir.batch2.maintenance.ActiveJobInstanceProcessor#process() the JobInstanceProcessor}.
  * The JobInstanceProcessor counts the outstanding chunks for a job, and uses these statistics to fire the working state transitions (below).
  *
  * </p><p>
@@ -131,7 +131,7 @@
  *        </li>
  *    <li> Gated jobs that have a reducer step will transtion (IN_PROGRESS or ERRORED) -> FINALIZE when
  *         starting the reduction step
- *         {@link ca.uhn.fhir.batch2.maintenance.JobInstanceProcessor#triggerGatedExecutions}
+ *         {@link ca.uhn.fhir.batch2.maintenance.ActiveJobInstanceProcessor#triggerGatedExecutions}
  *         </li>
  * </ul>
  *

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
@@ -93,7 +93,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	IJobCompletionHandler<TestJobParameters> myCompletionHandler;
 	@Mock
 	private ISchedulerService mySchedulerService;
-	@Mock
+	@Mock(strictness = Mock.Strictness.STRICT_STUBS)
 	private IJobPersistence myJobPersistence;
 	@Mock
 	private WorkChunkProcessor myJobExecutorSvc;
@@ -123,7 +123,6 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 			myStorageSettings,
 			myJobDefinitionRegistry,
 			batchJobSender,
-			myJobExecutorSvc,
 			myReductionStepExecutorService,
 			myInterceptorService
 		);
@@ -142,12 +141,12 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 		myJobDefinitionRegistry.addJobDefinition(createJobDefinition());
 		JobInstance instance = createInstance();
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(List.of(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(List.of(instance));
 		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(instance));
 		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), eq(INSTANCE_ID), any()))
 			.thenReturn(page);
 
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		verify(myJobPersistence, times(1)).updateInstance(any(), any());
 	}
@@ -161,9 +160,9 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		);
 
 		JobInstance instance = createInstance();
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(List.of(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(List.of(instance));
 
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		String assumedRoleLogText = String.format("Job definition %s for instance %s is currently unavailable", JOB_DEFINITION_ID,  instance.getInstanceId());
 
@@ -186,14 +185,14 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		myJobDefinitionRegistry.addJobDefinition(createJobDefinition());
 		JobInstance instance = createInstance();
 		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(instance));
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Lists.newArrayList(instance));
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false)))
 			.thenReturn(chunks.iterator());
 		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), eq(instance.getInstanceId()), eq(Set.of(WorkChunkStatusEnum.READY))))
 			.thenReturn(Page.empty());
 		stubUpdateInstanceCallback(instance);
 
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		verify(myJobPersistence, times(1)).updateInstance(eq(INSTANCE_ID), any());
 
@@ -231,7 +230,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		JobInstance instance = createInstance();
 		instance.setErrorMessage("This is an error message");
 		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(createInstance()));
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Lists.newArrayList(instance));
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false)))
 			.thenReturn(chunks.iterator());
 		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), eq(instance.getInstanceId()), eq(Set.of(WorkChunkStatusEnum.READY))))
@@ -239,7 +238,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		stubUpdateInstanceCallback(instance);
 
 		// Execute
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		// Verify
 		verify(myJobPersistence, times(1)).updateInstance(eq(INSTANCE_ID), any());
@@ -272,7 +271,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 		JobInstance instance1 = createInstance();
 		instance1.setCurrentGatedStepId(STEP_1);
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance1));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Lists.newArrayList(instance1));
 		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(instance1));
 		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), anyString(), eq(Set.of(WorkChunkStatusEnum.READY))))
 			.thenAnswer((args) -> {
@@ -287,7 +286,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		stubUpdateInstanceCallback(instance1);
 
 		// Execute
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		// Verify
 		verify(myWorkChannelProducer, times(2)).send(myMessageCaptor.capture());
@@ -309,15 +308,13 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		JobInstance instance = createInstance();
 		instance.setStatus(StatusEnum.FAILED);
 		instance.setEndTime(parseTime("2001-01-01T12:12:12Z"));
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getEndedStatuses()))).thenReturn(Lists.newArrayList(instance));
 		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(instance));
-		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), eq(instance.getInstanceId()), eq(Set.of(WorkChunkStatusEnum.READY))))
-			.thenReturn(Page.empty());
 
-		mySvc.runMaintenancePass();
+		mySvc.runEndedJobMaintenancePass();
 
 		verify(myJobPersistence, times(1)).deleteInstanceAndChunks(eq(INSTANCE_ID));
-		verify(myJobPersistence).updatePollWaitingChunksForJobIfReady(eq(instance.getInstanceId()));
+		verify(myJobPersistence, times(1)).deleteChunksAndMarkInstanceAsChunksPurged(eq(INSTANCE_ID));
 		verifyNoMoreInteractions(myJobPersistence);
 	}
 
@@ -334,7 +331,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 		myJobDefinitionRegistry.addJobDefinition(createJobDefinition(t -> t.completionHandler(myCompletionHandler)));
 		JobInstance instance = createInstance();
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Lists.newArrayList(instance));
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), anyBoolean())).thenAnswer(t->chunks.iterator());
 		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(instance));
 		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), eq(INSTANCE_ID), eq(Set.of(WorkChunkStatusEnum.READY))))
@@ -343,7 +340,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 		// Execute
 
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		// Verify
 
@@ -355,7 +352,6 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		assertEquals(0.25, instance.getCombinedRecordsProcessedPerSecond());
 		assertEquals(parseTime("2022-02-12T14:10:00-04:00"), instance.getEndTime());
 
-		verify(myJobPersistence, times(1)).deleteChunksAndMarkInstanceAsChunksPurged(eq(INSTANCE_ID));
 		verify(myCompletionHandler, times(1)).jobComplete(myJobCompletionCaptor.capture());
 		verify(myJobPersistence).updatePollWaitingChunksForJobIfReady(eq(instance.getInstanceId()));
 		verifyNoMoreInteractions(myJobPersistence);
@@ -378,14 +374,14 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		myJobDefinitionRegistry.addJobDefinition(createJobDefinition());
 		JobInstance instance = createInstance();
 		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(instance));
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Lists.newArrayList(instance));
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), anyBoolean()))
 			.thenAnswer(t->chunks.iterator());
 		when(myJobPersistence.fetchAllWorkChunkMetadataForJobInStates(any(Pageable.class), eq(instance.getInstanceId()), eq(Set.of(WorkChunkStatusEnum.READY))))
 			.thenReturn(Page.empty());
 		stubUpdateInstanceCallback(instance);
 
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 
 		assertEquals(0.8333333333333334, instance.getProgress());
 		assertEquals(StatusEnum.FAILED, instance.getStatus());
@@ -396,9 +392,14 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 		// twice - once to move to FAILED, and once to purge the chunks
 		verify(myJobPersistence, times(1)).updateInstance(eq(INSTANCE_ID), any());
-		verify(myJobPersistence, times(1)).deleteChunksAndMarkInstanceAsChunksPurged(eq(INSTANCE_ID));
 		verify(myJobPersistence).updatePollWaitingChunksForJobIfReady(eq(instance.getInstanceId()));
-		verifyNoMoreInteractions(myJobPersistence);
+
+		// Now run the ended job maintenance task
+
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getEndedStatuses()))).thenReturn(Lists.newArrayList(instance));
+		mySvc.runEndedJobMaintenancePass();
+		verify(myJobPersistence, times(1)).deleteChunksAndMarkInstanceAsChunksPurged(eq(INSTANCE_ID));
+//		verifyNoMoreInteractions(myJobPersistence);
 	}
 
 	private void runEnqueueReadyChunksTest(List<WorkChunk> theChunks, JobDefinition<TestJobParameters> theJobDefinition) {
@@ -411,13 +412,13 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		instance.setJobDefinitionId(theJobDefinition.getJobDefinitionId());
 
 		// mocks
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Lists.newArrayList(instance));
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(List.of(instance));
 		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(instance));
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), anyBoolean()))
 			.thenAnswer(t -> theChunks.stream().map(c -> c.setStatus(WorkChunkStatusEnum.READY)).toList().iterator());
 
 		// test
-		mySvc.runMaintenancePass();
+		mySvc.runActiveJobMaintenancePass();
 	}
 
 	@Test
@@ -526,28 +527,28 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	}
 
 	@Test
-	void triggerMaintenancePass_noneInProgress_runsMaintenance() {
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Collections.emptyList());
-		mySvc.triggerMaintenancePass();
+	void triggerActiveMaintenancePass_noneInProgress_runsJobMaintenance() {
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Collections.emptyList());
+		mySvc.triggerActiveJobMaintenancePass();
 
 		// Verify maintenance was only called once
-		verify(myJobPersistence, times(1)).fetchInstances(anyInt(), eq(0));
+		verify(myJobPersistence, times(1)).fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()));
 	}
 
 	@Test
-	void triggerMaintenancePassDisabled_noneInProgress_doesNotRunMaintenace() {
+	void triggerActiveJobMaintenancePassDisabled_noneInProgress_doesNotRunMaintenace() {
 		myStorageSettings.setJobFastTrackingEnabled(false);
-		mySvc.triggerMaintenancePass();
+		mySvc.triggerActiveJobMaintenancePass();
 		verifyNoMoreInteractions(myJobPersistence);
 	}
 
 	@Test
-	void triggerMaintenancePass_twoSimultaneousRequests_onlyCallOnce() throws InterruptedException, ExecutionException {
+	void triggerActiveJobMaintenancePass_twoSimultaneousRequests_onlyCallOnce() throws InterruptedException, ExecutionException {
 		CountDownLatch simulatedMaintenancePasslatch = new CountDownLatch(1);
 		CountDownLatch maintenancePassCalled = new CountDownLatch(1);
 		CountDownLatch secondCall = new CountDownLatch(1);
 
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0)))
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses())))
 			.thenAnswer(t -> {
 				maintenancePassCalled.countDown();
 				simulatedMaintenancePasslatch.await();
@@ -559,9 +560,9 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 			});
 
 		// Trigger a thread blocking on our latch maintenance pass in the background
-		Future<Boolean> result1 = Executors.newSingleThreadExecutor().submit(() -> mySvc.triggerMaintenancePass());
+		Future<Boolean> result1 = Executors.newSingleThreadExecutor().submit(() -> mySvc.triggerActiveJobMaintenancePass());
 		// Trigger a thread blocking on the semaphore maintenance pass in the background
-		Future<Boolean> result2 = Executors.newSingleThreadExecutor().submit(() -> mySvc.triggerMaintenancePass());
+		Future<Boolean> result2 = Executors.newSingleThreadExecutor().submit(() -> mySvc.triggerActiveJobMaintenancePass());
 
 		// Wait for the first background maintenance pass to block
 		maintenancePassCalled.await();
@@ -569,7 +570,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		await().until(() -> mySvc.getQueueLength() > 0);
 
 		// Now trigger a maintenance pass in the foreground.  It should abort right away since there is already one thread in queue
-		assertFalse(mySvc.triggerMaintenancePass());
+		assertFalse(mySvc.triggerActiveJobMaintenancePass());
 
 		// Now release the background task
 		simulatedMaintenancePasslatch.countDown();
@@ -578,7 +579,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		secondCall.await();
 
 		// Verify maintenance was only called once
-		verify(myJobPersistence, times(2)).fetchInstances(anyInt(), eq(0));
+		verify(myJobPersistence, times(2)).fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()));
 		assertTrue(result1.get());
 		assertTrue(result2.get());
 	}
@@ -594,18 +595,18 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	@Test
 	void holdMaintenanceForExpunge_whileHeld_maintenancePassSkips() throws Exception {
 		// Setup
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Collections.emptyList());
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Collections.emptyList());
 
 		// Acquire the hold — this takes the semaphore
-		try (Closeable hold = mySvc.holdMaintenanceForExpunge()) {
+		try (Closeable hold = mySvc.holdActiveJobMaintenanceForExpunge()) {
 			// runMaintenancePass() tries tryAcquire(), fails, and returns immediately
-			mySvc.runMaintenancePass();
-			verify(myJobPersistence, never()).fetchInstances(anyInt(), anyInt());
+			mySvc.runActiveJobMaintenancePass();
+			verify(myJobPersistence, never()).fetchInstances(anyInt(), anyInt(), any());
 		}
 
 		// Hold released — semaphore is free, maintenance runs normally
-		mySvc.runMaintenancePass();
-		verify(myJobPersistence, times(1)).fetchInstances(anyInt(), eq(0));
+		mySvc.runActiveJobMaintenancePass();
+		verify(myJobPersistence, times(1)).fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()));
 	}
 
 	/**
@@ -639,7 +640,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		CountDownLatch maintenanceStarted = new CountDownLatch(1);
 		CountDownLatch maintenanceCanFinish = new CountDownLatch(1);
 
-		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenAnswer(t -> {
+		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenAnswer(t -> {
 			maintenanceStarted.countDown();
 			maintenanceCanFinish.await();
 			return Collections.emptyList();
@@ -650,12 +651,12 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		ExecutorService holdExecutor = Executors.newSingleThreadExecutor();
 		try {
 			// Thread B: start maintenance — acquires semaphore, parks in fetchInstances()
-			Future<?> maintenanceFuture = maintenanceExecutor.submit(() -> mySvc.runMaintenancePass());
+			Future<?> maintenanceFuture = maintenanceExecutor.submit(() -> mySvc.runActiveJobMaintenancePass());
 			maintenanceStarted.await();
 
 			// Thread C: try to acquire hold — blocks because Thread B holds the semaphore
 			Future<Closeable> holdFuture = holdExecutor.submit(() -> {
-				Closeable hold = mySvc.holdMaintenanceForExpunge();
+				Closeable hold = mySvc.holdActiveJobMaintenanceForExpunge();
 				holdAcquired.set(true);
 				return hold;
 			});
@@ -690,14 +691,14 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	// Created by claude-opus-4-6
 	@Test
 	void holdMaintenanceForExpunge_closeMultipleTimes_noError() throws Exception {
-		Closeable hold = mySvc.holdMaintenanceForExpunge();
+		Closeable hold = mySvc.holdActiveJobMaintenanceForExpunge();
 		hold.close();
 		hold.close(); // Must not double-release the semaphore
 
 		// Maintenance runs normally — proves the semaphore has exactly 1 permit
 		when(myJobPersistence.fetchInstances(anyInt(), eq(0))).thenReturn(Collections.emptyList());
-		mySvc.runMaintenancePass();
-		verify(myJobPersistence, times(1)).fetchInstances(anyInt(), eq(0));
+		mySvc.runActiveJobMaintenancePass();
+		verify(myJobPersistence, times(1)).fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()));
 	}
 
 	private static Date parseTime(String theDate) {

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
@@ -598,7 +598,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 		when(myJobPersistence.fetchInstances(anyInt(), eq(0), eq(StatusEnum.getNotEndedStatuses()))).thenReturn(Collections.emptyList());
 
 		// Acquire the hold — this takes the semaphore
-		try (Closeable hold = mySvc.holdActiveJobMaintenanceForExpunge()) {
+		try (Closeable hold = mySvc.holdJobMaintenanceForExpunge()) {
 			// runMaintenancePass() tries tryAcquire(), fails, and returns immediately
 			mySvc.runActiveJobMaintenancePass();
 			verify(myJobPersistence, never()).fetchInstances(anyInt(), anyInt(), any());
@@ -656,7 +656,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 			// Thread C: try to acquire hold — blocks because Thread B holds the semaphore
 			Future<Closeable> holdFuture = holdExecutor.submit(() -> {
-				Closeable hold = mySvc.holdActiveJobMaintenanceForExpunge();
+				Closeable hold = mySvc.holdJobMaintenanceForExpunge();
 				holdAcquired.set(true);
 				return hold;
 			});
@@ -691,7 +691,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	// Created by claude-opus-4-6
 	@Test
 	void holdMaintenanceForExpunge_closeMultipleTimes_noError() throws Exception {
-		Closeable hold = mySvc.holdActiveJobMaintenanceForExpunge();
+		Closeable hold = mySvc.holdJobMaintenanceForExpunge();
 		hold.close();
 		hold.close(); // Must not double-release the semaphore
 

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
@@ -1,6 +1,7 @@
 package ca.uhn.fhir.batch2.maintenance;
 
 import ca.uhn.fhir.batch2.api.IJobCompletionHandler;
+import ca.uhn.fhir.batch2.api.IJobMaintenanceService;
 import ca.uhn.fhir.batch2.api.IJobPersistence;
 import ca.uhn.fhir.batch2.api.IReductionStepExecutorService;
 import ca.uhn.fhir.batch2.api.JobCompletionDetails;
@@ -585,9 +586,9 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	}
 
 	/**
-	 * Verifies that runMaintenancePass() is a no-op while the expunge hold is active.
+	 * Verifies that {@link IJobMaintenanceService#runActiveJobMaintenancePass()} is a no-op while the expunge hold is active.
 	 *
-	 * <p>runMaintenancePass() uses tryAcquire() (non-blocking) on the semaphore, so it
+	 * {@link IJobMaintenanceService#runActiveJobMaintenancePass()} uses tryAcquire() (non-blocking) on the semaphore, so it
 	 * silently skips when the semaphore is unavailable. After the hold is released,
 	 * maintenance should run normally.
 	 */
@@ -599,8 +600,10 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 		// Acquire the hold — this takes the semaphore
 		try (Closeable hold = mySvc.holdJobMaintenanceForExpunge()) {
-			// runMaintenancePass() tries tryAcquire(), fails, and returns immediately
+
+			/// {@link IJobMaintenanceService#runActiveJobMaintenancePass()} tries tryAcquire(), fails, and returns immediately
 			mySvc.runActiveJobMaintenancePass();
+
 			verify(myJobPersistence, never()).fetchInstances(anyInt(), anyInt(), any());
 		}
 
@@ -624,7 +627,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	 *
 	 * <p>Timeline:
 	 * <pre>
-	 * Thread B:  runMaintenancePass() → acquires semaphore → fetchInstances() → PARKS on maintenanceCanFinish
+	 * Thread B:  {@link IJobMaintenanceService#runActiveJobMaintenancePass()} → acquires semaphore → fetchInstances() → PARKS on maintenanceCanFinish
 	 * Test:      maintenanceStarted.await() returns → we know semaphore is held
 	 * Thread C:  holdMaintenanceForExpunge() → tryAcquire() → BLOCKS (semaphore held by B)
 	 * Test:      Awaitility confirms holdAcquired is still false (C is blocked)

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4b/pom.xml
+++ b/hapi-fhir-validation-resources-r4b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>8.11.11-SNAPSHOT</version>
+	<version>8.11.12-SNAPSHOT</version>
 
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.11-SNAPSHOT</version>
+		<version>8.11.12-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>


### PR DESCRIPTION
The Batch2 maintenance job has been split into two separate steps that can be executed separately: The active job maintenance (handles advancing gated jobs) and the ended job maintenance (purges old files). The active job maintenance is now executed at a much higher frequency (every 5 seconds as opposed to every minute) so that active batch jobs can don't spend a lot of time waiting between steps.