### PR TITLE
Document sendStringParametersAsUnicode=false JDBC requirement for SQL…

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8074-document-mssql-unicode-params.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8074-document-mssql-unicode-params.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 8074
+title: "Documentation has been added recommending the `sendStringParametersAsUnicode=false` 
+JDBC connection parameter for MS SQL Server, which avoids implicit NVARCHAR conversions that 
+prevent index usage and can significantly degrade performance."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8075-fix-mssql-dialect-in-docs.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8075-fix-mssql-dialect-in-docs.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 8075
+title: "The database support documentation listed an incorrect Hibernate dialect class for 
+MS SQL Server. It now lists `HapiFhirSQLServerDialect`."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/database_support.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/database_support.md
@@ -6,12 +6,24 @@ The supported databases are regularly tested for ongoing compliance and performa
 
 | Database                                                                    | Status        | Hibernate Dialect Class                                  | Notes                                                                                                                             |
 |-----------------------------------------------------------------------------|---------------|----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| [MS SQL Server](https://www.microsoft.com/en-us/sql-server/sql-server-2019) | **Supported** | `ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect`        |                                                                                                                                   |
+| [MS SQL Server](https://www.microsoft.com/en-us/sql-server/sql-server-2019) | **Supported** | `ca.uhn.fhir.jpa.model.dialect.HapiFhirSQLServerDialect` | See [Microsoft SQL Server](#microsoft-sql-server) below for an important JDBC driver setting.                                     |
 | [PostgreSQL](https://www.postgresql.org/)                                   | **Supported** | `ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect`  |                                                                                                                                   |
 | [Oracle](https://www.oracle.com/ca-en/database/12c-database/)               | **Supported** | `ca.uhn.fhir.jpa.model.dialect.HapiFhirOracleDialect`    |                                                                                                                                   |
 | [Cockroach DB](https://www.cockroachlabs.com/)                              | Experimental  | `ca.uhn.fhir.jpa.model.dialect.HapiFhirCockroachDialect` | A CockroachDB dialect was contributed by a HAPI FHIR community member. This dialect is not regularly tested, use with caution.    |
 | MySQL                                                                       | Deprecated    | `ca.uhn.fhir.jpa.model.dialect.HapiFhirMySQLDialect`     | MySQL and MariaDB exhibit poor performance with HAPI FHIR and have therefore been deprecated. These databases should not be used. |
 | MariaDB                                                                     | Deprecated    | `ca.uhn.fhir.jpa.model.dialect.HapiFhirMariaDBDialect`   | MySQL and MariaDB exhibit poor performance with HAPI FHIR and have therefore been deprecated. These databases should not be used. |
+
+# Microsoft SQL Server
+
+The HAPI FHIR JPA schema uses plain `VARCHAR` columns (not `NVARCHAR`). The Microsoft SQL Server JDBC driver sends string parameters as Unicode (`NVARCHAR`) by default (`sendStringParametersAsUnicode=true`), so every string-parameter comparison forces an implicit `NVARCHAR`-to-`VARCHAR` conversion on the server side. This prevents SQL Server from using indexes on those columns and can severely degrade query performance on large datasets.
+
+When using SQL Server, always add `sendStringParametersAsUnicode=false` to the JDBC connection URL, e.g.:
+
+```
+jdbc:sqlserver://localhost:1433;databaseName=hapi;sendStringParametersAsUnicode=false
+```
+
+For more information, see [Microsoft JDBC driver documentation](https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties).
 
 # Experimental Support
 

--- a/hapi-fhir-jpa/src/main/java/ca/uhn/fhir/jpa/model/dialect/HapiFhirSQLServerDialect.java
+++ b/hapi-fhir-jpa/src/main/java/ca/uhn/fhir/jpa/model/dialect/HapiFhirSQLServerDialect.java
@@ -26,6 +26,15 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 /**
  * Dialect for MS SQL Server database.
  * Minimum version: 12.0 (SQL Server 2014 and Azure SQL Database)
+ * <p>
+ * The HAPI FHIR schema uses plain {@code VARCHAR} columns, but the Microsoft SQL Server JDBC
+ * driver sends string parameters as Unicode ({@code NVARCHAR}) by default. The resulting implicit
+ * {@code NVARCHAR}-to-{@code VARCHAR} conversions prevent SQL Server from using indexes on those
+ * columns and can severely degrade query performance. Always add
+ * {@code sendStringParametersAsUnicode=false} to the JDBC connection URL, e.g.:
+ * <pre>
+ * jdbc:sqlserver://localhost:1433;databaseName=hapi;sendStringParametersAsUnicode=false
+ * </pre>
  */
 public class HapiFhirSQLServerDialect extends SQLServerDialect implements IHapiFhirDialect {
 


### PR DESCRIPTION
The MS SQL Server JDBC driver sends string parameters as Unicode (NVARCHAR) by default, while the HAPI FHIR schema uses VARCHAR columns. The implicit conversions prevent index usage and can severely degrade query performance. Document the recommended setting in the database support docs and the `HapiFhirSQLServerDialect` javadoc.

Also fix the database support table, which listed the H2 dialect class for MS SQL Server instead of `HapiFhirSQLServerDialect`.

Closes #8074
Closes #8075