### PR TITLE
Fix delete-expunge SQLGrammarException on SQL Server in database part…

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8079-mssql-dbpm-delete-expunge.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8079-mssql-dbpm-delete-expunge.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 8079
+title: "Previously, when running on Microsoft SQL Server with Database Partition Mode enabled, 
+delete-expunge operations failed with a SQLGrammarException. This has been corrected."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/Batch2SupportConfig.java
@@ -36,6 +36,7 @@ import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSqlBuilder;
 import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSvcImpl;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.searchparam.MatchUrlService;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -77,8 +78,14 @@ public class Batch2SupportConfig {
 			JpaStorageSettings theStorageSettings,
 			IIdHelperService theIdHelper,
 			IResourceLinkDao theResourceLinkDao,
-			PartitionSettings thePartitionSettings) {
+			PartitionSettings thePartitionSettings,
+			DialectSvc theDialectSvc) {
 		return new DeleteExpungeSqlBuilder(
-				theResourceTableFKProvider, theStorageSettings, theIdHelper, theResourceLinkDao, thePartitionSettings);
+				theResourceTableFKProvider,
+				theStorageSettings,
+				theIdHelper,
+				theResourceLinkDao,
+				thePartitionSettings,
+				theDialectSvc);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSqlBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSqlBuilder.java
@@ -28,17 +28,22 @@ import ca.uhn.fhir.jpa.dao.expunge.ResourceTableFKProvider;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.ResourceLink;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import ca.uhn.fhir.jpa.util.QueryChunker;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -51,18 +56,21 @@ public class DeleteExpungeSqlBuilder {
 	private final PartitionSettings myPartitionSettings;
 	private final IIdHelperService<JpaPid> myIdHelper;
 	private final IResourceLinkDao myResourceLinkDao;
+	private final DialectSvc myDialectSvc;
 
 	public DeleteExpungeSqlBuilder(
 			ResourceTableFKProvider theResourceTableFKProvider,
 			JpaStorageSettings theStorageSettings,
 			IIdHelperService<JpaPid> theIdHelper,
 			IResourceLinkDao theResourceLinkDao,
-			PartitionSettings thePartitionSettings) {
+			PartitionSettings thePartitionSettings,
+			DialectSvc theDialectSvc) {
 		myResourceTableFKProvider = theResourceTableFKProvider;
 		myStorageSettings = theStorageSettings;
 		myIdHelper = theIdHelper;
 		myResourceLinkDao = theResourceLinkDao;
 		myPartitionSettings = thePartitionSettings;
+		myDialectSvc = theDialectSvc;
 	}
 
 	@Nonnull
@@ -217,6 +225,10 @@ public class DeleteExpungeSqlBuilder {
 		builder.append("DELETE FROM ");
 		builder.append(theResourceForeignKey.myTable);
 		builder.append(" WHERE ");
+		if (myPartitionSettings.isDatabasePartitionMode() && myDialectSvc.isMssql()) {
+			appendMsSqlPartitionAwareInClause(builder, thePids, theResourceForeignKey);
+			return builder.toString();
+		}
 		if (myPartitionSettings.isDatabasePartitionMode()) {
 			builder.append("(");
 			builder.append(theResourceForeignKey.myPartitionIdColumn);
@@ -245,6 +257,48 @@ public class DeleteExpungeSqlBuilder {
 		}
 		builder.append(")");
 		return builder.toString();
+	}
+
+	/**
+	 * In Database Partition Mode, for most databases we emit a row-value constructor
+	 * predicate like <code>(PARTITION_ID,RES_ID) IN ((1,2),(1,3))</code>, but SQL Server
+	 * does not support that syntax in IN predicates. So for that specific platform we
+	 * group the PIDs by partition and emit
+	 * <code>(PARTITION_ID = 1 AND RES_ID IN (2,3)) OR (PARTITION_ID = 2 AND RES_ID IN (5))</code>
+	 * instead, for the same reasons described in
+	 * {@link ca.uhn.fhir.jpa.search.builder.SearchBuilder#loadCurrentResourceVersionsForMsSqlDbpm(List)}.
+	 */
+	private void appendMsSqlPartitionAwareInClause(
+			StringBuilder theBuilder, Set<JpaPid> thePids, ResourceForeignKey theResourceForeignKey) {
+		// Tree keys/values keep the generated SQL deterministic
+		Multimap<Integer, Long> partitionIdToPids =
+				MultimapBuilder.treeKeys().treeSetValues().build();
+		for (JpaPid pid : thePids) {
+			partitionIdToPids.put(pid.getPartitionId(), pid.getId());
+		}
+
+		for (Iterator<Map.Entry<Integer, Collection<Long>>> partitionIter =
+						partitionIdToPids.asMap().entrySet().iterator();
+				partitionIter.hasNext(); ) {
+			Map.Entry<Integer, Collection<Long>> entry = partitionIter.next();
+			theBuilder.append("(");
+			theBuilder.append(theResourceForeignKey.myPartitionIdColumn);
+			theBuilder.append(" = ");
+			theBuilder.append(entry.getKey());
+			theBuilder.append(" AND ");
+			theBuilder.append(theResourceForeignKey.myResourceIdColumn);
+			theBuilder.append(" IN (");
+			for (Iterator<Long> pidIter = entry.getValue().iterator(); pidIter.hasNext(); ) {
+				theBuilder.append(pidIter.next());
+				if (pidIter.hasNext()) {
+					theBuilder.append(",");
+				}
+			}
+			theBuilder.append("))");
+			if (partitionIter.hasNext()) {
+				theBuilder.append(" OR ");
+			}
+		}
 	}
 
 	public static class DeleteExpungeSqlResult {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSqlBuilderTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/delete/batch2/DeleteExpungeSqlBuilderTest.java
@@ -1,14 +1,15 @@
-package ca.uhn.fhir.jpa.batch2;
+package ca.uhn.fhir.jpa.delete.batch2;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.dao.data.IResourceLinkDao;
+import ca.uhn.fhir.jpa.dao.expunge.ResourceForeignKey;
 import ca.uhn.fhir.jpa.dao.expunge.ResourceTableFKProvider;
-import ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSqlBuilder;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.entity.ResourceLink;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.util.DialectSvc;
 import ca.uhn.fhir.jpa.util.QueryChunker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,6 +44,8 @@ class DeleteExpungeSqlBuilderTest {
 	private IResourceLinkDao myResourceLinkDao;
 	@Mock
 	private PartitionSettings myPartitionSettings;
+	@Mock
+	private DialectSvc myDialectSvc;
 	@InjectMocks
 	private DeleteExpungeSqlBuilder myDeleteExpungeSqlBuilderTest;
 
@@ -150,5 +154,72 @@ class DeleteExpungeSqlBuilderTest {
 		// With maxRounds=1, the loop exhausts after one cascade round but RI is disabled → no throw
 		assertThatCode(() -> myDeleteExpungeSqlBuilderTest.validateOkToDeleteAndExpunge(pids, true, 1))
 				.doesNotThrowAnyException();
+	}
+
+	@Test
+	void convertPidsToDeleteExpungeSql_dbpmOnMssql_groupsPidsByPartitionInsteadOfTupleIn() {
+		// Given: DBPM enabled on SQL Server, which does not support row-value constructors in IN predicates
+		when(myStorageSettings.isEnforceReferentialIntegrityOnDelete()).thenReturn(false);
+		when(myPartitionSettings.isDatabasePartitionMode()).thenReturn(true);
+		when(myDialectSvc.isMssql()).thenReturn(true);
+		when(myResourceTableFKProvider.getResourceForeignKeys())
+				.thenReturn(List.of(new ResourceForeignKey("HFJ_HISTORY_TAG", "PARTITION_ID", "RES_ID")));
+
+		List<JpaPid> pids = List.of(
+				JpaPid.fromId(2353L, 1),
+				JpaPid.fromId(2354L, 1),
+				JpaPid.fromId(99L, 2));
+
+		// When
+		DeleteExpungeSqlBuilder.DeleteExpungeSqlResult result =
+				myDeleteExpungeSqlBuilderTest.convertPidsToDeleteExpungeSql(pids, false, null);
+
+		// Then: PIDs are grouped per partition with no row-value constructor
+		assertThat(result.getSqlStatements())
+				.containsExactly(
+						"DELETE FROM HFJ_HISTORY_TAG WHERE (PARTITION_ID = 1 AND RES_ID IN (2353,2354)) OR (PARTITION_ID = 2 AND RES_ID IN (99))",
+						"DELETE FROM HFJ_RESOURCE WHERE (PARTITION_ID = 1 AND RES_ID IN (2353,2354)) OR (PARTITION_ID = 2 AND RES_ID IN (99))");
+	}
+
+	@Test
+	void convertPidsToDeleteExpungeSql_dbpmOnOtherDatabases_keepsTupleInForm() {
+		// Given: DBPM enabled on a database that supports row-value constructors (myDialectSvc.isMssql() == false)
+		when(myStorageSettings.isEnforceReferentialIntegrityOnDelete()).thenReturn(false);
+		when(myPartitionSettings.isDatabasePartitionMode()).thenReturn(true);
+		when(myResourceTableFKProvider.getResourceForeignKeys())
+				.thenReturn(List.of(new ResourceForeignKey("HFJ_HISTORY_TAG", "PARTITION_ID", "RES_ID")));
+
+		List<JpaPid> pids = List.of(JpaPid.fromId(2353L, 1));
+
+		// When
+		DeleteExpungeSqlBuilder.DeleteExpungeSqlResult result =
+				myDeleteExpungeSqlBuilderTest.convertPidsToDeleteExpungeSql(pids, false, null);
+
+		// Then
+		assertThat(result.getSqlStatements())
+				.containsExactly(
+						"DELETE FROM HFJ_HISTORY_TAG WHERE (PARTITION_ID,RES_ID) IN ((1,2353))",
+						"DELETE FROM HFJ_RESOURCE WHERE (PARTITION_ID,RES_ID) IN ((1,2353))");
+	}
+
+	@Test
+	void convertPidsToDeleteExpungeSql_noDbpm_keepsPlainInForm() {
+		// Given: DBPM disabled - the dialect is irrelevant
+		when(myStorageSettings.isEnforceReferentialIntegrityOnDelete()).thenReturn(false);
+		when(myPartitionSettings.isDatabasePartitionMode()).thenReturn(false);
+		when(myResourceTableFKProvider.getResourceForeignKeys())
+				.thenReturn(List.of(new ResourceForeignKey("HFJ_HISTORY_TAG", "PARTITION_ID", "RES_ID")));
+
+		List<JpaPid> pids = List.of(JpaPid.fromId(2353L, 1));
+
+		// When
+		DeleteExpungeSqlBuilder.DeleteExpungeSqlResult result =
+				myDeleteExpungeSqlBuilderTest.convertPidsToDeleteExpungeSql(pids, false, null);
+
+		// Then
+		assertThat(result.getSqlStatements())
+				.containsExactly(
+						"DELETE FROM HFJ_HISTORY_TAG WHERE RES_ID IN (2353)",
+						"DELETE FROM HFJ_RESOURCE WHERE RES_ID IN (2353)");
 	}
 }

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/DbpmEnabledTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/dbpartitionmode/DbpmEnabledTest.java
@@ -1,25 +1,25 @@
 package ca.uhn.fhir.jpa.dao.r5.dbpartitionmode;
 
+import ca.uhn.fhir.batch2.jobs.expunge.DeleteExpungeAppCtx;
+import ca.uhn.fhir.batch2.jobs.expunge.DeleteExpungeJobParameters;
+import ca.uhn.fhir.batch2.jobs.parameters.PartitionedUrl;
 import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.api.svc.ResolveIdentityMode;
-import ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants;
+import ca.uhn.fhir.jpa.batch.models.Batch2JobStartResponse;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
-import ca.uhn.fhir.jpa.provider.TerminologyUploaderProvider;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.term.TerminologyTestHelper;
 import ca.uhn.fhir.jpa.term.ZipCollectionBuilder;
 import ca.uhn.fhir.jpa.util.DialectSvc;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.util.ClasspathUtil;
-import org.hl7.fhir.r5.model.Attachment;
-import org.hl7.fhir.r5.model.CodeSystem;
-import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.SearchParameter;
-import org.hl7.fhir.r5.model.UriType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -148,6 +148,64 @@ public class DbpmEnabledTest extends BaseDbpmResourceProviderR5Test {
 		}
 	}
 
+
+	/**
+	 * SQL Server does not support row-value constructors in IN predicates, so on that
+	 * platform the delete-expunge DELETE statements group the PIDs by partition instead
+	 * of using the <code>(PARTITION_ID,RES_ID) IN ((1,2),...)</code> form.
+	 *
+	 * @see ca.uhn.fhir.jpa.delete.batch2.DeleteExpungeSqlBuilder
+	 */
+	@Test
+	void testDeleteExpunge_MsSql() {
+		DialectSvc.setForceMsSqlMode(true);
+		try {
+			// Setup
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(1));
+			createPatient(withId("A1"), withFamily("A1"));
+			createPatient(withId("B1"), withFamily("B1"));
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(2));
+			createPatient(withId("A2"), withFamily("A2"));
+
+			DeleteExpungeJobParameters jobParameters = new DeleteExpungeJobParameters();
+			jobParameters.addPartitionedUrl(new PartitionedUrl()
+				.setUrl("Patient?_id=A1,B1")
+				.setRequestPartitionId(RequestPartitionId.fromPartitionId(1)));
+			jobParameters.addPartitionedUrl(new PartitionedUrl()
+				.setUrl("Patient?_id=A2")
+				.setRequestPartitionId(RequestPartitionId.fromPartitionId(2)));
+
+			JobInstanceStartRequest startRequest = new JobInstanceStartRequest();
+			startRequest.setParameters(jobParameters);
+			startRequest.setJobDefinitionId(DeleteExpungeAppCtx.JOB_DELETE_EXPUNGE);
+
+			// Test
+			myCaptureQueriesListener.clear();
+			Batch2JobStartResponse startResponse = myJobCoordinator.startInstance(new SystemRequestDetails(), startRequest);
+			JobInstance jobInstance = myBatch2JobHelper.awaitJobCompletion(startResponse);
+
+			// Verify
+			assertEquals(3, jobInstance.getCombinedRecordsProcessed());
+
+			// The raw delete-expunge statements must use the grouped-OR form, not a row-value constructor
+			List<String> deleteExpungeSql = myCaptureQueriesListener.getDeleteQueries().stream()
+				.map(t -> t.getSql(true, false))
+				.filter(t -> t.startsWith("DELETE FROM HFJ_"))
+				.toList();
+			assertThat(deleteExpungeSql).isNotEmpty();
+			assertThat(deleteExpungeSql).allSatisfy(sql -> assertThat(sql).doesNotContain("(PARTITION_ID,RES_ID) IN"));
+			assertThat(deleteExpungeSql).anySatisfy(sql -> assertThat(sql)
+				.matches("DELETE FROM HFJ_RESOURCE WHERE \\(PARTITION_ID = \\d+ AND RES_ID IN \\([\\d,]+\\)\\)"));
+
+			// The resources are expunged from both partitions
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(1));
+			assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(SearchParameterMap.newSynchronous(), newSrd()))).isEmpty();
+			myPartitionSelectorInterceptor.setNextPartition(RequestPartitionId.fromPartitionId(2));
+			assertThat(toUnqualifiedVersionlessIdValues(myPatientDao.search(SearchParameterMap.newSynchronous(), newSrd()))).isEmpty();
+		} finally {
+			DialectSvc.setForceMsSqlMode(false);
+		}
+	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})


### PR DESCRIPTION
Closes #8079

 When Database Partition Mode is enabled, DeleteExpungeSqlBuilder emits DELETE statements using row-value constructors — WHERE (PARTITION_ID,RES_ID) IN ((1,2353),...) — which SQL Server does not support in IN predicates, so every $delete-expunge batch job failed with a SQLGrammarException.

On MSSQL (detected via DialectSvc, now injected into the builder), the PIDs are grouped by partition and emitted as WHERE (PARTITION_ID = 1 AND RES_ID IN (2353,2354)) OR (PARTITION_ID = 2 AND RES_ID IN (99)), following the precedent of SearchBuilder#loadCurrentResourceVersionsForMsSqlDbpm. SQL generated for all other databases, and for non-partitioned mode, is unchanged.
  
  Testing

- Unit tests in DeleteExpungeSqlBuilderTest assert the generated SQL for MSSQL+DBPM, non-MSSQL DBPM, and non-DBPM (test class relocated to match the
  builder's package for access to the package-private method)
- End-to-end test in DbpmEnabledTest runs the delete-expunge batch2 job in forced-MSSQL mode across two partitions and verifies the emitted DELETE
  statements and that resources are expunged

