### PR TITLE
Migrate hapi-fhir GitHub Actions CI builds to Java 21

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -4,7 +4,7 @@ inputs:
   java-version:
     description: "The Java version to use"
     required: false
-    default: "17"
+    default: "21"
   cache-path:
     description: "The path for the Maven cache"
     required: false

--- a/.github/actions/build-module/action.yml
+++ b/.github/actions/build-module/action.yml
@@ -19,11 +19,11 @@ runs:
       with:
         fetch-depth: 1
 
-    - name: Set up Java 17
+    - name: Set up Java 21
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: Setup Docker
       uses: docker/setup-docker@v2

--- a/.github/actions/checkstyle-validation/action.yml
+++ b/.github/actions/checkstyle-validation/action.yml
@@ -5,7 +5,7 @@ inputs:
   java-version:
     description: 'The Java version to use'
     required: false
-    default: '17'
+    default: '21'
   maven-cache-key:
     description: 'The cache key for Maven dependencies'
     required: true

--- a/.github/actions/generate-module-list/action.yml
+++ b/.github/actions/generate-module-list/action.yml
@@ -15,11 +15,11 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
-        java-version: '17'
+        distribution: 'temurin'
+        java-version: '21'
 
     - name: Debug - Print passed in ignored modules in a newline-separated list
       shell: bash

--- a/.github/actions/run-tests-and-archive-results/action.yml
+++ b/.github/actions/run-tests-and-archive-results/action.yml
@@ -5,7 +5,7 @@ inputs:
   java-version:
     description: 'Java version to use'
     required: false
-    default: '17'
+    default: '21'
   maven-cache-folder:
     description: 'Folder path for Maven cache'
     required: true

--- a/.github/workflows/parallel-pipeline-build.yml
+++ b/.github/workflows/parallel-pipeline-build.yml
@@ -23,7 +23,7 @@ jobs:
         id: cache-maven
         uses: ./.github/actions/build-cache
         with:
-          java-version: '17'
+          java-version: '21'
           cache-path: $HOME/.m2/repository
 
   checkstyle:
@@ -37,7 +37,7 @@ jobs:
       - name: Run Checkstyle Validation
         uses: ./.github/actions/checkstyle-validation
         with:
-          java-version: '17'
+          java-version: '21'
           maven-cache-key: ${{ github.ref_name }}-maven-${{ hashFiles('**/pom.xml') }}
           hapi-cache-key: ${{ github.ref_name }}-hapi-${{ github.run_id }}
 
@@ -87,7 +87,7 @@ jobs:
       - name: Run Tests and Archive Results
         uses: ./.github/actions/run-tests-and-archive-results
         with:
-          java-version: '17'
+          java-version: '21'
           maven-cache-folder: $HOME/.m2/repository
           module-name: ${{ matrix.module }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Get Maven version
         id: get_version

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -12,10 +12,10 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: spotless:check
         run: mvn spotless:check

--- a/pom.xml
+++ b/pom.xml
@@ -2798,9 +2798,9 @@
 									<version>[3.9.0,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>17</version>
+									<version>[17,)</version>
 									<message>
-										HAPI FHIR is targeting JDK 17 for published binaries
+										HAPI FHIR targets JDK 17 for published binaries (enforced via maven.compiler.release=17, which rejects post-17 APIs); builds run on JDK 17 or newer (CI uses JDK 21).
 									</message>
 								</requireJavaVersion>
 							</rules>


### PR DESCRIPTION
Bump the JDK used by the GitHub Actions PR/test pipeline, release, and spotless workflows (and their composite actions) from 17 to 21. Source/ target compatibility stays at Java 17: maven.compiler.release=17 makes javac reject any post-17 API even when compiling on JDK 21. Also fix the deprecated 'adopt' distribution (no Java 21) to 'temurin' in generate-module-list, and clarify the maven-enforcer requireJavaVersion rule (now [17,)) and its message.