### PR TITLE
GL-8842: Widen MDM EID-match-only bulk export expansion to all partitions

### DIFF
--- a/hapi-deployable-pom/pom.xml
+++ b/hapi-deployable-pom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		 <groupId>ca.uhn.hapi.fhir</groupId>
 		 <artifactId>hapi-fhir</artifactId>
-		 <version>8.11.13-SNAPSHOT</version>
+		 <version>8.11.14-SNAPSHOT</version>
 
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>8.11.13-SNAPSHOT</version>
+	<version>8.11.14-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-checkstyle/pom.xml
+++ b/hapi-fhir-checkstyle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-cli</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-cli/pom.xml
+++ b/hapi-fhir-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-apache-http5/pom.xml
+++ b/hapi-fhir-client-apache-http5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-client/pom.xml
+++ b/hapi-fhir-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-converter/pom.xml
+++ b/hapi-fhir-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-dist/pom.xml
+++ b/hapi-fhir-dist/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8842-bulk-export-mdm-eid-match-only-partition.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8842-bulk-export-mdm-eid-match-only-partition.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 8842
+jira: SMILE-11727
+title: "Fixed a regression that caused HTTP 500 errors during bulk export and da Vinci bulk export
+when operating in PATIENT_ID partitioning mode with MDM in EID-match-only mode."

--- a/hapi-fhir-jacoco/pom.xml
+++ b/hapi-fhir-jacoco/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jaxrsserver-base/pom.xml
+++ b/hapi-fhir-jaxrsserver-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpa-hibernate-services/pom.xml
+++ b/hapi-fhir-jpa-hibernate-services/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpa/pom.xml
+++ b/hapi-fhir-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpander.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpander.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
 import ca.uhn.fhir.jpa.api.svc.ResolveIdentityMode;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.mdm.api.IMdmSettings;
 import ca.uhn.fhir.mdm.svc.IBulkExportMdmEidMatchOnlyResourceExpander;
 import ca.uhn.fhir.mdm.svc.IBulkExportMdmResourceExpander;
 import ca.uhn.fhir.mdm.svc.MdmEidMatchOnlyExpandSvc;
@@ -57,6 +58,12 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 	private final IIdHelperService<JpaPid> myIdHelperService;
 
 	/**
+	 * MDM settings. Mutable because settings are not available at construction time and are pushed in
+	 * later via {@link #setMdmSettings(IMdmSettings)} by {@code MdmExpandersHolder}.
+	 */
+	private IMdmSettings myMdmSettings;
+
+	/**
 	 * Constructor
 	 */
 	public BulkExportMdmEidMatchOnlyResourceExpander(
@@ -68,6 +75,24 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 		myMdmEidMatchOnlyLinkExpandSvc = theMdmEidMatchOnlyLinkExpandSvc;
 		myFhirContext = theFhirContext;
 		myIdHelperService = theIdHelperService;
+	}
+
+	@Override
+	public void setMdmSettings(IMdmSettings theMdmSettings) {
+		myMdmSettings = theMdmSettings;
+	}
+
+	/**
+	 * Determines the partition to use when expanding group/patient members. When MDM is configured to
+	 * search all partitions for matching, members may live on partitions other than the request partition
+	 * (e.g. the Group's default partition), so expansion must widen to {@link RequestPartitionId#allPartitions()}.
+	 * Otherwise the original request partition is used.
+	 */
+	private RequestPartitionId determineExpansionPartition(RequestPartitionId theRequestPartitionId) {
+		if (myMdmSettings != null && myMdmSettings.getSearchAllPartitionForMatch()) {
+			return RequestPartitionId.allPartitions();
+		}
+		return theRequestPartitionId;
 	}
 
 	/**
@@ -96,6 +121,8 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 		IFhirResourceDao<?> groupDao = myDaoRegistry.getResourceDao("Group");
 		IBaseResource groupResource = groupDao.read(groupId, srd);
 
+		RequestPartitionId expansionPartition = determineExpansionPartition(requestPartitionId);
+
 		Set<String> allResourceIds = new HashSet<>();
 		FhirTerser terser = myFhirContext.newTerser();
 		// Extract all member.entity references from the Group resource
@@ -106,7 +133,7 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 			if (!entityRef.getReferenceElement().isEmpty()) {
 				IIdType memberId = entityRef.getReferenceElement();
 				Set<String> expanded =
-						myMdmEidMatchOnlyLinkExpandSvc.expandMdmBySourceResourceId(requestPartitionId, memberId);
+						myMdmEidMatchOnlyLinkExpandSvc.expandMdmBySourceResourceId(expansionPartition, memberId);
 				allResourceIds.addAll(expanded);
 			}
 		}
@@ -115,7 +142,7 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 				.map(id -> myFhirContext.getVersion().newIdType(id))
 				.collect(Collectors.toList());
 		List<JpaPid> pidList = myIdHelperService.resolveResourcePids(
-				requestPartitionId,
+				expansionPartition,
 				idTypes,
 				ResolveIdentityMode.excludeDeleted().cacheOk());
 		return new HashSet<>(pidList);
@@ -132,7 +159,8 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 	public Set<String> expandPatient(String thePatientId, RequestPartitionId theRequestPartitionId) {
 		IIdType patientIdType =
 				myFhirContext.getVersion().newIdType(thePatientId).withResourceType("Patient");
-		return myMdmEidMatchOnlyLinkExpandSvc.expandMdmBySourceResourceId(theRequestPartitionId, patientIdType);
+		RequestPartitionId expansionPartition = determineExpansionPartition(theRequestPartitionId);
+		return myMdmEidMatchOnlyLinkExpandSvc.expandMdmBySourceResourceId(expansionPartition, patientIdType);
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpander.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpander.java
@@ -87,12 +87,15 @@ public class BulkExportMdmEidMatchOnlyResourceExpander implements IBulkExportMdm
 	 * search all partitions for matching, members may live on partitions other than the request partition
 	 * (e.g. the Group's default partition), so expansion must widen to {@link RequestPartitionId#allPartitions()}.
 	 * Otherwise the original request partition is used.
+	 * <p>
+	 * In practice {@code myMdmSettings} is always set before this expander is used (the holder only hands
+	 * out this expander once MDM settings have been applied), so the null check is a defensive fallback:
+	 * if settings are somehow unset, we degrade to the request partition rather than throwing an NPE.
 	 */
 	private RequestPartitionId determineExpansionPartition(RequestPartitionId theRequestPartitionId) {
-		if (myMdmSettings != null && myMdmSettings.getSearchAllPartitionForMatch()) {
-			return RequestPartitionId.allPartitions();
-		}
-		return theRequestPartitionId;
+		return (myMdmSettings != null && myMdmSettings.getSearchAllPartitionForMatch())
+				? RequestPartitionId.allPartitions()
+				: theRequestPartitionId;
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpanderTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpanderTest.java
@@ -98,7 +98,7 @@ class BulkExportMdmEidMatchOnlyResourceExpanderTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	void expandGroup_widensMemberExpandAndResolveOnlyWhenSearchAllPartitionForMatchEnabled(
+	void expandGroup_withSearchAllPartitionForMatch_widensMemberExpandAndResolveOnlyWhenEnabled(
 			boolean theSearchAllPartitionForMatch) {
 		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
 		setupGroupRead();
@@ -126,7 +126,9 @@ class BulkExportMdmEidMatchOnlyResourceExpanderTest {
 	}
 
 	@Test
-	void expandGroup_whenSettingsNull_usesRequestPartitionForMemberExpandAndResolve() {
+	void expandGroup_withNullSettings_usesRequestPartitionForMemberExpandAndResolve() {
+		// Defensive fallback: settings should always be set before this expander runs, but if they are
+		// somehow null, expansion must degrade to the request partition rather than throw.
 		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
 		setupGroupRead();
 
@@ -144,7 +146,7 @@ class BulkExportMdmEidMatchOnlyResourceExpanderTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	void expandPatient_widensToAllPartitionsOnlyWhenSearchAllPartitionForMatchEnabled(
+	void expandPatient_withSearchAllPartitionForMatch_widensToAllPartitionsOnlyWhenEnabled(
 			boolean theSearchAllPartitionForMatch) {
 		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
 		when(myMdmEidMatchOnlyExpandSvc.expandMdmBySourceResourceId(any(), any()))

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpanderTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/export/svc/BulkExportMdmEidMatchOnlyResourceExpanderTest.java
@@ -1,0 +1,162 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.bulk.export.svc;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.api.svc.IIdHelperService;
+import ca.uhn.fhir.jpa.api.svc.ResolveIdentityMode;
+import ca.uhn.fhir.jpa.model.dao.JpaPid;
+import ca.uhn.fhir.mdm.rules.config.MdmSettings;
+import ca.uhn.fhir.mdm.svc.MdmEidMatchOnlyExpandSvc;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Group;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// Created by claude-opus-4-8
+@ExtendWith(MockitoExtension.class)
+class BulkExportMdmEidMatchOnlyResourceExpanderTest {
+
+	private static final FhirContext ourFhirContext = FhirContext.forR4();
+
+	@Mock
+	private DaoRegistry myDaoRegistry;
+
+	@Mock
+	private MdmEidMatchOnlyExpandSvc myMdmEidMatchOnlyExpandSvc;
+
+	@Mock
+	private IIdHelperService<JpaPid> myIdHelperService;
+
+	@SuppressWarnings("rawtypes")
+	@Mock
+	private IFhirResourceDao myGroupDao;
+
+	private BulkExportMdmEidMatchOnlyResourceExpander myExpander;
+
+	@BeforeEach
+	void beforeEach() {
+		myExpander = new BulkExportMdmEidMatchOnlyResourceExpander(
+				myDaoRegistry, myMdmEidMatchOnlyExpandSvc, ourFhirContext, myIdHelperService);
+	}
+
+	private MdmSettings settingsWith(boolean theSearchAllPartitionForMatch) {
+		MdmSettings settings = new MdmSettings(null);
+		settings.setSearchAllPartitionForMatch(theSearchAllPartitionForMatch);
+		return settings;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void setupGroupRead() {
+		Group group = new Group();
+		group.addMember().getEntity().setReference("Patient/bulk-p1");
+		when(myDaoRegistry.getResourceDao("Group")).thenReturn(myGroupDao);
+		when(myGroupDao.read(any(IIdType.class), any(SystemRequestDetails.class))).thenReturn(group);
+		when(myMdmEidMatchOnlyExpandSvc.expandMdmBySourceResourceId(any(), any()))
+				.thenReturn(Set.of("Patient/bulk-p1"));
+		when(myIdHelperService.resolveResourcePids(
+						any(RequestPartitionId.class), anyList(), any(ResolveIdentityMode.class)))
+				.thenReturn(List.of(JpaPid.fromId(1L)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void expandGroup_widensMemberExpandAndResolveOnlyWhenSearchAllPartitionForMatchEnabled(
+			boolean theSearchAllPartitionForMatch) {
+		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
+		setupGroupRead();
+		myExpander.setMdmSettings(settingsWith(theSearchAllPartitionForMatch));
+
+		myExpander.expandGroup("Group/g1", requestPartitionId);
+
+		RequestPartitionId expectedPartition =
+				theSearchAllPartitionForMatch ? RequestPartitionId.allPartitions() : requestPartitionId;
+
+		ArgumentCaptor<RequestPartitionId> expandPartitionCaptor = ArgumentCaptor.forClass(RequestPartitionId.class);
+		verify(myMdmEidMatchOnlyExpandSvc).expandMdmBySourceResourceId(expandPartitionCaptor.capture(), any());
+		assertThat(expandPartitionCaptor.getValue()).isEqualTo(expectedPartition);
+
+		ArgumentCaptor<RequestPartitionId> resolvePartitionCaptor = ArgumentCaptor.forClass(RequestPartitionId.class);
+		verify(myIdHelperService)
+				.resolveResourcePids(resolvePartitionCaptor.capture(), anyList(), any(ResolveIdentityMode.class));
+		assertThat(resolvePartitionCaptor.getValue()).isEqualTo(expectedPartition);
+
+		ArgumentCaptor<SystemRequestDetails> srdCaptor = ArgumentCaptor.forClass(SystemRequestDetails.class);
+		verify(myGroupDao).read(any(IIdType.class), srdCaptor.capture());
+		assertThat(srdCaptor.getValue().getRequestPartitionId())
+				.as("the Group read itself always stays on the request partition")
+				.isEqualTo(requestPartitionId);
+	}
+
+	@Test
+	void expandGroup_whenSettingsNull_usesRequestPartitionForMemberExpandAndResolve() {
+		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
+		setupGroupRead();
+
+		myExpander.expandGroup("Group/g1", requestPartitionId);
+
+		ArgumentCaptor<RequestPartitionId> expandPartitionCaptor = ArgumentCaptor.forClass(RequestPartitionId.class);
+		verify(myMdmEidMatchOnlyExpandSvc).expandMdmBySourceResourceId(expandPartitionCaptor.capture(), any());
+		assertThat(expandPartitionCaptor.getValue()).isEqualTo(requestPartitionId);
+
+		ArgumentCaptor<RequestPartitionId> resolvePartitionCaptor = ArgumentCaptor.forClass(RequestPartitionId.class);
+		verify(myIdHelperService)
+				.resolveResourcePids(resolvePartitionCaptor.capture(), anyList(), any(ResolveIdentityMode.class));
+		assertThat(resolvePartitionCaptor.getValue()).isEqualTo(requestPartitionId);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void expandPatient_widensToAllPartitionsOnlyWhenSearchAllPartitionForMatchEnabled(
+			boolean theSearchAllPartitionForMatch) {
+		RequestPartitionId requestPartitionId = RequestPartitionId.fromPartitionId(0);
+		when(myMdmEidMatchOnlyExpandSvc.expandMdmBySourceResourceId(any(), any()))
+				.thenReturn(Collections.emptySet());
+		myExpander.setMdmSettings(settingsWith(theSearchAllPartitionForMatch));
+
+		myExpander.expandPatient("Patient/bulk-p1", requestPartitionId);
+
+		RequestPartitionId expectedPartition =
+				theSearchAllPartitionForMatch ? RequestPartitionId.allPartitions() : requestPartitionId;
+		ArgumentCaptor<RequestPartitionId> partitionCaptor = ArgumentCaptor.forClass(RequestPartitionId.class);
+		verify(myMdmEidMatchOnlyExpandSvc).expandMdmBySourceResourceId(partitionCaptor.capture(), any());
+		assertThat(partitionCaptor.getValue()).isEqualTo(expectedPartition);
+	}
+}

--- a/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-elastic-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-hfql/pom.xml
+++ b/hapi-fhir-jpaserver-hfql/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-ips/pom.xml
+++ b/hapi-fhir-jpaserver-ips/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-mdm/pom.xml
+++ b/hapi-fhir-jpaserver-mdm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-model/pom.xml
+++ b/hapi-fhir-jpaserver-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-searchparam/pom.xml
+++ b/hapi-fhir-jpaserver-searchparam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-jpaserver-test-dstu2/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-dstu3/pom.xml
+++ b/hapi-fhir-jpaserver-test-dstu3/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r4b/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-r5/pom.xml
+++ b/hapi-fhir-jpaserver-test-r5/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-test-utilities/pom.xml
+++ b/hapi-fhir-jpaserver-test-utilities/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-repositories/pom.xml
+++ b/hapi-fhir-repositories/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-server-cds-hooks/pom.xml
+++ b/hapi-fhir-server-cds-hooks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/pom.xml
+++ b/hapi-fhir-server-mdm/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/IBulkExportMdmEidMatchOnlyResourceExpander.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/IBulkExportMdmEidMatchOnlyResourceExpander.java
@@ -19,9 +19,19 @@
  */
 package ca.uhn.fhir.mdm.svc;
 
+import ca.uhn.fhir.mdm.api.IMdmSettings;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 
 public interface IBulkExportMdmEidMatchOnlyResourceExpander<T extends IResourcePersistentId>
 		extends IBulkExportMdmResourceExpander<T> {
-	// marker interface
+
+	/**
+	 * Sets the MDM settings on this expander. The settings determine whether group/patient member
+	 * expansion should search across all partitions (when {@link IMdmSettings#getSearchAllPartitionForMatch()}
+	 * is enabled) rather than only the resolved request partition. This is required because EID-match-only
+	 * members may live on partitions other than the Group's own partition.
+	 *
+	 * @param theMdmSettings the MDM settings to apply
+	 */
+	void setMdmSettings(IMdmSettings theMdmSettings);
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/MdmExpandersHolder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/MdmExpandersHolder.java
@@ -176,6 +176,9 @@ public class MdmExpandersHolder {
 	public void setMdmSettings(IMdmSettings theMdmSettings) {
 		myMdmSettings = theMdmSettings;
 		myLinkExpandSvcInstanceToUse = determineExpandSvsInstanceToUse();
+		if (myBulkExportMDMEidMatchOnlyResourceExpander != null) {
+			myBulkExportMDMEidMatchOnlyResourceExpander.setMdmSettings(theMdmSettings);
+		}
 		myBulkExportMDMResourceExpanderInstanceToUse = determineBulkExportMDMResourceExpanderInstanceToUse();
 	}
 }

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/MdmExpandersHolder.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/svc/MdmExpandersHolder.java
@@ -130,6 +130,14 @@ public class MdmExpandersHolder {
 	 */
 	public IBulkExportMdmResourceExpander determineBulkExportMDMResourceExpanderInstanceToUse() {
 		if (isMatchOnlyWithEidSystems()) {
+			// The EID-match-only bulk-export expander is null on persistence backends that do not
+			// support MDM bulk export (e.g. Mongo passes null for it, while still supporting
+			// EID-match-only search). Guard the settings cascade; returning the (possibly null)
+			// instance preserves the pre-existing contract — it is only ever dereferenced on
+			// backends where bulk export is supported and the expander is non-null.
+			if (myBulkExportMDMEidMatchOnlyResourceExpander != null) {
+				myBulkExportMDMEidMatchOnlyResourceExpander.setMdmSettings(myMdmSettings);
+			}
 			return myBulkExportMDMEidMatchOnlyResourceExpander;
 		} else {
 			return myBulkExportMDMResourceExpander;
@@ -176,9 +184,6 @@ public class MdmExpandersHolder {
 	public void setMdmSettings(IMdmSettings theMdmSettings) {
 		myMdmSettings = theMdmSettings;
 		myLinkExpandSvcInstanceToUse = determineExpandSvsInstanceToUse();
-		if (myBulkExportMDMEidMatchOnlyResourceExpander != null) {
-			myBulkExportMDMEidMatchOnlyResourceExpander.setMdmSettings(theMdmSettings);
-		}
 		myBulkExportMDMResourceExpanderInstanceToUse = determineBulkExportMDMResourceExpanderInstanceToUse();
 	}
 }

--- a/hapi-fhir-server-openapi/pom.xml
+++ b/hapi-fhir-server-openapi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-caffeine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-api</artifactId>
-			<version>8.11.13-SNAPSHOT</version>
+			<version>8.11.14-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-guava/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir-serviceloaders</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
+++ b/hapi-fhir-serviceloaders/hapi-fhir-caching-testing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>hapi-fhir</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>hapi-deployable-pom</artifactId>
 		<groupId>ca.uhn.hapi.fhir</groupId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-apache/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>hapi-fhir-spring-boot-sample-client-apache</artifactId>

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-client-okhttp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/hapi-fhir-spring-boot-sample-server-jersey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot-samples</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir-spring-boot</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 	</parent>
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-deployable-pom</artifactId>
-      <version>8.11.13-SNAPSHOT</version>
+      <version>8.11.14-SNAPSHOT</version>
 
       <relativePath>../../hapi-deployable-pom/pom.xml</relativePath>
    </parent>

--- a/hapi-fhir-spring-boot/pom.xml
+++ b/hapi-fhir-spring-boot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-sql-migrate/pom.xml
+++ b/hapi-fhir-sql-migrate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-jobs/pom.xml
+++ b/hapi-fhir-storage-batch2-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2-test-utilities/pom.xml
+++ b/hapi-fhir-storage-batch2-test-utilities/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-batch2/pom.xml
+++ b/hapi-fhir-storage-batch2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-mdm/pom.xml
+++ b/hapi-fhir-storage-mdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage-test-utilities/pom.xml
+++ b/hapi-fhir-storage-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-storage/pom.xml
+++ b/hapi-fhir-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2.1/pom.xml
+++ b/hapi-fhir-structures-dstu2.1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2.1/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2.1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu2/pom.xml
+++ b/hapi-fhir-validation-resources-dstu2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-dstu3/pom.xml
+++ b/hapi-fhir-validation-resources-dstu3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4/pom.xml
+++ b/hapi-fhir-validation-resources-r4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r4b/pom.xml
+++ b/hapi-fhir-validation-resources-r4b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation-resources-r5/pom.xml
+++ b/hapi-fhir-validation-resources-r5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-fhir-validation/pom.xml
+++ b/hapi-fhir-validation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-deployable-pom</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../hapi-deployable-pom/pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir</artifactId>
 	<packaging>pom</packaging>
-	<version>8.11.13-SNAPSHOT</version>
+	<version>8.11.14-SNAPSHOT</version>
 
 	<name>HAPI-FHIR</name>
 	<description>An open-source implementation of the FHIR specification in Java.</description>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-client/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ca.uhn.hapi.fhir</groupId>
 		<artifactId>hapi-fhir</artifactId>
-		<version>8.11.13-SNAPSHOT</version>
+		<version>8.11.14-SNAPSHOT</version>
 
 		<relativePath>../../pom.xml</relativePath>
 	</parent>


### PR DESCRIPTION
**Companion CDR MR (integration tests):** https://gitlab.com/simpatico.ai/cdr/-/merge_requests/7286

## Summary

This fixes a regression introduced in PR #7487 ("Add Patient ID mode resource policies") where Group/Patient bulk `$export` with auto-MDM expansion in EID-match-only mode failed under `PATIENT_ID` partitioning with `HAPI-2001: Resource ... is not known`. The root cause was that `PatientIdPartitionInterceptor` began resolving Group reads to the default partition only, but `BulkExportMdmEidMatchOnlyResourceExpander` was never updated to widen member expansion to all partitions — so group members living on their own `PATIENT_ID` partitions were invisible during EID-match-only expansion.

1. `BulkExportMdmEidMatchOnlyResourceExpander` now calls `determineExpansionPartition()` before expanding group members and resolving PIDs: when `IMdmSettings.getSearchAllPartitionForMatch()` is true, it widens to `RequestPartitionId.allPartitions()` instead of using the request partition (which is the Group's partition, not the members').
2. `IBulkExportMdmEidMatchOnlyResourceExpander` is no longer a marker interface — it now declares `setMdmSettings(IMdmSettings)` so implementations can receive settings.
3. `MdmExpandersHolder.setMdmSettings` cascades settings into the EID-match-only expander, mirroring the existing pattern for the full-MDM search-expansion path in `MdmSearchExpansionSvc`.
4. Scope is intentionally narrow: the Group read itself stays on its resolved partition; only member link expansion and PID resolution widen. Full-MDM expansion is unaffected.
5. Integration tests (Group `$export` / `$davinci-data-export` auto-MDM expansion across `PATIENT_ID` partitions) live in the companion CDR MR and pass GREEN against this fix.

## Code Review Suggestions

- [ ] **`myMdmSettings` nullability in `determineExpansionPartition`**: The field is initialized to `null` and set later via `setMdmSettings`. The null guard is correct, but reviewers should confirm that `MdmExpandersHolder.setMdmSettings` is always called before any bulk export invocation. If MDM settings are not available (e.g., MDM not configured), the null path silently falls back to the request partition.
- [ ] **Interface change to `IBulkExportMdmEidMatchOnlyResourceExpander`**: Adding `setMdmSettings` is non-breaking within HAPI (the only known implementation is `BulkExportMdmEidMatchOnlyResourceExpander`), but downstream implementors outside the repo would require an update. Confirm this interface is considered internal/non-API.
- [ ] **`expandPatient` path also widened**: Confirm a Patient bulk export with EID-match-only should also cross partition boundaries for the same reasons as Group export.
- [ ] **Ordering in `setMdmSettings`**: The cascade is called before `determineBulkExportMDMResourceExpanderInstanceToUse()`. Verify the ordering does not matter.

## QA Test Suggestions

### Setup
- [ ] HAPI-FHIR server with MDM in EID-match-only mode and `PATIENT_ID` partitioning active.
- [ ] Enable `searchAllPartitionForMatch` in MDM settings.
- [ ] Create a Group on partition A with Patient members assigned to their own `PATIENT_ID` partitions (B, C).

### Test Cases
- [ ] **Group bulk export finds cross-partition members**: Trigger a Group `$export`; confirm all members — including those on non-default partitions — appear in the output.
- [ ] **`HAPI-2001` no longer thrown** during a partition-spanning Group bulk export.
- [ ] **`searchAllPartitionForMatch = false` baseline**: confirm expansion does NOT widen — only same-partition members returned (fix gated correctly).
- [ ] **Patient bulk export (EID-match-only)**: confirm MDM-linked patients on other partitions resolve.
- [ ] **Full-MDM path unaffected**: existing Group/Patient export behavior unchanged.
- [ ] **Regression vs HAPI 8.9.6**: behavior matches pre-#7487; the companion CDR MR's integration tests are the primary signal.

Jira: SMILE-11727 · GitLab issue: simpatico.ai/cdr#8842
