### PR TITLE
Improve progress calculation for Batch2 jobs

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8097-improve-batch2-progress-calculation.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8097-improve-batch2-progress-calculation.yaml
@@ -1,0 +1,4 @@
+---
+type: add
+issue: 8097
+title: "The mechanism for calculating Batch2 job progress has been improved to allow specific steps in the job to have different weights in the overall progress calculation. This allows jobs with unbalanced effort levels between steps to have more accurate progress returned to the user."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/BaseExpandDistributionIntoFilesStep.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/BaseExpandDistributionIntoFilesStep.java
@@ -79,7 +79,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyUtil.getJobProperties;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
 import static ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc.MAKE_LOADING_VERSION_CURRENT;
 import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/BaseImportTerminologyFileStep.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/BaseImportTerminologyFileStep.java
@@ -57,7 +57,7 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.*;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
 import static ca.uhn.fhir.jpa.term.TermCodeSystemStorageSvcImpl.DONT_POPULATE_PARENT_PIDS_CS_USERDATA_KEY;
 import static ca.uhn.fhir.util.TestUtil.sleepAtLeast;
 import static org.apache.commons.lang3.StringUtils.*;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/ImportTerminologyStepChunkConceptsForGeneratingClosure.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/ImportTerminologyStepChunkConceptsForGeneratingClosure.java
@@ -38,7 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
 
 public class ImportTerminologyStepChunkConceptsForGeneratingClosure<PT extends ImportTerminologyJobParameters>
 		extends BaseImportTerminologyStep

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/ImportTerminologyStepGenerateConceptClosures.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/ImportTerminologyStepGenerateConceptClosures.java
@@ -39,7 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
 
 public class ImportTerminologyStepGenerateConceptClosures<PT extends ImportTerminologyJobParameters>
 		implements IJobStepWorker<PT, TerminologyFileSetJson, TerminologyFileSetJson>,

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/TerminologyConstants.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/TerminologyConstants.java
@@ -21,15 +21,31 @@ package ca.uhn.fhir.jpa.batch2.jobs.term.base;
 
 public class TerminologyConstants {
 
+	/** Non-instantiable */
+	private TerminologyConstants() {}
+
 	public static final String IMGTHLA_URI = "http://www.ebi.ac.uk/ipd/imgt/hla";
 	public static final String LOINC_URI = "http://loinc.org";
 	public static final String SCT_URI = "http://snomed.info/sct";
 	public static final String ICD10_URI = "http://hl7.org/fhir/sid/icd-10";
 	public static final String ICD10CM_URI = "http://hl7.org/fhir/sid/icd-10-cm";
 	public static final String IEEE_11073_10101_URI = "urn:iso:std:iso:11073:10101";
+	public static final String STEP_ID_FINALIZE_IMPORT = "finalize-import";
+	public static final String STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION = "chunk-concepts-for-closure-generation";
+	public static final String STEP_ID_GENERATE_CONCEPT_CLOSURES = "generate-concept-closures";
 
-	/** Non-instantiable */
-	private TerminologyConstants() {}
+	/// Fixed step weight for the closure generation step. We assign this step 30% of
+	/// the total weight for two reasons:
+	/// * We don't actually assign any work chunks to this step until the previous step,
+	///   so unless we assign a minimum weight, our progress goes down when we get to
+	///   the previous step.
+	/// * The work chunks go faster for this step then they do for earlier steps. Assigning
+	///   30% of the total is a good-enough rough approximation.
+	public static final double STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES = 0.3;
+
+	/// Fixed step weight for the "finalize" step at the end of an import terminology
+	/// job. This step is very fast so we give it a minimal weight.
+	public static final double STEP_WEIGHT_FINALIZE = 0.01;
 
 	public static final String FILENAME_LOINC_UPLOAD_PROPERTIES_FILE = "loincupload.properties";
 	public static final String FILENAME_LOINC_DISTRIBUTION_FILE = "loinc.zip";

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
@@ -101,7 +101,8 @@ public class ImportCustomTerminologyJobAppCtx {
 						importCustomTerminologyStepGenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
+				.setStepWeightForProgressCalculator(
+						STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
@@ -97,12 +97,15 @@ public class ImportCustomTerminologyJobAppCtx {
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importIcdStepGenerateConceptClosures())
+				// This step doesn't gain any work chunks until the previous step, we want to give it
+				// a fixed portion of the overall progress
 				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importCustomTerminologyStepFinalize())
+				// This step takes very little time and shouldn't factor significantly into the progress
 				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
@@ -29,9 +29,11 @@ import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_GENERATE_CONCEPT_CLOSURES;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_FINALIZE;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES;
 
 @Configuration
 public class ImportCustomTerminologyJobAppCtx {
@@ -99,14 +101,14 @@ public class ImportCustomTerminologyJobAppCtx {
 						importCustomTerminologyStepGenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importCustomTerminologyStepFinalize())
 				// This step takes very little time and shouldn't factor significantly into the progress
-				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, STEP_WEIGHT_FINALIZE)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/custom/ImportCustomTerminologyJobAppCtx.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_GENERATE_CONCEPT_CLOSURES;
 
 @Configuration
 public class ImportCustomTerminologyJobAppCtx {
@@ -92,15 +93,17 @@ public class ImportCustomTerminologyJobAppCtx {
 						TerminologyFileSetJson.class,
 						importIcdStepChunkConceptsForClosureGeneration())
 				.addIntermediateStep(
-						"generate-concept-closures",
+						STEP_ID_GENERATE_CONCEPT_CLOSURES,
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importIcdStepGenerateConceptClosures())
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importCustomTerminologyStepFinalize())
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
@@ -149,7 +149,8 @@ public class ImportIcdJobAppCtx {
 						importIcdStepGenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
+				.setStepWeightForProgressCalculator(
+						STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_GENERATE_CONCEPT_CLOSURES;
 
 /**
  * This file is the Batch2 Job Definition for the SNOMED CT Import job.
@@ -107,6 +108,7 @@ public class ImportIcdJobAppCtx {
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importIcd10StepFinalize())
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}
 
@@ -139,15 +141,17 @@ public class ImportIcdJobAppCtx {
 						TerminologyFileSetJson.class,
 						importIcdStepChunkConceptsForClosureGeneration())
 				.addIntermediateStep(
-						"generate-concept-closures",
+						STEP_ID_GENERATE_CONCEPT_CLOSURES,
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importIcdStepGenerateConceptClosures())
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importIcd10StepFinalize())
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
@@ -39,9 +39,11 @@ import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_GENERATE_CONCEPT_CLOSURES;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_FINALIZE;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES;
 
 /**
  * This file is the Batch2 Job Definition for the SNOMED CT Import job.
@@ -147,14 +149,14 @@ public class ImportIcdJobAppCtx {
 						importIcdStepGenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importIcd10StepFinalize())
 				// This step takes very little time and shouldn't factor significantly into the progress
-				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, STEP_WEIGHT_FINALIZE)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/icd/ImportIcdJobAppCtx.java
@@ -145,12 +145,15 @@ public class ImportIcdJobAppCtx {
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importIcdStepGenerateConceptClosures())
+				// This step doesn't gain any work chunks until the previous step, we want to give it
+				// a fixed portion of the overall progress
 				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize ICD-10 Import",
 						ImportTerminologyResultJson.class,
 						importIcd10StepFinalize())
+				// This step takes very little time and shouldn't factor significantly into the progress
 				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
@@ -195,7 +195,8 @@ public class ImportLoincJobAppCtx {
 						importLoincStep22GenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
+				.setStepWeightForProgressCalculator(
+						TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						TerminologyConstants.STEP_ID_FINALIZE_IMPORT,
 						"Finalize LOINC Import",

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
@@ -47,6 +47,8 @@ public class ImportLoincJobAppCtx {
 	public static final String JOB_ID_IMPORT_TERM_LOINC = "IMPORT_TERM_LOINC";
 	public static final String STEP_ID_FINALIZE_IMPORT = "finalize-import";
 	public static final String STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION = "chunk-concepts-for-closure-generation";
+	public static final String STEP_ID_GENERATE_CONCEPT_CLOSURES = "generate-concept-closures";
+	public static final String STEP_ID_IMPORT_PART_LINK_FILE = "import-part-link-file";
 
 	private final DaoRegistry myDaoRegistry;
 	private final ITermCodeSystemStorageSvc myTermCodeSystemStorageSvc;
@@ -159,10 +161,12 @@ public class ImportLoincJobAppCtx {
 						TerminologyFileSetJson.class,
 						importLoincStep16PartFile())
 				.addIntermediateStep(
-						"import-part-link-file",
+						STEP_ID_IMPORT_PART_LINK_FILE,
 						"Import LOINC Part Link File",
 						TerminologyFileSetJson.class,
 						importLoincStep17PartLink())
+				// Part link file uses a large number of smaller files, so limit its weight
+				.setStepWeightForProgressCalculator(STEP_ID_IMPORT_PART_LINK_FILE, 0.1)
 				.addIntermediateStep(
 						"import-consumer-name",
 						"Import LOINC Consumer Names",
@@ -184,15 +188,17 @@ public class ImportLoincJobAppCtx {
 						TerminologyFileSetJson.class,
 						importLoincStep21ChunkConceptsForClosureGeneration())
 				.addIntermediateStep(
-						"generate-concept-closures",
+						STEP_ID_GENERATE_CONCEPT_CLOSURES,
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importLoincStep22GenerateConceptClosures())
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize LOINC Import",
 						ImportTerminologyResultJson.class,
 						importLoincStep23Finalize())
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
@@ -29,12 +29,16 @@ import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyResultJson;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyStepChunkConceptsForGeneratingClosure;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyStepFinalize;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyStepGenerateConceptClosures;
+import ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyFileSetJson;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_FINALIZE;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES;
 
 /**
  * This file is the Batch2 Job Definition for the LOINC Import job.
@@ -45,9 +49,6 @@ import org.springframework.context.annotation.Configuration;
 public class ImportLoincJobAppCtx {
 
 	public static final String JOB_ID_IMPORT_TERM_LOINC = "IMPORT_TERM_LOINC";
-	public static final String STEP_ID_FINALIZE_IMPORT = "finalize-import";
-	public static final String STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION = "chunk-concepts-for-closure-generation";
-	public static final String STEP_ID_GENERATE_CONCEPT_CLOSURES = "generate-concept-closures";
 	public static final String STEP_ID_IMPORT_PART_LINK_FILE = "import-part-link-file";
 
 	private final DaoRegistry myDaoRegistry;
@@ -183,25 +184,25 @@ public class ImportLoincJobAppCtx {
 						TerminologyFileSetJson.class,
 						importLoincStep20LinguisticVariant())
 				.addIntermediateStep(
-						STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION,
+						TerminologyConstants.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION,
 						"Create work chunks for calculating concept closures",
 						TerminologyFileSetJson.class,
 						importLoincStep21ChunkConceptsForClosureGeneration())
 				.addIntermediateStep(
-						STEP_ID_GENERATE_CONCEPT_CLOSURES,
+						TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES,
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importLoincStep22GenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
+				.setStepWeightForProgressCalculator(TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
-						STEP_ID_FINALIZE_IMPORT,
+						TerminologyConstants.STEP_ID_FINALIZE_IMPORT,
 						"Finalize LOINC Import",
 						ImportTerminologyResultJson.class,
 						importLoincStep23Finalize())
 				// This step takes very little time and shouldn't factor significantly into the progress
-				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
+				.setStepWeightForProgressCalculator(TerminologyConstants.STEP_ID_FINALIZE_IMPORT, STEP_WEIGHT_FINALIZE)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincJobAppCtx.java
@@ -192,12 +192,15 @@ public class ImportLoincJobAppCtx {
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importLoincStep22GenerateConceptClosures())
+				// This step doesn't gain any work chunks until the previous step, we want to give it
+				// a fixed portion of the overall progress
 				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize LOINC Import",
 						ImportTerminologyResultJson.class,
 						importLoincStep23Finalize())
+				// This step takes very little time and shouldn't factor significantly into the progress
 				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincStep1ExpandDistributionIntoFilesStep.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportLoincStep1ExpandDistributionIntoFilesStep.java
@@ -45,7 +45,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.function.Supplier;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_ALL_VALUESET_ID;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_GENERIC_VALUESET_URL;
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
@@ -111,7 +111,8 @@ public class ImportSnomedCtJobAppCtx {
 						importSnomedStep5GenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
+				.setStepWeightForProgressCalculator(
+						STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize Snomed Import",

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
@@ -37,9 +37,11 @@ import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_GENERATE_CONCEPT_CLOSURES;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_ID_GENERATE_CONCEPT_CLOSURES;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_FINALIZE;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES;
 
 /**
  * This file is the Batch2 Job Definition for the SNOMED CT Import job.
@@ -109,14 +111,14 @@ public class ImportSnomedCtJobAppCtx {
 						importSnomedStep5GenerateConceptClosures())
 				// This step doesn't gain any work chunks until the previous step, we want to give it
 				// a fixed portion of the overall progress
-				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, STEP_WEIGHT_GENERATE_CONCEPT_CLOSURES)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize Snomed Import",
 						ImportTerminologyResultJson.class,
 						importSnomedStep6Finalize())
 				// This step takes very little time and shouldn't factor significantly into the progress
-				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, STEP_WEIGHT_FINALIZE)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_CHUNK_CONCEPTS_FOR_CLOSURE_GENERATION;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_FINALIZE_IMPORT;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx.STEP_ID_GENERATE_CONCEPT_CLOSURES;
 
 /**
  * This file is the Batch2 Job Definition for the SNOMED CT Import job.
@@ -102,15 +103,17 @@ public class ImportSnomedCtJobAppCtx {
 						TerminologyFileSetJson.class,
 						importSnomedStep4ChunkConceptsForClosureGeneration())
 				.addIntermediateStep(
-						"generate-concept-closures",
+						STEP_ID_GENERATE_CONCEPT_CLOSURES,
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importSnomedStep5GenerateConceptClosures())
+				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize Snomed Import",
 						ImportTerminologyResultJson.class,
 						importSnomedStep6Finalize())
+				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/snomedct/ImportSnomedCtJobAppCtx.java
@@ -107,12 +107,15 @@ public class ImportSnomedCtJobAppCtx {
 						"Generate concept closures",
 						TerminologyFileSetJson.class,
 						importSnomedStep5GenerateConceptClosures())
+				// This step doesn't gain any work chunks until the previous step, we want to give it
+				// a fixed portion of the overall progress
 				.setStepWeightForProgressCalculator(STEP_ID_GENERATE_CONCEPT_CLOSURES, 0.3)
 				.addFinalReducerStep(
 						STEP_ID_FINALIZE_IMPORT,
 						"Finalize Snomed Import",
 						ImportTerminologyResultJson.class,
 						importSnomedStep6Finalize())
+				// This step takes very little time and shouldn't factor significantly into the progress
 				.setStepWeightForProgressCalculator(STEP_ID_FINALIZE_IMPORT, 0.01)
 				.build();
 	}

--- a/hapi-fhir-jpaserver-test-dstu2/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestDstu2Test.java
+++ b/hapi-fhir-jpaserver-test-dstu2/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestDstu2Test.java
@@ -265,6 +265,7 @@ public class RestHookTestDstu2Test extends BaseResourceProviderDstu2Test {
 
 		subscriptionTemp.setCriteria(criteria1);
 		myClient.update().resource(subscriptionTemp).withId(subscriptionTemp.getIdElement()).execute();
+		waitForQueueToDrain();
 
 		Observation observation2 = sendObservation(code);
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -12,6 +12,7 @@ import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import static ca.uhn.fhir.util.HapiExtensions.EXT_VALUESET_EXPANSION_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
@@ -152,6 +154,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		myJpaValidationSupportChain.invalidateCaches();
 
 		CodeSystem cs = (CodeSystem) myValidationSupport.fetchCodeSystem("http://loinc.org");
+		assertNotNull(cs);
 		assertEquals("2.68", cs.getVersion());
 
 		runInTransaction(()->{

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/ImportTerminologyTestHarnessApp.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/ImportTerminologyTestHarnessApp.java
@@ -22,7 +22,6 @@ package ca.uhn.fhir.jpa.term;
 import ca.uhn.fhir.batch2.api.IJobMaintenanceService;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect;
-import ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect;
 import ca.uhn.fhir.jpa.provider.TerminologyUploaderProvider;
 import ca.uhn.fhir.jpa.test.config.TestR4Config;
 import ca.uhn.fhir.rest.server.provider.ResourceProviderFactory;
@@ -35,7 +34,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 
 import java.io.File;
-import java.time.Duration;
 
 public class ImportTerminologyTestHarnessApp {
 	private static final Logger ourLog = LoggerFactory.getLogger(ImportTerminologyTestHarnessApp.class);
@@ -70,20 +68,20 @@ public class ImportTerminologyTestHarnessApp {
 
 		@Override
 		public void setConnectionProperties(BasicDataSource theDataSource) {
-						theDataSource.setDriver(new org.h2.Driver());
-						theDataSource.setUrl("jdbc:h2:file:./target/term-loading-test-db/db");
-//			theDataSource.setDriver(new org.postgresql.Driver());
-//			theDataSource.setUrl("jdbc:postgresql://localhost:5432/cdr");
-//			theDataSource.setMaxWait(Duration.ofSeconds(30));
-//			theDataSource.setUsername("cdr");
-//			theDataSource.setPassword("cdr");
-//			theDataSource.setMaxTotal(ourMaxThreads);
+			theDataSource.setDriver(new org.h2.Driver());
+			theDataSource.setUrl("jdbc:h2:file:./target/term-loading-test-db/db");
+			//			theDataSource.setDriver(new org.postgresql.Driver());
+			//			theDataSource.setUrl("jdbc:postgresql://localhost:5432/cdr");
+			//			theDataSource.setMaxWait(Duration.ofSeconds(30));
+			//			theDataSource.setUsername("cdr");
+			//			theDataSource.setPassword("cdr");
+			//			theDataSource.setMaxTotal(ourMaxThreads);
 		}
 
 		@Override
 		public String getHibernateDialect() {
 			return HapiFhirH2Dialect.class.getName();
-//			return HapiFhirPostgresDialect.class.getName();
+			//			return HapiFhirPostgresDialect.class.getName();
 		}
 	}
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/ImportTerminologyTestHarnessApp.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/ImportTerminologyTestHarnessApp.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.term;
 
 import ca.uhn.fhir.batch2.api.IJobMaintenanceService;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect;
 import ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect;
 import ca.uhn.fhir.jpa.provider.TerminologyUploaderProvider;
 import ca.uhn.fhir.jpa.test.config.TestR4Config;
@@ -69,19 +70,20 @@ public class ImportTerminologyTestHarnessApp {
 
 		@Override
 		public void setConnectionProperties(BasicDataSource theDataSource) {
-			//			theDataSource.setDriver(new org.h2.Driver());
-			//			theDataSource.setUrl("jdbc:h2:file:./target/term-loading-test-db/db");
-			theDataSource.setDriver(new org.postgresql.Driver());
-			theDataSource.setUrl("jdbc:postgresql://localhost:5432/cdr");
-			theDataSource.setMaxWait(Duration.ofSeconds(30));
-			theDataSource.setUsername("cdr");
-			theDataSource.setPassword("cdr");
-			theDataSource.setMaxTotal(ourMaxThreads);
+						theDataSource.setDriver(new org.h2.Driver());
+						theDataSource.setUrl("jdbc:h2:file:./target/term-loading-test-db/db");
+//			theDataSource.setDriver(new org.postgresql.Driver());
+//			theDataSource.setUrl("jdbc:postgresql://localhost:5432/cdr");
+//			theDataSource.setMaxWait(Duration.ofSeconds(30));
+//			theDataSource.setUsername("cdr");
+//			theDataSource.setPassword("cdr");
+//			theDataSource.setMaxTotal(ourMaxThreads);
 		}
 
 		@Override
 		public String getHibernateDialect() {
-			return HapiFhirPostgresDialect.class.getName();
+			return HapiFhirH2Dialect.class.getName();
+//			return HapiFhirPostgresDialect.class.getName();
 		}
 	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
@@ -22,11 +22,9 @@ package ca.uhn.fhir.batch2.coordinator;
 import ca.uhn.fhir.batch2.api.IJobPersistence;
 import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
 import ca.uhn.fhir.batch2.maintenance.JobChunkProgressAccumulator;
-import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.JobWorkCursor;
 import ca.uhn.fhir.batch2.model.StatusEnum;
-import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
 import ca.uhn.fhir.batch2.model.WorkChunkData;
 import ca.uhn.fhir.batch2.progress.InstanceProgress;
 import ca.uhn.fhir.batch2.progress.JobInstanceProgressCalculator;
@@ -100,13 +98,7 @@ public class ReductionStepDataSink<PT extends IModelJson, IT extends IModelJson,
 			 * reducer touches. If the two could never collide we wouldn't need this duplication
 			 * here. Until then though, this is safer.
 			 */
-
-			JobDefinition<?> jobDefinition = myJobDefinitionRegistry
-					.getJobDefinition(instance.getJobDefinitionId(), instance.getJobDefinitionVersion())
-					.orElseThrow();
-			StepWeightingForProgressCalculator stepWeightingForProgressCalculator =
-					jobDefinition.getStepWeightingForProgressCalculator();
-			progress.updateInstanceForReductionStep(stepWeightingForProgressCalculator, instance);
+			progress.updateInstanceForReductionStep(myJobDefinitionRegistry, instance);
 
 			instance.setReport(dataString);
 			instance.setStatus(StatusEnum.COMPLETED);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSink.java
@@ -22,9 +22,11 @@ package ca.uhn.fhir.batch2.coordinator;
 import ca.uhn.fhir.batch2.api.IJobPersistence;
 import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
 import ca.uhn.fhir.batch2.maintenance.JobChunkProgressAccumulator;
+import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.JobWorkCursor;
 import ca.uhn.fhir.batch2.model.StatusEnum;
+import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
 import ca.uhn.fhir.batch2.model.WorkChunkData;
 import ca.uhn.fhir.batch2.progress.InstanceProgress;
 import ca.uhn.fhir.batch2.progress.JobInstanceProgressCalculator;
@@ -99,7 +101,12 @@ public class ReductionStepDataSink<PT extends IModelJson, IT extends IModelJson,
 			 * here. Until then though, this is safer.
 			 */
 
-			progress.updateInstanceForReductionStep(instance);
+			JobDefinition<?> jobDefinition = myJobDefinitionRegistry
+					.getJobDefinition(instance.getJobDefinitionId(), instance.getJobDefinitionVersion())
+					.orElseThrow();
+			StepWeightingForProgressCalculator stepWeightingForProgressCalculator =
+					jobDefinition.getStepWeightingForProgressCalculator();
+			progress.updateInstanceForReductionStep(stepWeightingForProgressCalculator, instance);
 
 			instance.setReport(dataString);
 			instance.setStatus(StatusEnum.COMPLETED);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
@@ -544,7 +544,7 @@ public class JobDefinition<PT extends IModelJson> {
 		 */
 		public Builder<PT, NIT> setStepWeightForProgressCalculator(String theStepId, double theWeight) {
 			Validate.isTrue(
-					mySteps.stream().anyMatch(t -> t.getStepId().equals(theStepId)), "Unknown stepL: %s", theStepId);
+					mySteps.stream().anyMatch(t -> t.getStepId().equals(theStepId)), "Unknown step: %s", theStepId);
 			// theWeight is validated in setStepWeightForProgressCalculator
 			myStepWeightingBuilder.setStepWeightForProgressCalculator(theStepId, theWeight);
 			return this;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
@@ -53,6 +53,7 @@ public class JobDefinition<PT extends IModelJson> {
 	private final IJobCompletionHandler<PT> myCompletionHandler;
 	private final IJobCompletionHandler<PT> myErrorHandler;
 	private final Map<String, Integer> myStepIdToStepIndex;
+	private final StepWeightingForProgressCalculator myStepWeightingForProgressCalculator;
 
 	/**
 	 * Constructor
@@ -67,13 +68,15 @@ public class JobDefinition<PT extends IModelJson> {
 			IJobParametersValidator<PT> theParametersValidator,
 			boolean theGatedExecution,
 			IJobCompletionHandler<PT> theCompletionHandler,
-			IJobCompletionHandler<PT> theErrorHandler) {
+			IJobCompletionHandler<PT> theErrorHandler,
+			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator) {
 		Validate.isTrue(VALID_INITIAL_STATUSES.contains(theInitialStatus), "Initial status is invalid");
 		Validate.isTrue(theJobDefinitionId.length() <= ID_MAX_LENGTH, "Maximum ID length is %d", ID_MAX_LENGTH);
 		Validate.notBlank(theJobDefinitionId, "No job definition ID supplied");
 		Validate.notBlank(theJobDescription, "No job description supplied");
 		Validate.isTrue(theJobDefinitionVersion >= 1, "No job definition version supplied (must be >= 1)");
 		Validate.isTrue(theSteps.size() >= 2, "At least 2 steps must be supplied");
+		Validate.notNull(theStepWeightingForProgressCalculator, "No step weighting calculator supplied");
 		myInitialStatus = theInitialStatus;
 		myJobDefinitionId = theJobDefinitionId;
 		myJobDefinitionVersion = theJobDefinitionVersion;
@@ -84,6 +87,7 @@ public class JobDefinition<PT extends IModelJson> {
 		myGatedExecution = theGatedExecution;
 		myCompletionHandler = theCompletionHandler;
 		myErrorHandler = theErrorHandler;
+		myStepWeightingForProgressCalculator = theStepWeightingForProgressCalculator;
 
 		myStepIdToStepIndex = new HashMap<>();
 		for (int i = 0; i < mySteps.size(); i++) {
@@ -177,8 +181,13 @@ public class JobDefinition<PT extends IModelJson> {
 		return index;
 	}
 
+	public StepWeightingForProgressCalculator getStepWeightingForProgressCalculator() {
+		return myStepWeightingForProgressCalculator;
+	}
+
 	public static class Builder<PT extends IModelJson, NIT extends IModelJson> {
 
+		private StepWeightingForProgressCalculator.Builder myStepWeightingBuilder;
 		private StatusEnum myInitialStatus = StatusEnum.QUEUED;
 		private final List<JobDefinitionStep<PT, ?, ?>> mySteps;
 		private String myJobDefinitionId;
@@ -196,6 +205,7 @@ public class JobDefinition<PT extends IModelJson> {
 
 		Builder() {
 			mySteps = new ArrayList<>();
+			myStepWeightingBuilder = StepWeightingForProgressCalculator.newBuilder();
 		}
 
 		Builder(
@@ -209,7 +219,8 @@ public class JobDefinition<PT extends IModelJson> {
 				@Nullable IJobParametersValidator<PT> theParametersValidator,
 				boolean theGatedExecution,
 				IJobCompletionHandler<PT> theCompletionHandler,
-				IJobCompletionHandler<PT> theErrorHandler) {
+				IJobCompletionHandler<PT> theErrorHandler,
+				StepWeightingForProgressCalculator.Builder theStepWeightingBuilder) {
 			myInitialStatus = theInitialStatus;
 			mySteps = theSteps;
 			myJobDefinitionId = theJobDefinitionId;
@@ -221,6 +232,7 @@ public class JobDefinition<PT extends IModelJson> {
 			myGatedExecution = theGatedExecution;
 			myCompletionHandler = theCompletionHandler;
 			myErrorHandler = theErrorHandler;
+			myStepWeightingBuilder = theStepWeightingBuilder;
 		}
 
 		/**
@@ -267,7 +279,8 @@ public class JobDefinition<PT extends IModelJson> {
 					myParametersValidator,
 					myGatedExecution,
 					myCompletionHandler,
-					myErrorHandler);
+					myErrorHandler,
+					myStepWeightingBuilder);
 		}
 
 		/**
@@ -297,7 +310,8 @@ public class JobDefinition<PT extends IModelJson> {
 					myParametersValidator,
 					myGatedExecution,
 					myCompletionHandler,
-					myErrorHandler);
+					myErrorHandler,
+					myStepWeightingBuilder);
 		}
 
 		/**
@@ -324,7 +338,8 @@ public class JobDefinition<PT extends IModelJson> {
 					myParametersValidator,
 					myGatedExecution,
 					myCompletionHandler,
-					myErrorHandler);
+					myErrorHandler,
+					myStepWeightingBuilder);
 		}
 
 		public <OT extends IModelJson> Builder<PT, OT> addFinalReducerStep(
@@ -349,11 +364,14 @@ public class JobDefinition<PT extends IModelJson> {
 					myParametersValidator,
 					myGatedExecution,
 					myCompletionHandler,
-					myErrorHandler);
+					myErrorHandler,
+					myStepWeightingBuilder);
 		}
 
 		public JobDefinition<PT> build() {
 			Validate.notNull(myJobParametersType, "No job parameters type was supplied");
+			StepWeightingForProgressCalculator stepWeightingForProgressCalculator =
+					myStepWeightingBuilder.build(mySteps);
 			return new JobDefinition<>(
 					myInitialStatus,
 					myJobDefinitionId,
@@ -364,7 +382,8 @@ public class JobDefinition<PT extends IModelJson> {
 					myParametersValidator,
 					myGatedExecution,
 					myCompletionHandler,
-					myErrorHandler);
+					myErrorHandler,
+					stepWeightingForProgressCalculator);
 		}
 
 		public Builder<PT, NIT> setJobDescription(String theJobDescription) {
@@ -509,6 +528,26 @@ public class JobDefinition<PT extends IModelJson> {
 		public Builder<PT, NIT> setInitialStatus(StatusEnum theInitialStatus) {
 			Validate.isTrue(VALID_INITIAL_STATUSES.contains(theInitialStatus), "Initial status is invalid");
 			myInitialStatus = theInitialStatus;
+			return this;
+		}
+
+		/**
+		 * Supplies an optional weight for a specific job step when calculating the overall progress of the job.
+		 * The value here will not affect the actual job performance in any way, it just affects
+		 * how we calculate the "job complete %" number returned to the client while the job executes.
+		 *
+		 * @param theStepId The step ID to assign a weight to.
+		 * @param theWeight A weight. Value must be <code>i >= 0.0</code> and <code>i < 1.0</code>. The
+		 *                  combined weight of all steps must not exceed 1.0. If a given step should always
+		 *                  count for 20% of the total completion status, assign it a weight of <code>0.2</code>.
+		 * @see StepWeightingForProgressCalculator
+		 */
+		public Builder<PT, NIT> setStepWeightForProgressCalculator(String theStepId, double theWeight) {
+			Validate.notBlank(theStepId, "theStepId must not be blank");
+			Validate.isTrue(theWeight >= 0.0d && theWeight < 1.0d, "theWeight must be >= 0.0 and < 1.0");
+			Validate.isTrue(
+					mySteps.stream().anyMatch(t -> t.getStepId().equals(theStepId)), "Unknown stepL: %s", theStepId);
+			myStepWeightingBuilder.setStepWeightForProgressCalculator(theStepId, theWeight);
 			return this;
 		}
 	}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/JobDefinition.java
@@ -537,16 +537,15 @@ public class JobDefinition<PT extends IModelJson> {
 		 * how we calculate the "job complete %" number returned to the client while the job executes.
 		 *
 		 * @param theStepId The step ID to assign a weight to.
-		 * @param theWeight A weight. Value must be <code>i >= 0.0</code> and <code>i < 1.0</code>. The
+		 * @param theWeight A weight. Value must be <code>i &gt; 0.0</code> and <code>i &lt; 1.0</code>. The
 		 *                  combined weight of all steps must not exceed 1.0. If a given step should always
 		 *                  count for 20% of the total completion status, assign it a weight of <code>0.2</code>.
 		 * @see StepWeightingForProgressCalculator
 		 */
 		public Builder<PT, NIT> setStepWeightForProgressCalculator(String theStepId, double theWeight) {
-			Validate.notBlank(theStepId, "theStepId must not be blank");
-			Validate.isTrue(theWeight >= 0.0d && theWeight < 1.0d, "theWeight must be >= 0.0 and < 1.0");
 			Validate.isTrue(
 					mySteps.stream().anyMatch(t -> t.getStepId().equals(theStepId)), "Unknown stepL: %s", theStepId);
+			// theWeight is validated in setStepWeightForProgressCalculator
 			myStepWeightingBuilder.setStepWeightForProgressCalculator(theStepId, theWeight);
 			return this;
 		}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StepWeightingForProgressCalculator.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StepWeightingForProgressCalculator.java
@@ -16,8 +16,8 @@ import java.util.stream.Collectors;
  * However, it's also possible to assign weights to specific steps, if a specific
  * step is expected to process steps faster than others, or if it won't get
  * populated with steps until later in the process.
- * An individual step may have an explicit weight assigned, which is a double between
- * 0.0-0.999.
+ * An individual step may have an explicit weight assigned, which is a double that
+ * is <code>&gt; 0.0</code> and <code>&lt; 1.0</code>.
  */
 public class StepWeightingForProgressCalculator {
 
@@ -80,6 +80,8 @@ public class StepWeightingForProgressCalculator {
 		Builder() {}
 
 		void setStepWeightForProgressCalculator(String theStepId, double theWeight) {
+			Validate.notBlank(theStepId, "theStepId must not be blank");
+			Validate.isTrue(theWeight < 1.0d, "theWeight must be >= 0.0 and < 1.0");
 			Validate.isTrue(
 					theWeight > 0.0,
 					"All steps must have at least a small amount of weight, so step weight can not be <= 0.0");

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StepWeightingForProgressCalculator.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StepWeightingForProgressCalculator.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
  * is <code>&gt; 0.0</code> and <code>&lt; 1.0</code>.
  */
 public class StepWeightingForProgressCalculator {
+	private static final double WEIGHT_SUM_EPSILON = 1e-9;
 
 	private final double myWeightForStepsWithoutExplicitWeight;
 	private final Set<String> myStepIdsWithoutExplicitWeight;
@@ -31,7 +32,7 @@ public class StepWeightingForProgressCalculator {
 			double theWeightForStepsWithoutExplicitWeight) {
 		Validate.notNull(theStepIdToWeight, "theStepIdToWeight must not be null");
 		myStepIdToWeight = Map.copyOf(theStepIdToWeight);
-		myStepIdsWithoutExplicitWeight = theStepIdsWithoutExplicitWeight;
+		myStepIdsWithoutExplicitWeight = Set.copyOf(theStepIdsWithoutExplicitWeight);
 		myWeightForStepsWithoutExplicitWeight = theWeightForStepsWithoutExplicitWeight;
 	}
 
@@ -102,8 +103,16 @@ public class StepWeightingForProgressCalculator {
 				combinedWeightTotal += myStepIdToWeight.get(stepId);
 			}
 
+			/*
+			 * Because double is IEEE 754 binary floating point, most "round" decimals like
+			 * 0.1, 0.3, 0.4 cannot be represented exactly in binary — they're stored as the
+			 * nearest representable value, slightly above or below. When you add several of
+			 * them, the tiny representation errors accumulate, and the sum can land just
+			 * above the true mathematical total. Weights such as 0.3 + 0.3 + 0.4 can sum to
+			 * 1.0000000000000002 and spuriously cause failures.
+			 */
 			Validate.isTrue(
-					combinedWeightTotal <= 1.0,
+					combinedWeightTotal <= 1.0 + WEIGHT_SUM_EPSILON,
 					"Combined step weights can not be greater than 1.0, but was %s",
 					combinedWeightTotal);
 

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StepWeightingForProgressCalculator.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/model/StepWeightingForProgressCalculator.java
@@ -1,0 +1,122 @@
+package ca.uhn.fhir.batch2.model;
+
+import ca.uhn.fhir.model.api.IModelJson;
+import org.apache.commons.lang3.Validate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Given a Batch2 job with a series of steps, by default we calculate the job progress
+ * by counting all of the work chunks across all steps, dividing:
+ * <code>total incomplete chunks / total chunks</code>.
+ * However, it's also possible to assign weights to specific steps, if a specific
+ * step is expected to process steps faster than others, or if it won't get
+ * populated with steps until later in the process.
+ * An individual step may have an explicit weight assigned, which is a double between
+ * 0.0-0.999.
+ */
+public class StepWeightingForProgressCalculator {
+
+	private final double myWeightForStepsWithoutExplicitWeight;
+	private final Set<String> myStepIdsWithoutExplicitWeight;
+	private final Map<String, Double> myStepIdToWeight;
+
+	StepWeightingForProgressCalculator(
+			Map<String, Double> theStepIdToWeight,
+			Set<String> theStepIdsWithoutExplicitWeight,
+			double theWeightForStepsWithoutExplicitWeight) {
+		Validate.notNull(theStepIdToWeight, "theStepIdToWeight must not be null");
+		myStepIdToWeight = Map.copyOf(theStepIdToWeight);
+		myStepIdsWithoutExplicitWeight = theStepIdsWithoutExplicitWeight;
+		myWeightForStepsWithoutExplicitWeight = theWeightForStepsWithoutExplicitWeight;
+	}
+
+	/**
+	 * Returns the list of step IDs that do not have an explicit weight assigned.
+	 */
+	public Set<String> getStepIdsWithoutExplicitWeight() {
+		return myStepIdsWithoutExplicitWeight;
+	}
+
+	/**
+	 * If there are one or more steps with an explicit weight assigned, this method returns
+	 * the combined weight for the remaining steps. For example, given a job with 10 steps, where
+	 * two steps have an explicit weight of <code>0.1</code> each and the remaining steps
+	 * have no explicit weight assigned, this method would return <code>0.8</code>.
+	 */
+	public double getCombinedWeightForStepIdsWithoutExplicitWeight() {
+		return myWeightForStepsWithoutExplicitWeight;
+	}
+
+	/**
+	 * Returns the list of step IDs that have an explicit weight assigned. The IDs
+	 * returns by this method may be passed to {@link #getWeightForStepId(String)}.
+	 */
+	public Set<String> getStepIdsWithExplicitWeight() {
+		return myStepIdToWeight.keySet();
+	}
+
+	/**
+	 * Returns the weight for a specific job step.
+	 */
+	public double getWeightForStepId(String theStepId) {
+		Double retVal = myStepIdToWeight.get(theStepId);
+		Validate.notNull(retVal, "No weight found for stepId %s", theStepId);
+		return retVal;
+	}
+
+	static Builder newBuilder() {
+		return new Builder();
+	}
+
+	static class Builder {
+
+		private final Map<String, Double> myStepIdToWeight = new HashMap<>();
+
+		Builder() {}
+
+		void setStepWeightForProgressCalculator(String theStepId, double theWeight) {
+			Validate.isTrue(
+					theWeight > 0.0,
+					"All steps must have at least a small amount of weight, so step weight can not be <= 0.0");
+			Double previousValue = myStepIdToWeight.put(theStepId, theWeight);
+			Validate.isTrue(previousValue == null, "Already have weight for step: %s", theStepId);
+		}
+
+		public <PT extends IModelJson> StepWeightingForProgressCalculator build(
+				List<JobDefinitionStep<PT, ?, ?>> theSteps) {
+
+			Set<String> remainingJobStepIds =
+					theSteps.stream().map(JobDefinitionStep::getStepId).collect(Collectors.toSet());
+
+			double combinedWeightTotal = 0.0;
+			for (String stepId : myStepIdToWeight.keySet()) {
+				Validate.isTrue(
+						remainingJobStepIds.remove(stepId), "Step weight provided for invalid step ID: %s", stepId);
+				combinedWeightTotal += myStepIdToWeight.get(stepId);
+			}
+
+			Validate.isTrue(
+					combinedWeightTotal <= 1.0,
+					"Combined step weights can not be greater than 1.0, but was %s",
+					combinedWeightTotal);
+
+			int remainingStepCount = remainingJobStepIds.size();
+			double weightForRemainingSteps = 0.0;
+			if (remainingStepCount > 0) {
+				Validate.isTrue(
+						combinedWeightTotal < 1.0,
+						"All steps must have at least a small amount of weight, no remaining room for steps: %s",
+						remainingJobStepIds);
+				weightForRemainingSteps = (1.0 - combinedWeightTotal);
+			}
+
+			return new StepWeightingForProgressCalculator(
+					myStepIdToWeight, remainingJobStepIds, weightForRemainingSteps);
+		}
+	}
+}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
@@ -19,6 +19,9 @@
  */
 package ca.uhn.fhir.batch2.progress;
 
+import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
+import ca.uhn.fhir.batch2.model.JobDefinition;
+import ca.uhn.fhir.batch2.model.JobDefinitionStep;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
@@ -27,6 +30,7 @@ import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
 import ca.uhn.fhir.util.IntCounter;
 import ca.uhn.fhir.util.Logs;
 import ca.uhn.fhir.util.StopWatch;
+import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
@@ -41,6 +45,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 public class InstanceProgress {
 	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
 	private final Map<String, Map<WorkChunkStatusEnum, Integer>> myStepToStatusCountMap = new HashMap<>();
@@ -48,10 +54,10 @@ public class InstanceProgress {
 	private final Set<String> myWarningMessages = new HashSet<>();
 	private int myRecordsProcessed = 0;
 	// these 4 cover all chunks
-	private final Map<String, IntCounter> myIncompleteChunkCount = new HashMap<>();
-	private final Map<String, IntCounter> myCompleteChunkCount = new HashMap<>();
-	private final Map<String, IntCounter> myErroredChunkCount = new HashMap<>();
-	private final Map<String, IntCounter> myFailedChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myStepIdToIncompleteChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myStepIdToCompleteChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myStepIdToErroredChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myStepIdToFailedChunkCount = new HashMap<>();
 	private int myErrorCountForAllStatuses = 0;
 	private Date myEarliestStartTime = null;
 	private Date myLatestEndTime = null;
@@ -97,19 +103,19 @@ public class InstanceProgress {
 			case POLL_WAITING:
 			case IN_PROGRESS:
 				myAllIncompleteChunkCount++;
-				myIncompleteChunkCount
+				myStepIdToIncompleteChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
 				break;
 			case COMPLETED:
 				myAllCompleteChunkCount++;
-				myCompleteChunkCount
+				myStepIdToCompleteChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
 				break;
 			case ERRORED:
 				myAllErroredChunkCount++;
-				myErroredChunkCount
+				myStepIdToErroredChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
 				if (myErrormessage == null) {
@@ -118,13 +124,14 @@ public class InstanceProgress {
 				break;
 			case FAILED:
 				myAllFailedChunkCount++;
-				myFailedChunkCount
+				myStepIdToFailedChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
 				myErrormessage = theChunk.getErrorMessage();
 				break;
 		}
-		ourLog.trace("Chunk has status {} with errored chunk count {}", theChunk.getStatus(), myErroredChunkCount);
+		ourLog.trace(
+				"Chunk has status {} with errored chunk count {}", theChunk.getStatus(), myStepIdToErroredChunkCount);
 	}
 
 	private void updateLatestEndTime(WorkChunk theChunk) {
@@ -156,13 +163,12 @@ public class InstanceProgress {
 	 * @param theInstance The Batch 2 {@link JobInstance} that we're updating
 	 */
 	public void updateInstanceForReductionStep(
-			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator, JobInstance theInstance) {
-		updateInstance(theStepWeightingForProgressCalculator, theInstance, true);
+			JobDefinitionRegistry theJobDefinitionRegistry, JobInstance theInstance) {
+		updateInstance(theJobDefinitionRegistry, theInstance, true);
 	}
 
-	public void updateInstance(
-			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator, JobInstance theInstance) {
-		updateInstance(theStepWeightingForProgressCalculator, theInstance, false);
+	public void updateInstance(JobDefinitionRegistry theJobDefinitionRegistry, JobInstance theInstance) {
+		updateInstance(theJobDefinitionRegistry, theInstance, false);
 
 		String newWarningMessage = StringUtils.right(String.join("\n", myWarningMessages), 4000);
 		theInstance.setWarningMessages(newWarningMessage);
@@ -175,9 +181,11 @@ public class InstanceProgress {
 	 * @param theInstance the instance to update with progress statistics
 	 */
 	public void updateInstance(
-			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator,
-			JobInstance theInstance,
-			boolean theCalledFromReducer) {
+			JobDefinitionRegistry theJobDefinitionRegistry, JobInstance theInstance, boolean theCalledFromReducer) {
+
+		JobDefinition<?> jobDefinition = theJobDefinitionRegistry.getJobDefinitionOrThrowException(
+				theInstance.getJobDefinitionId(), theInstance.getJobDefinitionVersion());
+
 		ourLog.debug("updateInstance {}: {}", theInstance.getInstanceId(), this);
 		if (myEarliestStartTime != null) {
 			theInstance.setStartTime(myEarliestStartTime);
@@ -188,36 +196,46 @@ public class InstanceProgress {
 		theInstance.setErrorCount(myErrorCountForAllStatuses);
 		theInstance.setCombinedRecordsProcessed(myRecordsProcessed);
 
-		double totalPercentComplete = 0.0;
+		StepWeightingForProgressCalculator stepWeightingForProgressCalculator =
+				jobDefinition.getStepWeightingForProgressCalculator();
 
-		for (String stepId : theStepWeightingForProgressCalculator.getStepIdsWithExplicitWeight()) {
+		Set<String> alreadyCompletedStepIds = getAlreadyCompletedStepIds(jobDefinition, theInstance);
+
+		double totalPercentComplete = 0.0;
+		for (String stepId : stepWeightingForProgressCalculator.getStepIdsWithExplicitWeight()) {
+			double stepWeight = stepWeightingForProgressCalculator.getWeightForStepId(stepId);
+			if (alreadyCompletedStepIds.contains(stepId)) {
+				totalPercentComplete += stepWeight;
+				continue;
+			}
+
 			final int chunkCount = getChunkCount(stepId);
-			final int conditionalChunkCount =
-					theCalledFromReducer ? (chunkCount - getCount(myIncompleteChunkCount, stepId)) : chunkCount;
+			final int conditionalChunkCount = theCalledFromReducer
+					? (chunkCount - getChunkCount(myStepIdToIncompleteChunkCount, stepId))
+					: chunkCount;
 			if (conditionalChunkCount == 0) {
 				continue;
 			}
 
 			final double stepPercentComplete =
-					(double) getCount(myCompleteChunkCount, stepId) / (double) conditionalChunkCount;
+					(double) getChunkCount(myStepIdToCompleteChunkCount, stepId) / (double) conditionalChunkCount;
 
-			double stepWeight = theStepWeightingForProgressCalculator.getWeightForStepId(stepId);
 			totalPercentComplete += stepWeight * stepPercentComplete;
 		}
 
-		Set<String> stepIdsWithoutExplicitWeight =
-				theStepWeightingForProgressCalculator.getStepIdsWithoutExplicitWeight();
+		Set<String> stepIdsWithoutExplicitWeight = stepWeightingForProgressCalculator.getStepIdsWithoutExplicitWeight();
 		if (!stepIdsWithoutExplicitWeight.isEmpty()) {
 			final int chunkCount = getChunkCount(stepIdsWithoutExplicitWeight);
 			final int conditionalChunkCount = theCalledFromReducer
-					? (chunkCount - getCount(myIncompleteChunkCount, stepIdsWithoutExplicitWeight))
+					? (chunkCount - getChunkCount(myStepIdToIncompleteChunkCount, stepIdsWithoutExplicitWeight))
 					: chunkCount;
 			if (conditionalChunkCount > 0) {
-				final double stepPercentComplete = (double) getCount(myCompleteChunkCount, stepIdsWithoutExplicitWeight)
-						/ (double) conditionalChunkCount;
+				final double stepPercentComplete =
+						(double) getChunkCount(myStepIdToCompleteChunkCount, stepIdsWithoutExplicitWeight)
+								/ (double) conditionalChunkCount;
 
 				double stepWeight =
-						theStepWeightingForProgressCalculator.getCombinedWeightForStepIdsWithoutExplicitWeight();
+						stepWeightingForProgressCalculator.getCombinedWeightForStepIdsWithoutExplicitWeight();
 				totalPercentComplete += stepWeight * stepPercentComplete;
 			}
 		}
@@ -242,14 +260,61 @@ public class InstanceProgress {
 			ourLog.trace("Status will change for {}: {}", theInstance.getInstanceId(), myNewStatus);
 		}
 
-		ourLog.trace("Updating status for instance with errors: {}", myErroredChunkCount);
+		ourLog.trace("Updating status for instance with errors: {}", myStepIdToErroredChunkCount);
 		ourLog.trace(
 				"Statistics for job {}: complete/in-progress/errored/failed chunk count {}/{}/{}/{}",
 				theInstance.getInstanceId(),
-				myCompleteChunkCount,
-				myIncompleteChunkCount,
-				myErroredChunkCount,
-				myFailedChunkCount);
+				myStepIdToCompleteChunkCount,
+				myStepIdToIncompleteChunkCount,
+				myStepIdToErroredChunkCount,
+				myStepIdToFailedChunkCount);
+	}
+
+	/**
+	 * Provide a Set of step IDs in a job execution that have already finished
+	 * executing.
+	 */
+	@Nonnull
+	private Set<String> getAlreadyCompletedStepIds(JobDefinition<?> theJobDefinition, JobInstance theInstance) {
+		Set<String> retVal = new HashSet<>();
+		if (theJobDefinition.isGatedExecution()) {
+			/*
+			 * For gated jobs, we know exactly which step we're in, so all the
+			 * steps before that step are completed.
+			 */
+			String currentGatedStepId = theInstance.getCurrentGatedStepId();
+			if (isNotBlank(currentGatedStepId)) {
+				for (JobDefinitionStep<?, ?, ?> step : theJobDefinition.getSteps()) {
+					if (step.getStepId().equals(currentGatedStepId)) {
+						break;
+					}
+					retVal.add(step.getStepId());
+				}
+			}
+		} else {
+			/*
+			 * For non-gated jobs, we consider a step to be completed if
+			 * all the chunks for it are complete, or if it has no chunks in
+			 * any state and all the previous steps are complete.
+			 */
+			boolean lastStepWasComplete = false;
+			for (JobDefinitionStep<?, ?, ?> step : theJobDefinition.getSteps()) {
+				String stepId = step.getStepId();
+
+				int completeChunksForStep = getChunkCount(myStepIdToCompleteChunkCount, stepId);
+				int totalChunksForStep = getChunkCount(stepId);
+				if (completeChunksForStep > 0 && completeChunksForStep == totalChunksForStep) {
+					lastStepWasComplete = true;
+					retVal.add(stepId);
+				} else if (lastStepWasComplete && totalChunksForStep == 0) {
+					retVal.add(stepId);
+				} else {
+					lastStepWasComplete = false;
+				}
+			}
+		}
+
+		return retVal;
 	}
 
 	private int getChunkCount(String theStepId) {
@@ -257,10 +322,10 @@ public class InstanceProgress {
 	}
 
 	private int getChunkCount(Collection<String> theStepId) {
-		return getCount(myIncompleteChunkCount, theStepId)
-				+ getCount(myCompleteChunkCount, theStepId)
-				+ getCount(myFailedChunkCount, theStepId)
-				+ getCount(myErroredChunkCount, theStepId);
+		return getChunkCount(myStepIdToIncompleteChunkCount, theStepId)
+				+ getChunkCount(myStepIdToCompleteChunkCount, theStepId)
+				+ getChunkCount(myStepIdToFailedChunkCount, theStepId)
+				+ getChunkCount(myStepIdToErroredChunkCount, theStepId);
 	}
 
 	/**
@@ -280,10 +345,10 @@ public class InstanceProgress {
 	@Override
 	public String toString() {
 		ToStringBuilder builder = new ToStringBuilder(this)
-				.append("myIncompleteChunkCount", myIncompleteChunkCount)
-				.append("myCompleteChunkCount", myCompleteChunkCount)
-				.append("myErroredChunkCount", myErroredChunkCount)
-				.append("myFailedChunkCount", myFailedChunkCount)
+				.append("myIncompleteChunkCount", myStepIdToIncompleteChunkCount)
+				.append("myCompleteChunkCount", myStepIdToCompleteChunkCount)
+				.append("myErroredChunkCount", myStepIdToErroredChunkCount)
+				.append("myFailedChunkCount", myStepIdToFailedChunkCount)
 				.append("myErrormessage", myErrormessage)
 				.append("myRecordsProcessed", myRecordsProcessed);
 
@@ -316,11 +381,11 @@ public class InstanceProgress {
 		return myStepProgressMap.get(theStepId);
 	}
 
-	private static int getCount(Map<String, IntCounter> theCounterMap, String theStepId) {
-		return getCount(theCounterMap, List.of(theStepId));
+	private static int getChunkCount(Map<String, IntCounter> theCounterMap, String theStepId) {
+		return getChunkCount(theCounterMap, List.of(theStepId));
 	}
 
-	private static int getCount(Map<String, IntCounter> theCounterMap, Collection<String> theStepIds) {
+	private static int getChunkCount(Map<String, IntCounter> theCounterMap, Collection<String> theStepIds) {
 		int retVal = 0;
 		for (String stepId : theStepIds) {
 			IntCounter counter = theCounterMap.get(stepId);

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
@@ -21,41 +21,46 @@ package ca.uhn.fhir.batch2.progress;
 
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.StatusEnum;
+import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
+import ca.uhn.fhir.util.Counter;
 import ca.uhn.fhir.util.Logs;
 import ca.uhn.fhir.util.StopWatch;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class InstanceProgress {
 	private static final Logger ourLog = Logs.getBatchTroubleshootingLog();
-
+	private final Map<String, Map<WorkChunkStatusEnum, Integer>> myStepToStatusCountMap = new HashMap<>();
+	private final Map<String, StepProgressData> myStepProgressMap = new HashMap<>();
+	private final Set<String> myWarningMessages = new HashSet<>();
 	private int myRecordsProcessed = 0;
-
 	// these 4 cover all chunks
-	private int myIncompleteChunkCount = 0;
-	private int myCompleteChunkCount = 0;
-	private int myErroredChunkCount = 0;
-	private int myFailedChunkCount = 0;
-
+	private Map<String, Counter> myIncompleteChunkCount = new HashMap<>();
+	private Map<String, Counter> myCompleteChunkCount = new HashMap<>();
+	private Map<String, Counter> myErroredChunkCount = new HashMap<>();
+	private Map<String, Counter> myFailedChunkCount = new HashMap<>();
 	private int myErrorCountForAllStatuses = 0;
 	private Date myEarliestStartTime = null;
 	private Date myLatestEndTime = null;
 	private String myErrormessage = null;
 	private StatusEnum myNewStatus = null;
-	private final Map<String, Map<WorkChunkStatusEnum, Integer>> myStepToStatusCountMap = new HashMap<>();
-	private final Map<String, StepProgressData> myStepProgressMap = new HashMap<>();
-	private final Set<String> myWarningMessages = new HashSet<>();
+	private int myAllIncompleteChunkCount;
+	private int myAllCompleteChunkCount;
+	private int myAllErroredChunkCount;
+	private int myAllFailedChunkCount;
 
 	public void addChunk(WorkChunk theChunk) {
 		myErrorCountForAllStatuses += theChunk.getErrorCount();
@@ -91,19 +96,31 @@ public class InstanceProgress {
 			case QUEUED:
 			case POLL_WAITING:
 			case IN_PROGRESS:
-				myIncompleteChunkCount++;
+				myAllIncompleteChunkCount++;
+				myIncompleteChunkCount
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
+						.getThenAdd();
 				break;
 			case COMPLETED:
-				myCompleteChunkCount++;
+				myAllCompleteChunkCount++;
+				myCompleteChunkCount
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
+						.getThenAdd();
 				break;
 			case ERRORED:
-				myErroredChunkCount++;
+				myAllErroredChunkCount++;
+				myErroredChunkCount
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
+						.getThenAdd();
 				if (myErrormessage == null) {
 					myErrormessage = theChunk.getErrorMessage();
 				}
 				break;
 			case FAILED:
-				myFailedChunkCount++;
+				myAllFailedChunkCount++;
+				myFailedChunkCount
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
+						.getThenAdd();
 				myErrormessage = theChunk.getErrorMessage();
 				break;
 		}
@@ -138,12 +155,14 @@ public class InstanceProgress {
 	 *
 	 * @param theInstance The Batch 2 {@link JobInstance} that we're updating
 	 */
-	public void updateInstanceForReductionStep(JobInstance theInstance) {
-		updateInstance(theInstance, true);
+	public void updateInstanceForReductionStep(
+			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator, JobInstance theInstance) {
+		updateInstance(theStepWeightingForProgressCalculator, theInstance, true);
 	}
 
-	public void updateInstance(JobInstance theInstance) {
-		updateInstance(theInstance, false);
+	public void updateInstance(
+			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator, JobInstance theInstance) {
+		updateInstance(theStepWeightingForProgressCalculator, theInstance, false);
 
 		String newWarningMessage = StringUtils.right(String.join("\n", myWarningMessages), 4000);
 		theInstance.setWarningMessages(newWarningMessage);
@@ -155,7 +174,10 @@ public class InstanceProgress {
 	 *
 	 * @param theInstance the instance to update with progress statistics
 	 */
-	public void updateInstance(JobInstance theInstance, boolean theCalledFromReducer) {
+	public void updateInstance(
+			StepWeightingForProgressCalculator theStepWeightingForProgressCalculator,
+			JobInstance theInstance,
+			boolean theCalledFromReducer) {
 		ourLog.debug("updateInstance {}: {}", theInstance.getInstanceId(), this);
 		if (myEarliestStartTime != null) {
 			theInstance.setStartTime(myEarliestStartTime);
@@ -166,12 +188,41 @@ public class InstanceProgress {
 		theInstance.setErrorCount(myErrorCountForAllStatuses);
 		theInstance.setCombinedRecordsProcessed(myRecordsProcessed);
 
-		if (getChunkCount() > 0) {
-			final int chunkCount = getChunkCount();
-			final int conditionalChunkCount = theCalledFromReducer ? (chunkCount - myIncompleteChunkCount) : chunkCount;
-			final double percentComplete = (double) (myCompleteChunkCount) / (double) conditionalChunkCount;
-			theInstance.setProgress(percentComplete);
+		double totalPercentComplete = 0.0;
+
+		for (String stepId : theStepWeightingForProgressCalculator.getStepIdsWithExplicitWeight()) {
+			final int chunkCount = getChunkCount(stepId);
+			final int conditionalChunkCount =
+					theCalledFromReducer ? (chunkCount - getCount(myIncompleteChunkCount, stepId)) : chunkCount;
+			if (conditionalChunkCount == 0) {
+				continue;
+			}
+
+			final double stepPercentComplete =
+					(double) getCount(myCompleteChunkCount, stepId) / (double) conditionalChunkCount;
+
+			double stepWeight = theStepWeightingForProgressCalculator.getWeightForStepId(stepId);
+			totalPercentComplete += stepWeight * stepPercentComplete;
 		}
+
+		Set<String> stepIdsWithoutExplicitWeight =
+				theStepWeightingForProgressCalculator.getStepIdsWithoutExplicitWeight();
+		if (!stepIdsWithoutExplicitWeight.isEmpty()) {
+			final int chunkCount = getChunkCount(stepIdsWithoutExplicitWeight);
+			final int conditionalChunkCount = theCalledFromReducer
+					? (chunkCount - getCount(myIncompleteChunkCount, stepIdsWithoutExplicitWeight))
+					: chunkCount;
+			if (conditionalChunkCount > 0) {
+				final double stepPercentComplete = (double) getCount(myCompleteChunkCount, stepIdsWithoutExplicitWeight)
+						/ (double) conditionalChunkCount;
+
+				double stepWeight =
+						theStepWeightingForProgressCalculator.getCombinedWeightForStepIdsWithoutExplicitWeight();
+				totalPercentComplete += stepWeight * stepPercentComplete;
+			}
+		}
+
+		theInstance.setProgress(totalPercentComplete);
 
 		if (myEarliestStartTime != null && myLatestEndTime != null) {
 			long elapsedTime = myLatestEndTime.getTime() - myEarliestStartTime.getTime();
@@ -180,7 +231,7 @@ public class InstanceProgress {
 				theInstance.setCombinedRecordsProcessedPerSecond(throughput);
 
 				String estimatedTimeRemaining =
-						StopWatch.formatEstimatedTimeRemaining(myCompleteChunkCount, getChunkCount(), elapsedTime);
+						StopWatch.formatEstimatedTimeRemaining(totalPercentComplete, 1.0, elapsedTime);
 				theInstance.setEstimatedTimeRemaining(estimatedTimeRemaining);
 			}
 		}
@@ -202,18 +253,29 @@ public class InstanceProgress {
 	}
 
 	private int getChunkCount() {
-		return myIncompleteChunkCount + myCompleteChunkCount + myFailedChunkCount + myErroredChunkCount;
+		return myAllIncompleteChunkCount + myAllCompleteChunkCount + myAllFailedChunkCount + myAllErroredChunkCount;
+	}
+
+	private int getChunkCount(String theStepId) {
+		return getChunkCount(List.of(theStepId));
+	}
+
+	private int getChunkCount(Collection<String> theStepId) {
+		return getCount(myIncompleteChunkCount, theStepId)
+				+ getCount(myCompleteChunkCount, theStepId)
+				+ getCount(myFailedChunkCount, theStepId)
+				+ getCount(myErroredChunkCount, theStepId);
 	}
 
 	/**
 	 * Transitions from IN_PROGRESS/ERRORED based on chunk statuses.
 	 */
 	public void calculateNewStatus(boolean theLastStepIsReduction) {
-		if (myFailedChunkCount > 0) {
+		if (myAllFailedChunkCount > 0) {
 			myNewStatus = StatusEnum.FAILED;
-		} else if (myErroredChunkCount > 0) {
+		} else if (myAllErroredChunkCount > 0) {
 			myNewStatus = StatusEnum.ERRORED;
-		} else if (myIncompleteChunkCount == 0 && myCompleteChunkCount > 0 && !theLastStepIsReduction) {
+		} else if (myAllIncompleteChunkCount == 0 && myAllCompleteChunkCount > 0 && !theLastStepIsReduction) {
 			myNewStatus = StatusEnum.COMPLETED;
 		}
 	}
@@ -255,5 +317,20 @@ public class InstanceProgress {
 	 */
 	public StepProgressData getStepProgress(String theStepId) {
 		return myStepProgressMap.get(theStepId);
+	}
+
+	private static int getCount(Map<String, Counter> theCounterMap, String theStepId) {
+		return getCount(theCounterMap, List.of(theStepId));
+	}
+
+	private static int getCount(Map<String, Counter> theCounterMap, Collection<String> theStepIds) {
+		int retVal = 0;
+		for (String stepId : theStepIds) {
+			Counter counter = theCounterMap.get(stepId);
+			if (counter != null) {
+				retVal += Math.toIntExact(counter.get());
+			}
+		}
+		return retVal;
 	}
 }

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
@@ -52,21 +52,17 @@ public class InstanceProgress {
 	private final Map<String, Map<WorkChunkStatusEnum, Integer>> myStepToStatusCountMap = new HashMap<>();
 	private final Map<String, StepProgressData> myStepProgressMap = new HashMap<>();
 	private final Set<String> myWarningMessages = new HashSet<>();
-	private int myRecordsProcessed = 0;
 	// these 4 cover all chunks
 	private final Map<String, IntCounter> myStepIdToIncompleteChunkCount = new HashMap<>();
 	private final Map<String, IntCounter> myStepIdToCompleteChunkCount = new HashMap<>();
 	private final Map<String, IntCounter> myStepIdToErroredChunkCount = new HashMap<>();
 	private final Map<String, IntCounter> myStepIdToFailedChunkCount = new HashMap<>();
+	private int myRecordsProcessed = 0;
 	private int myErrorCountForAllStatuses = 0;
 	private Date myEarliestStartTime = null;
 	private Date myLatestEndTime = null;
 	private String myErrormessage = null;
 	private StatusEnum myNewStatus = null;
-	private int myAllIncompleteChunkCount;
-	private int myAllCompleteChunkCount;
-	private int myAllErroredChunkCount;
-	private int myAllFailedChunkCount;
 
 	public void addChunk(WorkChunk theChunk) {
 		myErrorCountForAllStatuses += theChunk.getErrorCount();
@@ -102,19 +98,16 @@ public class InstanceProgress {
 			case QUEUED:
 			case POLL_WAITING:
 			case IN_PROGRESS:
-				myAllIncompleteChunkCount++;
 				myStepIdToIncompleteChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
 				break;
 			case COMPLETED:
-				myAllCompleteChunkCount++;
 				myStepIdToCompleteChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
 				break;
 			case ERRORED:
-				myAllErroredChunkCount++;
 				myStepIdToErroredChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
@@ -123,7 +116,6 @@ public class InstanceProgress {
 				}
 				break;
 			case FAILED:
-				myAllFailedChunkCount++;
 				myStepIdToFailedChunkCount
 						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
 						.increment();
@@ -332,12 +324,14 @@ public class InstanceProgress {
 	 * Transitions from IN_PROGRESS/ERRORED based on chunk statuses.
 	 */
 	public void calculateNewStatus(boolean theLastStepIsReduction) {
-		if (myAllFailedChunkCount > 0) {
+		if (hasChunkCounts(myStepIdToFailedChunkCount)) {
 			myNewStatus = StatusEnum.FAILED;
-		} else if (myAllErroredChunkCount > 0) {
+		} else if (hasChunkCounts(myStepIdToErroredChunkCount)) {
 			//noinspection deprecation
 			myNewStatus = StatusEnum.ERRORED;
-		} else if (myAllIncompleteChunkCount == 0 && myAllCompleteChunkCount > 0 && !theLastStepIsReduction) {
+		} else if (!hasChunkCounts(myStepIdToIncompleteChunkCount)
+				&& hasChunkCounts(myStepIdToCompleteChunkCount)
+				&& !theLastStepIsReduction) {
 			myNewStatus = StatusEnum.COMPLETED;
 		}
 	}
@@ -381,14 +375,18 @@ public class InstanceProgress {
 		return myStepProgressMap.get(theStepId);
 	}
 
-	private static int getChunkCount(Map<String, IntCounter> theCounterMap, String theStepId) {
-		return getChunkCount(theCounterMap, List.of(theStepId));
+	private static boolean hasChunkCounts(Map<String, IntCounter> theStepIdToChunkCountMap) {
+		return theStepIdToChunkCountMap.values().stream().anyMatch(t -> t.get() > 0);
 	}
 
-	private static int getChunkCount(Map<String, IntCounter> theCounterMap, Collection<String> theStepIds) {
+	private static int getChunkCount(Map<String, IntCounter> theStepIdToChunkCountMap, String theStepId) {
+		return getChunkCount(theStepIdToChunkCountMap, List.of(theStepId));
+	}
+
+	private static int getChunkCount(Map<String, IntCounter> theStepIdToChunkCountMap, Collection<String> theStepIds) {
 		int retVal = 0;
 		for (String stepId : theStepIds) {
-			IntCounter counter = theCounterMap.get(stepId);
+			IntCounter counter = theStepIdToChunkCountMap.get(stepId);
 			if (counter != null) {
 				retVal += counter.get();
 			}

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/InstanceProgress.java
@@ -24,7 +24,7 @@ import ca.uhn.fhir.batch2.model.StatusEnum;
 import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
-import ca.uhn.fhir.util.Counter;
+import ca.uhn.fhir.util.IntCounter;
 import ca.uhn.fhir.util.Logs;
 import ca.uhn.fhir.util.StopWatch;
 import org.apache.commons.lang3.StringUtils;
@@ -48,10 +48,10 @@ public class InstanceProgress {
 	private final Set<String> myWarningMessages = new HashSet<>();
 	private int myRecordsProcessed = 0;
 	// these 4 cover all chunks
-	private Map<String, Counter> myIncompleteChunkCount = new HashMap<>();
-	private Map<String, Counter> myCompleteChunkCount = new HashMap<>();
-	private Map<String, Counter> myErroredChunkCount = new HashMap<>();
-	private Map<String, Counter> myFailedChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myIncompleteChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myCompleteChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myErroredChunkCount = new HashMap<>();
+	private final Map<String, IntCounter> myFailedChunkCount = new HashMap<>();
 	private int myErrorCountForAllStatuses = 0;
 	private Date myEarliestStartTime = null;
 	private Date myLatestEndTime = null;
@@ -98,20 +98,20 @@ public class InstanceProgress {
 			case IN_PROGRESS:
 				myAllIncompleteChunkCount++;
 				myIncompleteChunkCount
-						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
-						.getThenAdd();
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
+						.increment();
 				break;
 			case COMPLETED:
 				myAllCompleteChunkCount++;
 				myCompleteChunkCount
-						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
-						.getThenAdd();
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
+						.increment();
 				break;
 			case ERRORED:
 				myAllErroredChunkCount++;
 				myErroredChunkCount
-						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
-						.getThenAdd();
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
+						.increment();
 				if (myErrormessage == null) {
 					myErrormessage = theChunk.getErrorMessage();
 				}
@@ -119,8 +119,8 @@ public class InstanceProgress {
 			case FAILED:
 				myAllFailedChunkCount++;
 				myFailedChunkCount
-						.computeIfAbsent(theChunk.getTargetStepId(), k -> new Counter())
-						.getThenAdd();
+						.computeIfAbsent(theChunk.getTargetStepId(), k -> new IntCounter())
+						.increment();
 				myErrormessage = theChunk.getErrorMessage();
 				break;
 		}
@@ -252,10 +252,6 @@ public class InstanceProgress {
 				myFailedChunkCount);
 	}
 
-	private int getChunkCount() {
-		return myAllIncompleteChunkCount + myAllCompleteChunkCount + myAllFailedChunkCount + myAllErroredChunkCount;
-	}
-
 	private int getChunkCount(String theStepId) {
 		return getChunkCount(List.of(theStepId));
 	}
@@ -274,6 +270,7 @@ public class InstanceProgress {
 		if (myAllFailedChunkCount > 0) {
 			myNewStatus = StatusEnum.FAILED;
 		} else if (myAllErroredChunkCount > 0) {
+			//noinspection deprecation
 			myNewStatus = StatusEnum.ERRORED;
 		} else if (myAllIncompleteChunkCount == 0 && myAllCompleteChunkCount > 0 && !theLastStepIsReduction) {
 			myNewStatus = StatusEnum.COMPLETED;
@@ -319,16 +316,16 @@ public class InstanceProgress {
 		return myStepProgressMap.get(theStepId);
 	}
 
-	private static int getCount(Map<String, Counter> theCounterMap, String theStepId) {
+	private static int getCount(Map<String, IntCounter> theCounterMap, String theStepId) {
 		return getCount(theCounterMap, List.of(theStepId));
 	}
 
-	private static int getCount(Map<String, Counter> theCounterMap, Collection<String> theStepIds) {
+	private static int getCount(Map<String, IntCounter> theCounterMap, Collection<String> theStepIds) {
 		int retVal = 0;
 		for (String stepId : theStepIds) {
-			Counter counter = theCounterMap.get(stepId);
+			IntCounter counter = theCounterMap.get(stepId);
 			if (counter != null) {
-				retVal += Math.toIntExact(counter.get());
+				retVal += counter.get();
 			}
 		}
 		return retVal;

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculator.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculator.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
 import ca.uhn.fhir.batch2.maintenance.JobChunkProgressAccumulator;
 import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.IInterceptorService;
@@ -63,7 +64,12 @@ public class JobInstanceProgressCalculator {
 		InstanceProgress instanceProgress = calculateInstanceProgress(theInstanceId);
 
 		myJobPersistence.updateInstance(theInstanceId, currentInstance -> {
-			instanceProgress.updateInstance(currentInstance);
+			JobDefinition<?> jobDefinition = myJobDefinitionRegistry
+					.getJobDefinition(currentInstance.getJobDefinitionId(), currentInstance.getJobDefinitionVersion())
+					.orElseThrow();
+			StepWeightingForProgressCalculator stepWeightingForProgressCalculator =
+					jobDefinition.getStepWeightingForProgressCalculator();
+			instanceProgress.updateInstance(stepWeightingForProgressCalculator, currentInstance);
 
 			if (currentInstance.getCombinedRecordsProcessed() > 0) {
 				ourLog.info(
@@ -118,6 +124,9 @@ public class JobInstanceProgressCalculator {
 
 	@Nonnull
 	public InstanceProgress calculateInstanceProgress(String instanceId) {
+		JobInstance jobInstance = getJobInstance(instanceId);
+		JobDefinition<IModelJson> jobDefinition = myJobDefinitionRegistry.getJobDefinitionOrThrowException(jobInstance);
+
 		InstanceProgress instanceProgress = new InstanceProgress();
 		Iterator<WorkChunk> workChunkIterator = myJobPersistence.fetchAllWorkChunksIterator(instanceId, false);
 
@@ -131,15 +140,9 @@ public class JobInstanceProgressCalculator {
 		}
 
 		// wipmb separate status update from stats collection in 6.8
-		instanceProgress.calculateNewStatus(lastStepIsReduction(instanceId));
+		instanceProgress.calculateNewStatus(jobDefinition.isLastStepReduction());
 
 		return instanceProgress;
-	}
-
-	private boolean lastStepIsReduction(String theInstanceId) {
-		JobInstance jobInstance = getJobInstance(theInstanceId);
-		JobDefinition<IModelJson> jobDefinition = myJobDefinitionRegistry.getJobDefinitionOrThrowException(jobInstance);
-		return jobDefinition.isLastStepReduction();
 	}
 
 	private JobInstance getJobInstance(String theInstanceId) {

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculator.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculator.java
@@ -24,7 +24,6 @@ import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
 import ca.uhn.fhir.batch2.maintenance.JobChunkProgressAccumulator;
 import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
-import ca.uhn.fhir.batch2.model.StepWeightingForProgressCalculator;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.IInterceptorService;
@@ -64,12 +63,7 @@ public class JobInstanceProgressCalculator {
 		InstanceProgress instanceProgress = calculateInstanceProgress(theInstanceId);
 
 		myJobPersistence.updateInstance(theInstanceId, currentInstance -> {
-			JobDefinition<?> jobDefinition = myJobDefinitionRegistry
-					.getJobDefinition(currentInstance.getJobDefinitionId(), currentInstance.getJobDefinitionVersion())
-					.orElseThrow();
-			StepWeightingForProgressCalculator stepWeightingForProgressCalculator =
-					jobDefinition.getStepWeightingForProgressCalculator();
-			instanceProgress.updateInstance(stepWeightingForProgressCalculator, currentInstance);
+			instanceProgress.updateInstance(myJobDefinitionRegistry, currentInstance);
 
 			if (currentInstance.getCombinedRecordsProcessed() > 0) {
 				ourLog.info(

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDefinitionTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDefinitionTest.java
@@ -62,15 +62,16 @@ class JobDefinitionTest extends BaseBatch2Test {
 
 	@Test
 	void stepWeight_FailOnAllWeightAddsUpToMoreThanOne() {
-		assertThatThrownBy(()->{
-			super.createJobDefinition(b -> {
-				b.setStepWeightForProgressCalculator(STEP_1, 0.49);
-				b.setStepWeightForProgressCalculator(STEP_2, 0.49);
-				// Adds up to more than 1.0
-				b.setStepWeightForProgressCalculator(STEP_3, 0.2);
-			});
-		}).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("Combined step weights can not be greater than 1.0, but was 1.18");
+		// Test
+		assertThatThrownBy(()-> super.createJobDefinition(b -> {
+			b.setStepWeightForProgressCalculator(STEP_1, 0.49);
+			b.setStepWeightForProgressCalculator(STEP_2, 0.49);
+			// Adds up to more than 1.0
+			b.setStepWeightForProgressCalculator(STEP_3, 0.2);
+		}))
+			// Validate
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageMatching("^Combined step weights can not be greater than 1.0, but was 1.1[789].*");
 	}
 
 }

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDefinitionTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDefinitionTest.java
@@ -1,13 +1,15 @@
 package ca.uhn.fhir.batch2.coordinator;
 
 import ca.uhn.fhir.batch2.model.JobDefinition;
+import ca.uhn.fhir.model.api.IModelJson;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
-class JobDefinitionTest {
+class JobDefinitionTest extends BaseBatch2Test {
 	private static final String JOB_DEF_ID = "Jeff";
 	private static final String JOB_DESC = "Jeff is curious";
 
@@ -35,4 +37,40 @@ class JobDefinitionTest {
 			assertEquals("At least 2 steps must be supplied", e.getMessage());
 		}
 	}
+
+	@Test
+	void stepWeight_FailOnZeroWeight() {
+		assertThatThrownBy(()->{
+			super.createJobDefinition(b -> {
+				b.setStepWeightForProgressCalculator(STEP_1, 0.0);
+			});
+		}).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("step weight can not be <= 0.0");
+	}
+
+	@Test
+	void stepWeight_FailOnAllWeightConsumedByNotAllSteps() {
+		assertThatThrownBy(()->{
+			super.createJobDefinition(b -> {
+				b.setStepWeightForProgressCalculator(STEP_1, 0.5);
+				b.setStepWeightForProgressCalculator(STEP_2, 0.5);
+				// Nothing left for step 3
+			});
+		}).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("no remaining room for steps: [STEP_3]");
+	}
+
+	@Test
+	void stepWeight_FailOnAllWeightAddsUpToMoreThanOne() {
+		assertThatThrownBy(()->{
+			super.createJobDefinition(b -> {
+				b.setStepWeightForProgressCalculator(STEP_1, 0.49);
+				b.setStepWeightForProgressCalculator(STEP_2, 0.49);
+				// Adds up to more than 1.0
+				b.setStepWeightForProgressCalculator(STEP_3, 0.2);
+			});
+		}).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Combined step weights can not be greater than 1.0, but was 1.18");
+	}
+
 }

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSinkTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSinkTest.java
@@ -1,7 +1,9 @@
 package ca.uhn.fhir.batch2.coordinator;
 
 import ca.uhn.fhir.batch2.api.IJobPersistence;
+import ca.uhn.fhir.batch2.api.IJobStepWorker;
 import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
+import ca.uhn.fhir.batch2.api.VoidModel;
 import ca.uhn.fhir.batch2.model.JobDefinition;
 import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.JobWorkCursor;
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,8 +46,17 @@ import static org.mockito.Mockito.when;
 public class ReductionStepDataSinkTest {
 
 	private static final String INSTANCE_ID = "instanceId";
+	private static final String JOB_DEFINITION_ID = "jobDefinitionId";
+
 	@Mock
 	private JobDefinitionRegistry myJobDefinitionRegistry;
+
+	private JobDefinition<MyModel> jobDefinition;
+	@Mock
+	private IJobStepWorker<MyModel, VoidModel, MyModel> myStep1;
+	@Mock
+	private IJobStepWorker<MyModel, MyModel, VoidModel> myStep2;
+
 
 	private static class TestJobParameters implements IModelJson { }
 
@@ -80,6 +92,16 @@ public class ReductionStepDataSinkTest {
 
 	@BeforeEach
 	public void init() {
+		jobDefinition = JobDefinition
+			.newBuilder()
+			.setJobDefinitionId(JOB_DEFINITION_ID)
+			.setJobDefinitionVersion(1)
+			.setJobDescription("A job")
+			.setParametersType(MyModel.class)
+			.addFirstStep("first-step", "Step", MyModel.class, myStep1)
+			.addLastStep("last-step", "Step", myStep2)
+				.build();
+
 		when(myJobDefinition.getJobDefinitionId())
 			.thenReturn("jobDefinition");
 		when(myWorkCursor.getJobDefinition())
@@ -105,8 +127,6 @@ public class ReductionStepDataSinkTest {
 		String data = "data";
 		StepOutputData stepData = new StepOutputData(data);
 		WorkChunkData<StepOutputData> chunkData = new WorkChunkData<>(stepData);
-		@SuppressWarnings("unchecked")
-		JobDefinition<IModelJson> jobDefinition = mock(JobDefinition.class);
 		myInterceptorService.registerAnonymousInterceptor(Pointcut.STORAGE_POSTCOMPLETE_BATCH_JOB, jobCompletionInterceptor);
 
 		// when
@@ -115,7 +135,10 @@ public class ReductionStepDataSinkTest {
 		stubUpdateInstanceCallback(instance);
 		when(myJobPersistence.fetchAllWorkChunksIterator(any(), anyBoolean())).thenReturn(Collections.emptyIterator());
 		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(instance));
-		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(instance)).thenReturn(jobDefinition);
+		@SuppressWarnings("rawtypes")
+		JobDefinition jobDefinitionUncast = jobDefinition;
+		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(instance)).thenReturn(jobDefinitionUncast);
+		when(myJobDefinitionRegistry.getJobDefinition(any(), anyInt())).thenReturn(Optional.of(jobDefinition));
 
 		// test
 		myDataSink.accept(chunkData);
@@ -131,8 +154,6 @@ public class ReductionStepDataSinkTest {
 		String data2 = "data2";
 		WorkChunkData<StepOutputData> firstData = new WorkChunkData<>(new StepOutputData(data));
 		WorkChunkData<StepOutputData> secondData = new WorkChunkData<>(new StepOutputData(data2));
-		@SuppressWarnings("unchecked")
-		JobDefinition<IModelJson> jobDefinition = mock(JobDefinition.class);
 
 		ourLogger.setLevel(Level.ERROR);
 
@@ -141,7 +162,10 @@ public class ReductionStepDataSinkTest {
 		when(myJobPersistence.fetchAllWorkChunksIterator(any(), anyBoolean())).thenReturn(Collections.emptyIterator());
 		stubUpdateInstanceCallback(instance);
 		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(instance));
-		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(instance)).thenReturn(jobDefinition);
+		@SuppressWarnings("rawtypes")
+		JobDefinition jobDefinitionUncast = jobDefinition;
+		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(instance)).thenReturn(jobDefinitionUncast);
+		when(myJobDefinitionRegistry.getJobDefinition(any(), anyInt())).thenReturn(Optional.of(jobDefinition));
 
 		// test
 		myDataSink.accept(firstData);
@@ -180,4 +204,9 @@ public class ReductionStepDataSinkTest {
 			fail("Unexpected exception", anyOtherEx);
 		}
 	}
+
+	public static class MyModel implements IModelJson {
+
+	}
+
 }

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSinkTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/ReductionStepDataSinkTest.java
@@ -48,7 +48,7 @@ public class ReductionStepDataSinkTest {
 	private static final String INSTANCE_ID = "instanceId";
 	private static final String JOB_DEFINITION_ID = "jobDefinitionId";
 
-	@Mock
+	@Mock(strictness = Mock.Strictness.STRICT_STUBS)
 	private JobDefinitionRegistry myJobDefinitionRegistry;
 
 	private JobDefinition<MyModel> jobDefinition;
@@ -138,7 +138,7 @@ public class ReductionStepDataSinkTest {
 		@SuppressWarnings("rawtypes")
 		JobDefinition jobDefinitionUncast = jobDefinition;
 		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(instance)).thenReturn(jobDefinitionUncast);
-		when(myJobDefinitionRegistry.getJobDefinition(any(), anyInt())).thenReturn(Optional.of(jobDefinition));
+		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(any(), anyInt())).thenReturn(jobDefinitionUncast);
 
 		// test
 		myDataSink.accept(chunkData);
@@ -165,7 +165,7 @@ public class ReductionStepDataSinkTest {
 		@SuppressWarnings("rawtypes")
 		JobDefinition jobDefinitionUncast = jobDefinition;
 		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(instance)).thenReturn(jobDefinitionUncast);
-		when(myJobDefinitionRegistry.getJobDefinition(any(), anyInt())).thenReturn(Optional.of(jobDefinition));
+		when(myJobDefinitionRegistry.getJobDefinitionOrThrowException(any(), anyInt())).thenReturn(jobDefinitionUncast);
 
 		// test
 		myDataSink.accept(firstData);

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/maintenance/JobMaintenanceServiceImplTest.java
@@ -404,8 +404,11 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	}
 
 	private void runEnqueueReadyChunksTest(List<WorkChunk> theChunks, JobDefinition<TestJobParameters> theJobDefinition) {
-		myJobDefinitionRegistry.addJobDefinition(theJobDefinition);
 		JobInstance instance = createInstance();
+		instance.setJobDefinitionId(theJobDefinition.getJobDefinitionId());
+
+		myJobDefinitionRegistry.addJobDefinition(theJobDefinition);
+
 		// we'll set the instance to the first step id
 		theChunks.stream().findFirst().ifPresent(c -> {
 			instance.setCurrentGatedStepId(c.getTargetStepId());
@@ -486,11 +489,13 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 	@Test
 	public void testMaintenancePass_whenUpdateFails_skipsWorkChunkAndLogs() {
 		// setup
+		JobDefinition<TestJobParameters> jobDefinition = createJobDefinitionWithReduction();
 		List<WorkChunk> chunks = List.of(
 			createWorkChunkStep2().setStatus(WorkChunkStatusEnum.READY),
 			createWorkChunkStep2().setStatus(WorkChunkStatusEnum.READY)
 		);
 		JobInstance instance = createInstance();
+		instance.setJobDefinitionId(jobDefinition.getJobDefinitionId());
 		instance.setCurrentGatedStepId(STEP_2);
 
 		myLogCapture.setLoggerLevel(Level.ERROR);
@@ -514,7 +519,7 @@ public class JobMaintenanceServiceImplTest extends BaseBatch2Test {
 
 
 		// test
-		runEnqueueReadyChunksTest(chunks, createJobDefinitionWithReduction());
+		runEnqueueReadyChunksTest(chunks, jobDefinition);
 
 		// verify
 		verify(myJobPersistence, times(2)).enqueueWorkChunkForProcessing(anyString(), any());

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculatorTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculatorTest.java
@@ -22,6 +22,8 @@ import jakarta.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -48,7 +50,7 @@ class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
 	@Mock
 	private IJobStepWorker<MyJsonModel, MyJsonModel, MyJsonModel> myIntermediateStep;
 	@Mock
-	private IReductionStepWorker<MyJsonModel, MyJsonModel, MyJsonModel> myFinalStep;
+	private IJobStepWorker<MyJsonModel, MyJsonModel, VoidModel> myLastStep;
 
 	@BeforeEach
 	void before() {
@@ -157,167 +159,45 @@ class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
 
 
 
-	@Test
-	void tesCalculateProgress_() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void tesCalculateProgress_WeightedStepWithNoChunksPassedToIt(boolean theGatedJob) {
 
 		JobDefinition<MyJsonModel> jobDefinition = JobDefinition.newBuilder()
 			.setJobDefinitionId("TEST_JOB")
 			.setJobDescription("Import Terminology - LOINC")
 			.setJobDefinitionVersion(1)
-			.gatedExecution()
+			.gatedExecution(theGatedJob)
 			.setParametersType(MyJsonModel.class)
 			.setParametersValidator(new MyJsonModelValidator())
 			.addFirstStep(
-				"expand-zip",
-				"Expand LOINC distribution",
+				STEP_1,
+				"Step 1",
 				MyJsonModel.class,
 				myFirstStep)
 			.addIntermediateStep(
-				"import-concepts",
+				STEP_2,
 				"Import LOINC concepts",
 				MyJsonModel.class,
 				myIntermediateStep)
-			.addIntermediateStep(
-				"import-hierarchy-concepts",
-				"Import LOINC hierarchy Concepts",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-hierarchy",
-				"Import LOINC hierarchy",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-answer-lists",
-				"Import LOINC answer lists",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-answer-list-links",
-				"Import LOINC answer list links",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-rsna-playbook",
-				"Import LOINC RSNA playbook",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-part-related-code-mapping",
-				"Import LOINC Part Related Code Mappings",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-document-ontology",
-				"Import LOINC Document Ontology",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-univeral-lab-orderset",
-				"Import LOINC Lab Order Set",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-ieee-medical-device-code",
-				"Import LOINC IEEE Medical Device Codes",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-imaging-document-code",
-				"Import LOINC Imaging Document Codes",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-group-file",
-				"Import LOINC Group File",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-group-terms-file",
-				"Import LOINC Group Terms File",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-parent-group-file",
-				"Import LOINC Parent Group File",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-part-file",
-				"Import LOINC Part File",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-part-link-file",
-				"Import LOINC Part Link File",
-				MyJsonModel.class,
-				myIntermediateStep)
-			// Part link file uses a large number of smaller files, so limit its weight
-			.setStepWeightForProgressCalculator("import-part-link-file", 0.1)
-			.addIntermediateStep(
-				"import-consumer-name",
-				"Import LOINC Consumer Names",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-coding-properties",
-				"Import LOINC Coding Properties",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"import-linguistic-variant",
-				"Import LOINC Linguistic Variants",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"chunk-concepts-for-closure-generation",
-				"Create work chunks for calculating concept closures",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.addIntermediateStep(
-				"generate-concept-closures",
-				"Generate concept closures",
-				MyJsonModel.class,
-				myIntermediateStep)
-			.setStepWeightForProgressCalculator("generate-concept-closures", 0.3)
-			.addFinalReducerStep(
-				"finalize-import",
-				"Finalize LOINC Import",
-				MyJsonModel.class,
-				myFinalStep)
-			.setStepWeightForProgressCalculator("finalize-import", 0.01)
+			.setStepWeightForProgressCalculator(STEP_2, 0.5)
+			.addLastStep(
+				STEP_3,
+				"Step 3",
+				myLastStep)
 			.build();
 		myJobDefinitionRegistry.addJobDefinition(jobDefinition);
 
 		JobInstance jobInstance = newJobInstance();
 		jobInstance.setJobDefinitionId(jobDefinition.getJobDefinitionId());
 		jobInstance.setJobDefinitionVersion(jobDefinition.getJobDefinitionVersion());
+		jobInstance.setCurrentGatedStepId(STEP_3);
 		mockFetchAndUpdateInstance(jobInstance);
 
+		// No chunks in step 2, and we're already in step 3
 		List<WorkChunk> chunks = new ArrayList<>();
-		chunks.addAll(createWorkChunks("chunk-concepts-for-closure-generation", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("expand-zip", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("finalize-import", 0, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("generate-concept-closures", 127, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-answer-list-links", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-answer-lists", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-coding-properties", 0, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-concepts", 110, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-consumer-name", 68, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-document-ontology", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-group-file", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-group-terms-file", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-hierarchy", 135, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-hierarchy-concepts", 135, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-ieee-medical-device-code", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-imaging-document-code", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-linguistic-variant", 0, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-parent-group-file", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-part-file", 2, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-part-link-file", 1900, WorkChunkStatusEnum.IN_PROGRESS));
-		chunks.addAll(createWorkChunks("import-part-link-file", 88, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-part-related-code-mapping", 1, WorkChunkStatusEnum.COMPLETED));
-		chunks.addAll(createWorkChunks("import-rsna-playbook", 1, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_1, 2, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_3, 2, WorkChunkStatusEnum.IN_PROGRESS));
 		chunks.addAll(createWorkChunks("import-univeral-lab-orderset", 1, WorkChunkStatusEnum.COMPLETED));
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
 
@@ -325,8 +205,11 @@ class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
 		mySvc.calculateAndStoreInstanceProgress(INSTANCE_ID);
 
 		// Verify
-		assertEquals(0.894, jobInstance.getProgress(), 0.001);
 
+		// 50% of progress is the second step which had a 0.5 weighting and is complete
+		// despite having no chunks. The other 50% is the other two steps, which have equal
+		// parts COMPLETE and IN_PROGRESS, so the total is 75%.
+		assertEquals(0.75, jobInstance.getProgress(), 0.001);
 
 	}
 	

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculatorTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculatorTest.java
@@ -1,0 +1,394 @@
+package ca.uhn.fhir.batch2.progress;
+
+import ca.uhn.fhir.batch2.api.IJobPersistence;
+import ca.uhn.fhir.batch2.api.IJobStepWorker;
+import ca.uhn.fhir.batch2.api.IReductionStepWorker;
+import ca.uhn.fhir.batch2.api.VoidModel;
+import ca.uhn.fhir.batch2.coordinator.BaseBatch2Test;
+import ca.uhn.fhir.batch2.coordinator.JobCoordinatorImplTest;
+import ca.uhn.fhir.batch2.coordinator.JobDefinitionRegistry;
+import ca.uhn.fhir.batch2.maintenance.JobChunkProgressAccumulator;
+import ca.uhn.fhir.batch2.model.JobDefinition;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.StatusEnum;
+import ca.uhn.fhir.batch2.model.WorkChunk;
+import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
+import ca.uhn.fhir.interceptor.api.IInterceptorService;
+import ca.uhn.fhir.interceptor.executor.InterceptorService;
+import ca.uhn.fhir.model.api.IModelJson;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
+
+	private JobInstanceProgressCalculator mySvc;
+	@Mock
+	private IJobPersistence myJobPersistence;
+	private JobChunkProgressAccumulator myProgressAccumulator = new JobChunkProgressAccumulator();
+	private JobDefinitionRegistry myJobDefinitionRegistry = new JobDefinitionRegistry();
+	private IInterceptorService myInterceptorSvc = new InterceptorService();
+	@Mock
+	private IJobStepWorker<MyJsonModel, VoidModel, MyJsonModel> myFirstStep;
+	@Mock
+	private IJobStepWorker<MyJsonModel, MyJsonModel, MyJsonModel> myIntermediateStep;
+	@Mock
+	private IReductionStepWorker<MyJsonModel, MyJsonModel, MyJsonModel> myFinalStep;
+
+	@BeforeEach
+	void before() {
+		mySvc = new JobInstanceProgressCalculator(myJobPersistence,
+			myProgressAccumulator,
+			myJobDefinitionRegistry,
+			myInterceptorSvc);
+	}
+
+	@Test
+	void testCalculateProgress_AllStepsEqualWeight() {
+		// Setup
+		myJobDefinitionRegistry.addJobDefinition(createJobDefinitionWithReduction());
+
+		JobInstance jobInstance = newJobInstance();
+
+		mockFetchAndUpdateInstance(jobInstance);
+		List<WorkChunk> chunks = new ArrayList<>();
+		chunks.addAll(createWorkChunks(STEP_1, 2, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_2, 1, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_2, 1, WorkChunkStatusEnum.IN_PROGRESS));
+		chunks.addAll(createWorkChunks(STEP_3, 2, WorkChunkStatusEnum.QUEUED));
+		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
+
+		// Test
+		mySvc.calculateAndStoreInstanceProgress(INSTANCE_ID);
+
+		// Verify
+		assertEquals(0.5, jobInstance.getProgress());
+	}
+
+	@Test
+	void testCalculateProgress_FinalStepHoldsMinimalWeight() {
+		// Setup
+		myJobDefinitionRegistry.addJobDefinition(createJobDefinitionWithReduction(
+			b -> b.setStepWeightForProgressCalculator(STEP_3, 0.01)
+		));
+
+		JobInstance jobInstance = newJobInstance();
+
+		mockFetchAndUpdateInstance(jobInstance);
+		List<WorkChunk> chunks = new ArrayList<>();
+		// Most of the weight is on these steps, 80% are done
+		chunks.addAll(createWorkChunks(STEP_1, 2, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_2, 6, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_2, 2, WorkChunkStatusEnum.IN_PROGRESS));
+		// Little weight on this step
+		chunks.addAll(createWorkChunks(STEP_3, 200, WorkChunkStatusEnum.QUEUED));
+		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
+
+		// Test
+		mySvc.calculateAndStoreInstanceProgress(INSTANCE_ID);
+
+		// Verify
+		assertEquals(0.792, jobInstance.getProgress(), 0.001);
+	}
+
+	@Test
+	void testCalculateProgress_MultipleStepsHaveMinimalWeight() {
+		// Setup
+		myJobDefinitionRegistry.addJobDefinition(createJobDefinitionWithReduction(
+			b -> b.setStepWeightForProgressCalculator(STEP_1, 0.01),
+			b -> b.setStepWeightForProgressCalculator(STEP_2, 0.01)
+		));
+
+		JobInstance jobInstance = newJobInstance();
+
+		mockFetchAndUpdateInstance(jobInstance);
+		List<WorkChunk> chunks = new ArrayList<>();
+		chunks.addAll(createWorkChunks(STEP_1, 5000, WorkChunkStatusEnum.QUEUED));
+		chunks.addAll(createWorkChunks(STEP_1, 50, WorkChunkStatusEnum.COMPLETED));
+		chunks.addAll(createWorkChunks(STEP_2, 5000, WorkChunkStatusEnum.IN_PROGRESS));
+		chunks.addAll(createWorkChunks(STEP_2, 50, WorkChunkStatusEnum.COMPLETED));
+		// Only this step has normal weight
+		chunks.addAll(createWorkChunks(STEP_3, 1, WorkChunkStatusEnum.IN_PROGRESS));
+		chunks.addAll(createWorkChunks(STEP_3, 1, WorkChunkStatusEnum.COMPLETED));
+		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
+
+		// Test
+		mySvc.calculateAndStoreInstanceProgress(INSTANCE_ID);
+
+		// Verify
+		assertEquals(0.49, jobInstance.getProgress(), 0.001);
+	}
+
+
+	@Test
+	void testCalculateProgress_NoChunks() {
+		// Setup
+		myJobDefinitionRegistry.addJobDefinition(createJobDefinitionWithReduction(
+			b -> b.setStepWeightForProgressCalculator(STEP_2, 0.01)
+		));
+
+		JobInstance jobInstance = newJobInstance();
+
+		mockFetchAndUpdateInstance(jobInstance);
+		List<WorkChunk> chunks = List.of();
+		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
+
+		// Test
+		mySvc.calculateAndStoreInstanceProgress(INSTANCE_ID);
+
+		// Verify
+		assertEquals(0.0, jobInstance.getProgress(), 0.001);
+	}
+
+
+
+	@Test
+	void testLoinc() {
+
+		JobDefinition<MyJsonModel> jobDefinition = JobDefinition.newBuilder()
+			.setInitialStatus(StatusEnum.BUILDING)
+			.setJobDefinitionId("JOB_ID_IMPORT_TERM_LOINC")
+			.setJobDescription("Import Terminology - LOINC")
+			.setJobDefinitionVersion(1)
+			.gatedExecution()
+			.setParametersType(MyJsonModel.class)
+			.setParametersValidator(new MyJsonModelValidator())
+			.addFirstStep(
+				"expand-zip",
+				"Expand LOINC distribution",
+				MyJsonModel.class,
+				myFirstStep)
+			.addIntermediateStep(
+				"import-concepts",
+				"Import LOINC concepts",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-hierarchy-concepts",
+				"Import LOINC hierarchy Concepts",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-hierarchy",
+				"Import LOINC hierarchy",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-answer-lists",
+				"Import LOINC answer lists",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-answer-list-links",
+				"Import LOINC answer list links",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-rsna-playbook",
+				"Import LOINC RSNA playbook",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-part-related-code-mapping",
+				"Import LOINC Part Related Code Mappings",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-document-ontology",
+				"Import LOINC Document Ontology",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-univeral-lab-orderset",
+				"Import LOINC Lab Order Set",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-ieee-medical-device-code",
+				"Import LOINC IEEE Medical Device Codes",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-imaging-document-code",
+				"Import LOINC Imaging Document Codes",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-group-file",
+				"Import LOINC Group File",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-group-terms-file",
+				"Import LOINC Group Terms File",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-parent-group-file",
+				"Import LOINC Parent Group File",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-part-file",
+				"Import LOINC Part File",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-part-link-file",
+				"Import LOINC Part Link File",
+				MyJsonModel.class,
+				myIntermediateStep)
+			// Part link file uses a large number of smaller files, so limit its weight
+			.setStepWeightForProgressCalculator("import-part-link-file", 0.1)
+			.addIntermediateStep(
+				"import-consumer-name",
+				"Import LOINC Consumer Names",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-coding-properties",
+				"Import LOINC Coding Properties",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"import-linguistic-variant",
+				"Import LOINC Linguistic Variants",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"chunk-concepts-for-closure-generation",
+				"Create work chunks for calculating concept closures",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.addIntermediateStep(
+				"generate-concept-closures",
+				"Generate concept closures",
+				MyJsonModel.class,
+				myIntermediateStep)
+			.setStepWeightForProgressCalculator("generate-concept-closures", 0.3)
+			.addFinalReducerStep(
+				"finalize-import",
+				"Finalize LOINC Import",
+				MyJsonModel.class,
+				myFinalStep)
+			.setStepWeightForProgressCalculator("finalize-import", 0.01)
+			.build();
+		myJobDefinitionRegistry.addJobDefinition(jobDefinition);
+
+		JobInstance jobInstance = newJobInstance();
+		jobInstance.setJobDefinitionId(jobDefinition.getJobDefinitionId());
+		jobInstance.setJobDefinitionVersion(jobDefinition.getJobDefinitionVersion());
+		mockFetchAndUpdateInstance(jobInstance);
+
+//		/*
+		List<WorkChunk> chunks = new ArrayList<>();
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("chunk-concepts-for-closure-generation", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("expand-zip", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 0
+		chunks.addAll(createWorkChunks("finalize-import", 0, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 127
+		chunks.addAll(createWorkChunks("generate-concept-closures", 127, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-answer-list-links", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-answer-lists", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 0
+		chunks.addAll(createWorkChunks("import-coding-properties", 0, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 110
+		chunks.addAll(createWorkChunks("import-concepts", 110, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 68
+		chunks.addAll(createWorkChunks("import-consumer-name", 68, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-document-ontology", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-group-file", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-group-terms-file", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 185
+		chunks.addAll(createWorkChunks("import-hierarchy", 135, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 185
+		chunks.addAll(createWorkChunks("import-hierarchy-concepts", 135, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-ieee-medical-device-code", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-imaging-document-code", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 0
+		chunks.addAll(createWorkChunks("import-linguistic-variant", 0, WorkChunkStatusEnum.COMPLETED));
+//		 *  Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-parent-group-file:", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 2
+		chunks.addAll(createWorkChunks("import-part-file", 2, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1988
+		chunks.addAll(createWorkChunks("import-part-link-file", 1900, WorkChunkStatusEnum.IN_PROGRESS));
+		chunks.addAll(createWorkChunks("import-part-link-file", 88, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-part-related-code-mapping", 1, WorkChunkStatusEnum.COMPLETED));
+//		 *  Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-rsna-playbook", 1, WorkChunkStatusEnum.COMPLETED));
+//		 * : Incomplete: 0, Complete: 1
+		chunks.addAll(createWorkChunks("import-univeral-lab-orderset", 1, WorkChunkStatusEnum.COMPLETED));
+//		 */
+		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
+
+		// Test
+		mySvc.calculateAndStoreInstanceProgress(INSTANCE_ID);
+
+		// Verify
+		assertEquals(0.894, jobInstance.getProgress(), 0.001);
+
+
+	}
+	
+
+
+	private void mockFetchAndUpdateInstance(JobInstance jobInstance) {
+		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(jobInstance));
+		when(myJobPersistence.updateInstance(eq(INSTANCE_ID), any())).thenAnswer(t -> t.getArgument(1, IJobPersistence.JobInstanceUpdateCallback.class).doUpdate(jobInstance));
+	}
+
+	private static List<WorkChunk> createWorkChunks(String theStepId, int theCount, WorkChunkStatusEnum theStatus) {
+		List<WorkChunk> retVal = new ArrayList<>();
+		for (int i = 0; i < theCount; i++) {
+			WorkChunk chunk = JobCoordinatorImplTest.createWorkChunk(theStepId, null);
+			chunk.setStatus(theStatus);
+			retVal.add(chunk);
+		}
+		return retVal;
+	}
+
+	@Nonnull
+	private static JobInstance newJobInstance() {
+		JobInstance jobInstance = new JobInstance();
+		jobInstance.setJobDefinitionId(REDUCTION_JOB_ID);
+		jobInstance.setJobDefinitionVersion(1);
+		return jobInstance;
+	}
+
+	private class MyJsonModel implements IModelJson {
+	}
+
+	private class MyJsonModelValidator implements ca.uhn.fhir.batch2.api.IJobParametersValidator<MyJsonModel> {
+		@Nullable
+		@Override
+		public List<String> validate(RequestDetails theRequestDetails, @Nonnull MyJsonModel theParameters) {
+			return List.of();
+		}
+	}
+}

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculatorTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/progress/JobInstanceProgressCalculatorTest.java
@@ -40,9 +40,9 @@ class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
 	private JobInstanceProgressCalculator mySvc;
 	@Mock
 	private IJobPersistence myJobPersistence;
-	private JobChunkProgressAccumulator myProgressAccumulator = new JobChunkProgressAccumulator();
-	private JobDefinitionRegistry myJobDefinitionRegistry = new JobDefinitionRegistry();
-	private IInterceptorService myInterceptorSvc = new InterceptorService();
+	private final JobChunkProgressAccumulator myProgressAccumulator = new JobChunkProgressAccumulator();
+	private final JobDefinitionRegistry myJobDefinitionRegistry = new JobDefinitionRegistry();
+	private final IInterceptorService myInterceptorSvc = new InterceptorService();
 	@Mock
 	private IJobStepWorker<MyJsonModel, VoidModel, MyJsonModel> myFirstStep;
 	@Mock
@@ -158,11 +158,10 @@ class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
 
 
 	@Test
-	void testLoinc() {
+	void tesCalculateProgress_() {
 
 		JobDefinition<MyJsonModel> jobDefinition = JobDefinition.newBuilder()
-			.setInitialStatus(StatusEnum.BUILDING)
-			.setJobDefinitionId("JOB_ID_IMPORT_TERM_LOINC")
+			.setJobDefinitionId("TEST_JOB")
 			.setJobDescription("Import Terminology - LOINC")
 			.setJobDefinitionVersion(1)
 			.gatedExecution()
@@ -295,56 +294,31 @@ class JobInstanceProgressCalculatorTest extends BaseBatch2Test {
 		jobInstance.setJobDefinitionVersion(jobDefinition.getJobDefinitionVersion());
 		mockFetchAndUpdateInstance(jobInstance);
 
-//		/*
 		List<WorkChunk> chunks = new ArrayList<>();
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("chunk-concepts-for-closure-generation", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("expand-zip", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 0
 		chunks.addAll(createWorkChunks("finalize-import", 0, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 127
 		chunks.addAll(createWorkChunks("generate-concept-closures", 127, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-answer-list-links", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-answer-lists", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 0
 		chunks.addAll(createWorkChunks("import-coding-properties", 0, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 110
 		chunks.addAll(createWorkChunks("import-concepts", 110, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 68
 		chunks.addAll(createWorkChunks("import-consumer-name", 68, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-document-ontology", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-group-file", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-group-terms-file", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 185
 		chunks.addAll(createWorkChunks("import-hierarchy", 135, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 185
 		chunks.addAll(createWorkChunks("import-hierarchy-concepts", 135, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-ieee-medical-device-code", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-imaging-document-code", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 0
 		chunks.addAll(createWorkChunks("import-linguistic-variant", 0, WorkChunkStatusEnum.COMPLETED));
-//		 *  Incomplete: 0, Complete: 1
-		chunks.addAll(createWorkChunks("import-parent-group-file:", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 2
+		chunks.addAll(createWorkChunks("import-parent-group-file", 1, WorkChunkStatusEnum.COMPLETED));
 		chunks.addAll(createWorkChunks("import-part-file", 2, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1988
 		chunks.addAll(createWorkChunks("import-part-link-file", 1900, WorkChunkStatusEnum.IN_PROGRESS));
 		chunks.addAll(createWorkChunks("import-part-link-file", 88, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-part-related-code-mapping", 1, WorkChunkStatusEnum.COMPLETED));
-//		 *  Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-rsna-playbook", 1, WorkChunkStatusEnum.COMPLETED));
-//		 * : Incomplete: 0, Complete: 1
 		chunks.addAll(createWorkChunks("import-univeral-lab-orderset", 1, WorkChunkStatusEnum.COMPLETED));
-//		 */
 		when(myJobPersistence.fetchAllWorkChunksIterator(eq(INSTANCE_ID), eq(false))).thenReturn(chunks.iterator());
 
 		// Test

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/Counter.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/Counter.java
@@ -17,11 +17,15 @@
  * limitations under the License.
  * #L%
  */
-package ca.uhn.fhir.jpa.util;
+package ca.uhn.fhir.util;
 
 public class Counter {
 
 	private long myCount;
+
+	public long get() {
+		return myCount;
+	}
 
 	public long getThenAdd() {
 		return myCount++;

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/IntCounter.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/util/IntCounter.java
@@ -19,15 +19,15 @@
  */
 package ca.uhn.fhir.util;
 
-public class Counter {
+public class IntCounter {
 
-	private long myCount;
+	private int myCount;
 
-	public long get() {
+	public int get() {
 		return myCount;
 	}
 
-	public long getThenAdd() {
-		return myCount++;
+	public void increment() {
+		myCount++;
 	}
 }


### PR DESCRIPTION
The mechanism for calculating Batch2 job progress has been improved to allow specific steps in the job to have different weights in the overall progress calculation. This allows jobs with unbalanced effort levels between steps to have more accurate progress returned to the user.