### PR TITLE
fix: handle boolean property type in DSTU3 remote terminology lookup (#6662)

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -360,6 +360,10 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 				org.hl7.fhir.dstu3.model.StringType stringType = (org.hl7.fhir.dstu3.model.StringType) theValue;
 				conceptProperty = new StringConceptProperty(theName, stringType.getValue());
 				break;
+			case IValidationSupport.TYPE_BOOLEAN:
+				org.hl7.fhir.dstu3.model.BooleanType booleanType = (org.hl7.fhir.dstu3.model.BooleanType) theValue;
+				conceptProperty = new BooleanConceptProperty(theName, booleanType.getValue());
+				break;
 			case IValidationSupport.TYPE_CODING:
 				org.hl7.fhir.dstu3.model.Coding coding = (org.hl7.fhir.dstu3.model.Coding) theValue;
 				conceptProperty =


### PR DESCRIPTION
## Summary

Fixes #6662 — boolean values from CodeSystem `$lookup` via Remote Terminology are returned as `valueString: "BooleanType[true]"` instead of `valueBoolean: true`.

## Root Cause

The DSTU3 `createConceptPropertyDstu3` method in `RemoteTerminologyServiceValidationSupport` was missing a `case` for `TYPE_BOOLEAN`. When a boolean property value came through the DSTU3 path, it fell through to the `default` case which called `theValue.toString()`, producing a `StringConceptProperty` with value `"BooleanType[true]"` instead of a proper `BooleanConceptProperty`.

The R4 `createConceptPropertyR4` method already handled this correctly (lines 508–511). The DSTU3 method was simply missing the equivalent case.

## Fix

Added the `TYPE_BOOLEAN` case to the DSTU3 `createConceptPropertyDstu3` switch statement, following the exact same pattern as the R4 version:

```java
case IValidationSupport.TYPE_BOOLEAN:
    org.hl7.fhir.dstu3.model.BooleanType booleanType = (org.hl7.fhir.dstu3.model.BooleanType) theValue;
    conceptProperty = new BooleanConceptProperty(theName, booleanType.getValue());
    break;
```

## Before / After

**Before (DSTU3):**
```json
{ "name": "value", "valueString": "BooleanType[true]" }
```

**After (DSTU3):**
```json
{ "name": "value", "valueBoolean": true }
```

## Verification

- The existing DSTU3 test `RemoteTerminologyLookupCodeDstu3Test.getPropertyValueArguments()` already includes `new BooleanType(true)` as a test case (line 103). With this fix, the boolean value will now be correctly round-tripped as a `BooleanConceptProperty` through the DSTU3 remote terminology flow.
- The fix is structurally identical to the already-working R4 implementation.
- No new dependencies or imports required — `org.hl7.fhir.dstu3.model.BooleanType` is already available in the DSTU3 structures module.

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
