### PR TITLE
Fix Integer Overflow When Calculating Max Search Results

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8088-fix-integer-overflow-in-max-results-calc.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8088-fix-integer-overflow-in-max-results-calc.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 8088
+title: "Fix the issue where an Integer overflow can occur when calcuating max search results for a very large resultset."


### PR DESCRIPTION
Closes #8088. See that issue for a detailed description of the problem.

### Root cause analysis

All quotes below are verbatim from the `v8.6.6` git tag. Three unguarded call-site candidates in the JPA search code (the *sinks* where the negative int hits Hibernate; the *source* of the negative value is the budget decrement just described):

**1. `SearchCoordinatorSvcImpl.getSynchronousMaxResultsToFetch()`**

```java
// hapi-fhir-jpaserver-base/.../SearchCoordinatorSvcImpl.java  (v8.6.6)
private Integer getSynchronousMaxResultsToFetch(
        SearchParameterMap theParams, Integer theLoadSynchronousUpTo) {
    if (theLoadSynchronousUpTo != null) {
        return theLoadSynchronousUpTo;
    }
    if (theParams.getCount() != null) {
        int valToReturn = theParams.getCount() + 1;       // ← (a) int +1
        if (theParams.getOffset() != null) {
            valToReturn += theParams.getOffset();          // ← (b) int +=
        }
        return valToReturn;
    }
    if (myStorageSettings.getFetchSizeDefaultMaximum() != null) {
        return myStorageSettings.getFetchSizeDefaultMaximum();
    }
    return myStorageSettings.getInternalSynchronousSearchSize();
}
```

Returns `int`, no clamp. Safe on its own with normal inputs, but the value flows downstream into the include-loading paths where it may be combined with further multipliers.

**2. `SearchBuilder.loadIncludes()` and `loadIncludesMatchAll()`**

```java
// hapi-fhir-jpaserver-base/.../SearchBuilder.java  (v8.6.6, line ~2485 / ~2475)
if (maxCount != null) {
    q.setMaxResults(maxCount);                            // ← Hibernate throws here
}
```

`maxCount` is the `Integer` argument supplied by the upstream caller. No null/negative check before `setMaxResults(int)`.

**3. `SearchBuilder.loadIncludesMatchSpecific()` — additional sink in 8.x**

```java
// hapi-fhir-jpaserver-base/.../SearchBuilder.java  (v8.6.6, line ~2286)
if (maxCount != null) {
    LinkedList<Object> bindVariables = new LinkedList<>();
    sql = SearchQueryBuilder.applyLimitToSql(
        myDialectProvider.getDialect(), null, maxCount, sql, null, bindVariables);
    // ...
}
```

`SearchQueryBuilder.applyLimitToSql(...)` takes the same `maxCount` and bakes it into a dialect-specific `LIMIT` / `TOP` clause. The SQL traces confirm this is the call site that produces the visible `TOP (1000)` → `TOP (997)` decrement pattern in 8.6.6. A negative `maxCount` here is what triggers the failure.

**Where the budget arithmetic actually lives:**

The decrementing is in the caller orchestration of `loadIncludesMatchSpecific` / `loadIncludesMatchAll` — i.e. wherever `theMaxCount` is computed before being passed in. From source inspection it appears to be in `SearchBuilder.loadIncludes()` itself or the `IncludesIterator`-style helpers it delegates to, where running totals are subtracted from the initial budget. The exact line needs git-log bisection from the budget-introduction commit (some HAPI 8.0.0-era refactor) — I haven't pinpointed it yet; that's a collaboration target for the PR. The fix proposal below is sink-defensive and works regardless of which arithmetic line produces the negative.

### Proposed fix

**Minimum-viable patch (low risk):** Clamp `maxCount` immediately before every sink that consumes it — `setMaxResults(int)` and `applyLimitToSql(int)`. Three call sites in `SearchBuilder.java` and the arithmetic in `SearchCoordinatorSvcImpl.getSynchronousMaxResultsToFetch()`:

```java
// before — any of the three sinks
if (maxCount != null) {
    q.setMaxResults(maxCount);              // negative wraps in
}

// after — defensive clamp at the sink
if (maxCount != null) {
    int clamped = (maxCount < 0) ? Integer.MAX_VALUE : maxCount;
    q.setMaxResults(clamped);
}
```

And in `SearchCoordinatorSvcImpl.getSynchronousMaxResultsToFetch()`, promote the arithmetic to `long` so the value passed onward can't go negative in the first place:

```java
// after
if (theParams.getCount() != null) {
    long valToReturn = (long) theParams.getCount() + 1L;
    if (theParams.getOffset() != null) {
        valToReturn += theParams.getOffset();
    }
    return (int) Math.min(valToReturn, Integer.MAX_VALUE);
}
```

The two together stop the negative value from reaching Hibernate regardless of which failure mode is in play (initial-multiplication overflow OR budget-decrement-past-zero).

**Patch for the budget-decrement mode specifically:** Wherever the running budget is subtracted from, clamp at zero before passing onward:

```java
// before
int remainingBudget = initialBudget - alreadyFoundCount;
loadIncludesMatchSpecific(..., remainingBudget, ...);

// after
int remainingBudget = Math.max(0, initialBudget - alreadyFoundCount);
if (remainingBudget == 0) {
    // budget exhausted — stop recursion gracefully rather than emitting more SQL
    break;
}
loadIncludesMatchSpecific(..., remainingBudget, ...);
```

`Math.max(0, ...)` is the minimum-invasive change; the `if (remainingBudget == 0) break;` is the semantic improvement that prevents emitting a pointless `LIMIT 0` query.

**Higher-quality patch:** Throw an `InvalidRequestException` with a HAPI-specific code if the computed multiplier exceeds a configured threshold, telling the client which include expansion was responsible:

```java
if (calculated > MAX_INCLUDE_EXPANSION_BUDGET) {
    throw new InvalidRequestException(
        Msg.code(####) + "Wildcard _include/_revinclude expansion ("
        + expandedIncludes.size() + " params, _count="
        + pageSize + ") would exceed server limits. Use explicit includes.");
}
```

This is the more user-friendly fix. The clamp alone is the minimal-disruption defensive layer.

### Test plan

Three tests, one per failure mode plus an end-to-end sanity check:

```java
// hapi-fhir-jpaserver-test-r4/.../IncludeExpansionOverflowTest.java

@Test
public void includeBudget_neverGoesNegativeAcrossRecursionPasses() {
    // GIVEN a deep, wide include graph: a Patient with many Observations,
    //   each with references to Performer + Specimen + Encounter, recursing back to Patient
    // AND a small initial budget (e.g. 10) that will be exhausted quickly
    populateDeepIncludeGraph(/* breadthPerLevel = */ 50, /* depth = */ 5);

    SearchParameterMap map = new SearchParameterMap();
    map.setCount(10);
    map.addInclude(IBaseResource.INCLUDE_ALL.asRecursive());

    // WHEN the search executes
    IBundleProvider results = myPatientDao.search(map);

    // THEN no IllegalArgumentException from Hibernate; bundle is bounded but returned
    assertDoesNotThrow(() -> results.getResources(0, 100));
    // AND no SQL with LIMIT 0 or LIMIT (negative) was emitted
    assertNoNegativeLimitInExecutedSql();
}

@Test
public void initialMaxResults_doesNotOverflowWithLargeCount() {
    // GIVEN _count near Integer.MAX_VALUE / declaredReferenceParamCount
    //   so that naive int multiplication would overflow
    SearchParameterMap map = new SearchParameterMap();
    map.setCount(Integer.MAX_VALUE / 4);
    map.addInclude(IBaseResource.INCLUDE_ALL.asRecursive());
    map.addRevInclude(IBaseResource.INCLUDE_ALL);

    // WHEN the search executes
    IBundleProvider results = myServiceRequestDao.search(map);

    // THEN no IllegalArgumentException; either bundle returned or InvalidRequestException
    assertDoesNotThrow(() -> results.getResources(0, 10));
}

@Test
public void applyLimitToSql_rejectsOrClampsNegativeMaxCount() {
    // Focused unit test against the clamp at the sink.
    // Sanity check that a negative maxCount never produces TOP (-N) / LIMIT -N
    // even if upstream code regresses.
    String sql = "SELECT * FROM HFJ_RES_LINK WHERE SRC_RESOURCE_ID = ?";
    String result = SearchQueryBuilder.applyLimitToSql(
        dialectMsSql, null, /* maxCount = */ -50, sql, null, new LinkedList<>());
    // Expect either: clamped to a positive (Integer.MAX_VALUE), or thrown
    assertThat(result).doesNotContain("-50");
    assertThat(result).doesNotMatch(".*\\bTOP\\s*\\(?-\\d+.*");
    assertThat(result).doesNotMatch(".*\\bLIMIT\\s+-\\d+.*");
}
```

The first test specifically targets the budget-decrement mode (the one supported by trace evidence); the second targets the multiplication-overflow mode; the third is a focused regression guard at the sink that's cheap to run and catches any future caller that regresses.

### Reproduction environment

- **HAPI FHIR 8.6.6** (primary, verified against the `v8.6.6` git tag)
- Postgres 17.6
- Smile CDR 2025.11.R06 (bundles HAPI 8.6.6)
- Hibernate Core 6.6.x

Cross-checked in HAPI **8.2.2** (Smile CDR 2025.05.R04, the maintainer's local sandbox) — same code pattern, same vulnerability.

### Next steps / collaboration

1. **Bisect to find the commit that introduced budget tracking** (no budget on 7.0.3 link walks; budget present on 8.6.6). This pins the regression window for the changelog.
2. **Pinpoint the exact decrementing line** in the include-orchestration code where the running budget goes negative.
3. Write the unit tests above against that line.
4. Submit the sink clamp + the budget `Math.max(0, ...)` + the user-friendly `InvalidRequestException` together (or split into separate PRs if reviewers prefer).
