### PR TITLE
Allow search operations to use custom IBundleProvider as return type

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8120-allow-ibundleprovider-subclass.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8120-allow-ibundleprovider-subclass.yaml
@@ -1,0 +1,6 @@
+---
+type: add
+issue: 8120
+title: "Plain providers implementing the `@Search` operation may now use a method
+  signature returning a subclass of `IBundleProvider` instead of needing to directly
+  return this type. Thanks to Bob van der Linden for the contribution!"

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
@@ -414,7 +414,7 @@ public abstract class BaseMethodBinding {
 		Class<?> returnTypeFromMethod = theMethod.getReturnType();
 		if (MethodOutcome.class.isAssignableFrom(returnTypeFromMethod)) {
 			// returns a method outcome
-		} else if (IBundleProvider.class.equals(returnTypeFromMethod)) {
+		} else if (IBundleProvider.class.isAssignableFrom(returnTypeFromMethod)) {
 			// returns a bundle provider
 		} else if (void.class.equals(returnTypeFromMethod)) {
 			// returns a bundle

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/method/SearchMethodBindingTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/method/SearchMethodBindingTest.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import com.google.common.collect.ImmutableMap;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -77,6 +78,13 @@ public class SearchMethodBindingTest {
 			mockSearchRequest(ImmutableMap.of("refChainBlacklist.goodChain", new String[]{"foo"})))).isEqualTo(MethodMatchEnum.EXACT);
 	}
 
+	@Test
+	public void searchMayReturnSimpleBundleProvider() throws NoSuchMethodException {
+		SearchMethodBinding binding = getBinding("returnsSimpleBundleProvider");
+
+		assertThat(binding).isNotNull();
+	}
+
 	private SearchMethodBinding getBinding(String name, Class<?>... parameters) throws NoSuchMethodException {
 		return new SearchMethodBinding(IBaseResource.class,
 			IBaseResource.class,
@@ -119,6 +127,11 @@ public class SearchMethodBindingTest {
 
 		@Search
 		public IBaseResource withChainBlacklist(@OptionalParam(name = "refChainBlacklist", chainWhitelist = "goodChain", chainBlacklist = "badChain") ReferenceParam param) {
+			return null;
+		}
+
+		@Search
+		public SimpleBundleProvider returnsSimpleBundleProvider() {
 			return null;
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -1016,6 +1016,10 @@
 			<name>Tanmay Darmorha</name>
 			<organization>Optum</organization>
 		</developer>
+		<developer>
+			<id>bobvanderlinden</id>
+			<name>Bob van der Linden</name>
+		</developer>
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Currently it is not possible to create a subclass of IBundleProvider and use that as the return type of a search operation. The return type has to be IBundleProvider. This could result in casting behavior in other places of the HAPI application.

In order to avoid casting, we can allow subclasses of IBundleProvider to be used as return type.

In our project, we have a IBundleProvider that holds additional information, like how the database is being queried. In places where we know the search operation beforehand, we would like to make use of the concrete return type instead of IBundleProvider without explicit casting.