### PR TITLE
Fix Consent composite search tuple correlation

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/QueryStack.java
@@ -67,6 +67,7 @@ import ca.uhn.fhir.jpa.util.FhirPathUtils;
 import ca.uhn.fhir.model.api.IQueryParameterAnd;
 import ca.uhn.fhir.model.api.IQueryParameterOr;
 import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.QualifiedParamList;
@@ -91,6 +92,7 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
+import ca.uhn.fhir.util.UrlUtil;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -588,6 +590,20 @@ public class QueryStack {
 					JpaParamUtil.resolveCompositeComponents(mySearchParamRegistry, theParamDef);
 			RuntimeSearchParam left = componentParams.get(0).getComponentParameter();
 			IQueryParameterType leftValue = cp.getLeftValue();
+			RuntimeSearchParam right = componentParams.get(1).getComponentParameter();
+			IQueryParameterType rightValue = cp.getRightValue();
+
+			Condition tokenDatePredicate = createPredicateTokenDateComposite(
+					theResourceName, left, leftValue, right, rightValue, theRequestPartitionId, theSqlBuilder);
+			if (tokenDatePredicate != null) {
+				if (orCondidtion == null) {
+					orCondidtion = toOrPredicate(tokenDatePredicate);
+				} else {
+					orCondidtion = toOrPredicate(orCondidtion, tokenDatePredicate);
+				}
+				continue;
+			}
+
 			Condition leftPredicate = createPredicateCompositePart(
 					theSourceJoinColumn,
 					theResourceName,
@@ -597,8 +613,6 @@ public class QueryStack {
 					theRequestPartitionId,
 					theSqlBuilder);
 
-			RuntimeSearchParam right = componentParams.get(1).getComponentParameter();
-			IQueryParameterType rightValue = cp.getRightValue();
 			Condition rightPredicate = createPredicateCompositePart(
 					theSourceJoinColumn,
 					theResourceName,
@@ -618,6 +632,56 @@ public class QueryStack {
 		}
 
 		return orCondidtion;
+	}
+
+	private Condition createPredicateTokenDateComposite(
+			String theResourceName,
+			RuntimeSearchParam theLeftParam,
+			IQueryParameterType theLeftValue,
+			RuntimeSearchParam theRightParam,
+			IQueryParameterType theRightValue,
+			RequestPartitionId theRequestPartitionId,
+			SearchQueryBuilder theSqlBuilder) {
+		if (theLeftParam.getParamType() == RestSearchParameterTypeEnum.TOKEN
+				&& theRightParam.getParamType() == RestSearchParameterTypeEnum.DATE
+				&& theRightValue instanceof DateParam rightDate) {
+			return createPredicateTokenDateComposite(
+					theResourceName, theLeftParam, theLeftValue, rightDate, theRequestPartitionId, theSqlBuilder);
+		}
+		if (theLeftParam.getParamType() == RestSearchParameterTypeEnum.DATE
+				&& theRightParam.getParamType() == RestSearchParameterTypeEnum.TOKEN
+				&& theLeftValue instanceof DateParam leftDate) {
+			return createPredicateTokenDateComposite(
+					theResourceName, theRightParam, theRightValue, leftDate, theRequestPartitionId, theSqlBuilder);
+		}
+		return null;
+	}
+
+	private Condition createPredicateTokenDateComposite(
+			String theResourceName,
+			RuntimeSearchParam theTokenParam,
+			IQueryParameterType theTokenValue,
+			DateParam theDateValue,
+			RequestPartitionId theRequestPartitionId,
+			SearchQueryBuilder theSqlBuilder) {
+		String tokenValue = theTokenValue.getValueAsQueryToken();
+		if (isBlank(tokenValue)
+				|| !tokenValue.contains("|")
+				|| tokenValue.startsWith("|")
+				|| tokenValue.endsWith("|")
+				|| theDateValue.getPrecision().ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+			return null;
+		}
+
+		String indexString = theResourceName + "?" + UrlUtil.escapeUrlParam(theTokenParam.getName()) + "="
+				+ UrlUtil.escapeUrlParam(tokenValue);
+		ComboNonUniqueSearchParameterPredicateBuilder predicateBuilder =
+				theSqlBuilder.addComboNonUniquePredicateBuilder();
+		Condition hashPredicate = predicateBuilder.createPredicateHashComplete(
+				theRequestPartitionId, Collections.singletonList(indexString));
+		Condition datePredicate = predicateBuilder.createPredicateDateParams(
+				Collections.singletonList(Collections.singletonList(theDateValue)));
+		return toAndPredicate(hashPredicate, datePredicate);
 	}
 
 	private Condition createPredicateCompositePart(

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -100,6 +100,7 @@ import javax.measure.unit.Unit;
 
 import static ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum.DATE;
 import static ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum.REFERENCE;
+import static ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum.TOKEN;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trim;
@@ -370,6 +371,81 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 					theRequestDetails, theResourceType, theParams, runtimeParam);
 			retVal.addAll(comboNonUniqueParams);
 		}
+		retVal.addAll(extractSearchParamComboNonUniqueForTokenDateCompositeParams(theResourceType, theParams));
+		return retVal;
+	}
+
+	private SearchParamSet<ResourceIndexedComboTokenNonUnique>
+			extractSearchParamComboNonUniqueForTokenDateCompositeParams(
+					String theResourceType, ResourceIndexedSearchParams theParams) {
+		SearchParamSet<ResourceIndexedComboTokenNonUnique> retVal = new SearchParamSet<>();
+
+		for (ResourceIndexedSearchParamComposite nextComposite : theParams.myCompositeParams) {
+			if (!isTokenDateComposite(nextComposite)) {
+				continue;
+			}
+
+			RuntimeSearchParam runtimeParam = mySearchParamRegistry.getActiveSearchParam(
+					theResourceType,
+					nextComposite.getSearchParamName(),
+					ISearchParamRegistry.SearchParamLookupContextEnum.INDEX);
+			if (runtimeParam == null) {
+				continue;
+			}
+
+			ResourceIndexedSearchParamComposite.Component tokenComponent = nextComposite.getComponents().stream()
+					.filter(t -> t.getSearchParameterType() == TOKEN)
+					.findFirst()
+					.orElseThrow();
+			ResourceIndexedSearchParamComposite.Component dateComponent = nextComposite.getComponents().stream()
+					.filter(t -> t.getSearchParameterType() == DATE)
+					.findFirst()
+					.orElseThrow();
+
+			List<List<String>> tokenChoices = new ArrayList<>();
+			tokenChoices.add(extractTokenDateCompositeTokenChoices(tokenComponent));
+			Set<String> indexStrings =
+					ResourceIndexedSearchParams.extractCompositeStringUniquesValueChains(theResourceType, tokenChoices);
+
+			for (BaseResourceIndexedSearchParam nextDateParam : dateComponent.getParamIndexValues()) {
+				if (nextDateParam instanceof ResourceIndexedSearchParamDate dateParam) {
+					retVal.addAll(convertQueryStringsToNonUniqueIndexEntities(runtimeParam, indexStrings, dateParam));
+				}
+			}
+		}
+
+		return retVal;
+	}
+
+	private boolean isTokenDateComposite(ResourceIndexedSearchParamComposite theComposite) {
+		if (theComposite.getComponents().size() != 2) {
+			return false;
+		}
+
+		long tokenCount = theComposite.getComponents().stream()
+				.filter(t -> t.getSearchParameterType() == TOKEN)
+				.count();
+		long dateCount = theComposite.getComponents().stream()
+				.filter(t -> t.getSearchParameterType() == DATE)
+				.count();
+		return tokenCount == 1 && dateCount == 1;
+	}
+
+	private List<String> extractTokenDateCompositeTokenChoices(
+			ResourceIndexedSearchParamComposite.Component theTokenComponent) {
+		List<String> retVal = new ArrayList<>();
+		String paramName = UrlUtil.escapeUrlParam(theTokenComponent.getSearchParamName());
+
+		for (BaseResourceIndexedSearchParam nextParam : theTokenComponent.getParamIndexValues()) {
+			if (!(nextParam instanceof ResourceIndexedSearchParamToken)) {
+				continue;
+			}
+			String paramValue = nextParam.toQueryParameterType().getValueAsQueryToken();
+			if (isNotBlank(paramValue)) {
+				retVal.add(paramName + "=" + UrlUtil.escapeUrlParam(paramValue));
+			}
+		}
+
 		return retVal;
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchCustomSearchParamTest.java
@@ -39,6 +39,7 @@ import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Consent;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.DecimalType;
@@ -52,6 +53,7 @@ import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.MessageHeader;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.PractitionerRole;
 import org.hl7.fhir.r4.model.Reference;
@@ -375,6 +377,66 @@ public class FhirResourceDaoR4SearchCustomSearchParamTest extends BaseJpaR4Test 
 		// Ensure that no exceptions are thrown
 		mySearchParameterDao.create(fooSp, mySrd);
 		mySearchParamRegistry.forceRefresh();
+	}
+
+	@Test
+	public void testCompositeParamOnNestedConsentProvisionDoesNotMatchAcrossRepeatedChildren() {
+		String codeSystem = "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3";
+		String codeSearchParamUrl = "http://example.org/SearchParameter/consent-provision-code";
+		String periodSearchParamUrl = "http://example.org/SearchParameter/consent-provision-period";
+
+		SearchParameter codeSp = new SearchParameter();
+		codeSp.setId("consent-provision-code");
+		codeSp.setUrl(codeSearchParamUrl);
+		codeSp.setCode("mii-provision-provision-code");
+		codeSp.addBase("Consent");
+		codeSp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		codeSp.setType(Enumerations.SearchParamType.TOKEN);
+		codeSp.setExpression("Consent.provision.provision.code");
+		mySearchParameterDao.update(codeSp, mySrd);
+
+		SearchParameter periodSp = new SearchParameter();
+		periodSp.setId("consent-provision-period");
+		periodSp.setUrl(periodSearchParamUrl);
+		periodSp.setCode("mii-provision-provision-period");
+		periodSp.addBase("Consent");
+		periodSp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		periodSp.setType(Enumerations.SearchParamType.DATE);
+		periodSp.setExpression("Consent.provision.provision.period");
+		mySearchParameterDao.update(periodSp, mySrd);
+
+		SearchParameter compositeSp = new SearchParameter();
+		compositeSp.setId("consent-provision-code-period");
+		compositeSp.setUrl("http://example.org/SearchParameter/consent-provision-code-period");
+		compositeSp.setCode("mii-provision-provision-code-period");
+		compositeSp.addBase("Consent");
+		compositeSp.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		compositeSp.setType(Enumerations.SearchParamType.COMPOSITE);
+		compositeSp.setExpression("Consent.provision.provision");
+		compositeSp.addComponent().setDefinition(codeSearchParamUrl).setExpression("code");
+		compositeSp.addComponent().setDefinition(periodSearchParamUrl).setExpression("period");
+		mySearchParameterDao.update(compositeSp, mySrd);
+		mySearchParamRegistry.forceRefresh();
+
+		Consent consent = new Consent();
+		consent.setId("CONSENT-8126");
+		consent.setStatus(Consent.ConsentState.ACTIVE);
+		consent.getProvision()
+			.addProvision()
+			.addCode(new CodeableConcept(new Coding(codeSystem, "2.16.840.1.113883.3.1937.777.24.5.3.7", null)))
+			.setPeriod(new Period().setEndElement(new DateTimeType("2054-06-01")));
+		consent.getProvision()
+			.addProvision()
+			.addCode(new CodeableConcept(new Coding(codeSystem, "2.16.840.1.113883.3.1937.777.24.5.3.20", null)))
+			.setPeriod(new Period().setEndElement(new DateTimeType("2053-06-01")));
+		myConsentDao.update(consent, mySrd);
+
+		assertThat(myTestDaoSearch.searchForIds("Consent?mii-provision-provision-code-period="
+				+ codeSystem + "|2.16.840.1.113883.3.1937.777.24.5.3.7$ge2054-01-01"))
+			.containsExactly("CONSENT-8126");
+		assertThat(myTestDaoSearch.searchForIds("Consent?mii-provision-provision-code-period="
+				+ codeSystem + "|2.16.840.1.113883.3.1937.777.24.5.3.20$ge2054-01-01"))
+			.isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #8126.

This updates SQL-backed composite search handling for token/date composite SearchParameters so matches remain correlated to the same extracted composite tuple. The regression case is a `Consent` resource with two nested `provision.provision` entries where the token component matches one child and the date component matches another child.

## Root cause

Composite extraction already preserves tuple boundaries with one `ResourceIndexedSearchParamComposite` per composite expression element. The SQL query path did not use that tuple-scoped data. It expanded composite searches into independent component predicates and combined them with `AND`, which allowed values from different repeated child elements to satisfy one composite search.

## Changes

- Add a regression test for a custom Consent token/date composite SearchParameter over `Consent.provision.provision`.
- Populate tuple-scoped non-unique combo index rows for token/date composites from the existing composite extraction output.
- Use those tuple-scoped combo rows for fully-qualified token plus day-or-coarser date composite SQL searches.
- Preserve the existing generic component-predicate fallback for other composite shapes and broader token/date searches.

## Validation

- `git diff --check`
- Targeted regression test with Java 21:

```bash
mvn -pl hapi-fhir-jpaserver-test-r4 -am -Dtest=FhirResourceDaoR4SearchCustomSearchParamTest#testCompositeParamOnNestedConsentProvisionDoesNotMatchAcrossRepeatedChildren -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Djacoco.skip=true test
```

Result: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`; reactor `BUILD SUCCESS`.

## Note

Because this adds new tuple-scoped index material for token/date composites, existing stored resources need reindexing before they can benefit from the stricter SQL path.
