### PR TITLE
Fix nightly SNAPSHOT central-publish job getting force-cancelled mid-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3339,6 +3339,8 @@
 							<publishingServerId>central</publishingServerId>
 							<autoPublish>true</autoPublish>
 							<waitUntil>uploaded</waitUntil>
+							<waitMaxTime>1800</waitMaxTime>
+							<waitPollingInterval>10</waitPollingInterval>
 							<excludeArtifacts>
 								<excludeArtifact>hapi-fhir-base-test-jaxrsserver-kotlin</excludeArtifact>
 								<excludeArtifact>hapi-fhir-jpaserver-uhnfhirtest</excludeArtifact>

--- a/snapshot-deploy-job.yml
+++ b/snapshot-deploy-job.yml
@@ -3,6 +3,7 @@
 
 jobs:
   - job: DeploySnapshot
+    timeoutInMinutes: 90
 
     # We'll run the process on the latest version of ubuntu because they tend to be the fastest
     pool:


### PR DESCRIPTION
…upload

Azure's default 60-minute job timeout was racing the central-publishing plugin's own 30-minute waitMaxTime, force-killing the job before the plugin could report a real timeout error. Set an explicit 90-minute job timeout (matching snapshot-release-pipeline.yml's convention) and make waitMaxTime/waitPollingInterval explicit in the central-repo profile instead of relying on plugin defaults.