### PR TITLE
Pin hapi-fhir-typescript to Node 16.20.2 (stopgap)

### DIFF
--- a/hapi-fhir-typescript/pom.xml
+++ b/hapi-fhir-typescript/pom.xml
@@ -26,7 +26,11 @@
 
 		<ts.npm.package.name>@smile-cdr/fhirts</ts.npm.package.name>
 		<ts.typescript.version>^5.4.0</ts.typescript.version>
-		<ts.node.version>v24.18.0</ts.node.version>
+		<!-- Pinned to the last Node 16 LTS release as a stopgap: the CDR CI compile-check runner
+		     (hdp-ci-maven, Amazon Linux 2, glibc 2.26) can't execute Node 18+ prebuilt binaries,
+		     which require glibc >= 2.28. Bump this once that runner's base image is upgraded. -->
+		<!-- TODO JM-GGG Temp fix until runner's base image is upgraded -->
+		<ts.node.version>v16.20.2</ts.node.version>
 		<ts.npm.install.args>install --no-audit --no-fund</ts.npm.install.args>
 		<ts.npm.publish.args>publish --access public</ts.npm.publish.args>
 		<ts.npm.workdir>${project.build.directory}/npm</ts.npm.workdir>


### PR DESCRIPTION
## Summary

The CDR "Compile against CDR" check has been failing on every PR since `hapi-fhir-typescript` was introduced (#8118) because the module pins Node `v24.18.0`, and CDR's CI runner (`hdp-ci-maven`, Amazon Linux 2, glibc 2.26) can't execute Node 18+ prebuilt binaries, which require glibc >= 2.28. `npm install` fails immediately because Node itself can't start:

```
node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by node)
```

## Fix

Pin `ts.node.version` to `v16.20.2`, the last Node 16 LTS release, which runs fine on glibc 2.26.

This is a **stopgap**. The real fix is upgrading the CI runner's base image. Amazon Linux 2 itself reached end-of-support on 2026-06-30. Bump this pin once that lands.

## Test plan

- [x] Verified locally against the actual `registry.gitlab.com/simpatico.ai/cdr/hdp-ci-maven:3.9-amazoncorretto-21` image via Docker, using the exact CI invocation (`mvn --batch-mode --errors clean install -q -P DIST -Dmaven.test.skip`) - `BUILD SUCCESS`.
- [x] Confirmed Node `v18.20.4` reproduces the exact glibc error seen in CI on that same image; `v16.20.2` does not.