### PR TITLE
Patient-ID partition mode: transaction conditional update by identifier should not duplicate

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8152-patient-id-partition-conditional-update-no-body-id.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8152-patient-id-partition-conditional-update-no-body-id.yaml
@@ -1,0 +1,5 @@
+---
+type: add
+issue: 8152
+title: "In Patient ID partition mode, transaction conditional updates for existing Patients are now supported when the
+  underlying storage supports an all-partition search."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -763,7 +763,12 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 						next.myResourceDefinition.getName(),
 						next.myMatchUrlSearchMap,
 						next.getAssociatedResource());
-				if (partition.isAllPartitions()) {
+				if (partition.isAllPartitions() && !myPartitionSettings.isAllPartitionSearchSupported()) {
+					// I couldn't determine from the history why allPartitions
+					// was originally defaulted to the outer/transaction partition; it may have been because
+					// all-partition search was not supported. Now that isAllPartitionSearchSupported() makes that
+					// explicit, we only apply this fallback when all-partition search is unsupported. Otherwise, we
+					// keep allPartitions so the pre-fetch can search across all partitions.
 					partition = theOuterRequestPartitionId;
 				}
 			}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.provider.ProviderConstants;
@@ -1086,6 +1087,52 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 					"HAPI-1326: Resource of type Observation has no values placing it in the Patient compartment",
 					e.getMessage());
 		}
+	}
+
+	@Test
+	void testTransaction_ConditionalUpdatePatientByIdentifier_differentBodyId_rejectedWith2279_noDuplicate() {
+		myPartitionSettings.setAllPartitionSearchSupported(true);
+
+		createPatient(withId("A"), withIdentifier("http://acme.org/mrn", "PT00062"), withActiveTrue());
+
+		Patient update = new Patient();
+		update.setId("B");
+		update.addIdentifier().setSystem("http://acme.org/mrn").setValue("PT00062");
+		update.setActive(false);
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionUpdateEntry(update).conditional("Patient?identifier=http://acme.org/mrn|PT00062");
+
+		assertThatThrownBy(() -> mySystemDao.transaction(mySrd, bb.getBundleTyped()))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessage(
+				"HAPI-2279: Failed to UPDATE resource with match URL \"Patient?identifier=http://acme.org/mrn|PT00062\" because the matching resource does not match the provided ID");
+
+		// Only the original Patient A carries the MRN — no duplicate was created.
+		assertThat(myTestDaoSearch.searchForIds("Patient?identifier=http://acme.org/mrn|PT00062"))
+			.containsExactly("A");
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void testTransaction_ConditionalUpdatePatientByIdentifier_updatesInPlace(boolean theBodyCarriesMatchingId) {
+		myPartitionSettings.setAllPartitionSearchSupported(true);
+
+		createPatient(withId("A"), withIdentifier("http://acme.org/mrn", "PT00062"), withActiveTrue());
+
+		Patient update = new Patient();
+		if (theBodyCarriesMatchingId) {
+			update.setId("A");
+		}
+		update.addIdentifier().setSystem("http://acme.org/mrn").setValue("PT00062");
+		update.setActive(false);
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionUpdateEntry(update).conditional("Patient?identifier=http://acme.org/mrn|PT00062");
+
+		mySystemDao.transaction(mySrd, bb.getBundleTyped());
+
+		assertThat(myTestDaoSearch.searchForIds("Patient?identifier=http://acme.org/mrn|PT00062"))
+			.containsExactly("A");
+		assertThat(myPatientDao.read(new IdType("Patient/A"), mySrd).getActive()).isFalse();
 	}
 
 	@Test

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/BaseTransactionProcessor.java
@@ -1043,7 +1043,7 @@ public abstract class BaseTransactionProcessor {
 					IBaseResource resource = myVersionAdapter.getResource(theEntry);
 					String resourceType = myContext.getResourceType(resource);
 					nextWriteEntryRequestPartitionId = tryDetermineCreatePartitionForWriteEntryBeforePrefetch(
-							requestDetailsForEntry, resource, resourceType);
+							requestDetailsForEntry, resource, resourceType, url);
 					break;
 				}
 				case PUT: {
@@ -1060,7 +1060,7 @@ public abstract class BaseTransactionProcessor {
 						}
 						if (nextWriteEntryRequestPartitionId == null) {
 							nextWriteEntryRequestPartitionId = tryDetermineCreatePartitionForWriteEntryBeforePrefetch(
-									requestDetailsForEntry, resource, resourceType);
+									requestDetailsForEntry, resource, resourceType, url);
 							if (resourceId != null) {
 								theTransactionDetails.addResolvedPartition(
 										resourceId, nextWriteEntryRequestPartitionId);
@@ -1075,28 +1075,45 @@ public abstract class BaseTransactionProcessor {
 	}
 
 	/**
-	 * Determine the create partition for a transaction write entry, if possible. It may not be possible in
-	 * patient-ID partition mode: an entry whose Patient reference is an inline match URL (e.g.
-	 * {@code subject = "Patient?identifier=..."}) that pre-fetch hasn't resolved yet cannot be routed to a Patient
-	 * compartment. In that case, when all-partition search is supported
-	 * ({@link PartitionSettings#isAllPartitionSearchSupported()}) we return
-	 * {@link RequestPartitionId#allPartitions()} for now; the actual routing is determined later, per-entry at
-	 * write time, once pre-fetch has resolved the inline match URL. On infrastructure that cannot search across all
-	 * partitions, the partition must be determined before the transaction opens, so it cannot be deferred and the
-	 * rejection bubbles up.
+	 * Determine the create partition for a transaction write entry before pre-fetch, if possible. In patient-ID
+	 * partition mode the Patient compartment sometimes can't be resolved this early — an inline Patient match URL that
+	 * pre-fetch hasn't resolved yet (Msg 1326), or an id-less conditional-update Patient body (Msg 1321). When
+	 * all-partition search is supported ({@link PartitionSettings#isAllPartitionSearchSupported()}) we defer these to
+	 * {@link RequestPartitionId#allPartitions()} and let routing be settled per-entry at write time, once pre-fetch and
+	 * {@code PatientIdPartitionInterceptor}'s after-prefetch rewrite have resolved the match URL to a concrete Patient.
+	 * Where all-partition search is unsupported the partition must be fixed up front, so the rejection bubbles up
+	 * instead. The body comments spell out which codes and body shapes are deferred.
 	 * <p>
-	 * <b>Not a clean solution:</b> deferral is keyed off Msg 1326, an error code raised specifically by
-	 * {@code PatientIdPartitionInterceptor}, so the core transaction processor is coupled to an interceptor-specific
-	 * code. This is a pragmatic interim approach; a cleaner separation should be designed when time allows.
+	 * <b>Not a clean solution:</b> deferral is keyed off Msg 1321/1326, error codes raised specifically by
+	 * {@code PatientIdPartitionInterceptor}, so the core transaction processor is coupled to interceptor-specific
+	 * codes. This is a pragmatic interim approach; a cleaner separation should be designed when time allows.
+	 *
+	 * @param theEntryRequestUrl the entry's request URL; a conditional update is written via a match URL (contains
+	 *     {@code '?'})
 	 */
 	private RequestPartitionId tryDetermineCreatePartitionForWriteEntryBeforePrefetch(
-			RequestDetails theRequestDetails, IBaseResource theResource, String theResourceType) {
+			RequestDetails theRequestDetails,
+			IBaseResource theResource,
+			String theResourceType,
+			String theEntryRequestUrl) {
 		try {
 			return myRequestPartitionHelperService.determineCreatePartitionForRequest(
 					theRequestDetails, theResource, theResourceType);
 		} catch (MethodNotAllowedException e) {
-			// Msg 1326 is the patient-ID interceptor's "can't route to a compartment" signal (see javadoc).
-			if (myPartitionSettings.isAllPartitionSearchSupported() && messageStartsWith(e, Msg.code(1326))) {
+			if (!myPartitionSettings.isAllPartitionSearchSupported()) {
+				throw e;
+			}
+			// 1326: the entry's Patient compartment reference is not resolved before pre-fetch. Always deferrable.
+			if (messageStartsWith(e, Msg.code(1326))) {
+				return RequestPartitionId.allPartitions();
+			}
+			// 1321: a truly id-less Patient in a conditional update, whose identifier the after-prefetch rewrite might
+			// map to the existing Patient. Intentionally narrow, matching only an id-less body,
+			// and a more general fix is deferred to Tyner's broader fixes on patient id mode.
+			boolean conditionalUpdateOfIdlessPatient = isNotBlank(theEntryRequestUrl)
+					&& theEntryRequestUrl.indexOf('?') != -1
+					&& theResource.getIdElement().getIdPart() == null;
+			if (conditionalUpdateOfIdlessPatient && messageStartsWith(e, Msg.code(1321))) {
 				return RequestPartitionId.allPartitions();
 			}
 			throw e;
@@ -1562,7 +1579,7 @@ public abstract class BaseTransactionProcessor {
 							outcome = resourceDao.update(
 									res, null, false, false, requestDetailsForEntry, theTransactionDetails);
 						} else {
-							if (!shouldConditionalUpdateMatchId(theTransactionDetails, res.getIdElement())) {
+							if (!shouldConditionalUpdateMatchId(res.getIdElement())) {
 								res.setId((String) null);
 							}
 							String matchUrl;
@@ -1885,15 +1902,10 @@ public abstract class BaseTransactionProcessor {
 	/**
 	 * Check for if a resource id should be matched in a conditional update
 	 * If the FHIR version is older than R4, it follows the old specifications and does not match
-	 * If the resource id has been resolved, then it is an existing resource and does not need to be matched
 	 * If the resource id is local or a placeholder, the id is temporary and should not be matched
 	 */
-	private boolean shouldConditionalUpdateMatchId(TransactionDetails theTransactionDetails, IIdType theId) {
+	private boolean shouldConditionalUpdateMatchId(IIdType theId) {
 		if (myContext.getVersion().getVersion().isOlderThan(FhirVersionEnum.R4)) {
-			return false;
-		}
-		if (theTransactionDetails.hasResolvedResourceId(theId)
-				&& !theTransactionDetails.isResolvedResourceIdEmpty(theId)) {
 			return false;
 		}
 		if (theId != null && theId.getValue() != null) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -865,6 +865,7 @@ public class PatientIdPartitionInterceptor {
 	public void onTransactionWriteAfterPrefetch(
 			TransactionWriteAfterPrefetchDetails theDetails, TransactionDetails theTransactionDetails) {
 		rewriteInlinePatientMatchUrlReferences(theDetails.getEntries(), theTransactionDetails);
+		rewriteIdlessConditionalPatientUpdatesToDirect(theDetails.getEntries(), theTransactionDetails);
 	}
 
 	/**
@@ -925,19 +926,71 @@ public class PatientIdPartitionInterceptor {
 	 */
 	private void rewriteInlineMatchUrlReference(
 			IBaseReference theReference, String theReferenceValue, TransactionDetails theTransactionDetails) {
-		IResourcePersistentId<?> resolved =
-				theTransactionDetails.getResolvedMatchUrls().get(theReferenceValue);
-
 		// Act only on a match URL the pre-fetch resolved to a concrete Patient; otherwise leave the reference as is.
-		if (resolved == null || resolved == TransactionDetails.NOT_FOUND) {
-			return;
-		}
+		getPreFetchResolvedId(theReferenceValue, theTransactionDetails)
+				.ifPresent(resolvedId -> theReference.setReference(
+						resolvedId.toUnqualifiedVersionless().getValue()));
+	}
 
-		// Reuse the FHIR id the pre-fetch already resolved for this PID (TransactionDetails' reverse map)
-		// If the reverse map has no entry, leave the reference untouched.
-		IIdType resolvedId = theTransactionDetails.getReverseResolvedId(resolved);
-		if (resolvedId != null) {
-			theReference.setReference(resolvedId.toUnqualifiedVersionless().getValue());
+	/**
+	 * Returns the concrete FHIR id the pre-fetch resolved for the given match URL (via
+	 * {@link TransactionDetails#getResolvedMatchUrls()} and the reverse-id map), or empty if the URL was not
+	 * resolved to a single existing resource ({@link TransactionDetails#NOT_FOUND}, absent, or no reverse-mapped id).
+	 * No search is performed — we act only on what the pre-fetch put in the transaction details.
+	 */
+	private Optional<IIdType> getPreFetchResolvedId(String theMatchUrl, TransactionDetails theTransactionDetails) {
+		IResourcePersistentId<?> resolved =
+				theTransactionDetails.getResolvedMatchUrls().get(theMatchUrl);
+		if (resolved == null || resolved == TransactionDetails.NOT_FOUND) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(theTransactionDetails.getReverseResolvedId(resolved));
+	}
+
+	/**
+	 * Rewrites an id-less conditional-update Patient (e.g. {@code PUT Patient?identifier=http://acme.org/mrn|PT00062}
+	 * with no body id) into a direct {@code PUT Patient/<id>}, using the id the pre-fetch already resolved for the
+	 * conditional URL ({@link TransactionDetails#getResolvedMatchUrls()}). Without a body id the entry can't be routed
+	 * (a Patient's partition is {@code hash(<id>)}) and would fail with HAPI-1321; the direct URL lets the write route to
+	 * the existing Patient and update it in place instead of creating a duplicate.
+	 * <p>
+	 * Only a truly id-less body is rewritten. A body that already carries a client-assigned id is already routable and
+	 * handled by the normal conditional-update path.
+	 * <p>
+	 * An unmatched id-less conditional PUT ({@link TransactionDetails#NOT_FOUND} or absent) is left untouched and still
+	 * fails with HAPI-1321.
+	 */
+	private void rewriteIdlessConditionalPatientUpdatesToDirect(
+			List<IBase> theEntries, TransactionDetails theTransactionDetails) {
+		FhirTerser terser = myFhirContext.newTerser();
+		for (IBase entry : theEntries) {
+			String verb = terser.getSinglePrimitiveValueOrNull(entry, "request.method");
+			if (!"PUT".equals(verb)) {
+				continue;
+			}
+			String url = terser.getSinglePrimitiveValueOrNull(entry, "request.url");
+			if (!isPatientInlineMatchUrl(url)) {
+				continue;
+			}
+			IBaseResource resource = terser.getSingleValueOrNull(entry, "resource", IBaseResource.class);
+			if (resource == null || !PATIENT_STR.equals(myFhirContext.getResourceType(resource))) {
+				continue;
+			}
+			// Skip a body that already has an id — only a truly id-less body needs the rewrite (see method Javadoc).
+			if (resource.getIdElement().getIdPart() != null) {
+				continue;
+			}
+
+			Optional<IIdType> matchedId = getPreFetchResolvedId(url, theTransactionDetails);
+			if (matchedId.isEmpty()) {
+				continue;
+			}
+
+			// Convert the conditional PUT into a direct update by rewriting the request URL to the matched Patient id
+			// (verb stays PUT). We only rewrite the URL. The transaction processor's direct-update path then stamps
+			// the body id from that URL before the write, so the resource routes to the matched Patient.
+			String reference = matchedId.get().toUnqualifiedVersionless().getValue();
+			terser.setElement(entry, "request.url", reference);
 		}
 	}
 


### PR DESCRIPTION
Closes #8152.

In Patient-ID partition mode with an all-partition-search-capable backend, a transaction `PUT Patient?identifier=...` against an existing Patient either created a silent duplicate or failed with HAPI-1321, because the conditional match search was pinned to one write-derived partition instead of fanning out.

### Fixes

- **TransactionProcessor** — when all-partition search is supported, don't collapse an unresolvable conditional match search onto the outer write partition. Letting it fan out finds an existing Patient in another partition, so a mismatched body id now yields HAPI-2279 instead of a silent duplicate.
- **PatientIdPartitionInterceptor** — an id-less conditional PUT (`PUT Patient?identifier=X` with no body id) is rewritten after pre-fetch to a direct `PUT Patient/<id>` using the already-resolved match, so it updates the existing Patient instead of failing with HAPI-1321.
- **BaseTransactionProcessor.shouldConditionalUpdateMatchId** — no longer strips a *resolved* body id (placeholder ids still stripped), so a same-id conditional update stays routable and updates in place. See below.

### Why remove the resolved-id branch in `shouldConditionalUpdateMatchId`

This method decides whether to keep or strip the id carried on the resource **body** before a conditional update runs. The old code had a branch that stripped the body id whenever that id was already "resolved" during the transaction (checked via `TransactionDetails.hasResolvedResourceId`, keyed by the id's value). Once the TransactionProcessor fix above lets the conditional match search succeed, that branch breaks a **same-id** conditional update in Patient-ID partition mode. Consider `PUT Patient?identifier=X` whose body carries the existing Patient's own id `A`:

1. Pre-fetch resolves the identifier to the existing Patient `A` and registers `A` in the transaction's resolved-id set.
2. At write time, the branch checks the **body id** (`A`) against that set. Because `A` is now resolved, the check matches and the body id is **stripped** — the resource becomes id-less.
3. The write then determines the storage partition for that now id-less Patient. In Patient-ID partition mode the partition is `hash(id)`, which needs an id, so the request fails with **HAPI-1321** instead of updating Patient `A`.

Removing the branch keeps the matching body id, so the Patient stays routable and updates in place. Placeholder ids (`urn:` / `#`) are still stripped by the remaining check.

(The branch only ever affected the same-id case: it keys on the body id's own value, and only the matched id — not a *different* client-provided id — is in the resolved set. The different-body-id → HAPI-2279 behavior comes from the TransactionProcessor fix above, not from this branch.)




