### PR TITLE
Free host disk space before nightly SNAPSHOT deploy job

### DIFF
--- a/snapshot-deploy-job.yml
+++ b/snapshot-deploy-job.yml
@@ -25,6 +25,20 @@ jobs:
 
     steps:
 
+      # Microsoft-hosted images ship with a bunch of preinstalled SDKs we don't use (.NET, Android, Haskell)
+      # that eat into the free disk space on the VM. The WAR assembly step for hapi-fhir-jpaserver-uhnfhirtest
+      # has failed with "No space left on device" on this job before, so we clear that space up front.
+      # This runs with `target: host` because the rest of the job's steps execute inside the container
+      # defined above, but these preinstalled SDKs live on the host VM.
+      - bash: |
+          echo "Disk space before cleanup:"
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup || true
+          echo "Disk space after cleanup:"
+          df -h /
+        displayName: 'Free up host disk space before build'
+        target: host
+
       # We need a valid signing key to sign our builds for deployment to sonatype. We have uploaded
       # both our private and public keys to Azure as 'secure files' that we load into individual pipelines.
 


### PR DESCRIPTION
The WAR assembly step for hapi-fhir-jpaserver-uhnfhirtest has been failing with "No space left on device" on the Microsoft-hosted agent. Remove the preinstalled .NET/Android/Haskell SDKs the image ships with before the build starts to reclaim that space.