### PR TITLE
8035 backward compatibility of infer system param for R4 validation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8035-only-send-infer-system-for-r5-remote-terminology.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8035-only-send-infer-system-for-r5-remote-terminology.yaml
@@ -3,5 +3,5 @@ type: fix
 issue: 8035
 title: "The `inferSystem` parameter added to remote terminology `$validate-code` requests in 8.10.0 was
   sent for all FHIR versions, which broke strict R4-compliant remote terminology servers (e.g. VSAC, CMS) that
-  do not recognize it. This fix ensures that `inferSystem` being sent for R5 and newer FHIR contexts. 
+  do not recognize it. This fix ensures `inferSystem` is only sent for R5 and newer FHIR contexts.
   A new `setInferSystemEnabled` toggle on `RemoteTerminologyServiceValidationSupport` allows overriding this behavior."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8035-only-send-infer-system-for-r5-remote-terminology.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8035-only-send-infer-system-for-r5-remote-terminology.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 8035
+title: "The `inferSystem` parameter added to remote terminology `$validate-code` requests in 8.10.0 was
+  sent for all FHIR versions, which broke strict R4-compliant remote terminology servers (e.g. VSAC, CMS) that
+  do not recognize it. This fix ensures that `inferSystem` being sent for R5 and newer FHIR contexts. 
+  A new `setInferSystemEnabled` toggle on `RemoteTerminologyServiceValidationSupport` allows overriding this behavior."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8035-only-send-infer-system-for-r5-remote-terminology.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8035-only-send-infer-system-for-r5-remote-terminology.yaml
@@ -1,7 +1,7 @@
 ---
 type: fix
 issue: 8035
-title: "The `inferSystem` parameter added to remote terminology `$validate-code` requests in 8.10.0 was
-  sent for all FHIR versions, which broke strict R4-compliant remote terminology servers (e.g. VSAC, CMS) that
-  do not recognize it. This fix ensures `inferSystem` is only sent for R5 and newer FHIR contexts.
-  A new `setInferSystemEnabled` toggle on `RemoteTerminologyServiceValidationSupport` allows overriding this behavior."
+title: "The `inferSystem` parameter added to remote terminology `$validate-code` requests in 8.10.0 
+was sent for all FHIR versions, breaking strict R4 servers (e.g. VSAC, CMS) that reject it. It is 
+now sent only for R5+ contexts, restoring R4 compatibility. A new `setInferSystemEnabled` toggle on
+`RemoteTerminologyServiceValidationSupport` allows overriding this behavior."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/validation/validation_support_modules.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/validation/validation_support_modules.md
@@ -162,6 +162,12 @@ This module will invoke the following operations on the remote terminology serve
 * **POST [base]/CodeSystem/$validate-code** &ndash; Validate codes in fields where no specific ValueSet is bound 
 * **POST [base]/ValueSet/$validate-code** &ndash; Validate codes in fields where a specific ValueSet is bound 
 
+## Inferring the Code System
+
+When a code is validated but its system cannot be determined locally, this module can send the `inferSystem=true` parameter on `$validate-code` to ask the remote server to infer the system. Because `inferSystem` is an R5+ `$validate-code` parameter that strict R4/DSTU3 servers (e.g. VSAC, CMS) reject, it is only sent for R5 and newer FHIR contexts by default.
+
+Use `setInferSystemEnabled(Boolean)` to override this behavior: `null` (default) sends it only for R5+, `TRUE` always sends it (e.g. for an R4 server that does support it), and `FALSE` never sends it.
+
 # UnknownCodeSystemWarningValidationSupport
 
 [JavaDoc](/hapi-fhir/apidocs/hapi-fhir-validation/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.html) / [Source](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/UnknownCodeSystemWarningValidationSupport.java)

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -76,6 +76,13 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 	private String myBaseUrl;
 	private final List<Object> myClientInterceptors = new ArrayList<>();
 
+	/**
+	 * Override for sending {@code inferSystem} on remote {@code $validate-code}:
+	 * {@code null} (default) sends it only for R5+, {@code TRUE} always sends it, {@code FALSE} never does.
+	 */
+	@Nullable
+	private Boolean myInferSystemEnabled = null;
+
 	@Nullable
 	private final IRestfulClientFactory myRestfulClientFactory;
 
@@ -1030,7 +1037,7 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 		ParametersUtil.addParameterToParametersString(fhirContext, params, "code", theCode);
 		if (isNotBlank(theCodeSystem)) {
 			ParametersUtil.addParameterToParametersUri(fhirContext, params, "system", theCodeSystem);
-		} else {
+		} else if (shouldInferSystem(fhirContext)) {
 			// system could not be determined locally — ask the remote server to infer it
 			ParametersUtil.addParameterToParametersBoolean(fhirContext, params, "inferSystem", true);
 		}
@@ -1041,6 +1048,27 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 			ParametersUtil.addParameterToParameters(fhirContext, params, "valueSet", theValueSet);
 		}
 		return params;
+	}
+
+	/**
+	 * {@code inferSystem} is an R5+ {@code $validate-code} parameter that strict R4/DSTU3 servers
+	 * (e.g. VSAC, CMS) reject, so by default it is only sent for R5+; see {@link #setInferSystemEnabled(Boolean)}.
+	 */
+	private boolean shouldInferSystem(FhirContext theFhirContext) {
+		if (myInferSystemEnabled != null) {
+			return myInferSystemEnabled;
+		}
+		return theFhirContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.R4);
+	}
+
+	@Nullable
+	public Boolean getInferSystemEnabled() {
+		return myInferSystemEnabled;
+	}
+
+	public RemoteTerminologyServiceValidationSupport setInferSystemEnabled(@Nullable Boolean theInferSystemEnabled) {
+		myInferSystemEnabled = theInferSystemEnabled;
+		return this;
 	}
 
 	/**

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/RemoteTerminologyServiceValidationSupportR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/RemoteTerminologyServiceValidationSupportR4Test.java
@@ -345,13 +345,12 @@ public class RemoteTerminologyServiceValidationSupportR4Test extends BaseValidat
 	}
 
 	/**
-	 * When the stub ValueSet passed in has no compose and the ValueSet is not locally available,
-	 * inferSystem=true should be sent in the remote $validate-code call so the terminology server
-	 * can determine the system from the ValueSet definition.
+	 * inferSystem is R5+, so an R4 context must not send it by default (breaks strict R4 servers like
+	 * VSAC/CMS). See <a href="https://github.com/hapifhir/hapi-fhir/issues/8035">#8035</a>.
 	 */
 	// Created by claude-sonnet-4-6
 	@Test
-	void validateCodeInValueSet_stubValueSet_noSystem_sendsInferSystem() {
+	void validateCodeInValueSet_stubValueSet_noSystemR4_doesNotSendInferSystem() {
 		ValueSet stubValueSet = new ValueSet();
 		stubValueSet.setUrl("http://example.org/valueset/test-vs");
 
@@ -359,7 +358,7 @@ public class RemoteTerminologyServiceValidationSupportR4Test extends BaseValidat
 
 		mySvc.validateCodeInValueSet(null, new ConceptValidationOptions(), null, "test-code", null, stubValueSet);
 
-		assertThat(myValueSetProvider.myLastValidateCodeInferSystem.booleanValue()).isTrue();
+		assertThat(myValueSetProvider.myLastValidateCodeInferSystem).isNull();
 	}
 
 	/**
@@ -382,5 +381,23 @@ public class RemoteTerminologyServiceValidationSupportR4Test extends BaseValidat
 			stubValueSet);
 
 		assertThat(myValueSetProvider.myLastValidateCodeInferSystem).isNull();
+	}
+
+	@Test
+	void validateCodeInValueSet_stubValueSet_inferSystemForced_sendsInferSystem() {
+		ValueSet stubValueSet = new ValueSet();
+		stubValueSet.setUrl("http://example.org/valueset/test-vs");
+
+		myValueSetProvider.myValidateCodeResult = new Parameters().addParameter("result", true);
+
+		// set inferSystem = true so it is sent for servers (can be R4) that supports it
+		mySvc.setInferSystemEnabled(true);
+		try {
+			mySvc.validateCodeInValueSet(null, new ConceptValidationOptions(), null, "test-code", null, stubValueSet);
+		} finally {
+			mySvc.setInferSystemEnabled(null);
+		}
+
+		assertThat(myValueSetProvider.myLastValidateCodeInferSystem.booleanValue()).isTrue();
 	}
 }

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/RemoteTerminologyServiceValidationSupportR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/RemoteTerminologyServiceValidationSupportR4Test.java
@@ -352,7 +352,7 @@ public class RemoteTerminologyServiceValidationSupportR4Test extends BaseValidat
 	@Test
 	void validateCodeInValueSet_stubValueSet_noSystemR4_doesNotSendInferSystem() {
 		ValueSet stubValueSet = new ValueSet();
-		stubValueSet.setUrl("http://example.org/valueset/test-vs");
+		stubValueSet.setUrl(VALUE_SET_URL);
 
 		myValueSetProvider.myValidateCodeResult = new Parameters().addParameter("result", true);
 
@@ -368,14 +368,14 @@ public class RemoteTerminologyServiceValidationSupportR4Test extends BaseValidat
 	@Test
 	void validateCodeInValueSet_stubValueSet_withSystem_doesNotSendInferSystem() {
 		ValueSet stubValueSet = new ValueSet();
-		stubValueSet.setUrl("http://example.org/valueset/test-vs");
+		stubValueSet.setUrl(VALUE_SET_URL);
 
 		myValueSetProvider.myValidateCodeResult = new Parameters().addParameter("result", true);
 
 		mySvc.validateCodeInValueSet(
 			null,
 			new ConceptValidationOptions(),
-			"http://example.org/codesystem/test-cs",
+			VALUE_SET_URL,
 			"test-code",
 			null,
 			stubValueSet);
@@ -386,7 +386,7 @@ public class RemoteTerminologyServiceValidationSupportR4Test extends BaseValidat
 	@Test
 	void validateCodeInValueSet_stubValueSet_inferSystemForced_sendsInferSystem() {
 		ValueSet stubValueSet = new ValueSet();
-		stubValueSet.setUrl("http://example.org/valueset/test-vs");
+		stubValueSet.setUrl(VALUE_SET_URL);
 
 		myValueSetProvider.myValidateCodeResult = new Parameters().addParameter("result", true);
 

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/RemoteTerminologyServiceValidationSupportR5Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/RemoteTerminologyServiceValidationSupportR5Test.java
@@ -1,15 +1,27 @@
 package org.hl7.fhir.r5.validation;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.ConceptValidationOptions;
 import ca.uhn.fhir.context.support.LookupCodeRequest;
 import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.fhirpath.BaseValidationTestWithInlineMocks;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
 import org.hl7.fhir.common.hapi.validation.support.RemoteTerminologyServiceValidationSupport;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r5.model.BooleanType;
+import org.hl7.fhir.r5.model.CodeType;
+import org.hl7.fhir.r5.model.Parameters;
+import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.UriType;
+import org.hl7.fhir.r5.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class RemoteTerminologyServiceValidationSupportR5Test extends BaseValidationTestWithInlineMocks {
@@ -18,10 +30,12 @@ public class RemoteTerminologyServiceValidationSupportR5Test extends BaseValidat
 	@RegisterExtension
 	public static RestfulServerExtension myRestfulServerExtension = new RestfulServerExtension(ourCtx);
 
+	private final MyValueSetProvider myValueSetProvider = new MyValueSetProvider();
 	private RemoteTerminologyServiceValidationSupport mySvc;
 
 	@BeforeEach
 	public void before() {
+		myRestfulServerExtension.getRestfulServer().registerProvider(myValueSetProvider);
 		String baseUrl = "http://localhost:" + myRestfulServerExtension.getPort();
 		mySvc = new RemoteTerminologyServiceValidationSupport(ourCtx);
 		mySvc.setBaseUrl(baseUrl);
@@ -32,5 +46,46 @@ public class RemoteTerminologyServiceValidationSupportR5Test extends BaseValidat
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> mySvc.lookupCode(
 			new ValidationSupportContext(ourCtx.getValidationSupport()),
 			new LookupCodeRequest(ANY_NONBLANK_VALUE, ANY_NONBLANK_VALUE)));
+	}
+
+	/**
+	 * inferSystem is R5+, so an R5 context sends it by default when the system is unknown (counterpart
+	 * to the R4 behavior). See <a href="https://github.com/hapifhir/hapi-fhir/issues/8035">#8035</a>.
+	 */
+	@Test
+	void validateCodeInValueSet_stubValueSet_noSystemR5_sendsInferSystem() {
+		ValueSet stubValueSet = new ValueSet();
+		stubValueSet.setUrl("http://example.org/valueset/test-vs");
+
+		myValueSetProvider.myValidateCodeResult = new Parameters().addParameter("result", true);
+
+		mySvc.validateCodeInValueSet(null, new ConceptValidationOptions(), null, "test-code", null, stubValueSet);
+
+		assertThat(myValueSetProvider.myLastValidateCodeInferSystem.booleanValue()).isTrue();
+	}
+
+	private static class MyValueSetProvider implements IResourceProvider {
+		private Parameters myValidateCodeResult;
+		private BooleanType myLastValidateCodeInferSystem;
+
+		// Created by claude-opus-4-8
+		@Operation(name = "validate-code", idempotent = true, returnParameters = {
+			@OperationParam(name = "result", type = BooleanType.class, min = 1),
+			@OperationParam(name = "message", type = StringType.class),
+			@OperationParam(name = "display", type = StringType.class)
+		})
+		public Parameters validateCode(
+			@OperationParam(name = "url", min = 0, max = 1) UriType theValueSetUrl,
+			@OperationParam(name = "code", min = 0, max = 1) CodeType theCode,
+			@OperationParam(name = "inferSystem", min = 0, max = 1) BooleanType theInferSystem,
+			@OperationParam(name = "valueSet") ValueSet theValueSet) {
+			myLastValidateCodeInferSystem = theInferSystem;
+			return myValidateCodeResult;
+		}
+
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return ValueSet.class;
+		}
 	}
 }

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/RemoteTerminologyServiceValidationSupportR5Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/RemoteTerminologyServiceValidationSupportR5Test.java
@@ -25,8 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class RemoteTerminologyServiceValidationSupportR5Test extends BaseValidationTestWithInlineMocks {
+	private static final String VALUE_SET_URL = "http://example.org/valueset/test-vs";
 	private static final String ANY_NONBLANK_VALUE = "anything";
 	private static final FhirContext ourCtx = FhirContext.forR5Cached();
+
 	@RegisterExtension
 	public static RestfulServerExtension myRestfulServerExtension = new RestfulServerExtension(ourCtx);
 
@@ -55,7 +57,7 @@ public class RemoteTerminologyServiceValidationSupportR5Test extends BaseValidat
 	@Test
 	void validateCodeInValueSet_stubValueSet_noSystemR5_sendsInferSystem() {
 		ValueSet stubValueSet = new ValueSet();
-		stubValueSet.setUrl("http://example.org/valueset/test-vs");
+		stubValueSet.setUrl(VALUE_SET_URL);
 
 		myValueSetProvider.myValidateCodeResult = new Parameters().addParameter("result", true);
 


### PR DESCRIPTION
Closes #8035

The `inferSystem=true` parameter added to remote terminology `$validate-code` requests in 8.10.0 (#7616) was sent for **all** FHIR versions whenever a code's system could not be determined locally. `inferSystem` is an R5+ `$validate-code` parameter, so strict R4/DSTU3-compliant remote terminology servers (e.g. VSAC, CMS) that don't recognize it rejected these requests, breaking validation that had worked before 8.10.0.

### Fix

- **RemoteTerminologyServiceValidationSupport** — `inferSystem=true` is now only sent for R5 and newer FHIR contexts by default, gated by a new `shouldInferSystem(FhirContext)` check. R4/DSTU3 contexts no longer send the parameter, restoring compatibility with strict R4 servers.
- **New `setInferSystemEnabled(Boolean)` toggle** — provides an escape hatch to override the default: `null` (default) sends it only for R5+, `TRUE` always sends it (e.g. for an R4 server that does support inference), and `FALSE` never sends it.

### Tests

- `RemoteTerminologyServiceValidationSupportR4Test` — updated to assert an R4 context does **not** send `inferSystem` by default, plus a new test verifying `setInferSystemEnabled(true)` forces it to be sent.
- `RemoteTerminologyServiceValidationSupportR5Test` — new test (with a stub `$validate-code` provider) verifying an R5 context still sends `inferSystem` by default.

### Docs

- New "Inferring the Code System" section in the RemoteTerminologyServiceValidationSupport validation-support-modules docs describing the R5+ default and the `setInferSystemEnabled` toggle.
