### PR TITLE
Add IPS narrative templates for MedicationAdministration and MedicationDispense

### DIFF
--- a/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/medicationsummary.html
+++ b/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/medicationsummary.html
@@ -14,6 +14,22 @@ Status: MedicationStatement.status.display
 Route: MedicationStatement.dosage[x].{ route.text || route.coding[x].display (separated by <br />) } (concatenate with comma, e.g. x, y, z)
 Sig: MedicationStatement.dosage[x].text (display all sigs separated by <br />)
 Date: MedicationStatement.effectiveDateTime || MedicationStatement.effectivePeriod.start
+
+Table 3 Medication Administrations
+Medication: MedicationAdministration.medicationCodeableConcept.text || MedicationAdministration.medicationCodeableConcept.coding[x].display (separated by <br />) || Medication.code.text || Medication.code.coding[x].display (separated by <br />)
+Status: MedicationAdministration.status.display
+Route: MedicationAdministration.dosage.route.text || MedicationAdministration.dosage.route.coding[x].display
+Sig: MedicationAdministration.dosage.text
+Comments: MedicationAdministration.note[x].text (separated by <br />)
+Date: MedicationAdministration.effectiveDateTime || MedicationAdministration.effectivePeriod.start
+
+Table 4 Medication Dispenses
+Medication: MedicationDispense.medicationCodeableConcept.text || MedicationDispense.medicationCodeableConcept.coding[x].display (separated by <br />) || Medication.code.text || Medication.code.coding[x].display (separated by <br />)
+Status: MedicationDispense.status.display
+Route: MedicationDispense.dosageInstruction[x].{ route.text || route.coding[x].display (separated by <br />) } (concatenate with comma, e.g. x, y, z)
+Sig: MedicationDispense.dosageInstruction[x].text (display all sigs separated by <br />)
+Comments: MedicationDispense.note[x].text (separated by <br />)
+Date Handed Over: MedicationDispense.whenHandedOver
 */-->
 <div xmlns:th="http://www.thymeleaf.org">
 
@@ -83,6 +99,82 @@ Date: MedicationStatement.effectiveDateTime || MedicationStatement.effectivePeri
 							<td th:insert="~{IpsUtilityFragments :: concatDosageRoute (list=*{getDosage()})}">Route</td>
 							<td th:insert="~{IpsUtilityFragments :: concat (list=*{getDosage()},attr='text')}">Sig</td>
 							<td th:insert="~{IpsUtilityFragments :: renderTime (time=*{getEffective()})}">Date</td>
+						</tr>
+					</th:block>
+				</th:block>
+			</th:block>
+			</tbody>
+		</table>
+	</th:block>
+
+	<th:block th:if="${narrativeUtil.bundleHasEntriesWithResourceType(resource, 'MedicationAdministration')}">
+		<h5>Medication Summary: Medication Administrations</h5>
+		<table class="hapiPropertyTable">
+			<thead>
+			<tr>
+				<th>Medication</th>
+				<th>Status</th>
+				<th>Route</th>
+				<th>Sig</th>
+				<th>Comments</th>
+				<th>Date</th>
+			</tr>
+			</thead>
+			<tbody>
+			<th:block th:each="entry : ${resource.entry}" th:object="${entry.getResource()}">
+				<th:block th:if='*{getResourceType().name() == "MedicationAdministration"}'>
+					<th:block
+						th:with="extension=${entry.getResource().getExtensionByUrl('http://hl7.org/fhir/StructureDefinition/narrativeLink')}">
+						<tr th:id="${extension != null} ? ${#strings.arraySplit(extension.getValue().getValue(), '#')[1]} : ''">
+							<td th:insert="~{IpsUtilityFragments :: renderMedication (medicationType=${entry.getResource()})}">
+								Medication
+							</td>
+							<td th:text="*{getStatus() != null} ? *{getStatus().getDisplay()} : ''">Status</td>
+							<td th:insert="~{IpsUtilityFragments :: codeableConcept (cc=*{hasDosage()} ? *{getDosage().getRoute()} : null, attr='display')}">
+								Route
+							</td>
+							<td th:text="*{hasDosage()} ? *{getDosage().getText()} : ''">Sig</td>
+							<td th:insert="~{IpsUtilityFragments :: concat (list=*{getNote()},attr='text')}">Comments</td>
+							<td th:insert="~{IpsUtilityFragments :: renderTime (time=*{getEffective()})}">Date</td>
+						</tr>
+					</th:block>
+				</th:block>
+			</th:block>
+			</tbody>
+		</table>
+	</th:block>
+
+	<th:block th:if="${narrativeUtil.bundleHasEntriesWithResourceType(resource, 'MedicationDispense')}">
+		<h5>Medication Summary: Medication Dispenses</h5>
+		<table class="hapiPropertyTable">
+			<thead>
+			<tr>
+				<th>Medication</th>
+				<th>Status</th>
+				<th>Route</th>
+				<th>Sig</th>
+				<th>Comments</th>
+				<th>Date Handed Over</th>
+			</tr>
+			</thead>
+			<tbody>
+			<th:block th:each="entry : ${resource.entry}" th:object="${entry.getResource()}">
+				<th:block th:if='*{getResourceType().name() == "MedicationDispense"}'>
+					<th:block
+						th:with="extension=${entry.getResource().getExtensionByUrl('http://hl7.org/fhir/StructureDefinition/narrativeLink')}">
+						<tr th:id="${extension != null} ? ${#strings.arraySplit(extension.getValue().getValue(), '#')[1]} : ''">
+							<td th:insert="~{IpsUtilityFragments :: renderMedication (medicationType=${entry.getResource()})}">
+								Medication
+							</td>
+							<td th:text="*{getStatus() != null} ? *{getStatus().getDisplay()} : ''">Status</td>
+							<td th:insert="~{IpsUtilityFragments :: concatDosageRoute (list=*{getDosageInstruction()})}">
+								Route
+							</td>
+							<td th:insert="~{IpsUtilityFragments :: concat (list=*{getDosageInstruction()},attr='text')}">
+								Sig
+							</td>
+							<td th:insert="~{IpsUtilityFragments :: concat (list=*{getNote()},attr='text')}">Comments</td>
+							<td th:insert="~{IpsUtilityFragments :: renderTime (time=*{getWhenHandedOverElement()})}">Date Handed Over</td>
 						</tr>
 					</th:block>
 				</th:block>


### PR DESCRIPTION
Fixes #4836
This issue was asking for narrative templates for MedicationAdministration and MedicationDispense. A narrative template is essentially the human readable summary text for FHIR, usually in HTML.
To create these narrative templates, a few things needed to be done first. First, I confirmed that MedicationAdministration and MedicationDispense were already part of the Java logic coming in from the IPS Medication Summary section, but weren't rendering anything readable. I read DefaultJpaIpsGenerationStrategy to confirm both resource types were already being gathered there.
I had Claude Code build 2 new tables in medicationsummary.html, which model the existing MedicationRequest and MedicationStatement tables for consistency. I modeled the MedicationAdministration table after the MedicationStatement table, since it has a single dosage element based on effective date, and the MedicationDispense table after the MedicationRequest table, since it contains a list of dosage instructions based on handover date.
I also reused the shared file of reusable templates, IpsUtilityFragments, for things like formatting a date and rendering the medication name. Claude Code checked that the fragment calls matched the actual signatures already defined there.
Since most of the file structuring existed in IpsUtilityFragments, as well as models of existing tables, this fix was essentially confirming the structure, creating 2 new tables, and having Claude Code ensure the syntax was correct, while checking for errors.
