### PR TITLE
8159 failed to get sql log file

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8159-fix-sql-log-filter-file-read-from-jar.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8159-fix-sql-log-filter-file-read-from-jar.yaml
@@ -1,6 +1,6 @@
 ---
 type: fix
-issue: 8908
+issue: 8159
 title: "Fixed a bug where enabling Hibernate SQL logging caused a `FileNotFoundException` and failed to load 
 the SQL log filters when running from a packaged JAR. The filter file is now read as a classpath stream rather 
 than as a filesystem file."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8908-fix-sql-log-filter-file-read-from-jar.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8908-fix-sql-log-filter-file-read-from-jar.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 8908
+title: "Fixed a bug where enabling Hibernate SQL logging caused a `FileNotFoundException` and failed to load 
+the SQL log filters when running from a packaged JAR. The filter file is now read as a classpath stream rather 
+than as a filesystem file."

--- a/hapi-fhir-jpa/src/main/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringUtil.java
+++ b/hapi-fhir-jpa/src/main/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringUtil.java
@@ -26,9 +26,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.File;
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -147,8 +148,7 @@ public class SqlLoggerFilteringUtil {
 		}
 
 		ourLog.debug("Starting filters refresh");
-		File resource = new ClassPathResource(theFilterFilePath).getFile();
-		List<String> filterDefinitionLines = Files.readAllLines(resource.toPath());
+		List<String> filterDefinitionLines = readFilterDefinitionLines(new ClassPathResource(theFilterFilePath));
 
 		for (ISqlLoggerFilter filter : mySqlLoggerFilters) {
 			synchronized (filter.getLockingObject()) {
@@ -160,6 +160,18 @@ public class SqlLoggerFilteringUtil {
 			}
 		}
 		ourLog.debug("Ended filter refresh");
+	}
+
+	/**
+	 * Reads the filter definition lines from a classpath resource. Uses a stream rather than
+	 * {@link ClassPathResource#getFile()} so the resource can be read when it is packaged inside a JAR.
+	 */
+	@VisibleForTesting
+	List<String> readFilterDefinitionLines(ClassPathResource theResource) throws IOException {
+		try (BufferedReader reader =
+				new BufferedReader(new InputStreamReader(theResource.getInputStream(), StandardCharsets.UTF_8))) {
+			return reader.lines().collect(Collectors.toList());
+		}
 	}
 
 	private void presentFilterDefinitionLineToFilters(String theFilterLine, List<ISqlLoggerFilter> theFilterList) {

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
@@ -330,7 +330,7 @@ public class SqlLoggerFilteringAndUtilTest {
 		}
 
 		/**
-		 * Regression test for the filter file being packaged inside a JAR (see GitLab #8908).
+		 * Regression test for the filter file being packaged inside a JAR (see GitHub #8159).
 		 */
 		@Test
 		void readsFilterDefinitionLines_whenResourcePackagedInJar_success() throws Exception {

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
@@ -34,7 +34,6 @@ import java.util.jar.JarOutputStream;
 import static ca.uhn.fhir.jpa.logging.SqlLoggerFilteringUtil.FILTER_FILE_PATH;
 import static ca.uhn.fhir.jpa.logging.SqlLoggerFilteringUtil.FILTER_UPDATE_INTERVAL_SECS;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
@@ -347,9 +347,6 @@ public class SqlLoggerFilteringAndUtilTest {
 			try (URLClassLoader jarClassLoader = new URLClassLoader(new URL[] {jarFile.toURI().toURL()}, null)) {
 				ClassPathResource resource = new ClassPathResource(FILTER_FILE_PATH, jarClassLoader);
 
-				// The previous implementation used getFile(), which throws for a JAR-packaged resource
-				assertThatThrownBy(resource::getFile).isInstanceOf(FileNotFoundException.class);
-
 				// The stream-based read must succeed for a JAR-packaged resource
 				List<String> lines = SqlLoggerFilteringUtil.getInstance().readFilterDefinitionLines(resource);
 
@@ -357,6 +354,4 @@ public class SqlLoggerFilteringAndUtilTest {
 			}
 		}
 	}
-
-
 }

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,15 +18,24 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static ca.uhn.fhir.jpa.logging.SqlLoggerFilteringUtil.FILTER_FILE_PATH;
 import static ca.uhn.fhir.jpa.logging.SqlLoggerFilteringUtil.FILTER_UPDATE_INTERVAL_SECS;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -193,6 +203,9 @@ public class SqlLoggerFilteringAndUtilTest {
 
 		private ch.qos.logback.classic.Logger myHibernateLogger;
 
+		@TempDir
+		File myTempDir;
+
 		@BeforeEach
 		void setUp() {
 			mySpiedUtil = spy(myTestedUtil);
@@ -318,6 +331,31 @@ public class SqlLoggerFilteringAndUtilTest {
 			}
 		}
 
+		/**
+		 * Regression test for the filter file being packaged inside a JAR (see GitLab #8908).
+		 */
+		@Test
+		void readsFilterDefinitionLines_whenResourcePackagedInJar_success() throws Exception {
+			// Package the filter file inside a JAR so it is only reachable through a jar: URL (no filesystem File)
+			File jarFile = new File(myTempDir, "sql-log-filters.jar");
+			try (JarOutputStream jarOut = new JarOutputStream(new FileOutputStream(jarFile))) {
+				jarOut.putNextEntry(new JarEntry(FILTER_FILE_PATH));
+				jarOut.write("test: select\n# a comment line\n".getBytes(StandardCharsets.UTF_8));
+				jarOut.closeEntry();
+			}
+
+			try (URLClassLoader jarClassLoader = new URLClassLoader(new URL[] {jarFile.toURI().toURL()}, null)) {
+				ClassPathResource resource = new ClassPathResource(FILTER_FILE_PATH, jarClassLoader);
+
+				// The previous implementation used getFile(), which throws for a JAR-packaged resource
+				assertThatThrownBy(resource::getFile).isInstanceOf(FileNotFoundException.class);
+
+				// The stream-based read must succeed for a JAR-packaged resource
+				List<String> lines = SqlLoggerFilteringUtil.getInstance().readFilterDefinitionLines(resource);
+
+				assertThat(lines).containsExactly("test: select", "# a comment line");
+			}
+		}
 	}
 
 

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/logging/SqlLoggerFilteringAndUtilTest.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;


### PR DESCRIPTION
Closes #8159.

## Summary

Fixes a `FileNotFoundException` that occurred when enabling Hibernate SQL logging while running from a packaged JAR. `SqlLoggerFilteringUtil` loaded the SQL log filter file via `ClassPathResource.getFile()`, which fails for resources inside a JAR since they have no filesystem `File`.

## Changes

- Read the filter file as a classpath stream (`getInputStream()`) instead of resolving it to a `File`, so it works both on the filesystem and when packaged in a JAR.
- Added a regression test that packages the filter file inside a JAR and verifies the lines are read correctly.