### PR TITLE
Update to org.hl7.fhir.core 6.9.12

### DIFF
--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -42,7 +42,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
+			<artifactId>okhttp-jvm</artifactId>
 		</dependency>
 
 		<!-- conformance profile -->

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ValidateTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4ValidateTest.java
@@ -660,8 +660,9 @@ public class FhirResourceDaoR4ValidateTest extends BaseJpaR4Test {
 		String codingIsNotInValueSetMessageWithBindingSpecificReason ="None of the codings provided are in the value set 'ValueSet[http://mytest/ValueSet/OrgContactSampleVS]' (http://mytest/ValueSet/OrgContactSampleVS), and";
 		String unknownCodeSystemMessage = "CodeSystem is unknown and can't be validated: http://mylocalcodesystem for 'http://mylocalcodesystem#mylocalcode'";
 		String unableToValidateCodeMessage = "Unable to validate code http://mylocalcodesystem#mylocalcode - No codes in ValueSet belong to CodeSystem with URL http://mylocalcodesystem";
+		String noneOfTheCodingsMessage = "None of the codings provided are in the value set 'ValueSet[http://mytest/ValueSet/OrgContactSampleVS]' (http://mytest/ValueSet/OrgContactSampleVS), and a coding is recommended to come from this value set (codes = http://mylocalcodesystem#mylocalcode)";
 		// We control the severity of the unknownCodeSystemMessage through the ValidationMessageUnknownCodeSystemPostProcessingInterceptor
-		// but the severity of the other two messages is determined by the core validator based on binding strength currently.
+        // but the severity of the other messages is determined by the core validator, which is currently based on binding strength.return Stream.of(
 		return Stream.of(
 			Arguments.of(Enumerations.BindingStrength.REQUIRED, "Error",
 				List.of(unableToValidateCodeMessage, unknownCodeSystemMessage, codingIsNotInValueSetMessageWithBindingSpecificReason),
@@ -676,11 +677,11 @@ public class FhirResourceDaoR4ValidateTest extends BaseJpaR4Test {
 				List.of(unableToValidateCodeMessage, unknownCodeSystemMessage, codingIsNotInValueSetMessageWithBindingSpecificReason),
 				List.of("Warning", "Warning", "Warning")),
 			Arguments.of(Enumerations.BindingStrength.PREFERRED, "Error",
-				List.of(unableToValidateCodeMessage, unknownCodeSystemMessage),
-				List.of("Warning", "Error")),
+				List.of(unableToValidateCodeMessage, unknownCodeSystemMessage, noneOfTheCodingsMessage),
+				List.of("Warning", "Error", "Information")),
 			Arguments.of(Enumerations.BindingStrength.PREFERRED, "Warning",
-				List.of(unableToValidateCodeMessage, unknownCodeSystemMessage),
-				List.of("Warning", "Warning")),
+				List.of(unableToValidateCodeMessage, unknownCodeSystemMessage, noneOfTheCodingsMessage),
+				List.of("Warning", "Warning", "Information")),
 			Arguments.of(Enumerations.BindingStrength.EXAMPLE, "Error",
 				List.of(unknownCodeSystemMessage),
 				List.of("Error")),

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/BaseJpaR4Test.java
@@ -1084,6 +1084,11 @@ public abstract class BaseJpaR4Test extends BaseJpaTest implements ITestDataBuil
 		}
 
 		@Override
+        public String relativeDatePlaceHolder() {
+			return null;
+		}
+
+		@Override
 		public ContainedReferenceValidationPolicy policyForContained(IResourceValidator validator,
 																	 Object appContext,
 																	 org.hl7.fhir.r5.model.StructureDefinition structure,

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/validation/ValidatorPolicyAdvisor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/validation/ValidatorPolicyAdvisor.java
@@ -126,6 +126,11 @@ public class ValidatorPolicyAdvisor implements IValidationPolicyAdvisor {
 		return List.of();
 	}
 
+	public String relativeDatePlaceHolder() {
+		// We don't require a placeholder value. null in this return ensures real values are returned.
+		return null;
+	}
+
 	@Override
 	public boolean isSuppressMessageId(String path, String messageId) {
 		if (myValidationSettings != null

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -272,6 +272,13 @@
 					<dependencySourceIncludes>
 						<include>ca.uhn.hapi.fhir:org.hl7.fhir.dstu2</include>
 					</dependencySourceIncludes>
+					<additionalDependencies>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs-annotations</artifactId>
+							<version>4.9.8</version>
+						</dependency>
+					</additionalDependencies>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -276,7 +276,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -322,6 +322,11 @@
 							<artifactId>okhttp</artifactId>
 							<version>${okhttp_version}</version>
 						</dependency>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs-annotations</artifactId>
+							<version>4.9.8</version>
+						</dependency>
 					</additionalDependencies>
 				</configuration>
 			</plugin>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -325,7 +325,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -251,6 +251,11 @@
 							<artifactId>okhttp</artifactId>
 							<version>${okhttp_version}</version>
 						</dependency>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs-annotations</artifactId>
+							<version>4.9.8</version>
+						</dependency>
 					</additionalDependencies>
 				</configuration>
 			</plugin>
@@ -320,6 +325,11 @@
 							<groupId>com.squareup.okhttp3</groupId>
 							<artifactId>okhttp</artifactId>
 							<version>${okhttp_version}</version>
+						</dependency>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs-annotations</artifactId>
+							<version>4.9.8</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -254,7 +254,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>
@@ -329,7 +329,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -265,7 +265,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>
@@ -325,7 +325,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -262,6 +262,11 @@
 							<artifactId>okhttp</artifactId>
 							<version>${okhttp_version}</version>
 						</dependency>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs-annotations</artifactId>
+							<version>4.9.8</version>
+						</dependency>
 					</additionalDependencies>
 				</configuration>
 			</plugin>
@@ -316,6 +321,11 @@
 							<groupId>com.squareup.okhttp3</groupId>
 							<artifactId>okhttp</artifactId>
 							<version>${okhttp_version}</version>
+						</dependency>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs-annotations</artifactId>
+							<version>4.9.8</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
+++ b/hapi-fhir-structures-r5/src/main/java/org/hl7/fhir/r5/hapi/ctx/HapiWorkerContext.java
@@ -29,6 +29,7 @@ import org.hl7.fhir.r5.model.ResourceType;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.r5.profilemodel.PEBuilder;
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientManager;
 import org.hl7.fhir.r5.terminologies.expansion.ValueSetExpansionOutcome;
 import org.hl7.fhir.r5.terminologies.utilities.CodingValidationRequest;
 import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
@@ -467,6 +468,14 @@ public final class HapiWorkerContext extends I18nBase implements IWorkerContext 
 
 	@Override
 	public TimeTracker clock() {
+		return null;
+	}
+
+	@Override
+	public TerminologyClientManager getTerminologyClientManager() {
+		// This is only used in one place in org.hl7.fhir.core:
+		// https://github.com/hapifhir/org.hl7.fhir.core/blob/10bcacefd50a0a00db98562ed65e6d7287f8842d/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/CompliesWithChecker.java#L486
+		// In that instance, non-null values could enter incomplete code that will throw an Error.
 		return null;
 	}
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/FhirDefaultPolicyAdvisor.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/FhirDefaultPolicyAdvisor.java
@@ -95,6 +95,12 @@ public class FhirDefaultPolicyAdvisor implements IValidationPolicyAdvisor {
 	}
 
 	@Override
+	public String relativeDatePlaceHolder() {
+		// We don't require a placeholder value. null in this return ensures real values are returned.
+		return null;
+	}
+
+	@Override
 	public boolean isSuppressMessageId(String path, String messageId) {
 		// Note: getReferencePolicy() currently returns IGNORE unconditionally, so this condition
 		// is always true. The guard is retained for correctness if a subclass overrides

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
@@ -41,6 +41,7 @@ import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.r5.profilemodel.PEBuilder;
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientManager;
 import org.hl7.fhir.r5.terminologies.expansion.ValueSetExpansionOutcome;
 import org.hl7.fhir.r5.terminologies.utilities.CodingValidationRequest;
 import org.hl7.fhir.r5.terminologies.utilities.TerminologyServiceErrorClass;
@@ -654,17 +655,18 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 			public void cachePackage(PackageInformation packageInfo) {}
 
 			@Override
-			public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader) throws FHIRException {
+			public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader, boolean isMaster)
+					throws FHIRException {
 				return 0;
 			}
 
 			@Override
-			public int loadPackage(NpmPackage pi) throws FHIRException {
+			public int loadPackage(NpmPackage pi, boolean isMaster) throws FHIRException {
 				return 0;
 			}
 
 			@Override
-			public int loadPackage(String idAndVer) throws FHIRException {
+			public int loadPackage(String idAndVer, boolean isMaster) throws FHIRException {
 				return 0;
 			}
 
@@ -676,6 +678,11 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 
 			@Override
 			public PackageLoadController getPackageLoadController() {
+				return null;
+			}
+
+			@Override
+			public List<String> getLoadedPackages() {
 				return null;
 			}
 		};
@@ -1154,5 +1161,10 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 	@Override
 	public OperationOutcome validateTxResource(ValidationOptions options, Resource resource) {
 		throw new UnsupportedOperationException(Msg.code(2735));
+	}
+
+	@Override
+	public TerminologyClientManager getTerminologyClientManager() {
+		return null;
 	}
 }

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapterCoreTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapterCoreTest.java
@@ -210,6 +210,7 @@ public class WorkerContextValidationSupportAdapterCoreTest {
 					setup.getTest().asString("name"),
 					req,
 					resp,
+					null,
 					setup.getTest().asString("Content-Language"),
 					fp,
 					ext,
@@ -217,7 +218,7 @@ public class WorkerContextValidationSupportAdapterCoreTest {
 					Set.of());
 			assertNull(diff, diff);
 		} else if (setup.getTest().asString("operation").equals("cs-validate-code")) {
-			String diff = TxServiceTestHelper.getDiffForValidation(setup.getTest().str("name"), wrapper, setup.getTest().asString("name"), req, resp, setup.getTest().asString("Content-Language"), fp, ext, true, Set.of());
+			String diff = TxServiceTestHelper.getDiffForValidation(setup.getTest().str("name"), wrapper, setup.getTest().asString("name"), req, resp, null, setup.getTest().asString("Content-Language"), fp, ext, true, Set.of());
 			assertNull(diff, diff);
 		}
 	}

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/FhirInstanceValidatorR5Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r5/validation/FhirInstanceValidatorR5Test.java
@@ -673,12 +673,9 @@ public class FhirInstanceValidatorR5Test extends BaseTest {
 		ourLog.debug(ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(rp));
 
 
-		assertEquals(2, outcome.size());
+		assertEquals(1, outcome.size());
 		assertThat(outcome.get(0).getMessage()).contains("Unknown code 'http://terminology.hl7.org/CodeSystem/v2-0131#GAGAGAGA'");
 		assertEquals(ResultSeverityEnum.ERROR, outcome.get(0).getSeverity());
-		assertThat(outcome.get(1).getMessage()).contains("None of the codings provided are in the value set 'Patient Relationship Type'");
-		assertEquals(ResultSeverityEnum.INFORMATION, outcome.get(1).getSeverity());
-
 	}
 
 	// TODO: uncomment value false when https://github.com/hapifhir/org.hl7.fhir.core/issues/1766 is fixed

--- a/pom.xml
+++ b/pom.xml
@@ -1014,7 +1014,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.9.12-SNAPSHOT</fhir_core_version>
+		<fhir_core_version>6.9.12</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<spotless.exclude.pattern>**/test/**/*.java</spotless.exclude.pattern>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>

--- a/pom.xml
+++ b/pom.xml
@@ -1014,7 +1014,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.9.4.1</fhir_core_version>
+		<fhir_core_version>6.9.12-SNAPSHOT</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<spotless.exclude.pattern>**/test/**/*.java</spotless.exclude.pattern>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>
@@ -1084,7 +1084,7 @@
 		<httpcore5_version>5.3.1</httpcore5_version>
 		<maven_assembly_plugin_version>3.3.0</maven_assembly_plugin_version>
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
-		<okhttp_version>4.12.0</okhttp_version>
+		<okhttp_version>5.3.2</okhttp_version>
 		<!--
 		Note: As of 2024-11, the opentelemetry-agent-for-testing dependency published to Maven
 		uses a version which lines up with the OTEL instrumentation version, but with "-alpha"
@@ -1368,11 +1368,13 @@
 				<artifactId>okhttp</artifactId>
 				<version>${okhttp_version}</version>
 			</dependency>
-			<!-- Pinned here for CVE: CVE-2022-24329 -->
+			<!-- OkHttp 5.x publishes as Kotlin Multiplatform; the plain "okhttp" artifact
+			     above is a metadata-only shell for Maven consumers. Actual compile-time
+			     usage must depend on this JVM variant instead. -->
 			<dependency>
-				<groupId>com.squareup.okio</groupId>
-				<artifactId>okio-jvm</artifactId>
-				<version>3.9.1</version>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>okhttp-jvm</artifactId>
+				<version>${okhttp_version}</version>
 			</dependency>
 
 			<!-- Pinned here for CVE: CVE-2025-7962 This is used transitively in simplejavamail which has no fix yet -->

--- a/pom.xml
+++ b/pom.xml
@@ -1122,6 +1122,8 @@
 		<elastic_apm_version>1.52.0</elastic_apm_version>
 		<elasticsearch_version>8.19.9</elasticsearch_version>
 		<ucum_version>1.0.9</ucum_version>
+		<!-- only required for third party libraries when generating JavaDoc. Not to be used internally. -->
+		<spotbugs_annotations_version>4.9.8</spotbugs_annotations_version>
 
 		<!-- Site properties -->
 		<fontawesomeVersion>5.4.1</fontawesomeVersion>
@@ -1143,6 +1145,7 @@
 		<maven-license-plugin-version>2.5.0</maven-license-plugin-version>
 		<maven-enforcer-plugin-version>3.5.0</maven-enforcer-plugin-version>
 		<maven-checkstyle-version>3.6.0</maven-checkstyle-version>
+
 	</properties>
 
 	<dependencyManagement>

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -172,6 +172,6 @@
 
 	<properties>
 		<!--<kotlin.compiler.incremental>true</kotlin.compiler.incremental>-->
-		<kotlin.version>1.9.23</kotlin.version>
+		<kotlin.version>2.2.21</kotlin.version>
 	</properties>
 </project>


### PR DESCRIPTION
This updates org.hl7.fhir.core to 6.9.12

Notes regarding these changes:

okhttp_version was updated to 5.3.2 for two reasons:
 - org.hl7.fhir.core uses that same version, and this prevents us from having to track two different versions in our code.
 - the okio library in the older versions of okhttp contained vulnerabilities (this is why org.hl7.fhir.core updated its version of the library)
 
There was a pinned okio dependency in dependencyManagement that is no longer needed, as the okio dependency used by the more current okhttp is more recent, and has no known vulnerabilities. 

kotlin.version was also updated in hapi-fhir-base-test-jaxrsserver-kotlin as this was old and incompatible with the kotlin used in the new okio

There are a number of added methods, altered signatures, and updated tests that correspond to the ones done in HAPI master in the following PRs:

https://github.com/hapifhir/hapi-fhir/pull/8119 <- simple dependency update
https://github.com/hapifhir/hapi-fhir/pull/8081 <- slightly more complex dependency updates to allow for org.hl7.fhir.core's usage of spotugs, which impacted JavaDoc generation
https://github.com/hapifhir/hapi-fhir/pull/7962 <- changes to pom.xml and to numerous classes to account for changed method signatures in org.hl7.fhir.core. All of the functional changes are very minimal, applying to methods that have always returned null, or have had no-op functionality. There is one change to validation output, which was accepted by reviewers in this pull as correct.



