### PR TITLE
Update org.hl7.fhir.core to 6.9.12

### DIFF
--- a/hapi-fhir-client-okhttp/pom.xml
+++ b/hapi-fhir-client-okhttp/pom.xml
@@ -42,7 +42,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
+			<artifactId>okhttp-jvm</artifactId>
 		</dependency>
 
 		<!-- conformance profile -->

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/validation/ValidatorPolicyAdvisor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/validation/ValidatorPolicyAdvisor.java
@@ -133,6 +133,12 @@ public class ValidatorPolicyAdvisor implements IValidationPolicyAdvisor {
 	}
 
 	@Override
+	public boolean isSuppressMessageId(String path, String messageId) {
+		// Call this instead of the org.hl7.fhir.core default implementation, which always returns false
+		return this.isSuppressMessageId(path, messageId, null);
+	}
+
+	@Override
 	public boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments) {
 		if (myValidationSettings != null
 				&& !myValidationSettings

--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -276,7 +276,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -325,7 +325,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r4b/pom.xml
+++ b/hapi-fhir-structures-r4b/pom.xml
@@ -254,7 +254,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>
@@ -329,7 +329,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -265,7 +265,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>
@@ -325,7 +325,7 @@
 						<dependency>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-annotations</artifactId>
-							<version>4.9.8</version>
+							<version>${spotbugs_annotations_version}</version>
 						</dependency>
 					</additionalDependencies>
 				</configuration>

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/FhirDefaultPolicyAdvisor.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/FhirDefaultPolicyAdvisor.java
@@ -101,6 +101,12 @@ public class FhirDefaultPolicyAdvisor implements IValidationPolicyAdvisor {
 	}
 
 	@Override
+    	public boolean isSuppressMessageId(String path, String messageId) {
+    		// Call this instead of the org.hl7.fhir.core default implementation, which always returns false
+    		return this.isSuppressMessageId(path, messageId, null);
+    	}
+
+	@Override
 	public boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments) {
 		// Note: getReferencePolicy() currently returns IGNORE unconditionally, so this condition
 		// is always true. The guard is retained for correctness if a subclass overrides

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/FhirDefaultPolicyAdvisor.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/FhirDefaultPolicyAdvisor.java
@@ -101,10 +101,10 @@ public class FhirDefaultPolicyAdvisor implements IValidationPolicyAdvisor {
 	}
 
 	@Override
-    	public boolean isSuppressMessageId(String path, String messageId) {
-    		// Call this instead of the org.hl7.fhir.core default implementation, which always returns false
-    		return this.isSuppressMessageId(path, messageId, null);
-    	}
+	public boolean isSuppressMessageId(String path, String messageId) {
+		// Call this instead of the org.hl7.fhir.core default implementation, which always returns false
+		return this.isSuppressMessageId(path, messageId, null);
+	}
 
 	@Override
 	public boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments) {

--- a/pom.xml
+++ b/pom.xml
@@ -1031,7 +1031,7 @@
 	</licenses>
 
 	<properties>
-		<fhir_core_version>6.9.11</fhir_core_version>
+		<fhir_core_version>6.9.12</fhir_core_version>
 		<spotless_version>2.41.1</spotless_version>
 		<spotless.exclude.pattern>**/test/**/*.java</spotless.exclude.pattern>
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>
@@ -1101,7 +1101,7 @@
 		<httpcore5_version>5.3.1</httpcore5_version>
 		<maven_assembly_plugin_version>3.3.0</maven_assembly_plugin_version>
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
-		<okhttp_version>4.12.0</okhttp_version>
+		<okhttp_version>5.3.2</okhttp_version>
 		<!--
 		Note: As of 2024-11, the opentelemetry-agent-for-testing dependency published to Maven
 		uses a version which lines up with the OTEL instrumentation version, but with "-alpha"
@@ -1139,6 +1139,8 @@
 		<elastic_apm_version>1.52.0</elastic_apm_version>
 		<elasticsearch_version>8.19.9</elasticsearch_version>
 		<ucum_version>1.0.9</ucum_version>
+		<!-- only required for third party libraries when generating JavaDoc. Not to be used internally. -->
+		<spotbugs_annotations_version>4.9.8</spotbugs_annotations_version>
 
 		<!-- Site properties -->
 		<fontawesomeVersion>5.4.1</fontawesomeVersion>
@@ -1385,11 +1387,13 @@
 				<artifactId>okhttp</artifactId>
 				<version>${okhttp_version}</version>
 			</dependency>
-			<!-- Pinned here for CVE: CVE-2022-24329 -->
+			<!-- OkHttp 5.x publishes as Kotlin Multiplatform; the plain "okhttp" artifact
+			     above is a metadata-only shell for Maven consumers. Actual compile-time
+			     usage must depend on this JVM variant instead. -->
 			<dependency>
-				<groupId>com.squareup.okio</groupId>
-				<artifactId>okio-jvm</artifactId>
-				<version>3.9.1</version>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>okhttp-jvm</artifactId>
+				<version>${okhttp_version}</version>
 			</dependency>
 
 			<!-- Pinned here for CVE: CVE-2025-7962 This is used transitively in simplejavamail which has no fix yet -->

--- a/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
+++ b/tests/hapi-fhir-base-test-jaxrsserver-kotlin/pom.xml
@@ -172,6 +172,6 @@
 
 	<properties>
 		<!--<kotlin.compiler.incremental>true</kotlin.compiler.incremental>-->
-		<kotlin.version>1.9.23</kotlin.version>
+		<kotlin.version>2.2.21</kotlin.version>
 	</properties>
 </project>


### PR DESCRIPTION
This updates org.hl7.fhir.core to 6.9.12

Notes regarding these changes:

okhttp_version was updated to 5.3.2 for two reasons:

org.hl7.fhir.core uses that same version, and this prevents us from having to track two different versions in our code.
the okio library in the older versions of okhttp contained vulnerabilities (this is why org.hl7.fhir.core updated its version of the library)

There was a pinned okio dependency in dependencyManagement that is no longer needed, as the okio dependency used by the more current okhttp is more recent, and has no known vulnerabilities. 

kotlin.version was also updated in hapi-fhir-base-test-jaxrsserver-kotlin as this was old and incompatible with the kotlin used in the new okio. This was been approved by @JPercival in a related PR: https://github.com/hapifhir/hapi-fhir/pull/8166#discussion_r3589971408 

This also brings in a quality of life improvement from https://github.com/hapifhir/hapi-fhir/pull/8166, which manages the spotbugs-annotations version via a property instead of literal versions. See comment thread in another PR here: https://github.com/hapifhir/hapi-fhir/pull/8166#discussion_r3589940666 