### PR TITLE
Allow interceptors to select an alternate batch2 job definition for bulk export kickoff

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -1167,13 +1167,15 @@ public enum Pointcut implements IPointcut {
 	 * Invoked when a Bulk Export job is being kicked off, but before any permission checks
 	 * have been done.
 	 * This hook can be used to modify or update parameters as need be before
-	 * authorization/permission checks are done.
+	 * authorization/permission checks are done. Among the parameters a hook may set is
+	 * <code>jobDefinitionIdOverride</code>, which routes the export to an alternate
+	 * registered batch2 job definition instead of the default <code>BULK_EXPORT</code> job.
 	 * <p>
 	 * Hooks may accept the following parameters:
 	 * </p>
 	 * <ul>
 	 * <li>
-	 * ca.uhn.fhir.jpa.bulk.export.api.BulkDataExportOptions - The details of the job being kicked off
+	 * ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters - The (mutable) parameters of the job being kicked off
 	 * </li>
 	 * <li>
 	 * ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is about to be processed, including details such as the
@@ -1205,14 +1207,16 @@ public enum Pointcut implements IPointcut {
 	 * Invoked when a Bulk Export job is being kicked off. Hook methods may modify
 	 * the request, or raise an exception to prevent it from being initiated.
 	 * This hook is not guaranteed to be called before permission checks, and so
-	 * anu implementers should be cautious of changing the options in ways that would
-	 * affect permissions.
+	 * any implementers should be cautious of changing the options in ways that would
+	 * affect permissions. Like {@link #STORAGE_PRE_INITIATE_BULK_EXPORT}, this hook
+	 * receives the mutable job parameters, so anything settable there (including
+	 * <code>jobDefinitionIdOverride</code>) is also honored when set from this hook.
 	 * <p>
 	 * Hooks may accept the following parameters:
 	 * </p>
 	 * <ul>
 	 * <li>
-	 * ca.uhn.fhir.jpa.bulk.export.api.BulkDataExportOptions - The details of the job being kicked off
+	 * ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters - The (mutable) parameters of the job being kicked off
 	 * </li>
 	 * <li>
 	 * ca.uhn.fhir.rest.api.server.RequestDetails - A bean containing details about the request that is about to be processed, including details such as the

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/ms-20260721-bulk-export-job-override.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/ms-20260721-bulk-export-job-override.yaml
@@ -1,0 +1,14 @@
+---
+type: add
+jira: PRAR-4911
+title: "A new jobDefinitionIdOverride property has been added to BulkExportJobParameters. When set
+by server-side interceptor code (typically on the STORAGE_PRE_INITIATE_BULK_EXPORT pointcut,
+though STORAGE_INITIATE_BULK_EXPORT works equally), the bulk export kickoff
+(including the $export and $davinci-data-export operations) starts the named registered batch2 job
+definition instead of the default BULK_EXPORT job, while parameter parsing, permission checks, and
+$export-poll-status remain unchanged. The property cannot be set from the client request. Note that
+in a mixed-version cluster, a job instance whose stored parameters contain this new property cannot
+be deserialized by older binaries, so the feature should only be used once all nodes are upgraded.
+Also note that exports run under an alternate job definition are not covered by the automatic
+bulk-export file purge, which only applies to BULK_EXPORT instances; retention of their output is
+the responsibility of the alternate job's operator."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportProviderR4Test.java
@@ -31,6 +31,7 @@ import ca.uhn.fhir.rest.server.tenant.UrlBaseTenantIdentificationStrategy;
 import ca.uhn.fhir.test.utilities.HttpClientExtension;
 import ca.uhn.fhir.test.utilities.MockInvoker;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
+import ca.uhn.fhir.util.Batch2JobDefinitionConstants;
 import ca.uhn.fhir.util.JsonUtil;
 import ca.uhn.fhir.util.SearchParameterUtil;
 import ca.uhn.fhir.util.UrlUtil;
@@ -1259,6 +1260,99 @@ public class BulkDataExportProviderR4Test {
 		// verify
 		assertTrue(preInitiateCalled.get());
 		assertTrue(initiateCalled.get());
+	}
+
+	@Test
+	public void testInitiateBulkExport_hookSetsJobDefinitionIdOverride_jobStartsWithOverriddenId() throws IOException {
+		// setup
+		String overriddenJobId = "MY_CUSTOM_EXPORT_JOB";
+		when(myInterceptorBroadcaster.hasHooks(eq(Pointcut.STORAGE_PRE_INITIATE_BULK_EXPORT))).thenReturn(true);
+		when(myInterceptorBroadcaster.getInvokersForPointcut(eq(Pointcut.STORAGE_PRE_INITIATE_BULK_EXPORT))).thenReturn(MockInvoker.list(params -> {
+			params.get(BulkExportJobParameters.class).setJobDefinitionIdOverride(overriddenJobId);
+			return true;
+		}));
+		when(myJobCoordinator.startInstance(isNotNull(), any())).thenReturn(createJobStartResponse());
+
+		// test
+		HttpGet get = new HttpGet(String.format("http://localhost:%s/%s", myServer.getPort(), ProviderConstants.OPERATION_EXPORT));
+		get.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RESPOND_ASYNC);
+		try (CloseableHttpResponse response = myClient.execute(get)) {
+			assertEquals(202, response.getStatusLine().getStatusCode());
+		}
+
+		// verify
+		JobInstanceStartRequest startRequest = verifyJobStart();
+		assertEquals(overriddenJobId, startRequest.getJobDefinitionId());
+		assertEquals(overriddenJobId, startRequest.getParameters(BulkExportJobParameters.class).getJobDefinitionIdOverride());
+	}
+
+	@Test
+	public void testInitiateBulkExport_initiateHookSetsJobDefinitionIdOverride_jobStartsWithOverriddenId() throws IOException {
+		// setup - the override is honored from STORAGE_INITIATE_BULK_EXPORT too, since that
+		// hook receives the same mutable parameters before job start
+		String overriddenJobId = "MY_CUSTOM_EXPORT_JOB";
+		when(myInterceptorBroadcaster.hasHooks(eq(Pointcut.STORAGE_PRE_INITIATE_BULK_EXPORT))).thenReturn(false);
+		when(myInterceptorBroadcaster.hasHooks(eq(Pointcut.STORAGE_INITIATE_BULK_EXPORT))).thenReturn(true);
+		when(myInterceptorBroadcaster.getInvokersForPointcut(eq(Pointcut.STORAGE_INITIATE_BULK_EXPORT))).thenReturn(MockInvoker.list(params -> {
+			params.get(BulkExportJobParameters.class).setJobDefinitionIdOverride(overriddenJobId);
+			return true;
+		}));
+		when(myJobCoordinator.startInstance(isNotNull(), any())).thenReturn(createJobStartResponse());
+
+		// test
+		HttpGet get = new HttpGet(String.format("http://localhost:%s/%s", myServer.getPort(), ProviderConstants.OPERATION_EXPORT));
+		get.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RESPOND_ASYNC);
+		try (CloseableHttpResponse response = myClient.execute(get)) {
+			assertEquals(202, response.getStatusLine().getStatusCode());
+		}
+
+		// verify
+		JobInstanceStartRequest startRequest = verifyJobStart();
+		assertEquals(overriddenJobId, startRequest.getJobDefinitionId());
+	}
+
+	@Test
+	public void testInitiateBulkExport_noOverride_jobStartsWithDefaultBulkExportId() throws IOException {
+		// setup
+		when(myJobCoordinator.startInstance(isNotNull(), any())).thenReturn(createJobStartResponse());
+
+		// test
+		HttpGet get = new HttpGet(String.format("http://localhost:%s/%s", myServer.getPort(), ProviderConstants.OPERATION_EXPORT));
+		get.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RESPOND_ASYNC);
+		try (CloseableHttpResponse response = myClient.execute(get)) {
+			assertEquals(202, response.getStatusLine().getStatusCode());
+		}
+
+		// verify
+		JobInstanceStartRequest startRequest = verifyJobStart();
+		assertEquals(Batch2JobDefinitionConstants.BULK_EXPORT, startRequest.getJobDefinitionId());
+		assertNull(startRequest.getParameters(BulkExportJobParameters.class).getJobDefinitionIdOverride());
+	}
+
+	@Test
+	public void testInitiateBulkExport_jobDefinitionIdOverrideIsNotClientReachable() throws IOException {
+		// setup
+		when(myJobCoordinator.startInstance(isNotNull(), any())).thenReturn(createJobStartResponse());
+
+		// test - a client attempting to smuggle the override in as an operation parameter
+		// (body and query string) must have no effect on which job is started
+		Parameters input = new Parameters();
+		input.addParameter(JpaConstants.PARAM_EXPORT_OUTPUT_FORMAT, new StringType(Constants.CT_FHIR_NDJSON));
+		input.addParameter(JpaConstants.PARAM_EXPORT_TYPE, new StringType("Patient"));
+		input.addParameter("jobDefinitionIdOverride", new StringType("EVIL_JOB"));
+		input.addParameter("_jobDefinitionIdOverride", new StringType("EVIL_JOB"));
+
+		HttpPost post = new HttpPost(String.format("http://localhost:%s/%s?jobDefinitionIdOverride=EVIL_JOB", myServer.getPort(), ProviderConstants.OPERATION_EXPORT));
+		post.addHeader(Constants.HEADER_PREFER, Constants.HEADER_PREFER_RESPOND_ASYNC);
+		post.setEntity(new ResourceEntity(myCtx, input));
+		try (CloseableHttpResponse response = myClient.execute(post)) {
+			assertEquals(202, response.getStatusLine().getStatusCode());
+		}
+
+		// verify
+		JobInstanceStartRequest startRequest = verifyJobStart();
+		assertEquals(Batch2JobDefinitionConstants.BULK_EXPORT, startRequest.getJobDefinitionId());
+		assertNull(startRequest.getParameters(BulkExportJobParameters.class).getJobDefinitionIdOverride());
 	}
 
 	@Test

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/bulk/BulkExportJobParameters.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/api/server/bulk/BulkExportJobParameters.java
@@ -125,6 +125,18 @@ public class BulkExportJobParameters extends BaseBatchJobParameters {
 	@JsonProperty("includeHistory")
 	private boolean myIncludeHistory;
 
+	/**
+	 * If set, the export runs under this registered batch2 job definition instead of the
+	 * default <code>BULK_EXPORT</code> job. Intended to be set by server-side interceptor
+	 * code, typically hooked on <code>STORAGE_PRE_INITIATE_BULK_EXPORT</code> (though any
+	 * hook that receives these parameters before job start, such as
+	 * <code>STORAGE_INITIATE_BULK_EXPORT</code>, is honored equally); it is never populated
+	 * from the client request. The target job definition must accept
+	 * {@link BulkExportJobParameters} (or a subclass) as its parameters type.
+	 */
+	@JsonProperty("jobDefinitionIdOverride")
+	private String myJobDefinitionIdOverride;
+
 	public String getExportIdentifier() {
 		return myExportId;
 	}
@@ -317,6 +329,26 @@ public class BulkExportJobParameters extends BaseBatchJobParameters {
 	 */
 	public void setIncludeHistory(boolean theIncludeHistory) {
 		myIncludeHistory = theIncludeHistory;
+	}
+
+	/**
+	 * If set, the export runs under this registered batch2 job definition instead of the
+	 * default <code>BULK_EXPORT</code> job. Intended to be set by server-side interceptor
+	 * code, typically hooked on <code>STORAGE_PRE_INITIATE_BULK_EXPORT</code> (though any
+	 * hook that receives these parameters before job start, such as
+	 * <code>STORAGE_INITIATE_BULK_EXPORT</code>, is honored equally); it is never populated
+	 * from the client request. The target job definition must accept
+	 * {@link BulkExportJobParameters} (or a subclass) as its parameters type.
+	 */
+	public String getJobDefinitionIdOverride() {
+		return myJobDefinitionIdOverride;
+	}
+
+	/**
+	 * @see #getJobDefinitionIdOverride()
+	 */
+	public void setJobDefinitionIdOverride(String theJobDefinitionIdOverride) {
+		myJobDefinitionIdOverride = theJobDefinitionIdOverride;
 	}
 
 	public enum ExportStyle {

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobService.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobService.java
@@ -42,6 +42,8 @@ import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 /**
  * This class is responsible for initiating a bulk export job
  * with appropriate _type parameter and partitionId as well as
@@ -85,7 +87,10 @@ public class BulkExportJobService {
 		JobInstanceStartRequest startRequest = new JobInstanceStartRequest();
 		startRequest.setParameters(theBulkExportJobParameters);
 		startRequest.setUseCache(useCache);
-		startRequest.setJobDefinitionId(Batch2JobDefinitionConstants.BULK_EXPORT);
+		String jobDefinitionId = isNotBlank(theBulkExportJobParameters.getJobDefinitionIdOverride())
+				? theBulkExportJobParameters.getJobDefinitionIdOverride()
+				: Batch2JobDefinitionConstants.BULK_EXPORT;
+		startRequest.setJobDefinitionId(jobDefinitionId);
 		Batch2JobStartResponse response = myJobCoordinator.startInstance(theRequestDetails, startRequest);
 
 		BulkExportJobServiceUtil.writePollingLocationsToResponseHeaders(theRequestDetails, response.getInstanceId());


### PR DESCRIPTION
Adds a `jobDefinitionIdOverride` property to `BulkExportJobParameters`, honored by `BulkExportJobService.startJob()`. When server-side interceptor code sets it (typically on `STORAGE_PRE_INITIATE_BULK_EXPORT`; `STORAGE_INITIATE_BULK_EXPORT` is honored equally), the bulk export kickoff (`$export` and `$davinci-data-export`) starts the named registered batch2 job definition instead of the default `BULK_EXPORT` job. Parameter parsing, permission checks, and `$export-poll-status` are unchanged.

The property can never be populated from the client request — it exists only on the server-side parameters object, and a test pins that a value smuggled in as a request parameter is ignored.

Changes:

- `BulkExportJobParameters`: new `jobDefinitionIdOverride` JSON property with javadoc'd accessors.
- `BulkExportJobService.startJob()`: uses the override when non-blank, else `BULK_EXPORT` as before.
- `Pointcut`: `STORAGE_PRE_INITIATE_BULK_EXPORT` / `STORAGE_INITIATE_BULK_EXPORT` javadoc mentions the field; fixed a stale `BulkDataExportOptions` parameter reference and a typo.
- 4 new tests in `BulkDataExportProviderR4Test`: override honored (incl. serialize round-trip), default job id when no hook (first test to pin it), client-supplied value ignored, override honored from `STORAGE_INITIATE_BULK_EXPORT` as well.
- Changelog entry for 8.12.0, including two operational caveats: stored parameters containing the new property don't deserialize on older binaries in a mixed-version cluster, and instances of an alternate job definition are not covered by the automatic bulk-export file purge (which only targets `BULK_EXPORT` instances).

Tracked internally as PRAR-4911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
