### PR TITLE
Fix incorrect .profile value for ips-pasthistoryofillness

### DIFF
--- a/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/ips-narratives.properties
+++ b/hapi-fhir-jpaserver-ips/src/main/resources/ca/uhn/fhir/jpa/ips/narrative/ips-narratives.properties
@@ -43,7 +43,7 @@ ips-socialhistory.profile=https://hl7.org/fhir/uv/ips/StructureDefinition-Compos
 ips-socialhistory.narrative=classpath:ca/uhn/fhir/jpa/ips/narrative/socialhistory.html
 
 ips-pasthistoryofillness.resourceType=Bundle
-ips-pasthistoryofillness.profile=http://hl7.org/fhir/uv/ips/StructureDefinition/PastHistoryOfIllness-uv-ips
+ips-pasthistoryofillness.profile=https://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips-definitions.html#Composition.section:sectionPastIllnessHx
 ips-pasthistoryofillness.narrative=classpath:ca/uhn/fhir/jpa/ips/narrative/pasthistoryofillness.html
 
 ips-functionalstatus.resourceType=Bundle


### PR DESCRIPTION
Fix incorrect .profile value for ips-pasthistoryofillness in ips-narratives.properties  ips-pasthistoryofillness.profile was still using the old resource-level StructureDefinition canonical URL (http://hl7.org/fhir/uv/ips/StructureDefinition/PastHistoryOfIllness-uv-ips) instead of the Composition section-anchor format used by every other IPS section (https://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips-definitions.html#Composition.section:section...).  This appears to have been missed when #4834 (IPS Connectathon Fixes) updated the matching key for all other sections to the section-anchor format. Because the narrative generator matches on this value, the mismatch meant the Past History of Illness section's narrative was never generated.  Fixed by updating the profile line to ...#Composition.section:sectionPastIllnessHx, matching the pattern used by the other 12 sections.