### PR TITLE
GH-8208: JobDataSink must enqueue work chunks in their own transaction

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8208-jobdatasink-enqueue-tx.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8208-jobdatasink-enqueue-tx.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 8208
+title: "Previously, Batch2 marked a newly created work chunk as QUEUED using the calling job step's
+  transaction rather than its own. For non-gated jobs whose step holds a long-running transaction,
+  the chunk was published to the work channel while that update was still uncommitted, so worker
+  threads blocked on the chunk's row lock and chunks could be left stalled in READY. The state
+  update now runs in its own transaction, so it commits independently of the calling step."

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobDataSink.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/JobDataSink.java
@@ -128,17 +128,25 @@ class JobDataSink<PT extends IModelJson, IT extends IModelJson, OT extends IMode
 		myLastChunkId.set(chunkId);
 
 		if (!myGatedExecution) {
-			myJobPersistence.enqueueWorkChunkForProcessing(chunkId, updated -> {
-				if (updated == 1) {
-					JobWorkNotification workNotification = new JobWorkNotification(
-							myJobDefinitionId, myJobDefinitionVersion, instanceId, theTargetStepId, chunkId);
-					myBatchJobSender.sendWorkChannelMessage(workNotification);
-				} else {
-					ourLog.error(
-							"Expected to have updated 1 workchunk, but instead found {}. Chunk is not sent to queue.",
-							updated);
-				}
-			});
+			// The READY->QUEUED transition must not enlist in whatever transaction the calling step happens to
+			// have open, so it gets its own REQUIRES_NEW transaction on the default partition (BT2_WORK_CHUNK is
+			// unpartitioned, so targeting the default partition is required, not just for symmetry).
+			// The work channel message is deliberately sent from inside that transaction (transactional outbox),
+			// so the callback must stay within it.
+			myHapiTransactionService
+					.withSystemRequestOnDefaultPartition()
+					.withPropagation(Propagation.REQUIRES_NEW)
+					.execute(() -> myJobPersistence.enqueueWorkChunkForProcessing(chunkId, updated -> {
+						if (updated == 1) {
+							JobWorkNotification workNotification = new JobWorkNotification(
+									myJobDefinitionId, myJobDefinitionVersion, instanceId, theTargetStepId, chunkId);
+							myBatchJobSender.sendWorkChannelMessage(workNotification);
+						} else {
+							ourLog.error(
+									"Expected to have updated 1 workchunk, but instead found {}. Chunk is not sent to queue.",
+									updated);
+						}
+					}));
 		}
 	}
 

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDataSinkTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDataSinkTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -56,8 +57,9 @@ class JobDataSinkTest {
 	private static final int PID_COUNT = 729;
 	private static final String JOB_INSTANCE_ID = "17";
 	private static final String CHUNK_ID = "289";
+	private static final String PARENT_CHUNK_ID = "288";
 	public static final String FIRST_STEP_ID = "firstStep";
-	public static final String MIDDLE_STEP_ID = "middleStep";
+	private static final String MIDDLE_STEP_ID = "middleStep";
 	public static final String LAST_STEP_ID = "lastStep";
 
 	@Mock
@@ -159,8 +161,6 @@ class JobDataSinkTest {
 	}
 
 	/**
-	 * Primary reproduction for the {@literal JobDataSink} transaction demarcation defect.
-	 * <p>
 	 * A non-gated step (e.g. {@literal ResourceIdListStep} on the {@literal MDM_SUBMIT} job) sinks its child
 	 * chunks from inside a long-lived caller transaction, because the resource id stream is wrapped in
 	 * transaction advice so its {@literal ResultSet} stays open. The {@literal READY -> QUEUED} state update
@@ -193,24 +193,27 @@ class JobDataSinkTest {
 		assertThat(myFrameAtEnqueue)
 			.as("enqueueWorkChunkForProcessing must be invoked inside a transaction")
 			.isNotNull();
-		assertThat(myFrameAtEnqueue.getPropagation())
+		assertThat(myFrameAtEnqueue.propagation())
 			.as("enqueueWorkChunkForProcessing must run in its own REQUIRES_NEW transaction, not the caller's")
 			.isEqualTo(Propagation.REQUIRES_NEW);
 
 		assertThat(myFrameAtSend)
 			.as("sendWorkChannelMessage must be invoked inside a transaction (transactional outbox)")
 			.isNotNull();
-		assertThat(myFrameAtSend.getPropagation())
+		assertThat(myFrameAtSend.propagation())
 			.as("sendWorkChannelMessage must stay inside the REQUIRES_NEW enqueue transaction")
 			.isEqualTo(Propagation.REQUIRES_NEW);
 
-		assertThat(myFrameAtEnqueue.getRequestPartitionId())
+		assertThat(myFrameAtEnqueue.requestPartitionId())
 			.as("the enqueue must target the default partition, exactly as the chunk-creation call does")
 			.isEqualTo(RequestPartitionId.defaultPartition(new PartitionSettings()));
+
+		verify(myJobPersistence)
+			.enqueueWorkChunkForProcessing(eq(CHUNK_ID), any());
 	}
 
 	/**
-	 * Adjacent case A1: a gated job must not enqueue the chunk at all - the maintenance pass does that
+	 * A gated job must not enqueue the chunk at all - the maintenance pass does that
 	 * later - but the chunk creation must still happen in its own REQUIRES_NEW transaction.
 	 */
 	@Test
@@ -240,7 +243,7 @@ class JobDataSinkTest {
 		assertThat(myFrameAtCreate)
 			.as("onWorkChunkCreate must be invoked inside a transaction")
 			.isNotNull();
-		assertThat(myFrameAtCreate.getPropagation())
+		assertThat(myFrameAtCreate.propagation())
 			.as("onWorkChunkCreate must run in its own REQUIRES_NEW transaction")
 			.isEqualTo(Propagation.REQUIRES_NEW);
 		assertThat(myBatchWorkChunkCaptor.getValue().isGatedExecution)
@@ -249,7 +252,7 @@ class JobDataSinkTest {
 	}
 
 	/**
-	 * Adjacent case A2: {@literal acceptForFutureStep} is the second entry point into
+	 * {@literal acceptForFutureStep} is the second entry point into
 	 * {@literal acceptForStepId} and must get the same transaction demarcation as {@literal accept}.
 	 */
 	@Test
@@ -274,20 +277,20 @@ class JobDataSinkTest {
 		assertThat(myFrameAtEnqueue)
 			.as("enqueueWorkChunkForProcessing must be invoked inside a transaction")
 			.isNotNull();
-		assertThat(myFrameAtEnqueue.getPropagation())
+		assertThat(myFrameAtEnqueue.propagation())
 			.as("acceptForFutureStep must enqueue in its own REQUIRES_NEW transaction, not the caller's")
 			.isEqualTo(Propagation.REQUIRES_NEW);
 
 		assertThat(myFrameAtSend)
 			.as("sendWorkChannelMessage must be invoked inside a transaction (transactional outbox)")
 			.isNotNull();
-		assertThat(myFrameAtSend.getPropagation())
+		assertThat(myFrameAtSend.propagation())
 			.as("sendWorkChannelMessage must stay inside the REQUIRES_NEW enqueue transaction")
 			.isEqualTo(Propagation.REQUIRES_NEW);
 	}
 
 	/**
-	 * Adjacent case A4: the transactional-outbox ordering tripwire. The work channel message is
+	 * The transactional-outbox ordering tripwire: the work channel message is
 	 * deliberately sent from inside the {@literal enqueueWorkChunkForProcessing} callback, i.e. before the
 	 * {@literal READY -> QUEUED} transition commits. Hoisting the send out of the callback would break
 	 * at-least-once delivery.
@@ -388,7 +391,7 @@ class JobDataSinkTest {
 			(JobDefinitionStep<TestJobParameters, Step1Output, ?>) theJobDefinition.getSteps().get(1);
 		JobWorkCursor<TestJobParameters, VoidModel, Step1Output> cursor =
 			new JobWorkCursor<>(theJobDefinition, true, currentStep, nextStep);
-		WorkChunk chunk = new WorkChunk().setId(CHUNK_ID);
+		WorkChunk chunk = new WorkChunk().setId(PARENT_CHUNK_ID);
 		return new JobDataSink<>(myBatchJobSender, myJobPersistence, theJobDefinition, JOB_INSTANCE_ID, cursor, chunk, myHapiTransactionService);
 	}
 
@@ -428,25 +431,7 @@ class JobDataSinkTest {
 	/**
 	 * The demarcation of a single in-flight {@literal IHapiTransactionService} execution.
 	 */
-	private static class TransactionFrame {
-		private final Propagation myPropagation;
-		private final RequestPartitionId myRequestPartitionId;
-
-		TransactionFrame(@Nullable Propagation thePropagation, @Nullable RequestPartitionId theRequestPartitionId) {
-			myPropagation = thePropagation;
-			myRequestPartitionId = theRequestPartitionId;
-		}
-
-		@Nullable
-		Propagation getPropagation() {
-			return myPropagation;
-		}
-
-		@Nullable
-		RequestPartitionId getRequestPartitionId() {
-			return myRequestPartitionId;
-		}
-	}
+	private record TransactionFrame(@Nullable Propagation propagation, @Nullable RequestPartitionId requestPartitionId) {}
 
 	private static class Step1Output implements IModelJson {
 		@JsonProperty("pids")

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDataSinkTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/JobDataSinkTest.java
@@ -16,18 +16,22 @@ import ca.uhn.fhir.batch2.model.JobWorkCursor;
 import ca.uhn.fhir.batch2.model.JobWorkNotification;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.batch2.model.WorkChunkCreateEvent;
-import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.dao.tx.NonTransactionalHapiTransactionService;
+import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.model.api.IModelJson;
 import ca.uhn.fhir.util.JsonUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionCallback;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +57,7 @@ class JobDataSinkTest {
 	private static final String JOB_INSTANCE_ID = "17";
 	private static final String CHUNK_ID = "289";
 	public static final String FIRST_STEP_ID = "firstStep";
+	public static final String MIDDLE_STEP_ID = "middleStep";
 	public static final String LAST_STEP_ID = "lastStep";
 
 	@Mock
@@ -64,7 +70,16 @@ class JobDataSinkTest {
 	private ArgumentCaptor<JobWorkNotification> myJobWorkNotificationCaptor;
 	@Captor
 	private ArgumentCaptor<WorkChunkCreateEvent> myBatchWorkChunkCaptor;
-	private final IHapiTransactionService myHapiTransactionService = new NonTransactionalHapiTransactionService();
+	private final RecordingHapiTransactionService myHapiTransactionService = new RecordingHapiTransactionService();
+
+	/** The transaction frame that was open when {@link IJobPersistence#onWorkChunkCreate} was invoked. */
+	private TransactionFrame myFrameAtCreate;
+	/** The transaction frame that was open when {@link IJobPersistence#enqueueWorkChunkForProcessing} was invoked. */
+	private TransactionFrame myFrameAtEnqueue;
+	/** The transaction frame that was open when {@link BatchJobSender#sendWorkChannelMessage} was invoked. */
+	private TransactionFrame myFrameAtSend;
+	private boolean mySendWorkChannelMessageInvoked;
+	private boolean mySendWorkChannelMessageInvokedBeforeEnqueueReturned;
 
 	@Test
 	public void test_sink_accept() {
@@ -143,6 +158,296 @@ class JobDataSinkTest {
 		assertThat(stepOutput.getPids()).hasSize(PID_COUNT);
 	}
 
+	/**
+	 * Primary reproduction for the {@literal JobDataSink} transaction demarcation defect.
+	 * <p>
+	 * A non-gated step (e.g. {@literal ResourceIdListStep} on the {@literal MDM_SUBMIT} job) sinks its child
+	 * chunks from inside a long-lived caller transaction, because the resource id stream is wrapped in
+	 * transaction advice so its {@literal ResultSet} stays open. The {@literal READY -> QUEUED} state update
+	 * must not enlist in that caller transaction: it has to run in its own {@literal REQUIRES_NEW}
+	 * transaction on the default partition, exactly like the chunk-creation call immediately above it.
+	 * The outbox {@literal sendWorkChannelMessage} must happen inside that same transaction so that
+	 * at-least-once delivery is preserved.
+	 */
+	@Test
+	void testAccept_whenCallerHasOpenTransaction_enqueuesWorkChunkInItsOwnRequiresNewTransaction() {
+		// setup
+		JobDefinition<TestJobParameters> job = buildTwoStepJobDefinition(false);
+		JobDataSink<TestJobParameters, VoidModel, Step1Output> sink = buildSink(job);
+
+		when(myJobPersistence.onWorkChunkCreate(any())).thenReturn(CHUNK_ID);
+		recordTransactionFrameOnEnqueue();
+		recordTransactionFrameOnSend();
+
+		Step1Output output = new Step1Output();
+		output.addPid(1L);
+
+		// execute
+		// The caller (the step worker) already has a transaction open when it sinks the chunk
+		myHapiTransactionService.withSystemRequest().execute(() -> {
+			sink.accept(output);
+			return null;
+		});
+
+		// verify
+		assertThat(myFrameAtEnqueue)
+			.as("enqueueWorkChunkForProcessing must be invoked inside a transaction")
+			.isNotNull();
+		assertThat(myFrameAtEnqueue.getPropagation())
+			.as("enqueueWorkChunkForProcessing must run in its own REQUIRES_NEW transaction, not the caller's")
+			.isEqualTo(Propagation.REQUIRES_NEW);
+
+		assertThat(myFrameAtSend)
+			.as("sendWorkChannelMessage must be invoked inside a transaction (transactional outbox)")
+			.isNotNull();
+		assertThat(myFrameAtSend.getPropagation())
+			.as("sendWorkChannelMessage must stay inside the REQUIRES_NEW enqueue transaction")
+			.isEqualTo(Propagation.REQUIRES_NEW);
+
+		assertThat(myFrameAtEnqueue.getRequestPartitionId())
+			.as("the enqueue must target the default partition, exactly as the chunk-creation call does")
+			.isEqualTo(RequestPartitionId.defaultPartition(new PartitionSettings()));
+	}
+
+	/**
+	 * Adjacent case A1: a gated job must not enqueue the chunk at all - the maintenance pass does that
+	 * later - but the chunk creation must still happen in its own REQUIRES_NEW transaction.
+	 */
+	@Test
+	void testAccept_whenJobIsGated_createsChunkInRequiresNewTransactionAndDoesNotEnqueue() {
+		// setup
+		JobDefinition<TestJobParameters> job = buildTwoStepJobDefinition(true);
+		JobDataSink<TestJobParameters, VoidModel, Step1Output> sink = buildSink(job);
+
+		when(myJobPersistence.onWorkChunkCreate(myBatchWorkChunkCaptor.capture())).thenAnswer(theInvocation -> {
+			myFrameAtCreate = myHapiTransactionService.getCurrentFrame();
+			return CHUNK_ID;
+		});
+
+		Step1Output output = new Step1Output();
+		output.addPid(1L);
+
+		// execute
+		myHapiTransactionService.withSystemRequest().execute(() -> {
+			sink.accept(output);
+			return null;
+		});
+
+		// verify
+		verify(myJobPersistence, never()).enqueueWorkChunkForProcessing(anyString(), any());
+		verify(myBatchJobSender, never()).sendWorkChannelMessage(any());
+
+		assertThat(myFrameAtCreate)
+			.as("onWorkChunkCreate must be invoked inside a transaction")
+			.isNotNull();
+		assertThat(myFrameAtCreate.getPropagation())
+			.as("onWorkChunkCreate must run in its own REQUIRES_NEW transaction")
+			.isEqualTo(Propagation.REQUIRES_NEW);
+		assertThat(myBatchWorkChunkCaptor.getValue().isGatedExecution)
+			.as("a gated job must create its chunk in the gated state")
+			.isTrue();
+	}
+
+	/**
+	 * Adjacent case A2: {@literal acceptForFutureStep} is the second entry point into
+	 * {@literal acceptForStepId} and must get the same transaction demarcation as {@literal accept}.
+	 */
+	@Test
+	void testAcceptForFutureStep_whenCallerHasOpenTransaction_enqueuesWorkChunkInItsOwnRequiresNewTransaction() {
+		// setup
+		JobDefinition<TestJobParameters> job = buildThreeStepJobDefinition();
+		JobDataSink<TestJobParameters, VoidModel, Step1Output> sink = buildSink(job);
+
+		when(myJobPersistence.onWorkChunkCreate(any())).thenReturn(CHUNK_ID);
+		recordTransactionFrameOnEnqueue();
+		recordTransactionFrameOnSend();
+
+		Step2Output output = new Step2Output().setValue("skip-ahead");
+
+		// execute
+		myHapiTransactionService.withSystemRequest().execute(() -> {
+			sink.acceptForFutureStep(LAST_STEP_ID, output);
+			return null;
+		});
+
+		// verify
+		assertThat(myFrameAtEnqueue)
+			.as("enqueueWorkChunkForProcessing must be invoked inside a transaction")
+			.isNotNull();
+		assertThat(myFrameAtEnqueue.getPropagation())
+			.as("acceptForFutureStep must enqueue in its own REQUIRES_NEW transaction, not the caller's")
+			.isEqualTo(Propagation.REQUIRES_NEW);
+
+		assertThat(myFrameAtSend)
+			.as("sendWorkChannelMessage must be invoked inside a transaction (transactional outbox)")
+			.isNotNull();
+		assertThat(myFrameAtSend.getPropagation())
+			.as("sendWorkChannelMessage must stay inside the REQUIRES_NEW enqueue transaction")
+			.isEqualTo(Propagation.REQUIRES_NEW);
+	}
+
+	/**
+	 * Adjacent case A4: the transactional-outbox ordering tripwire. The work channel message is
+	 * deliberately sent from inside the {@literal enqueueWorkChunkForProcessing} callback, i.e. before the
+	 * {@literal READY -> QUEUED} transition commits. Hoisting the send out of the callback would break
+	 * at-least-once delivery.
+	 */
+	@Test
+	void testAccept_sendsWorkChannelMessageFromInsideTheEnqueueCallback() {
+		// setup
+		JobDefinition<TestJobParameters> job = buildTwoStepJobDefinition(false);
+		JobDataSink<TestJobParameters, VoidModel, Step1Output> sink = buildSink(job);
+
+		when(myJobPersistence.onWorkChunkCreate(any())).thenReturn(CHUNK_ID);
+		doAnswer(theInvocation -> {
+			Consumer<Integer> consumer = theInvocation.getArgument(1);
+			consumer.accept(1);
+			mySendWorkChannelMessageInvokedBeforeEnqueueReturned = mySendWorkChannelMessageInvoked;
+			return null;
+		}).when(myJobPersistence).enqueueWorkChunkForProcessing(anyString(), any());
+		doAnswer(theInvocation -> {
+			mySendWorkChannelMessageInvoked = true;
+			return null;
+		}).when(myBatchJobSender).sendWorkChannelMessage(any());
+
+		Step1Output output = new Step1Output();
+		output.addPid(1L);
+
+		// execute
+		sink.accept(output);
+
+		// verify
+		assertThat(mySendWorkChannelMessageInvoked)
+			.as("the work channel message must be sent")
+			.isTrue();
+		assertThat(mySendWorkChannelMessageInvokedBeforeEnqueueReturned)
+			.as("the work channel message must be sent from inside the enqueue callback, before it returns")
+			.isTrue();
+	}
+
+	private void recordTransactionFrameOnEnqueue() {
+		doAnswer(theInvocation -> {
+			myFrameAtEnqueue = myHapiTransactionService.getCurrentFrame();
+			Consumer<Integer> consumer = theInvocation.getArgument(1);
+			consumer.accept(1);
+			return null;
+		}).when(myJobPersistence).enqueueWorkChunkForProcessing(anyString(), any());
+	}
+
+	private void recordTransactionFrameOnSend() {
+		doAnswer(theInvocation -> {
+			myFrameAtSend = myHapiTransactionService.getCurrentFrame();
+			return null;
+		}).when(myBatchJobSender).sendWorkChannelMessage(any());
+	}
+
+	@Nonnull
+	private JobDefinition<TestJobParameters> buildTwoStepJobDefinition(boolean theGatedExecution) {
+		IJobStepWorker<TestJobParameters, VoidModel, Step1Output> firstStepWorker =
+			(details, sink) -> new RunOutcome(0);
+		IJobStepWorker<TestJobParameters, Step1Output, VoidModel> lastStepWorker =
+			(details, sink) -> new RunOutcome(0);
+
+		return JobDefinition.newBuilder()
+			.setJobDefinitionId(JOB_DEF_ID)
+			.setJobDescription(JOB_DESC)
+			.setJobDefinitionVersion(JOB_DEF_VERSION)
+			.setParametersType(TestJobParameters.class)
+			.gatedExecution(theGatedExecution)
+			.addFirstStep(FIRST_STEP_ID, "s1desc", Step1Output.class, firstStepWorker)
+			.addLastStep(LAST_STEP_ID, "s2desc", lastStepWorker)
+			.build();
+	}
+
+	@Nonnull
+	private JobDefinition<TestJobParameters> buildThreeStepJobDefinition() {
+		IJobStepWorker<TestJobParameters, VoidModel, Step1Output> firstStepWorker =
+			(details, sink) -> new RunOutcome(0);
+		IJobStepWorker<TestJobParameters, Step1Output, Step2Output> middleStepWorker =
+			(details, sink) -> new RunOutcome(0);
+		IJobStepWorker<TestJobParameters, Step2Output, VoidModel> lastStepWorker =
+			(details, sink) -> new RunOutcome(0);
+
+		return JobDefinition.newBuilder()
+			.setJobDefinitionId(JOB_DEF_ID)
+			.setJobDescription(JOB_DESC)
+			.setJobDefinitionVersion(JOB_DEF_VERSION)
+			.setParametersType(TestJobParameters.class)
+			.addFirstStep(FIRST_STEP_ID, "s1desc", Step1Output.class, firstStepWorker)
+			.addIntermediateStep(MIDDLE_STEP_ID, "s2desc", Step2Output.class, middleStepWorker)
+			.addLastStep(LAST_STEP_ID, "s3desc", lastStepWorker)
+			.build();
+	}
+
+	@Nonnull
+	@SuppressWarnings("unchecked")
+	private JobDataSink<TestJobParameters, VoidModel, Step1Output> buildSink(JobDefinition<TestJobParameters> theJobDefinition) {
+		JobDefinitionStep<TestJobParameters, VoidModel, Step1Output> currentStep =
+			(JobDefinitionStep<TestJobParameters, VoidModel, Step1Output>) theJobDefinition.getSteps().get(0);
+		JobDefinitionStep<TestJobParameters, Step1Output, ?> nextStep =
+			(JobDefinitionStep<TestJobParameters, Step1Output, ?>) theJobDefinition.getSteps().get(1);
+		JobWorkCursor<TestJobParameters, VoidModel, Step1Output> cursor =
+			new JobWorkCursor<>(theJobDefinition, true, currentStep, nextStep);
+		WorkChunk chunk = new WorkChunk().setId(CHUNK_ID);
+		return new JobDataSink<>(myBatchJobSender, myJobPersistence, theJobDefinition, JOB_INSTANCE_ID, cursor, chunk, myHapiTransactionService);
+	}
+
+	/**
+	 * A {@link NonTransactionalHapiTransactionService} that records the stack of transaction frames that
+	 * are currently open, so that a test can observe which demarcation was in effect at the moment a
+	 * collaborator was invoked.
+	 */
+	private static class RecordingHapiTransactionService extends NonTransactionalHapiTransactionService {
+		/**
+		 * Used as a stack. This is deliberately not an {@link java.util.ArrayDeque} - a frame opened by
+		 * {@literal withSystemRequest()} carries a {@literal null} propagation, and ArrayDeque rejects nulls.
+		 */
+		private final List<TransactionFrame> myOpenFrames = new ArrayList<>();
+
+		@Nullable
+		@Override
+		protected <T> T doExecute(ExecutionBuilder theExecutionBuilder, TransactionCallback<T> theCallback) {
+			myOpenFrames.add(new TransactionFrame(
+				theExecutionBuilder.getPropagation(), theExecutionBuilder.getRequestPartitionIdForTesting()));
+			try {
+				return super.doExecute(theExecutionBuilder, theCallback);
+			} finally {
+				myOpenFrames.remove(myOpenFrames.size() - 1);
+			}
+		}
+
+		@Nullable
+		TransactionFrame getCurrentFrame() {
+			if (myOpenFrames.isEmpty()) {
+				return null;
+			}
+			return myOpenFrames.get(myOpenFrames.size() - 1);
+		}
+	}
+
+	/**
+	 * The demarcation of a single in-flight {@literal IHapiTransactionService} execution.
+	 */
+	private static class TransactionFrame {
+		private final Propagation myPropagation;
+		private final RequestPartitionId myRequestPartitionId;
+
+		TransactionFrame(@Nullable Propagation thePropagation, @Nullable RequestPartitionId theRequestPartitionId) {
+			myPropagation = thePropagation;
+			myRequestPartitionId = theRequestPartitionId;
+		}
+
+		@Nullable
+		Propagation getPropagation() {
+			return myPropagation;
+		}
+
+		@Nullable
+		RequestPartitionId getRequestPartitionId() {
+			return myRequestPartitionId;
+		}
+	}
+
 	private static class Step1Output implements IModelJson {
 		@JsonProperty("pids")
 		private List<Long> myPids;
@@ -156,6 +461,20 @@ class JobDataSinkTest {
 
 		public void addPid(long thePid) {
 			getPids().add(thePid);
+		}
+	}
+
+	private static class Step2Output implements IModelJson {
+		@JsonProperty("value")
+		private String myValue;
+
+		public String getValue() {
+			return myValue;
+		}
+
+		public Step2Output setValue(String theValue) {
+			myValue = theValue;
+			return this;
 		}
 	}
 }


### PR DESCRIPTION
## For Code Reviewer

`JobDataSink.acceptForStepId` used to call `enqueueWorkChunkForProcessing` (the READY→QUEUED transition) as a bare persistence call, which meant it joined whatever transaction the calling job step had open. For non-gated jobs whose step keeps a long-running transaction (`$mdm-submit`'s `ResourceIdListStep` is the only built-in example — it holds one transaction open across the whole ID stream), the chunk was published to the work channel while the state update was still uncommitted. Worker threads picking up the notification then blocked on the chunk row lock for the duration of the step, and chunks could be left stalled in `READY`.

The fix wraps the enqueue in its own `REQUIRES_NEW` transaction targeted at the default partition (`BT2_WORK_CHUNK` is unpartitioned), matching how chunk creation is already handled. The outbox callback that sends the work channel message is deliberately kept *inside* that new transaction rather than moved outside it — this preserves the transactional-outbox pattern (at-least-once delivery tied to the commit) rather than introducing a window where the message could be sent before the state change commits, or dropped if the send fails after an early commit.

## For QA

- [ ] Non-gated batch2 jobs (e.g. `$mdm-submit`) no longer leave work chunks stalled in `READY` state when a step holds a long-running transaction while creating chunks.
- [ ] Work chunks transition READY → QUEUED and are picked up by worker threads without lock contention delays.
- [ ] Work channel notifications are still sent exactly once per successful enqueue (no duplicate or dropped notifications) — verified by `testSimultaneousDeque_beforeEnqueCommit_doesNotDropChunk`.
- [ ] Gated job execution is unaffected (this change only applies to the non-gated enqueue path).
- [ ] Existing batch2 job processing (bulk export, reindex, etc.) continues to function normally.

Closes #8208
