### PR TITLE
Fix ConsentInterceptor destroying sibling entries in repeating fields (e.g. contained) when replacing a resource

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/BaseRuntimeChildDefinition.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/BaseRuntimeChildDefinition.java
@@ -104,6 +104,26 @@ public abstract class BaseRuntimeChildDefinition {
 		default void remove(IBase theTarget, int theIndex) {
 			// implemented in subclasses
 		}
+
+		/**
+		 * Replace a single existing value with a new one, preserving its position among any
+		 * sibling values.
+		 * <p>
+		 * For single-valued fields, this behaves the same as {@link #setValue(IBase, IBase)}.
+		 * For repeating (list-valued) fields, unlike {@link #setValue(IBase, IBase)} (which
+		 * clears the entire list before adding the new value), this replaces only the entry
+		 * matching {@code theOldValue} (compared by reference), leaving all other entries in
+		 * place. If {@code theOldValue} can't be found, this behaves like
+		 * {@link #addValue(IBase, IBase)}.
+		 * </p>
+		 *
+		 * @param theTarget   field holding the value to replace (e.g. planDefinition.contained)
+		 * @param theOldValue the existing value being replaced
+		 * @param theNewValue the new value
+		 */
+		default void replace(IBase theTarget, IBase theOldValue, IBase theNewValue) {
+			setValue(theTarget, theNewValue);
+		}
 	}
 
 	BaseRuntimeElementDefinition<?> findResourceReferenceDefinition(

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/BaseRuntimeDeclaredChildDefinition.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/BaseRuntimeDeclaredChildDefinition.java
@@ -192,6 +192,21 @@ public abstract class BaseRuntimeDeclaredChildDefinition extends BaseRuntimeChil
 			}
 			existingList.remove(theIndex);
 		}
+
+		@Override
+		public void replace(IBase theTarget, IBase theOldValue, IBase theNewValue) {
+			@SuppressWarnings("unchecked")
+			List<IBase> existingList = (List<IBase>) getFieldValue(theTarget, myField);
+			if (existingList != null) {
+				for (int i = 0; i < existingList.size(); i++) {
+					if (existingList.get(i) == theOldValue) {
+						existingList.set(i, theNewValue);
+						return;
+					}
+				}
+			}
+			addValue(theTarget, theNewValue);
+		}
 	}
 
 	private final class FieldPlainAccessor implements IAccessor {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/RuntimeChildExt.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/RuntimeChildExt.java
@@ -105,6 +105,19 @@ public class RuntimeChildExt extends BaseRuntimeChildDefinition {
 					extensions.add(value);
 				}
 			}
+
+			@Override
+			@SuppressWarnings({"unchecked", "rawtypes"})
+			public void replace(IBase theTarget, IBase theOldValue, IBase theNewValue) {
+				List extensions = ((IBaseHasExtensions) theTarget).getExtension();
+				for (int i = 0; i < extensions.size(); i++) {
+					if (extensions.get(i) == theOldValue) {
+						extensions.set(i, theNewValue);
+						return;
+					}
+				}
+				addValue(theTarget, theNewValue);
+			}
 		};
 	}
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8212-fix-consent-interceptor-contained-resource-replacement.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8212-fix-consent-interceptor-contained-resource-replacement.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 8212
+title: "Previously, if an `IConsentService`'s `willSeeResource(...)` method returned a resource nested
+  inside a repeating field (such as `contained`) to indicate that it had been inspected, even when
+  unchanged, `ConsentInterceptor` would clear every other entry in that repeating field, keeping only
+  the returned resource. This has now been fixed. Thanks to Jens Villadsen for the contribution!"

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/consent/ConsentInterceptor.java
@@ -519,7 +519,10 @@ public class ConsentInterceptor {
 							IBase container = theContainingElementPath.get(theContainingElementPath.size() - 2);
 							BaseRuntimeChildDefinition containerChildElement =
 									theChildDefinitionPath.get(theChildDefinitionPath.size() - 1);
-							containerChildElement.getMutator().setValue(container, replacementResource);
+							// Use replace(..) rather than setValue(..): for a repeating field (e.g. contained),
+							// setValue clears the whole list before adding the replacement back, wiping out
+							// every sibling entry. replace(..) swaps only this element, in place.
+							containerChildElement.getMutator().replace(container, resource, replacementResource);
 							resource = replacementResource;
 						}
 					}

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/interceptor/ConsentInterceptorTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/interceptor/ConsentInterceptorTest.java
@@ -38,12 +38,15 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.PlanDefinition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -92,12 +95,15 @@ public class ConsentInterceptorTest {
 	private static final DummySystemProvider ourSystemProvider = new DummySystemProvider();
 	private static final HashMapResourceProvider<Bundle> ourBundleProvider =
 		 new HashMapResourceProvider<>(ourCtx, Bundle.class);
+	private static final HashMapResourceProvider<PlanDefinition> ourPlanDefinitionProvider =
+		 new HashMapResourceProvider<>(ourCtx, PlanDefinition.class);
 
 	@RegisterExtension
 	static final RestfulServerExtension ourServer = new RestfulServerExtension(ourCtx)
 		.registerProvider(ourPatientProvider)
 		.registerProvider(ourSystemProvider)
 		.registerProvider(ourBundleProvider)
+		.registerProvider(ourPlanDefinitionProvider)
 		.withPagingProvider(new FifoMemoryPagingProvider(10));
 
 	@Mock(answer = Answers.CALLS_REAL_METHODS)
@@ -124,6 +130,7 @@ public class ConsentInterceptorTest {
 		ourServer.registerInterceptor(myInterceptor);
 		ourPatientProvider.clear();
 		ourBundleProvider.clear();
+		ourPlanDefinitionProvider.clear();
 	}
 
 	@Test
@@ -1089,6 +1096,75 @@ public class ConsentInterceptorTest {
 	}
 
 
+
+	@Nested
+	class ContainedResources {
+
+		@BeforeEach
+		void storePlanDefinitionAndAllowConsentToSeeIt() {
+			PlanDefinition planDefinition = new PlanDefinition();
+			planDefinition.setId("plan-1");
+			planDefinition.setStatus(Enumerations.PublicationStatus.ACTIVE);
+			for (String id : new String[] {"activity-1", "activity-2", "activity-3"}) {
+				ActivityDefinition activityDefinition = new ActivityDefinition();
+				activityDefinition.setId(id);
+				activityDefinition.setStatus(Enumerations.PublicationStatus.DRAFT);
+				activityDefinition.setKind(ActivityDefinition.ActivityDefinitionKind.TASK);
+				planDefinition.addContained(activityDefinition);
+			}
+			ourPlanDefinitionProvider.store(planDefinition);
+
+			when(myConsentSvc.canSeeResource(any(), any(), any())).thenReturn(ConsentOutcome.PROCEED);
+		}
+
+		private PlanDefinition fetchPlanDefinition() throws IOException {
+			HttpGet httpGet = new HttpGet("http://localhost:" + myPort + "/PlanDefinition/plan-1");
+			try (CloseableHttpResponse status = myClient.execute(httpGet)) {
+				assertEquals(200, status.getStatusLine().getStatusCode());
+				String responseContent = IOUtils.toString(status.getEntity().getContent(), Charsets.UTF_8);
+				return ourCtx.newJsonParser().parseResource(PlanDefinition.class, responseContent);
+			}
+		}
+
+		/**
+		 * A consent service that returns a resource unchanged from willSeeResource (e.g. just to record that it
+		 * was "seen") used to be misread by ConsentInterceptor as "replace this element", which cleared the whole
+		 * `contained` list before adding the single replacement back.
+		 */
+		@Test
+		void allContainedResourcesSurviveWhenConsentServiceReportsResourceUnchanged() throws IOException {
+			when(myConsentSvc.willSeeResource(any(RequestDetails.class), any(IBaseResource.class), any()))
+				 .thenAnswer(t -> new ConsentOutcome(ConsentOperationStatusEnum.PROCEED, (IBaseResource) t.getArguments()[1]));
+
+			assertThat(fetchPlanDefinition().getContained()).hasSize(3);
+		}
+
+		/**
+		 * When a consent service genuinely replaces one contained resource, only that entry should change --
+		 * its siblings must stay in place, and the replacement must land at the original position.
+		 */
+		@Test
+		void subsettedContainedResourceIsReplacedInPlaceAmongSiblings() throws IOException {
+			when(myConsentSvc.willSeeResource(any(RequestDetails.class), any(IBaseResource.class), any())).thenAnswer(t -> {
+				IBaseResource resource = (IBaseResource) t.getArguments()[1];
+				if (resource instanceof ActivityDefinition && "activity-2".equals(resource.getIdElement().getIdPart())) {
+					ActivityDefinition replacement = new ActivityDefinition();
+					replacement.setId("activity-2");
+					replacement.setStatus(Enumerations.PublicationStatus.RETIRED);
+					return new ConsentOutcome(ConsentOperationStatusEnum.PROCEED, replacement);
+				}
+				return ConsentOutcome.PROCEED;
+			});
+
+			PlanDefinition response = fetchPlanDefinition();
+			assertThat(response.getContained()).hasSize(3);
+			assertThat(response.getContained().get(0).getIdElement().getIdPart()).isEqualTo("activity-1");
+			assertThat(response.getContained().get(1).getIdElement().getIdPart()).isEqualTo("activity-2");
+			assertThat(((ActivityDefinition) response.getContained().get(1)).getStatus())
+				 .isEqualTo(Enumerations.PublicationStatus.RETIRED);
+			assertThat(response.getContained().get(2).getIdElement().getIdPart()).isEqualTo("activity-3");
+		}
+	}
 
 	public static class DummyPatientResourceProvider extends HashMapResourceProvider<Patient> {
 


### PR DESCRIPTION
This pull request addresses an important bug (https://github.com/hapifhir/hapi-fhir/issues/8212) in the `ConsentInterceptor` related to handling resources in repeating fields (such as `contained`) when processed by an `IConsentService`. Previously, replacing a resource in a repeating field could inadvertently remove all sibling entries, but this is now fixed. The changes also add comprehensive tests to ensure correct behavior and document the fix.

**Bug fix for replacing resources in repeating fields:**

* Updated `IMutator` interface and its implementations (`BaseRuntimeDeclaredChildDefinition`, `RuntimeChildExt`) to add a `replace` method that swaps only the targeted entry in a repeating field, instead of clearing the entire list. [[1]](diffhunk://#diff-6e9d1d89fb052ee94d78a0f88626ea186f70e1ddce4bd1daab0fc22bfd83e79eR107-R126) [[2]](diffhunk://#diff-455d1c8eb812b6e6afbde387af8d4b099396d088658ba5ce289a66ff1735872eR195-R209) [[3]](diffhunk://#diff-87f9edb58e7f751fe7388f738f9285a1254d13daa3602b6294a1ad6940f0e21aR108-R120)
* Modified `ConsentInterceptor` to use the new `replace` method instead of `setValue`, ensuring that only the intended resource is replaced and sibling entries remain unaffected.

**Testing and documentation:**

* Added new tests in `ConsentInterceptorTest` to verify that all contained resources survive when unchanged and that replacements occur in place without disturbing sibling entries. [[1]](diffhunk://#diff-861318aa465cf629b70f801ef921f81e946ee4332d13a90e2e4548cd3b3ae2ffR41-R49) [[2]](diffhunk://#diff-861318aa465cf629b70f801ef921f81e946ee4332d13a90e2e4548cd3b3ae2ffR98-R106) [[3]](diffhunk://#diff-861318aa465cf629b70f801ef921f81e946ee4332d13a90e2e4548cd3b3ae2ffR133) [[4]](diffhunk://#diff-861318aa465cf629b70f801ef921f81e946ee4332d13a90e2e4548cd3b3ae2ffR1100-R1168)
* Added a changelog entry describing the bug and its resolution.