### PR TITLE
Fix same-partition Patient $merge blocked by compartment enforcement

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8200-same-partition-merge-compartment-enforcement.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8200-same-partition-merge-compartment-enforcement.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 8200
+title: "Previously, when the Patient ID Partitioning Interceptor was used together with the Patient Compartment Enforcing Interceptor, a Patient $merge could fail with an HTTP 412 error, because the merge tried to update patient compartment resources in place. This is now fixed by creating copies of those resources in the target Patient's compartment during the merge operation, similar to a cross-partition merge."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/PartitionAwareReplaceReferencesSvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/PartitionAwareReplaceReferencesSvc.java
@@ -302,18 +302,15 @@ public class PartitionAwareReplaceReferencesSvc {
 			List<IBaseResource> theUpdateList) {
 
 		for (IBaseResource resource : theResources) {
-			Integer currentPartitionId = RequestPartitionId.getPartitionFromUserDataIfPresent(resource)
-					.map(RequestPartitionId::getFirstPartitionIdOrNull)
-					.orElse(null);
+			RequestPartitionId currentPartition = determinePartition(resource, theRequestDetails);
 
 			// Rewrite source→target references so determineCreatePartitionForRequest
 			// routes based on the post-merge state.
 			replaceVersionlessReferences(resource, Map.of(theSourceRef, theTargetRef));
 
 			RequestPartitionId newPartition = determinePartition(resource, theRequestDetails);
-			Integer newPartitionId = newPartition.getFirstPartitionIdOrNull();
 
-			if (Objects.equals(currentPartitionId, newPartitionId)) {
+			if (Objects.equals(currentPartition, newPartition)) {
 				theUpdateList.add(resource);
 			} else {
 				theCopiesByDestPartition
@@ -323,21 +320,9 @@ public class PartitionAwareReplaceReferencesSvc {
 		}
 	}
 
-	/**
-	 * Determines the partition for a resource by temporarily clearing its existing
-	 * RESOURCE_PARTITION_ID and asking the partition helper to compute a fresh partition
-	 * based on the resource's current references. The original partition is restored afterward.
-	 */
 	private RequestPartitionId determinePartition(IBaseResource theResource, RequestDetails theRequestDetails) {
-		Object savedPartitionUserData = theResource.getUserData(Constants.RESOURCE_PARTITION_ID);
-		try {
-			theResource.setUserData(Constants.RESOURCE_PARTITION_ID, null);
-			String resourceType = myFhirContext.getResourceType(theResource);
-			return myRequestPartitionHelperSvc.determineCreatePartitionForRequest(
-					theRequestDetails, theResource, resourceType);
-		} finally {
-			theResource.setUserData(Constants.RESOURCE_PARTITION_ID, savedPartitionUserData);
-		}
+		return myRequestPartitionHelperSvc.determineCreatePartitionForRequestIgnoringCachedPartition(
+				theRequestDetails, theResource, myFhirContext.getResourceType(theResource));
 	}
 
 	private enum ChangeType {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeService.java
@@ -66,7 +66,7 @@ import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 
 import static ca.uhn.fhir.batch2.jobs.merge.MergeAppCtx.JOB_MERGE;
 import static ca.uhn.fhir.merge.MergeResourceHelper.addErrorToOperationOutcome;
@@ -174,7 +174,8 @@ public class ResourceMergeService {
 			IBaseResource sourceResource = mergeValidationResult.sourceResource;
 			IBaseResource targetResource = mergeValidationResult.targetResource;
 
-			boolean isPartitionAwareMerge = requiresPartitionAwareMerge(sourceResource, targetResource);
+			boolean isPartitionAwareMerge =
+					requiresPartitionAwareMerge(sourceResource, targetResource, theRequestDetails);
 			validatePartitionAwareMergeAsyncNotSupported(isPartitionAwareMerge, theRequestDetails);
 
 			if (theMergeOperationParameters.getPreview()) {
@@ -269,7 +270,8 @@ public class ResourceMergeService {
 
 		Date startTime = new Date();
 
-		boolean partitionAwareMerge = requiresPartitionAwareMerge(theSourceResource, theTargetResource);
+		boolean partitionAwareMerge =
+				requiresPartitionAwareMerge(theSourceResource, theTargetResource, theRequestDetails);
 
 		validateResourceLimit(theMergeOperationParameters, theSourceResource, theRequestDetails, partitionAwareMerge);
 
@@ -740,7 +742,8 @@ public class ResourceMergeService {
 		}
 	}
 
-	private boolean requiresPartitionAwareMerge(IBaseResource theSourceResource, IBaseResource theTargetResource) {
+	private boolean requiresPartitionAwareMerge(
+			IBaseResource theSourceResource, IBaseResource theTargetResource, RequestDetails theRequestDetails) {
 		if (!myPartitionSettings.isPartitioningEnabled()) {
 			return false;
 		}
@@ -750,16 +753,20 @@ public class ResourceMergeService {
 		// every merge through it, not just cross-partition ones.
 		// TODO: either add all-partition support to the regular replace-references path, or merge the
 		// two paths so that the partition-aware path handles all cases.
-		return isCrossPartitionMerge(theSourceResource, theTargetResource)
-				|| !myPartitionSettings.isAllPartitionSearchSupported();
-	}
-
-	private boolean isCrossPartitionMerge(IBaseResource theSourceResource, IBaseResource theTargetResource) {
-		if (!myPartitionSettings.isPartitioningEnabled()) {
-			return false;
+		if (!myPartitionSettings.isAllPartitionSearchSupported()) {
+			return true;
 		}
-		Optional<RequestPartitionId> srcPart = RequestPartitionId.getPartitionFromUserDataIfPresent(theSourceResource);
-		Optional<RequestPartitionId> tgtPart = RequestPartitionId.getPartitionFromUserDataIfPresent(theTargetResource);
-		return srcPart.isPresent() && tgtPart.isPresent() && !srcPart.get().equals(tgtPart.get());
+		// This is the same computation PatientCompartmentEnforcingInterceptor performs, so in Patient ID mode it
+		// detects not only a change of partition but also a change of patient compartment within the same
+		// partition. Such a compartment change requires copying the referring resources too, since otherwise the
+		// enforcer rejects the in-place update.
+		String resourceType = myFhirContext.getResourceType(theSourceResource);
+		RequestPartitionId sourcePartition =
+				myRequestPartitionHelperSvc.determineCreatePartitionForRequestIgnoringCachedPartition(
+						theRequestDetails, theSourceResource, resourceType);
+		RequestPartitionId targetPartition =
+				myRequestPartitionHelperSvc.determineCreatePartitionForRequestIgnoringCachedPartition(
+						theRequestDetails, theTargetResource, resourceType);
+		return !Objects.equals(sourcePartition, targetPartition);
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/merge/ResourceMergeServiceTest.java
@@ -67,7 +67,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -703,6 +702,12 @@ public class ResourceMergeServiceTest {
 			myTargetPatient.setUserData(Constants.RESOURCE_PARTITION_ID, RequestPartitionId.fromPartitionId(TARGET_PARTITION_ID));
 			setupValidationMockForSuccess(mySourcePatient, myTargetPatient);
 			when(myPartitionSettingsMock.isPartitioningEnabled()).thenReturn(true);
+			when(myRequestPartitionHelperSvcMock.determineCreatePartitionForRequestIgnoringCachedPartition(
+							any(), eq(mySourcePatient), any()))
+					.thenReturn(RequestPartitionId.fromPartitionId(SOURCE_PARTITION_ID));
+			when(myRequestPartitionHelperSvcMock.determineCreatePartitionForRequestIgnoringCachedPartition(
+							any(), eq(myTargetPatient), any()))
+					.thenReturn(RequestPartitionId.fromPartitionId(TARGET_PARTITION_ID));
 		}
 
 		@ParameterizedTest

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/partition/IRequestPartitionHelperSvc.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/partition/IRequestPartitionHelperSvc.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.interceptor.model.ReadPartitionIdRequestDetails;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.storage.IResourcePersistentId;
 import jakarta.annotation.Nonnull;
@@ -154,6 +155,28 @@ public interface IRequestPartitionHelperSvc {
 	@Nonnull
 	RequestPartitionId determineCreatePartitionForRequest(
 			@Nullable RequestDetails theRequest, @Nonnull IBaseResource theResource, @Nonnull String theResourceType);
+
+	/**
+	 * Same as {@link #determineCreatePartitionForRequest(RequestDetails, IBaseResource, String)}, except that the
+	 * partition cached in the resource's {@link Constants#RESOURCE_PARTITION_ID} user data is ignored, so the
+	 * partition is always recomputed from the resource's current content. The cached value is restored afterward.
+	 *
+	 * @param theRequest the request details from the context of the call
+	 * @param theResource the resource whose partition should be recomputed
+	 * @param theResourceType the resource type
+	 * @return the partition computed from the resource's current content
+	 */
+	@Nonnull
+	default RequestPartitionId determineCreatePartitionForRequestIgnoringCachedPartition(
+			@Nullable RequestDetails theRequest, @Nonnull IBaseResource theResource, @Nonnull String theResourceType) {
+		Object cachedPartition = theResource.getUserData(Constants.RESOURCE_PARTITION_ID);
+		try {
+			theResource.setUserData(Constants.RESOURCE_PARTITION_ID, null);
+			return determineCreatePartitionForRequest(theRequest, theResource, theResourceType);
+		} finally {
+			theResource.setUserData(Constants.RESOURCE_PARTITION_ID, cachedPartition);
+		}
+	}
 
 	@Nonnull
 	Set<Integer> toReadPartitions(@Nonnull RequestPartitionId theRequestPartitionId);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/PatientIdModePatientMergeR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/merge/PatientIdModePatientMergeR4Test.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.dao.TransactionPrePartitionResponse;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
+import ca.uhn.fhir.jpa.interceptor.PatientCompartmentEnforcingInterceptor;
 import ca.uhn.fhir.jpa.interceptor.PatientIdPartitionInterceptor;
 import ca.uhn.fhir.jpa.merge.MergeOperationTestHelper;
 import ca.uhn.fhir.jpa.merge.MergeTestParameters;
@@ -86,6 +87,8 @@ public class PatientIdModePatientMergeR4Test extends BaseResourceProviderR4Test 
 	private ResourceLinkServiceFactory myResourceLinkServiceFactory;
 	@Autowired
 	private HapiTransactionService myHapiTransactionService;
+	@Autowired
+	private PatientCompartmentEnforcingInterceptor myPatientCompartmentEnforcingInterceptor;
 	private PatientIdPartitionInterceptor myPartitionInterceptor;
 	private MergeOperationTestHelper myMergeHelper;
 	private IIdType myPatientIdSrc;
@@ -101,6 +104,7 @@ public class PatientIdModePatientMergeR4Test extends BaseResourceProviderR4Test 
 		myPartitionInterceptor = new PatientIdPartitionInterceptor(
 			getFhirContext(), mySearchParamExtractor, myPartitionSettings, myDaoRegistry);
 		registerInterceptor(myPartitionInterceptor);
+		registerInterceptor(myPatientCompartmentEnforcingInterceptor);
 
 		myPartitionSettings.setPartitioningEnabled(true);
 		myPartitionSettings.setUnnamedPartitionMode(true);
@@ -669,6 +673,79 @@ public class PatientIdModePatientMergeR4Test extends BaseResourceProviderR4Test 
 				.as("an indirect referrer, which only references a moved resource, still counts against the limit")
 				.contains("HAPI-3023")
 				.contains("exceeds the resource-limit");
+		}
+	}
+
+	@Nested
+	class SamePartitionMergeWithCompartmentEnforcement {
+
+		// "src-4963" and "tgt-1" both hash to partition 14829 under
+		// PatientIdPartitionInterceptor.defaultPartitionAlgorithm
+		private static final String SAME_PARTITION_SOURCE_ID_PART = "src-4963";
+		private static final String SAME_PARTITION_TARGET_ID_PART = "tgt-1";
+
+		private IIdType mySamePartitionSrc;
+		private IIdType mySamePartitionTgt;
+
+		@BeforeEach
+		void beforeEach() {
+			mySamePartitionSrc = createPatient("Patient/" + SAME_PARTITION_SOURCE_ID_PART, List.of())
+				.getIdElement().toUnqualifiedVersionless();
+			mySamePartitionTgt = createPatient("Patient/" + SAME_PARTITION_TARGET_ID_PART, List.of())
+				.getIdElement().toUnqualifiedVersionless();
+			assertInSamePartition(mySamePartitionSrc, mySamePartitionTgt);
+		}
+
+		// Observation(subject=PatientSrc) where PatientSrc and PatientTgt are in the SAME partition, with
+		// PatientCompartmentEnforcingInterceptor registered. The merge causes the Observation to change to the
+		// target Patient's compartment, so it needs to be moved rather than updated in place. The undo must
+		// then move it back under its original ID.
+		@Test
+		void testMergeThenUndo_compartmentResourceReferencingSource_whenPatientsInSamePartition_resourceIsMovedAndRestored() {
+			// Setup
+			IIdType obsId = createObservation(mySamePartitionSrc, null, null, "obs-same-partition");
+
+			IBaseResource patientSrcBefore = readResource(Patient.class, mySamePartitionSrc);
+			IBaseResource patientTgtBefore = readResource(Patient.class, mySamePartitionTgt);
+			IBaseResource obsBefore = readResource(Observation.class, obsId);
+
+			// Execute
+			MergeTestParameters mergeParams = new MergeTestParameters()
+				.sourceResource(new Reference(mySamePartitionSrc))
+				.targetResource(new Reference(mySamePartitionTgt));
+			Parameters result = callMerge(mergeParams);
+			myMergeHelper.validateSyncMergeOutcome(result, mergeParams.asParametersResource(), mySamePartitionTgt);
+
+			// Verify: Obs moved to the target patient's compartment, old ID deleted
+			Observation movedObs = assertSingleResourceMovedToTarget(
+				Observation.class, Map.of("obs-same-partition", obsId), mySamePartitionTgt, Observation::getIdentifier);
+			IIdType movedObsId = movedObs.getIdElement().toUnqualifiedVersionless();
+
+			// Undo merge
+			Parameters undoParams = new Parameters();
+			undoParams.addParameter().setName("source-resource").setValue(new Reference(mySamePartitionSrc));
+			undoParams.addParameter().setName("target-resource").setValue(new Reference(mySamePartitionTgt));
+			myMergeHelper.callUndoMergeOperation("Patient", undoParams);
+
+			// Verify: Obs restored under its original ID in the source patient's compartment
+			List<Observation> restoredObs = searchBySubject(Observation.class, mySamePartitionSrc.getValue());
+			assertThat(restoredObs).hasSize(1);
+			assertThat(restoredObs.get(0).getIdElement().toUnqualifiedVersionless())
+				.as("undo must restore the Observation under its original ID")
+				.isEqualTo(obsId);
+
+			myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(
+				patientSrcBefore, readResource(Patient.class, mySamePartitionSrc));
+			myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(
+				patientTgtBefore, readResource(Patient.class, mySamePartitionTgt));
+			myMergeHelper.assertResourcesAreEqualIgnoringVersionAndLastUpdated(
+				obsBefore, readResource(Observation.class, obsId));
+
+			assertResourceDeleted(movedObsId);
+
+			assertThat(searchBySubject(Observation.class, mySamePartitionTgt.getValue()))
+				.as("no Observation should reference the target after undo")
+				.isEmpty();
 		}
 	}
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptor.java
@@ -28,7 +28,6 @@ import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
 import ca.uhn.fhir.jpa.util.ResourceCompartmentUtil;
-import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -132,19 +131,10 @@ public class PatientCompartmentEnforcingInterceptor {
 	 */
 	private String determinePartition(
 			RequestDetails theRequestDetails, IBaseResource theResource, String resourceType) {
-		Object stashedPartition = theResource.getUserData(Constants.RESOURCE_PARTITION_ID);
-		if (stashedPartition != null) {
-			theResource.setUserData(Constants.RESOURCE_PARTITION_ID, null);
-		}
-		try {
-			assert myRequestPartitionHelperSvc != null;
-			RequestPartitionId requestPartition = myRequestPartitionHelperSvc.determineCreatePartitionForRequest(
-					theRequestDetails, theResource, resourceType);
-			return requestPartition.toJson();
-		} finally {
-			if (stashedPartition != null) {
-				theResource.setUserData(Constants.RESOURCE_PARTITION_ID, stashedPartition);
-			}
-		}
+		assert myRequestPartitionHelperSvc != null;
+		RequestPartitionId requestPartition =
+				myRequestPartitionHelperSvc.determineCreatePartitionForRequestIgnoringCachedPartition(
+						theRequestDetails, theResource, resourceType);
+		return requestPartition.toJson();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/hapifhir/hapi-fhir/issues/8200.

### The problem

In Patient ID partitioning mode, a Patient `$merge` failed with HTTP 412 / `HAPI-2476` when the source and
target Patients resolved to the **same** partition id and a patient-compartment resource referenced the
source.

The rejection comes from **`PatientCompartmentEnforcingInterceptor`**, which blocks any update that would
move a resource out of the patient compartment it was stored under. It and the merge asked different
questions:

- **The enforcer** compares the whole `RequestPartitionId`. `PatientIdPartitionInterceptor` puts the patient
  id part in the partition *name*, so the enforcer correctly sees the compartment would change, and throws
  `Msg.code(2476)`.
- **The merge** compared only the numeric partition id. Two patient ids can hash to the same partition, and
  when they do it found no difference — so it concluded the resource did not need to move and updated it in
  place, which is exactly the write the enforcer rejects.

### The fix

- `ResourceMergeService` (routing) and `PartitionAwareReplaceReferencesSvc` (per-resource classification)
  now compare the full `RequestPartitionId`, recomputed from resource content — the same question the
  enforcer asks.
- That computation moved to `IRequestPartitionHelperSvc`, and `PatientCompartmentEnforcingInterceptor` was
  refactored onto it, so the two cannot drift apart.

A compartment resource whose compartment changes is therefore **moved** rather than updated in place, even
when both patients hash to the same partition, and undo restores it under its original id.

### Tests

`PatientIdModePatientMergeR4Test.SamePartitionMergeWithCompartmentEnforcement` uses two patient ids that
collide onto one partition. It fails on the base branch and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
