### PR TITLE
Adding JS provider

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8236-add-execute-javascript-operation.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8236-add-execute-javascript-operation.yaml
@@ -1,0 +1,10 @@
+---
+type: add
+issue: 8236
+title: "A new system-level operation `$execute-javascript` has been added to the JPA server. It runs an
+  administrator-vetted, server-side JavaScript file (sandboxed via the embedded GraalJS engine, with no
+  host, filesystem or network access, and a configurable execution timeout) to transform FHIR resources.
+  Callers reference a script by name and cannot supply code over the wire. The provider is not wired in
+  by default; deployments must add the optional `org.graalvm.js:js` dependency, configure a scripts
+  directory via `JpaStorageSettings`, and register the `JavaScriptExecutionProvider` explicitly.
+  Thanks to Jens Kristian Villadsen for the contribution!"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
@@ -73,6 +73,7 @@ page.server_jpa.performance=Performance
 page.server_jpa.upgrading=Upgrade Guide
 page.server_jpa.diff=Diff Operation
 page.server_jpa.fhir_patch=FHIR Patch
+page.server_jpa.javascript_execution=JavaScript Execution Operation
 page.server_jpa.lastn=LastN Operation
 page.server_jpa.elastic=Lucene/Elasticsearch Indexing
 page.server_jpa.terminology=Terminology

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/javascript_execution.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/javascript_execution.md
@@ -1,0 +1,47 @@
+# JavaScript Execution Operation
+
+The system-level `$execute-javascript` operation runs a **server-side** JavaScript file (via the embedded GraalJS engine) to transform FHIR resources. Callers do **not** send code - they reference a script by name that an administrator has placed in a configured directory. The script receives the input resources as a JavaScript array called `input` and returns a single resource object or an array of resource objects, which are returned as `return` parameters.
+
+The operation is implemented by [JavaScriptExecutionProvider](/hapi-fhir/apidocs/hapi-fhir-jpaserver-base/ca/uhn/fhir/jpa/provider/JavaScriptExecutionProvider.html). Note that this provider is not wired into the JPA server by default - deployments which want to offer the operation need to add the `org.graalvm.js:js` dependency (declared as optional by `hapi-fhir-jpaserver-base`), construct the provider, and register it against their `RestfulServer`.
+
+# Security Model
+
+* The operation is unavailable unless a scripts directory has been configured via `JpaStorageSettings#setJavaScriptExecutionScriptsDirectory(String)`.
+* The `script` parameter is resolved to a file inside the configured scripts directory only (bare file name, no path traversal).
+* Each script runs in a GraalJS sandbox created with no host access - Java classes, the filesystem, the network and thread creation are all denied (no JVM/filesystem/network reach).
+* Each invocation is bounded by an execution timeout (`JpaStorageSettings#setJavaScriptExecutionTimeoutSeconds(long)`, default `30`); a script that overruns is stopped and the call fails.
+
+# Parameters
+
+Inputs may be supplied two ways (combined into `input` in order - inline resources first, then resolved references):
+
+* `script`: (*mandatory*) The name of the script to execute, with or without the `.js` suffix.
+* `resource`: (*optional, repeatable*) An inline FHIR resource.
+* `reference`: (*optional, repeatable*) A literal reference (e.g. `Patient/123`) that the server reads before the script runs.
+
+# Example
+
+An example script which sets `active=true` on every input resource and returns them:
+
+```javascript
+// add-active.js
+input.map(function (resource) {
+	resource.active = true;
+	return resource;
+});
+```
+
+Example request body to `POST [base]/$execute-javascript`:
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "script", "valueString": "add-active" },
+    { "name": "resource", "resource": { "resourceType": "Patient", "active": false, "name": [{ "family": "Doe" }] } },
+    { "name": "reference", "valueReference": { "reference": "Patient/123" } }
+  ]
+}
+```
+
+The response is a `Parameters` resource whose `return` parameters hold the transformed resources.

--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -374,6 +374,13 @@
 			<artifactId>hapi-fhir-caching-caffeine</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- GraalJS - sandboxed JavaScript engine used by the $execute-javascript operation. Optional:
+		only deployments which register the JavaScriptExecutionProvider need it on the classpath. -->
+		<dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-testing</artifactId>

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JavaScriptExecutionProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JavaScriptExecutionProvider.java
@@ -1,0 +1,331 @@
+/*-
+ * #%L
+ * HAPI FHIR JPA Server
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.provider;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.model.api.annotation.Description;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.provider.ProviderConstants;
+import ca.uhn.fhir.util.FileUtil;
+import ca.uhn.fhir.util.ParametersUtil;
+import ca.uhn.fhir.util.ValidateUtil;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * System-level operation that runs a server-side JavaScript file (via the embedded GraalJS engine)
+ * to transform FHIR resources.
+ *
+ * <p>Callers do <b>not</b> supply the JavaScript itself - they reference one of the scripts the
+ * server administrator has placed in the configured scripts directory
+ * ({@link JpaStorageSettings#setJavaScriptExecutionScriptsDirectory(String)}). This keeps the set of
+ * executable code fixed and vetted, instead of accepting arbitrary code over the wire.
+ *
+ * <p>Invoke it as {@code POST [base]/$execute-javascript} with a {@code Parameters} body carrying a
+ * {@code script} (the file name, with or without the {@code .js} suffix), any number of inline
+ * {@code resource} parameters, and any number of {@code reference} parameters - literal
+ * references the server reads before the script runs, e.g.
+ *
+ * <pre>{@code
+ * {
+ *   "resourceType": "Parameters",
+ *   "parameter": [
+ *     { "name": "script", "valueString": "merge-patients" },
+ *     { "name": "resource", "resource": { "resourceType": "Patient", "id": "1" } },
+ *     { "name": "reference", "valueReference": { "reference": "Patient/2" } }
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>Inside the script:
+ * <ul>
+ *   <li>{@code input} is a JavaScript array of the input resources (parsed JSON objects): the
+ *       inline {@code resource} parameters first, followed by the resources resolved from the
+ *       {@code reference} parameters, in declared order - possibly empty if none were sent.</li>
+ *   <li>The value the script evaluates to is collected as output. It may be a single resource
+ *       object or an array of resource objects. Each element is parsed back into a FHIR resource
+ *       and returned under a {@code return} parameter of the response {@code Parameters}.</li>
+ * </ul>
+ *
+ * <p><b>Security:</b> this operation is unavailable unless a scripts directory has been configured.
+ * The {@code script} parameter is only ever resolved to a file inside the configured scripts
+ * directory - the name is validated to a bare file name and the resolved path is verified to
+ * stay within that directory, so callers cannot traverse the filesystem or execute code that the
+ * administrator has not installed. As defense-in-depth, each script runs in a fresh GraalJS
+ * {@link Context} created with no host access - Java class lookup, filesystem, network, and
+ * thread creation are all denied by default - so scripts are limited to pure JavaScript and
+ * cannot reach the host JVM, filesystem or network. Each invocation is also bounded by an execution
+ * timeout ({@link JpaStorageSettings#setJavaScriptExecutionTimeoutSeconds(long)}, default 30s); a
+ * script that overruns has its context canceled and the call fails.
+ *
+ * <p>Note that this provider is not wired into the JPA server by default - deployments which want
+ * to offer the operation need to add the {@code org.graalvm.js:js} dependency (declared as optional
+ * by this module), construct this provider, and register it against their
+ * {@link ca.uhn.fhir.rest.server.RestfulServer}.
+ *
+ * @since 8.14.0
+ */
+
+public class JavaScriptExecutionProvider {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(JavaScriptExecutionProvider.class);
+
+	/** A script name is a bare file name (optionally ending in {@code .js}) - never a path. */
+	private static final Pattern SCRIPT_NAME_PATTERN = Pattern.compile("[A-Za-z0-9_-]+(\\.js)?");
+
+	/**
+	 * One engine shared by all evaluations: contexts created on a shared engine skip per-request
+	 * engine/language initialization and share the parsed-source cache. Isolation is unaffected -
+	 * each request still runs in its own fresh {@link Context} with no host access.
+	 */
+	private static final Engine ourEngine =
+			Engine.newBuilder().option("engine.WarnInterpreterOnly", "false").build();
+
+	private static final Source ourParseInputSource = Source.create("js", "var input = JSON.parse(__inputJson);");
+	private static final Source ourStringifySource = Source.create("js", "JSON.stringify");
+
+	private final FhirContext myFhirContext;
+	private final DaoRegistry myDaoRegistry;
+	private final JpaStorageSettings myStorageSettings;
+
+	private final ExecutorService myExecutor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+			.setNameFormat("js-exec-%d")
+			.setDaemon(true)
+			.build());
+
+	/**
+	 * Constructor
+	 */
+	public JavaScriptExecutionProvider(
+			FhirContext theFhirContext, DaoRegistry theDaoRegistry, JpaStorageSettings theStorageSettings) {
+		myFhirContext = theFhirContext;
+		myDaoRegistry = theDaoRegistry;
+		myStorageSettings = theStorageSettings;
+	}
+
+	@Description(
+			value =
+					"This operation runs a named, administrator-vetted server-side JavaScript file against the supplied resources and returns the transformed resources.",
+			shortDefinition = "Runs a vetted server-side JavaScript transformation over FHIR resources")
+	@Operation(name = ProviderConstants.OPERATION_EXECUTE_JAVASCRIPT, idempotent = true)
+	public IBaseParameters executeJavascript(
+			@Description("The name of the script to execute, with or without the '.js' suffix")
+					@OperationParam(name = "script", typeName = "string", min = 1, max = 1)
+					IPrimitiveType<String> theScriptName,
+			@Description("Inline resources to pass to the script as input")
+					@OperationParam(name = "resource", min = 0, max = OperationParam.MAX_UNLIMITED)
+					List<IBaseResource> theInputResources,
+			@Description("Literal references (e.g. Patient/123) resolved by the server before the script runs")
+					@OperationParam(
+							name = "reference",
+							typeName = "reference",
+							min = 0,
+							max = OperationParam.MAX_UNLIMITED)
+					List<IBaseReference> theReferences,
+			RequestDetails theRequestDetails) {
+
+		String scriptName = theScriptName != null ? theScriptName.getValue() : null;
+		ValidateUtil.isNotBlankOrThrowInvalidRequest(
+				scriptName, "A non-empty 'script' parameter (the script name) is required.");
+
+		String script = loadScript(scriptName);
+
+		// 'input' = inline 'resource' parameters first, then the resources resolved from the literal
+		// 'reference' parameters (read from the server before the script runs), in declared order.
+		List<IBaseResource> inputs = new ArrayList<>();
+		if (theInputResources != null) {
+			inputs.addAll(theInputResources);
+		}
+		if (theReferences != null) {
+			for (IBaseReference reference : theReferences) {
+				inputs.add(resolveReference(reference, theRequestDetails));
+			}
+		}
+
+		List<String> outputJsons = runScript(script, serializeInput(inputs));
+
+		IBaseParameters response = ParametersUtil.newInstance(myFhirContext);
+		for (IBaseResource resource : parseOutputResources(outputJsons)) {
+			ParametersUtil.addParameterToParameters(myFhirContext, response, "return", resource);
+		}
+		return response;
+	}
+
+	/** Reads the resource named by a literal reference (e.g. {@code Patient/123}) from the server. */
+	private IBaseResource resolveReference(IBaseReference theReference, RequestDetails theRequestDetails) {
+		IIdType id = theReference.getReferenceElement();
+		if (!id.hasResourceType() || !id.hasIdPart()) {
+			throw new InvalidRequestException(
+					Msg.code(6560) + "Each 'reference' parameter must contain a literal reference such as"
+							+ " 'Patient/123'; got: " + id.getValue());
+		}
+		return myDaoRegistry.getResourceDao(id.getResourceType()).read(id, theRequestDetails);
+	}
+
+	/**
+	 * Resolves a caller-supplied script name to a file inside the configured scripts directory,
+	 * rejecting anything that is not a plain name within that directory.
+	 */
+	private String loadScript(String theScriptName) {
+		String scriptsDirectory = myStorageSettings.getJavaScriptExecutionScriptsDirectory();
+		if (isBlank(scriptsDirectory)) {
+			throw new InvalidRequestException(Msg.code(6562)
+					+ "Server-side script execution is not configured (no scripts directory has been set).");
+		}
+		Path scriptsDir = Paths.get(scriptsDirectory).toAbsolutePath().normalize();
+
+		if (!SCRIPT_NAME_PATTERN.matcher(theScriptName).matches()) {
+			throw new InvalidRequestException(Msg.code(6563) + "Invalid script name: " + theScriptName);
+		}
+
+		String fileName = theScriptName.endsWith(".js") ? theScriptName : theScriptName + ".js";
+		Path scriptPath = scriptsDir.resolve(fileName).normalize();
+		// Defense-in-depth: even after name validation, confirm we never escaped the base directory.
+		if (!scriptPath.startsWith(scriptsDir)) {
+			throw new InvalidRequestException(Msg.code(6564) + "Invalid script name: " + theScriptName);
+		}
+		if (!Files.isRegularFile(scriptPath)) {
+			throw new InvalidRequestException(Msg.code(6565) + "Unknown script: " + theScriptName);
+		}
+
+		return FileUtil.loadFileAsString(scriptPath.toFile());
+	}
+
+	/** Serializes the input resources into a single JavaScript-parseable JSON array string. */
+	private String serializeInput(List<IBaseResource> theInputResources) {
+		IParser parser = myFhirContext.newJsonParser();
+		return theInputResources.stream()
+				.map(parser::encodeResourceToString)
+				.collect(Collectors.joining(",", "[", "]"));
+	}
+
+	/**
+	 * Runs the script on a pooled daemon thread and enforces the configured timeout. If the script
+	 * overruns, the GraalJS context is cancelled from the request thread - even a tight CPU-bound
+	 * loop is unwound cleanly, freeing the worker. Each context is fresh and isolated and the
+	 * sandbox denies all host access, so a cancelled script holds no shared state.
+	 *
+	 * @return the script output as one JSON string per returned resource
+	 */
+	private List<String> runScript(String theScript, String theInputJson) {
+		long timeoutSeconds = myStorageSettings.getJavaScriptExecutionTimeoutSeconds();
+
+		// No host access: scripts cannot reach Java classes, the filesystem, the network or threads.
+		Context context = Context.newBuilder("js").engine(ourEngine).build();
+		try {
+			Future<List<String>> future = myExecutor.submit(() -> evaluate(context, theScript, theInputJson));
+			return future.get(timeoutSeconds, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new InternalErrorException(Msg.code(6567) + "Interrupted while waiting for script to complete.", e);
+		} catch (TimeoutException e) {
+			throw new InvalidRequestException(
+					Msg.code(6568) + "JavaScript execution timed out after " + timeoutSeconds + " seconds.");
+		} catch (ExecutionException e) {
+			// A PolyglotException covers syntax/runtime JS errors as well as the sandbox blocking host
+			// access (e.g. an undefined 'Java'). Either way it is caller error -> 400, not 500.
+			ourLog.debug("JavaScript execution failed", e.getCause());
+			throw new InvalidRequestException(
+					Msg.code(6569) + "JavaScript execution failed: "
+							+ e.getCause().getMessage(),
+					e.getCause());
+		} finally {
+			// Cancels any in-flight evaluation (unblocking the worker) and releases the context.
+			context.close(true);
+		}
+	}
+
+	/**
+	 * Evaluates the script in the given fresh, sandboxed GraalJS context and returns the result as
+	 * one JSON string per resource. Runs on the worker thread - all {@link Value} access must
+	 * happen here, while the context is alive.
+	 */
+	private List<String> evaluate(Context theContext, String theScript, String theInputJson) {
+		theContext.getBindings("js").putMember("__inputJson", theInputJson);
+		theContext.eval(ourParseInputSource);
+
+		Value result = theContext.eval("js", theScript);
+		if (result == null || result.isNull()) {
+			return List.of();
+		}
+
+		Value stringify = theContext.eval(ourStringifySource);
+		List<String> outputJsons = new ArrayList<>();
+		if (result.hasArrayElements()) {
+			for (long i = 0; i < result.getArraySize(); i++) {
+				outputJsons.add(stringify.execute(result.getArrayElement(i)).asString());
+			}
+		} else {
+			outputJsons.add(stringify.execute(result).asString());
+		}
+		return outputJsons;
+	}
+
+	/** Parses the script's per-resource JSON output back into FHIR resources. */
+	private List<IBaseResource> parseOutputResources(List<String> theOutputJsons) {
+		IParser parser = myFhirContext.newJsonParser();
+		List<IBaseResource> resources = new ArrayList<>();
+		for (String outputJson : theOutputJsons) {
+			try {
+				resources.add(parser.parseResource(outputJson));
+			} catch (Exception e) {
+				throw new InvalidRequestException(
+						Msg.code(6572) + "Script must return FHIR resource object(s); could not parse script"
+								+ " result as a FHIR resource: " + e.getMessage(),
+						e);
+			}
+		}
+		return resources;
+	}
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JavaScriptExecutionProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JavaScriptExecutionProvider.java
@@ -116,7 +116,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  *
  * @since 8.14.0
  */
-
 public class JavaScriptExecutionProvider {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(JavaScriptExecutionProvider.class);

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/api/config/JpaStorageSettings.java
@@ -126,6 +126,14 @@ public class JpaStorageSettings extends StorageSettings {
 	private static final long DEFAULT_REST_DELETE_BY_URL_RESOURCE_ID_THRESHOLD = 10000;
 
 	/**
+	 * The default maximum number of seconds a single <code>$execute-javascript</code>
+	 * invocation may run before it is stopped.
+	 *
+	 * @since 8.14.0
+	 */
+	public static final long DEFAULT_JAVASCRIPT_EXECUTION_TIMEOUT_SECONDS = 30;
+
+	/**
 	 * If we are batching write operations in transactions, what should the maximum number of write operations per
 	 * transaction be?
 	 * @since 8.0.0
@@ -447,6 +455,23 @@ public class JpaStorageSettings extends StorageSettings {
 	 * @since 8.8.0
 	 */
 	private boolean myAllowDatabaseValidationOverride = false;
+
+	/**
+	 * The directory containing the vetted JavaScript files which the
+	 * <code>$execute-javascript</code> operation is allowed to run. If this is
+	 * <code>null</code> (the default), the operation is not available.
+	 *
+	 * @since 8.14.0
+	 */
+	private String myJavaScriptExecutionScriptsDirectory;
+
+	/**
+	 * The maximum number of wall-clock seconds a single <code>$execute-javascript</code>
+	 * invocation may run before it is stopped and the call fails.
+	 *
+	 * @since 8.14.0
+	 */
+	private long myJavaScriptExecutionTimeoutSeconds = DEFAULT_JAVASCRIPT_EXECUTION_TIMEOUT_SECONDS;
 
 	/**
 	 * Constructor
@@ -2825,6 +2850,50 @@ public class JpaStorageSettings extends StorageSettings {
 	 */
 	public boolean isAllowDatabaseValidationOverride() {
 		return myAllowDatabaseValidationOverride;
+	}
+
+	/**
+	 * The directory containing the vetted JavaScript files which the
+	 * <code>$execute-javascript</code> operation is allowed to run. If this is
+	 * <code>null</code> (the default), the operation is not available.
+	 *
+	 * @since 8.14.0
+	 */
+	public String getJavaScriptExecutionScriptsDirectory() {
+		return myJavaScriptExecutionScriptsDirectory;
+	}
+
+	/**
+	 * The directory containing the vetted JavaScript files which the
+	 * <code>$execute-javascript</code> operation is allowed to run. If this is
+	 * <code>null</code> (the default), the operation is not available.
+	 *
+	 * @since 8.14.0
+	 */
+	public void setJavaScriptExecutionScriptsDirectory(String theJavaScriptExecutionScriptsDirectory) {
+		myJavaScriptExecutionScriptsDirectory = theJavaScriptExecutionScriptsDirectory;
+	}
+
+	/**
+	 * The maximum number of wall-clock seconds a single <code>$execute-javascript</code>
+	 * invocation may run before it is stopped and the call fails. Defaults to
+	 * {@link #DEFAULT_JAVASCRIPT_EXECUTION_TIMEOUT_SECONDS}.
+	 *
+	 * @since 8.14.0
+	 */
+	public long getJavaScriptExecutionTimeoutSeconds() {
+		return myJavaScriptExecutionTimeoutSeconds;
+	}
+
+	/**
+	 * The maximum number of wall-clock seconds a single <code>$execute-javascript</code>
+	 * invocation may run before it is stopped and the call fails. Defaults to
+	 * {@link #DEFAULT_JAVASCRIPT_EXECUTION_TIMEOUT_SECONDS}.
+	 *
+	 * @since 8.14.0
+	 */
+	public void setJavaScriptExecutionTimeoutSeconds(long theJavaScriptExecutionTimeoutSeconds) {
+		myJavaScriptExecutionTimeoutSeconds = theJavaScriptExecutionTimeoutSeconds;
 	}
 
 	public enum StoreMetaSourceInformationEnum {

--- a/hapi-fhir-jpaserver-test-r4/pom.xml
+++ b/hapi-fhir-jpaserver-test-r4/pom.xml
@@ -49,6 +49,13 @@
 			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- GraalJS is an optional dependency of hapi-fhir-jpaserver-base, needed here to test the
+		$execute-javascript operation -->
+		<dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JavaScriptExecutionProviderR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/JavaScriptExecutionProviderR4Test.java
@@ -1,0 +1,236 @@
+package ca.uhn.fhir.jpa.provider.r4;
+
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
+import ca.uhn.fhir.jpa.provider.JavaScriptExecutionProvider;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.provider.ProviderConstants;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JavaScriptExecutionProviderR4Test extends BaseResourceProviderR4Test {
+
+	private JavaScriptExecutionProvider myProvider;
+
+	@BeforeEach
+	void registerProvider() throws URISyntaxException {
+		myStorageSettings.setJavaScriptExecutionScriptsDirectory(findScriptsDirectory());
+		// Keep the timeout short so the infinite-loop test finishes quickly.
+		myStorageSettings.setJavaScriptExecutionTimeoutSeconds(3);
+
+		myProvider = new JavaScriptExecutionProvider(myFhirContext, myDaoRegistry, myStorageSettings);
+		myServer.registerProvider(myProvider);
+	}
+
+	@AfterEach
+	void unregisterProvider() {
+		myServer.unregisterProvider(myProvider);
+
+		JpaStorageSettings defaults = new JpaStorageSettings();
+		myStorageSettings.setJavaScriptExecutionScriptsDirectory(defaults.getJavaScriptExecutionScriptsDirectory());
+		myStorageSettings.setJavaScriptExecutionTimeoutSeconds(defaults.getJavaScriptExecutionTimeoutSeconds());
+	}
+
+	private String findScriptsDirectory() throws URISyntaxException {
+		return new File(Objects.requireNonNull(getClass().getClassLoader().getResource("javascript"))
+						.toURI())
+				.getAbsolutePath();
+	}
+
+	private Parameters callOperation(Parameters theInput) {
+		return myClient.operation()
+				.onServer()
+				.named(ProviderConstants.OPERATION_EXECUTE_JAVASCRIPT)
+				.withParameters(theInput)
+				.execute();
+	}
+
+	private Parameters execute(String theScriptName, Resource... theResources) {
+		Parameters input = new Parameters();
+		input.addParameter().setName("script").setValue(new StringType(theScriptName));
+		for (Resource resource : theResources) {
+			input.addParameter().setName("resource").setResource(resource);
+		}
+		return callOperation(input);
+	}
+
+	private Patient newPatient(String theFamily) {
+		Patient patient = new Patient();
+		patient.addName().setFamily(theFamily);
+		return patient;
+	}
+
+	@Test
+	void transformsBothInputResources() {
+		Patient patientA = newPatient("A");
+		patientA.setActive(false);
+		Patient patientB = newPatient("B");
+		patientB.setActive(false);
+
+		Parameters output = execute("set-active", patientA, patientB);
+
+		List<Parameters.ParametersParameterComponent> returns = output.getParameter();
+		assertThat(returns).hasSize(2);
+		assertThat(returns.get(0).getName()).isEqualTo("return");
+		assertThat(((Patient) returns.get(0).getResource()).getActive()).isTrue();
+		assertThat(((Patient) returns.get(1).getResource()).getActive()).isTrue();
+	}
+
+	@Test
+	void mergesTwoResourcesIntoOne() {
+		// A script can read both inputs (input[0], input[1]) and emit a single combined resource.
+		Parameters output = execute("merge", newPatient("First"), newPatient("Second"));
+
+		assertThat(output.getParameter()).hasSize(1);
+		Patient merged = (Patient) output.getParameter().get(0).getResource();
+		assertThat(merged.getName().get(0).getFamily()).isEqualTo("First");
+		assertThat(merged.getName().get(1).getFamily()).isEqualTo("Second");
+	}
+
+	@Test
+	void acceptsASingleObjectResult() {
+		Parameters output = execute("set-gender", newPatient("A"));
+
+		assertThat(output.getParameter()).hasSize(1);
+		Patient result = (Patient) output.getParameter().get(0).getResource();
+		assertThat(result.getGender()).isEqualTo(Enumerations.AdministrativeGender.FEMALE);
+	}
+
+	@Test
+	void acceptsScriptNameWithJsSuffix() {
+		Parameters output = execute("set-gender.js", newPatient("A"));
+		assertThat(output.getParameter()).hasSize(1);
+	}
+
+	@Test
+	void canSynthesizeANewResource() {
+		Parameters output = execute("synthesize", newPatient("A"));
+
+		assertThat(output.getParameter()).hasSize(1);
+		Observation observation =
+				(Observation) output.getParameter().get(0).getResource();
+		assertThat(observation.getStatus()).isEqualTo(Observation.ObservationStatus.FINAL);
+	}
+
+	@Test
+	void emptyResultProducesEmptyParameters() {
+		Parameters output = execute("empty", newPatient("A"));
+		assertThat(output.getParameter()).isEmpty();
+	}
+
+	@Test
+	void resolvesLiteralReferencesBeforeExecution() {
+		// Store a resource on the server, then reference it (rather than inlining it).
+		IIdType id = createPatient(withFamily("Stored"), withActiveFalse()).toUnqualifiedVersionless();
+
+		Parameters input = new Parameters();
+		input.addParameter().setName("script").setValue(new StringType("set-active"));
+		input.addParameter().setName("reference").setValue(new Reference(id.getValue()));
+
+		Parameters output = callOperation(input);
+
+		assertThat(output.getParameter()).hasSize(1);
+		Patient result = (Patient) output.getParameter().get(0).getResource();
+		assertThat(result.getNameFirstRep().getFamily()).isEqualTo("Stored");
+		assertThat(result.getActive()).isTrue();
+	}
+
+	@Test
+	void mixesInlineResourcesAndReferences() {
+		IIdType id = createPatient(withFamily("FromServer")).toUnqualifiedVersionless();
+
+		Parameters input = new Parameters();
+		input.addParameter().setName("script").setValue(new StringType("merge")); // uses input[0] + input[1]
+		input.addParameter().setName("resource").setResource(newPatient("Inline")); // input[0]
+		input.addParameter().setName("reference").setValue(new Reference(id.getValue())); // input[1]
+
+		Parameters output = callOperation(input);
+
+		assertThat(output.getParameter()).hasSize(1);
+		Patient merged = (Patient) output.getParameter().get(0).getResource();
+		assertThat(merged.getName().get(0).getFamily()).isEqualTo("Inline");
+		assertThat(merged.getName().get(1).getFamily()).isEqualTo("FromServer");
+	}
+
+	@Test
+	void unresolvableReferenceIsRejected() {
+		Parameters input = new Parameters();
+		input.addParameter().setName("script").setValue(new StringType("set-active"));
+		input.addParameter().setName("reference").setValue(new Reference("Patient/does-not-exist"));
+
+		assertThatThrownBy(() -> callOperation(input)).isInstanceOf(ResourceNotFoundException.class);
+	}
+
+	@Test
+	void acceptsZeroResources() {
+		// 'input' is simply an empty array; a script can ignore it and synthesize output.
+		Parameters output = execute("synthesize");
+		assertThat(output.getParameter()).hasSize(1);
+		assertThat(output.getParameter().get(0).getResource()).isInstanceOf(Observation.class);
+	}
+
+	@Test
+	void scriptErrorIsReportedAsBadRequest() {
+		assertThatThrownBy(() -> execute("error")).isInstanceOf(InvalidRequestException.class);
+	}
+
+	@Test
+	void nonResourceResultIsRejected() {
+		assertThatThrownBy(() -> execute("non-resource")).isInstanceOf(InvalidRequestException.class);
+	}
+
+	@Test
+	@Timeout(20)
+	void longRunningScriptIsStoppedByTimeout() {
+		// The 3s timeout configured above must fire and abort the infinite loop, well within
+		// this test's own 20s budget.
+		assertThatThrownBy(() -> execute("infinite-loop"))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining("timed out");
+	}
+
+	@Test
+	void unknownScriptIsRejected() {
+		assertThatThrownBy(() -> execute("does-not-exist")).isInstanceOf(InvalidRequestException.class);
+	}
+
+	@Test
+	void pathTraversalIsRejected() {
+		assertThatThrownBy(() -> execute("../application")).isInstanceOf(InvalidRequestException.class);
+	}
+
+	@Test
+	void javaAccessIsBlockedBySandbox() {
+		// The sandbox denies all host access, so Java.type(...) must fail rather than
+		// giving the script a handle on the host JVM.
+		assertThatThrownBy(() -> execute("java-access")).isInstanceOf(InvalidRequestException.class);
+	}
+
+	@Test
+	void unconfiguredScriptsDirectoryIsRejected() {
+		myStorageSettings.setJavaScriptExecutionScriptsDirectory(null);
+
+		assertThatThrownBy(() -> execute("set-active"))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining("not configured");
+	}
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/empty.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/empty.js
@@ -1,0 +1,2 @@
+// Returns no resources.
+[];

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/error.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/error.js
@@ -1,0 +1,2 @@
+// Throws to exercise the error path.
+throw 'boom';

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/infinite-loop.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/infinite-loop.js
@@ -1,0 +1,4 @@
+// Never terminates — exercises the execution timeout / forced stop.
+while (true) {
+	// busy loop
+}

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/java-access.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/java-access.js
@@ -1,0 +1,3 @@
+// Attempts to reach a Java class; must be blocked by the GraalJS sandbox ('Java' is undefined).
+Java.type('java.lang.Runtime');
+[];

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/merge.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/merge.js
@@ -1,0 +1,3 @@
+// Merges the two input resources into a single resource (input[1]'s names appended to input[0]).
+input[0].name = input[0].name.concat(input[1].name);
+[input[0]];

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/non-resource.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/non-resource.js
@@ -1,0 +1,2 @@
+// Returns an object that is not a FHIR resource (no resourceType).
+[{ foo: 'bar' }];

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/set-active.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/set-active.js
@@ -1,0 +1,5 @@
+// Sets active=true on all input resources and returns them.
+input.map(function (p) {
+	p.active = true;
+	return p;
+});

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/set-gender.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/set-gender.js
@@ -1,0 +1,3 @@
+// Returns a single resource (input[0]) with gender set.
+input[0].gender = 'female';
+input[0];

--- a/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/synthesize.js
+++ b/hapi-fhir-jpaserver-test-r4/src/test/resources/javascript/synthesize.js
@@ -1,0 +1,2 @@
+// Ignores the inputs and synthesizes a brand-new resource.
+[{ resourceType: 'Observation', status: 'final' }];

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ProviderConstants.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/provider/ProviderConstants.java
@@ -60,6 +60,13 @@ public class ProviderConstants {
 	 */
 	public static final String DIFF_OPERATION_NAME = "$diff";
 
+	/**
+	 * Operation name: execute-javascript
+	 *
+	 * @since 8.14.0
+	 */
+	public static final String OPERATION_EXECUTE_JAVASCRIPT = "$execute-javascript";
+
 	public static final String DIFF_FROM_VERSION_PARAMETER = "fromVersion";
 
 	public static final String DIFF_FROM_PARAMETER = "from";

--- a/pom.xml
+++ b/pom.xml
@@ -1073,6 +1073,10 @@
 		<nullaway_version>0.7.9</nullaway_version>
 		<guava_version>33.2.1-jre</guava_version>
 		<gson_version>2.12.0</gson_version>
+		<!-- GraalJS - embeddable JavaScript engine used by the $execute-javascript operation. The
+		23.0.x line is the last that supports JDK 17 (23.1+ requires JDK 21). Runs in interpreter
+		mode on a stock (non-GraalVM) JDK. -->
+		<graalvm_js_version>23.0.8</graalvm_js_version>
 		<jaxb_bundle_version>2.2.11_1</jaxb_bundle_version>
 		<jaxb_api_version>2.3.1</jaxb_api_version>
 		<jaxb_core_version>2.3.0.1</jaxb_core_version>
@@ -1267,6 +1271,11 @@
 				<groupId>com.github.ben-manes.caffeine</groupId>
 				<artifactId>caffeine</artifactId>
 				<version>${caffeine_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.graalvm.js</groupId>
+				<artifactId>js</artifactId>
+				<version>${graalvm_js_version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.jsqlparser</groupId>


### PR DESCRIPTION
This pull request introduces a new system-level `$execute-javascript` operation to the JPA server, enabling administrator-vetted, server-side JavaScript execution for transforming FHIR resources. The operation is securely sandboxed using GraalJS and is not enabled by default; deployments must explicitly configure and enable it. The changes span documentation, configuration, dependency management, and the implementation of the operation itself.

**Key changes:**

### New Operation: JavaScript Execution

- Added the `JavaScriptExecutionProvider` class, implementing the `$execute-javascript` operation. This allows running server-side JavaScript files (from a configured scripts directory) to transform FHIR resources, with strict sandboxing and execution timeout. The operation does not accept code over the wire; only administrator-vetted scripts can be executed.

### Configuration and Security

- Extended `JpaStorageSettings` with new properties and methods to configure the scripts directory (`myJavaScriptExecutionScriptsDirectory`) and execution timeout (`myJavaScriptExecutionTimeoutSeconds`), including sensible defaults and documentation. [[1]](diffhunk://#diff-c4572cb4e9b615a4ab88f57c66f5df845f01258794fc02c22dd157415798e624R128-R135) [[2]](diffhunk://#diff-c4572cb4e9b615a4ab88f57c66f5df845f01258794fc02c22dd157415798e624R459-R475) [[3]](diffhunk://#diff-c4572cb4e9b615a4ab88f57c66f5df845f01258794fc02c22dd157415798e624R2855-R2898)

### Dependency Management

- Added the `org.graalvm.js:js` dependency as optional in `hapi-fhir-jpaserver-base` and as a test dependency in `hapi-fhir-jpaserver-test-r4`, since GraalJS is required to run the new operation. [[1]](diffhunk://#diff-57d02ea37eff80b48fd5d30e6174f879879500001c546355bef09199c46f87f0R377-R383) [[2]](diffhunk://#diff-30821fa749f521e0dae780dfbfdd07f96f528215b8aca16f118595b403100f5bR52-R58)

### Documentation

- Added a new documentation page detailing the `$execute-javascript` operation, including usage, security model, parameters, and an example. Updated the documentation index to reference this new operation. [[1]](diffhunk://#diff-0ce270e89f93667a60b0beccbdf0730edfe2aa704ab497edd475929b963fbe86R1-R47) [[2]](diffhunk://#diff-96683da8933a18da1216e3c9e21026e02009aef5030f73da26b966ea37d40b94R76)

### Changelog

- Documented the addition of the `$execute-javascript` operation in the changelog for version 8.14.0.