### PR TITLE
Fixing URN parsing for searches

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/1350-support-urn-shaped-canonical-reference-search.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/1350-support-urn-shaped-canonical-reference-search.yaml
@@ -1,0 +1,10 @@
+---
+type: fix
+issue: 1350
+title: "Previously, URN-shaped canonical references (e.g. `urn:oid:...` or `urn:uuid:...`) were not
+  indexed by the JPA server, and searching a canonical reference search parameter (such as
+  `QuestionnaireResponse?questionnaire=urn:uuid:...`) by such a value returned no results. Per the
+  FHIR specification canonical URLs may be URNs, so these values are now indexed and searchable in
+  the same way as http(s) canonical URLs, including versioned canonicals (`urn:oid:...|version`).
+  Note that resources stored before this fix must be reindexed (e.g. using `$reindex`) for such
+  searches to find them."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceLinkPredicateBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/builder/predicate/ResourceLinkPredicateBuilder.java
@@ -104,6 +104,7 @@ import static ca.uhn.fhir.rest.api.Constants.PARAM_TYPE;
 import static ca.uhn.fhir.rest.api.Constants.VALID_MODIFIERS;
 import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.apache.commons.lang3.StringUtils.trim;
 
 public class ResourceLinkPredicateBuilder extends BaseJoiningPredicateBuilder implements ICanMakeMissingParamPredicate {
@@ -256,6 +257,13 @@ public class ResourceLinkPredicateBuilder extends BaseJoiningPredicateBuilder im
 						} else {
 							targetQualifiedUrls.add(dt.getValue());
 						}
+					} else if (startsWith(ref.getValue(), "urn:")) {
+						/*
+						 * A URN-shaped value (e.g. urn:oid:..., urn:uuid:...) can never be a
+						 * local resource ID, but it is a legal canonical URL so we match it
+						 * against indexed canonical target URLs.
+						 */
+						targetQualifiedUrls.add(ref.getValue());
 					} else {
 						validateModifierUse(theRequest, theResourceType, ref);
 						validateResourceTypeInReferenceParam(ref.getResourceType());

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/BaseSearchParamExtractor.java
@@ -2171,7 +2171,13 @@ public abstract class BaseSearchParamExtractor implements ISearchParamExtractor 
 							break;
 						}
 
-						if (parsed.isAbsolute()) {
+						/*
+						 * Canonical URLs are usually absolute http(s) URLs, but the FHIR spec
+						 * also allows URN-shaped canonicals (e.g. urn:oid:..., urn:uuid:...) so
+						 * we index those the same way.
+						 */
+						boolean isUrn = StringUtils.startsWith(parsed.getValue(), "urn:");
+						if (parsed.isAbsolute() || isUrn) {
 							String refValue =
 									fakeReference.getReferenceElement().getValue();
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/SearchParamExtractorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/SearchParamExtractorR4Test.java
@@ -38,6 +38,7 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Quantity;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.ServiceRequest;
@@ -251,6 +252,46 @@ class SearchParamExtractorR4Test implements ITestDataBuilder {
 		assertEquals("Consent/999", ((Reference) links.iterator().next().getRef()).getReference());
 	}
 
+
+	// Created by Claude Fable 5
+	@Test
+	void testExtractResourceLinks_urnShapedCanonical_isExtractedAsCanonicalLink() {
+		String urnCanonical = "urn:uuid:0b34ba47-88a9-4e26-9e50-5b1a12a5cf3f";
+
+		QuestionnaireResponse qr = new QuestionnaireResponse();
+		qr.setQuestionnaire(urnCanonical);
+
+		SearchParamExtractorR4 extractor = new SearchParamExtractorR4(new StorageSettings(), new PartitionSettings(), ourCtx, mySearchParamRegistry);
+		ISearchParamExtractor.SearchParamSet<PathAndRef> links = extractor.extractResourceLinks(qr, false);
+
+		List<PathAndRef> questionnaireLinks = links.stream()
+			.filter(t -> "questionnaire".equals(t.getSearchParamName()))
+			.collect(Collectors.toList());
+		assertThat(questionnaireLinks).isNotEmpty();
+		assertThat(questionnaireLinks).allMatch(PathAndRef::isCanonical);
+		assertThat(questionnaireLinks)
+			.extracting(t -> t.getRef().getReferenceElement().getValue())
+			.contains(urnCanonical);
+	}
+
+	// Created by Claude Fable 5
+	@Test
+	void testExtractResourceLinks_urnShapedVersionedCanonical_indexesVersionedAndUnversioned() {
+		String urnCanonical = "urn:oid:1.2.3.4";
+		String versionedUrnCanonical = urnCanonical + "|1.0";
+
+		QuestionnaireResponse qr = new QuestionnaireResponse();
+		qr.setQuestionnaire(versionedUrnCanonical);
+
+		SearchParamExtractorR4 extractor = new SearchParamExtractorR4(new StorageSettings(), new PartitionSettings(), ourCtx, mySearchParamRegistry);
+		ISearchParamExtractor.SearchParamSet<PathAndRef> links = extractor.extractResourceLinks(qr, false);
+
+		List<String> questionnaireLinkValues = links.stream()
+			.filter(t -> "questionnaire".equals(t.getSearchParamName()))
+			.map(t -> t.getRef().getReferenceElement().getValue())
+			.collect(Collectors.toList());
+		assertThat(questionnaireLinkValues).contains(versionedUrnCanonical, urnCanonical);
+	}
 
 	@Test
 	void testExtractSearchParamTokenTest() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderQuestionnaireResponseR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderQuestionnaireResponseR4Test.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.rest.server.interceptor.RequestValidatingInterceptor;
+import ca.uhn.fhir.util.UrlUtil;
 import ca.uhn.fhir.validation.IValidatorModule;
 import ca.uhn.fhir.validation.ResultSeverityEnum;
 import org.apache.commons.io.IOUtils;
@@ -314,6 +315,67 @@ public class ResourceProviderQuestionnaireResponseR4Test extends BaseResourcePro
 		// THEN: The QuestionnaireResponse is found
 		assertThat(results.getEntry()).hasSize(1);
 		assertThat(results.getEntry().get(0).getResource().getIdElement()
+			.toUnqualifiedVersionless().getValue()).isEqualTo(qrId.getValue());
+	}
+
+	// Created by Claude Fable 5
+	/**
+	 * Verify that searching QuestionnaireResponse by a URN-shaped canonical questionnaire
+	 * (e.g. urn:uuid:... or urn:oid:...) works. Canonicals are allowed to be URNs per the
+	 * FHIR spec, but historically only http(s) canonicals were indexed and searchable.
+	 */
+	@Test
+	void testSearch_withUrnCanonicalQuestionnaire_shouldReturnQuestionnaireResponse() {
+		String urnCanonical = "urn:uuid:0b34ba47-88a9-4e26-9e50-5b1a12a5cf3f";
+
+		QuestionnaireResponse qr = new QuestionnaireResponse();
+		qr.setId("my-urn-qr");
+		qr.setQuestionnaire(urnCanonical);
+		qr.setStatus(QuestionnaireResponseStatus.COMPLETED);
+		IIdType qrId = myQuestionnaireResponseDao.update(qr, mySrd).getId().toUnqualifiedVersionless();
+
+		Bundle results = myClient.search()
+			.byUrl("QuestionnaireResponse?questionnaire=" + UrlUtil.escapeUrlParam(urnCanonical))
+			.returnBundle(Bundle.class)
+			.execute();
+
+		assertThat(results.getEntry()).hasSize(1);
+		assertThat(results.getEntry().get(0).getResource().getIdElement()
+			.toUnqualifiedVersionless().getValue()).isEqualTo(qrId.getValue());
+	}
+
+	// Created by Claude Fable 5
+	/**
+	 * Verify that a versioned URN-shaped canonical (urn:oid:...|version) is searchable
+	 * both by the versioned and the unversioned form.
+	 */
+	@Test
+	void testSearch_withVersionedUrnCanonicalQuestionnaire_shouldReturnQuestionnaireResponse() {
+		String urnCanonical = "urn:oid:1.2.3.4";
+		String versionedUrnCanonical = urnCanonical + "|1.0";
+
+		QuestionnaireResponse qr = new QuestionnaireResponse();
+		qr.setId("my-versioned-urn-qr");
+		qr.setQuestionnaire(versionedUrnCanonical);
+		qr.setStatus(QuestionnaireResponseStatus.COMPLETED);
+		IIdType qrId = myQuestionnaireResponseDao.update(qr, mySrd).getId().toUnqualifiedVersionless();
+
+		// Search by the versioned canonical
+		Bundle versionedResults = myClient.search()
+			.byUrl("QuestionnaireResponse?questionnaire=" + UrlUtil.escapeUrlParam(versionedUrnCanonical))
+			.returnBundle(Bundle.class)
+			.execute();
+		assertThat(versionedResults.getEntry()).hasSize(1);
+		assertThat(versionedResults.getEntry().get(0).getResource().getIdElement()
+			.toUnqualifiedVersionless().getValue()).isEqualTo(qrId.getValue());
+
+		// Search by the unversioned canonical
+		Bundle unversionedResults = myClient.search()
+			.byUrl("QuestionnaireResponse?questionnaire=" + UrlUtil.escapeUrlParam(urnCanonical))
+			.returnBundle(Bundle.class)
+			.execute();
+		assertThat(unversionedResults.getEntry()).hasSize(1);
+		assertThat(unversionedResults.getEntry().get(0).getResource().getIdElement()
 			.toUnqualifiedVersionless().getValue()).isEqualTo(qrId.getValue());
 	}
 


### PR DESCRIPTION
This pull request fixes an issue where URN-shaped canonical references (such as `urn:oid:...` or `urn:uuid:...`) were not previously indexed or searchable in the JPA server, despite being valid according to the FHIR specification. The changes ensure that these URN-shaped canonicals are now indexed and can be searched just like `http(s)` canonical URLs, including support for versioned URN canonicals. The update also adds comprehensive tests to verify this new behavior.

**Support for URN-shaped canonical references:**

* Updated the canonical indexing logic in `BaseSearchParamExtractor.java` to treat URN-shaped canonicals (e.g. `urn:oid:...`, `urn:uuid:...`) as valid and index them, not just `http(s)` URLs.
* Modified `ResourceLinkPredicateBuilder.java` to recognize and match URN-shaped canonical references during search queries, ensuring they are handled like other canonical URLs. [[1]](diffhunk://#diff-a52aef154110214ec0f36cf21345539dc6a63a537b1b17d2b009aa836d7adc2eR107) [[2]](diffhunk://#diff-a52aef154110214ec0f36cf21345539dc6a63a537b1b17d2b009aa836d7adc2eR260-R266)

**Testing and validation:**

* Added new tests in `SearchParamExtractorR4Test.java` to verify that URN-shaped canonicals and their versioned variants are correctly extracted and indexed as canonical links.
* Added new integration tests in `ResourceProviderQuestionnaireResponseR4Test.java` to confirm that searching for `QuestionnaireResponse` resources by URN-shaped canonical (both versioned and unversioned) returns the correct results.

**Documentation:**

* Added a changelog entry describing the fix and noting that resources stored before this fix must be reindexed for URN canonical searches to work.