### PR TITLE
Fix for $meta-add and $meta-delete operations within transaction bundles

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/RestOperationTypeEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/RestOperationTypeEnum.java
@@ -194,6 +194,15 @@ public enum RestOperationTypeEnum {
 		return CODE_TO_ENUM.get(theCode);
 	}
 
+	public static boolean isMetaOperation(String theCode) {
+		if (theCode == null) {
+			return false;
+		}
+
+		return theCode.equals(RestOperationTypeEnum.META_ADD.getCode())
+				|| theCode.equals(RestOperationTypeEnum.META_DELETE.getCode());
+	}
+
 	/**
 	 * Returns the code associated with this enumerated value
 	 */

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8243-meta-add-meta-delete-instance-operations-in-a-transaction-bundle.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8243-meta-add-meta-delete-instance-operations-in-a-transaction-bundle.yaml
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 8232
+jira: SMILE-8760
+title: "Previously, invoking an instance-level `$meta-add` or `$meta-delete` operation as an entry within a
+         `transaction` Bundle failed with `HAPI-1742: Invalid FHIR resource URL` when an `AuthorizationInterceptor`
+         was registered. The `AuthorizationInterceptor` now correctly handles these operation URLs, so the operations 
+         are authorized and applied as expected."

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
@@ -60,7 +60,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hl7.fhir.instance.model.api.IAnyResource.SP_RES_ID;
 
@@ -753,13 +752,13 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 
 				IBaseResource inputResource = nextPart.getResource();
 				IIdType inputResourceId = null;
-				String operationName = null;
+				String instanceOperation = null;
 				if (isNotBlank(url)) {
 
 					int lastSlashIdx = url.lastIndexOf('/');
 					if (lastSlashIdx != -1) {
-						operationName = url.substring(lastSlashIdx + 1);
-						if (operationName.startsWith("$")) {
+						instanceOperation = url.substring(lastSlashIdx + 1);
+						if (instanceOperation.startsWith("$")) {
 							url = url.substring(0, lastSlashIdx);
 						}
 					}
@@ -806,7 +805,8 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 				// This is done because a Bundle can contain a nested PATCH with Parameters,
 				// which is supported but a non-PATCH nested Parameters resource may be problematic.
 				// The exception being meta operations such as $meta-add and $meta-delete
-				if (!isMetaOperation(operationName) && isInvalidNestedParametersRequest(ctx, nextPart, operation)) {
+				if (!RestOperationTypeEnum.isMetaOperation(instanceOperation)
+						&& isInvalidNestedParametersRequest(ctx, nextPart, operation)) {
 					throw new InvalidRequestException(Msg.code(339)
 							+ String.format("Can not handle nested Parameters with %s operation", operation));
 				}
@@ -848,15 +848,6 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 		} else {
 			return null;
 		}
-	}
-
-	private boolean isMetaOperation(String theOperationName) {
-		if (isEmpty(theOperationName)) {
-			return false;
-		}
-
-		return theOperationName.equals(RestOperationTypeEnum.META_ADD.getCode())
-				|| theOperationName.equals(RestOperationTypeEnum.META_DELETE.getCode());
 	}
 
 	@Nullable

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hl7.fhir.instance.model.api.IAnyResource.SP_RES_ID;
 
@@ -744,16 +745,25 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 			boolean allComponentsAreGets = true;
 			for (BundleEntryParts nextPart : inputResources) {
 
+				String url = nextPart.getUrl();
 				if (isInvalidNestedBundleRequest(nextPart)) {
 					throw new InvalidRequestException(
-							Msg.code(2504) + "Can not handle nested Bundle request with url: " + nextPart.getUrl());
+							Msg.code(2504) + "Can not handle nested Bundle request with url: " + url);
 				}
 
 				IBaseResource inputResource = nextPart.getResource();
 				IIdType inputResourceId = null;
-				if (isNotBlank(nextPart.getUrl())) {
+				String operationName = null;
+				if (isNotBlank(url)) {
 
-					UrlUtil.UrlParts parts = UrlUtil.parseUrl(nextPart.getUrl());
+					int lastSlashIdx = url.lastIndexOf('/');
+					if (lastSlashIdx != -1) {
+						operationName = url.substring(lastSlashIdx + 1);
+						if (operationName.startsWith("$")) {
+							url = url.substring(0, lastSlashIdx);
+						}
+					}
+					UrlUtil.UrlParts parts = UrlUtil.parseUrl(url);
 
 					inputResourceId =
 							theRequestDetails.getFhirContext().getVersion().newIdType();
@@ -795,7 +805,8 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 
 				// This is done because a Bundle can contain a nested PATCH with Parameters,
 				// which is supported but a non-PATCH nested Parameters resource may be problematic.
-				if (isInvalidNestedParametersRequest(ctx, nextPart, operation)) {
+				// The exception being meta operations such as $meta-add and $meta-delete
+				if (!isMetaOperation(operationName) && isInvalidNestedParametersRequest(ctx, nextPart, operation)) {
 					throw new InvalidRequestException(Msg.code(339)
 							+ String.format("Can not handle nested Parameters with %s operation", operation));
 				}
@@ -837,6 +848,15 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 		} else {
 			return null;
 		}
+	}
+
+	private boolean isMetaOperation(String theOperationName) {
+		if (isEmpty(theOperationName)) {
+			return false;
+		}
+
+		return theOperationName.equals(RestOperationTypeEnum.META_ADD.getCode())
+				|| theOperationName.equals(RestOperationTypeEnum.META_DELETE.getCode());
 	}
 
 	@Nullable

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOpTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOpTest.java
@@ -1,18 +1,35 @@
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.model.api.IFhirVersion;
 import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.util.BundleUtil;
+import ca.uhn.fhir.util.bundle.BundleEntryParts;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 public class RuleImplOpTest {
 
@@ -92,5 +109,54 @@ public class RuleImplOpTest {
 		assertFalse(aRuleOp.matches(RuleOpEnum.WRITE, AppliesTypeEnum.ALL_RESOURCES, Collections.emptyList(), Collections.emptySet(), CLASSIFIER_TYPE, "Patient"));
 		assertFalse(aRuleOp.matches(RuleOpEnum.READ, AppliesTypeEnum.TYPES, Collections.emptyList(), Collections.emptySet(), CLASSIFIER_TYPE, "Patient"));
 		assertFalse(aRuleOp.matches(RuleOpEnum.READ, AppliesTypeEnum.ALL_RESOURCES, Collections.emptyList(), Collections.emptySet(), CLASSIFIER_TYPE, "Observation"));
+	}
+
+	@Test
+	public void testApplyRule_transactionEntryWithMetaAddOperation() {
+		// arrange
+		RuleImplOp rule = new RuleImplOp("rule");
+		rule.setOp(RuleOpEnum.TRANSACTION);
+
+		IBaseBundle transactionBundle = mock(IBaseBundle.class);
+		IBaseResource metaAddPayload = mock(IBaseResource.class);
+
+		IFhirVersion fhirVersion = mock(IFhirVersion.class);
+		when(fhirVersion.newIdType()).thenReturn(new IdDt());
+		FhirContext ctx = mock(FhirContext.class);
+		when(ctx.getResourceType(transactionBundle)).thenReturn("Bundle");
+		when(ctx.getVersion()).thenReturn(fhirVersion);
+
+		SystemRequestDetails requestDetails = new SystemRequestDetails();
+		requestDetails.setFhirContext(ctx);
+
+		BundleEntryParts metaAddEntry = new BundleEntryParts(
+				null, RequestTypeEnum.POST, "Patient/p1/$meta-add", metaAddPayload, null, RequestTypeEnum.POST);
+
+		// The instance-level authorization of Patient/p1 is delegated back to the rule applier; stub it to ALLOW.
+		IRuleApplier ruleApplier = mock(IRuleApplier.class);
+		AuthorizationInterceptor.Verdict allow = new AuthorizationInterceptor.Verdict(PolicyEnum.ALLOW, rule);
+		when(ruleApplier.applyRulesAndReturnDecision(any(), any(), any(), any(), any(), any()))
+				.thenReturn(allow);
+
+		try (MockedStatic<BundleUtil> bundleUtil = mockStatic(BundleUtil.class)) {
+			bundleUtil.when(() -> BundleUtil.getBundleType(ctx, transactionBundle)).thenReturn("transaction");
+			bundleUtil.when(() -> BundleUtil.toListOfEntries(ctx, transactionBundle))
+					.thenReturn(List.of(metaAddEntry));
+
+			// act
+			AuthorizationInterceptor.Verdict verdict = rule.applyRule(
+					RestOperationTypeEnum.TRANSACTION,
+					requestDetails,
+					transactionBundle,
+					null,
+					null,
+					ruleApplier,
+					EnumSet.noneOf(AuthorizationFlagsEnum.class),
+					Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED);
+
+			// assert
+			assertThat(verdict).isNotNull();
+			assertThat(verdict.getDecision()).isEqualTo(PolicyEnum.ALLOW);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #8243

### Root Cause

RuleImplOp.applyRuleToTransaction parsed each entry's request.url with UrlUtil.parseUrl(...) to derive the target resource for rule evaluation. For Patient/p1/$meta-add, the trailing $meta-add segment isn't a resource id or _history, so parseUrl threw HAPI-1742 — before the transaction processor (which already supports these operations, #7734) was ever reached.

### Changes:

- RuleImplOp: detect an operation URL (trailing segment starting with $) and parse only the ResourceType/id prefix, so authorization resolves against Patient/p1.
- Added isMetaOperation(...) and exempted $meta-add / $meta-delete from the nested-Parameters guard (Msg.code(339)), since these legitimately carry a Parameters body via POST.