### PR TITLE
Jr 20260806 manage subscription permission

### DIFF
--- a/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/SubscriptionInterceptors.java
+++ b/hapi-fhir-docs/src/main/java/ca/uhn/hapi/fhir/docs/SubscriptionInterceptors.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * HAPI FHIR - Docs
+ * %%
+ * Copyright (C) 2014 - 2026 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.hapi.fhir.docs;
+
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.jpa.subscription.submit.interceptor.SubscriptionValidatingInterceptor;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+public class SubscriptionInterceptors {
+
+	// START SNIPPET: validatingInterceptor
+	@Interceptor
+	public class MySubscriptionValidatingInterceptor extends SubscriptionValidatingInterceptor {
+
+		@Override
+		protected boolean isUserAuthorizedToWriteSubscriptions(
+				@Nonnull IBaseResource theSubscription,
+				@Nullable RequestDetails theRequestDetails,
+				@Nullable RequestPartitionId theRequestPartitionId,
+				@Nonnull Pointcut thePointcut) {
+			// Custom authorization logic here
+			// return true to allow the request, false to deny
+
+			return true;
+		}
+	}
+	// END SNIPPET: validatingInterceptor
+}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8246-manage-subscriptions.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/8246-manage-subscriptions.yaml
@@ -1,0 +1,5 @@
+---
+type: security
+issue: 8246
+title: "The `SubscriptionValidationInterceptor` can be subclassed to support custom authorization rules restricting
+who can create or update `Subscription` resources."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/files.properties
@@ -137,6 +137,7 @@ page.security.search_narrowing_interceptor=Search Narrowing Interceptor
 page.security.cors=CORS
 page.security.balp_interceptor=Basic Audit Log Pattern (BALP)
 page.security.binary_security_interceptor=Binary Resource Security Interceptor
+page.security.subscription_validating_interceptor=Subscription Validating Interceptor
 
 chapter.validation.title=Validation
 chapter.validation.chapter_type=reference

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/subscription_validating_interceptor.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/security/subscription_validating_interceptor.md
@@ -1,0 +1,22 @@
+# Subscription Validating Interceptor
+
+During its evaluation, a subscription has access to resources that the user who defined the subscription would not necessarily have access to. For this reason, it is important to restrict write access for Subscription resources to trustworthy users. In most cases, this can be accomplished by directly restricting write access on Subscription resources. However, use cases exist where it may be necessary to control the creation of these resources at a finer level of detail. 
+
+To support these cases, the `SubscriptionValidatingInterceptor` can be subclassed and extended to provide custom authorization rules for creating and updating `Subscriptions`.
+
+```java
+{{snippet:classpath:/ca/uhn/hapi/fhir/docs/SubscriptionInterceptors.java|validatingInterceptor}}
+``` 
+
+The method `isUserAuthorizedToWriteSubscriptions` accepts four parameters:
+
+| Parameter name        | Type               | Usage notes                                                                                                                                                                                 |
+|-----------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| theSubscription       | IBaseResource      | The subscription being written. It can be inspected to restrict the user to only Subscriptions having certain characteristics (e.g., white-list which URLs can be targetted by a rest hook) |
+| theRequestDetails     | RequestDetails     | The user session. It allows permission to be granted based on user identity.                                                                                                                |
+| theRequestPartitionId | RequestPartitionId | The target partition, if any. It allows restricting which partitions Subscriptions can be written to.                                                                                       |
+| thePointcut           | Pointcut           | Identifies whether this is a create or an update operation. It has the values `STORAGE_PRESTORAGE_RESOURCE_CREATED` or `STORAGE_PRESTORAGE_RESOURCE_UPDATED`.                               |
+
+It is recommended that the default implementation of this interceptor be unregistered before a custom interceptor is registered.
+
+Because the system's ability to update `Subscriptions` must not be denied, these custom rules will not be invoked if the pointcut is `STORAGE_PRESTORAGE_RESOURCE_UPDATED` and the request details object is of type `SystemRequestDetails`.

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -208,9 +208,8 @@ public class SubscriptionValidatingInterceptor {
 	 * @return true if the current user is authorized to perform the requested action on the specified partition
 	 */
 	@SuppressWarnings("unused")
-	public boolean isUserAuthorizedToManageSubscriptions(RequestDetails theRequestDetails,
-	                                                     RequestPartitionId theRequestPartitionId,
-	                                                     Pointcut thePointcut) {
+	public boolean isUserAuthorizedToManageSubscriptions(
+			RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 		return true;
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -51,6 +51,8 @@ import ca.uhn.fhir.subscription.SubscriptionConstants;
 import ca.uhn.fhir.util.HapiExtensions;
 import ca.uhn.fhir.util.SubscriptionUtil;
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.StringType;
@@ -132,9 +134,7 @@ public class SubscriptionValidatingInterceptor {
 			return;
 		}
 
-		if (!isUserAuthorizedToManageSubscriptions(theRequestDetails, theRequestPartitionId, thePointcut)) {
-			throw new ForbiddenOperationException(Msg.code(3026) + "User is not authorized to manage subscriptions");
-		}
+		validateAuthorization(theSubscription, theRequestDetails, theRequestPartitionId, thePointcut);
 
 		CanonicalSubscription subscription;
 		try {
@@ -198,18 +198,46 @@ public class SubscriptionValidatingInterceptor {
 		}
 	}
 
+	private void validateAuthorization(
+			IBaseResource theSubscription,
+			RequestDetails theRequestDetails,
+			RequestPartitionId theRequestPartitionId,
+			Pointcut thePointcut) {
+		// The system itself must be authorized to update subscriptions in order to activate them.
+		// See SubscriptionActivatingListener for an example. This must be allowed, regardless of any rules the
+		// implementor may define.
+		if (thePointcut == Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED
+				&& theRequestDetails instanceof SystemRequestDetails) {
+			return;
+		}
+
+		if (!isUserAuthorizedToManageSubscriptions(
+				theSubscription, theRequestDetails, theRequestPartitionId, thePointcut)) {
+			throw new ForbiddenOperationException(Msg.code(3026) + "User is not authorized to manage subscriptions");
+		}
+	}
+
 	/**
 	 * An override hook allowing an implementer to provide custom logic for authorizing a user to perform
 	 * subscription management operations.
 	 *
-	 * @param theRequestDetails     the details of the current request
-	 * @param theRequestPartitionId the id of the partition being accessed
-	 * @param thePointcut           the pointcut being invoked
-	 * @return true if the current user is authorized to perform the requested action on the specified partition
+	 * @param theSubscription       allows implementers to define authorization rules dependent on the
+	 *                              subscription resource being manipulated
+	 * @param theRequestDetails     allows implementers to define authorization rules dependent on the
+	 *                              details of the original request, including whether it is a user request
+	 *                              or a system request, and user session information is applicable
+	 * @param theRequestPartitionId allows implementers to define authorization rules dependent on the
+	 *                              partition being accessed, is any
+	 * @param thePointcut           allows implementers to define authorization rules dependent on the
+	 *                              operation implied by the current pointcut
+	 * @return true if the current user is authorized to proceed with the operation, otherwise the operation
+	 *         will be rejected with a 403 Forbidden response code
 	 */
-	@SuppressWarnings("unused")
-	public boolean isUserAuthorizedToManageSubscriptions(
-			RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+	protected boolean isUserAuthorizedToManageSubscriptions(
+			@Nonnull IBaseResource theSubscription,
+			@Nullable RequestDetails theRequestDetails,
+			@Nullable RequestPartitionId theRequestPartitionId,
+			@Nonnull Pointcut thePointcut) {
 		return true;
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -43,6 +43,7 @@ import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.param.UriParam;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
@@ -127,6 +128,10 @@ public class SubscriptionValidatingInterceptor {
 					+ thePointcut);
 		}
 
+		if (!isUserAuthorizedToManageSubscriptions()) {
+			throw new AuthenticationException(Msg.code(3026) + "User is not authorized to manage subscriptions");
+		}
+
 		if (!"Subscription".equals(myFhirContext.getResourceType(theSubscription))) {
 			return;
 		}
@@ -191,6 +196,10 @@ public class SubscriptionValidatingInterceptor {
 				validateMessageSubscriptionEndpoint(subscription.getEndpointUrl());
 			}
 		}
+	}
+
+	public boolean isUserAuthorizedToManageSubscriptions() {
+		return true;
 	}
 
 	private void validateCriteria(IBaseResource theSubscription, CanonicalSubscription theCanonicalSubscription) {
@@ -291,7 +300,7 @@ public class SubscriptionValidatingInterceptor {
 		myDaoRegistry.getResourceDao("SubscriptionTopic");
 		SearchParameterMap map = SearchParameterMap.newSynchronous();
 		map.add(SubscriptionTopic.SP_URL, new UriParam(theCriteria));
-		IFhirResourceDao subscriptionTopicDao = myDaoRegistry.getResourceDao("SubscriptionTopic");
+		IFhirResourceDao<?> subscriptionTopicDao = myDaoRegistry.getResourceDao("SubscriptionTopic");
 		IBundleProvider search = subscriptionTopicDao.search(map, new SystemRequestDetails());
 		return search.getResources(0, 1).stream().findFirst();
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -134,7 +134,7 @@ public class SubscriptionValidatingInterceptor {
 			return;
 		}
 
-		validateAuthorization(theSubscription, theRequestDetails, theRequestPartitionId, thePointcut);
+		checkSubscriptionWriteAuthorized(theSubscription, theRequestDetails, theRequestPartitionId, thePointcut);
 
 		CanonicalSubscription subscription;
 		try {
@@ -198,20 +198,19 @@ public class SubscriptionValidatingInterceptor {
 		}
 	}
 
-	private void validateAuthorization(
+	private void checkSubscriptionWriteAuthorized(
 			IBaseResource theSubscription,
 			RequestDetails theRequestDetails,
 			RequestPartitionId theRequestPartitionId,
 			Pointcut thePointcut) {
-		// The system itself must be authorized to update subscriptions in order to activate them.
-		// See SubscriptionActivatingListener for an example. This must be allowed, regardless of any rules the
-		// implementor may define.
+		// The system itself must be authorized to update subscriptions, for example to activate them.
+		// Implementors must be prevented from accidentally disallowing this.
 		if (thePointcut == Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED
 				&& theRequestDetails instanceof SystemRequestDetails) {
 			return;
 		}
 
-		if (!isUserAuthorizedToManageSubscriptions(
+		if (!isUserAuthorizedToWriteSubscriptions(
 				theSubscription, theRequestDetails, theRequestPartitionId, thePointcut)) {
 			throw new ForbiddenOperationException(Msg.code(3026) + "User is not authorized to manage subscriptions");
 		}
@@ -219,21 +218,23 @@ public class SubscriptionValidatingInterceptor {
 
 	/**
 	 * An override hook allowing an implementer to provide custom logic for authorizing a user to perform
-	 * subscription management operations.
+	 * subscription management operations. The default implementation returns true unconditionally, allowing
+	 * all calls. Note that calls on the pointcut STORAGE_PRESTORAGE_RESOURCE_UPDATED with a
+	 * {@link SystemRequestDetails} will not invoke this method.
 	 *
 	 * @param theSubscription       allows implementers to define authorization rules dependent on the
 	 *                              subscription resource being manipulated
 	 * @param theRequestDetails     allows implementers to define authorization rules dependent on the
 	 *                              details of the original request, including whether it is a user request
-	 *                              or a system request, and user session information is applicable
+	 *                              or a system request, and user session information if applicable
 	 * @param theRequestPartitionId allows implementers to define authorization rules dependent on the
-	 *                              partition being accessed, is any
+	 *                              partition being accessed, if any
 	 * @param thePointcut           allows implementers to define authorization rules dependent on the
 	 *                              operation implied by the current pointcut
 	 * @return true if the current user is authorized to proceed with the operation, otherwise the operation
 	 *         will be rejected with a 403 Forbidden response code
 	 */
-	protected boolean isUserAuthorizedToManageSubscriptions(
+	protected boolean isUserAuthorizedToWriteSubscriptions(
 			@Nonnull IBaseResource theSubscription,
 			@Nullable RequestDetails theRequestDetails,
 			@Nullable RequestPartitionId theRequestPartitionId,

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptor.java
@@ -43,7 +43,7 @@ import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.param.UriParam;
-import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
@@ -128,12 +128,12 @@ public class SubscriptionValidatingInterceptor {
 					+ thePointcut);
 		}
 
-		if (!isUserAuthorizedToManageSubscriptions()) {
-			throw new AuthenticationException(Msg.code(3026) + "User is not authorized to manage subscriptions");
-		}
-
 		if (!"Subscription".equals(myFhirContext.getResourceType(theSubscription))) {
 			return;
+		}
+
+		if (!isUserAuthorizedToManageSubscriptions(theRequestDetails, theRequestPartitionId, thePointcut)) {
+			throw new ForbiddenOperationException(Msg.code(3026) + "User is not authorized to manage subscriptions");
 		}
 
 		CanonicalSubscription subscription;
@@ -198,7 +198,19 @@ public class SubscriptionValidatingInterceptor {
 		}
 	}
 
-	public boolean isUserAuthorizedToManageSubscriptions() {
+	/**
+	 * An override hook allowing an implementer to provide custom logic for authorizing a user to perform
+	 * subscription management operations.
+	 *
+	 * @param theRequestDetails     the details of the current request
+	 * @param theRequestPartitionId the id of the partition being accessed
+	 * @param thePointcut           the pointcut being invoked
+	 * @return true if the current user is authorized to perform the requested action on the specified partition
+	 */
+	@SuppressWarnings("unused")
+	public boolean isUserAuthorizedToManageSubscriptions(RequestDetails theRequestDetails,
+	                                                     RequestPartitionId theRequestPartitionId,
+	                                                     Pointcut thePointcut) {
 		return true;
 	}
 
@@ -297,7 +309,6 @@ public class SubscriptionValidatingInterceptor {
 	}
 
 	private Optional<IBaseResource> findSubscriptionTopicByUrl(String theCriteria) {
-		myDaoRegistry.getResourceDao("SubscriptionTopic");
 		SearchParameterMap map = SearchParameterMap.newSynchronous();
 		map.add(SubscriptionTopic.SP_URL, new UriParam(theCriteria));
 		IFhirResourceDao<?> subscriptionTopicDao = myDaoRegistry.getResourceDao("SubscriptionTopic");

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -249,7 +249,7 @@ public class SubscriptionValidatingInterceptorTest {
 		final Subscription subscription = createSubscription();
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
-			public boolean isUserAuthorizedToManageSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+			public boolean isUserAuthorizedToWriteSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 				return false;
 			}
 		};
@@ -270,7 +270,7 @@ public class SubscriptionValidatingInterceptorTest {
 		final Patient patient = new Patient();
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
-			public boolean isUserAuthorizedToManageSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+			public boolean isUserAuthorizedToWriteSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 				return false;
 			}
 		};
@@ -288,13 +288,14 @@ public class SubscriptionValidatingInterceptorTest {
 	 */
 	@ParameterizedTest
 	@MethodSource("operationsByRequestType")
-	void testValidateSubmittedSubscription_operationsByRequestType(Pointcut theOperation, RequestDetails theRequestDetails) {
+	void testValidateSubmittedSubscription_operationsByRequestType(
+		Pointcut theOperation, RequestDetails theRequestDetails, boolean theExpectAllowed) {
 		// set up
 		final Subscription subscription = createSubscription();
 
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
-			public boolean isUserAuthorizedToManageSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+			public boolean isUserAuthorizedToWriteSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 				return false;
 			}
 		};
@@ -305,7 +306,7 @@ public class SubscriptionValidatingInterceptorTest {
 		overrideInterceptor.setSubscriptionChannelTypeValidatorFactoryForUnitTest(mySubscriptionChannelTypeValidatorFactory);
 		overrideInterceptor.setSubscriptionSettingsForUnitTest(mySubscriptionSettings);
 
-		if (theOperation == Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED && theRequestDetails instanceof SystemRequestDetails) {
+		if (theExpectAllowed) {
 			assertThatNoException().isThrownBy(() -> overrideInterceptor.validateSubmittedSubscription(
 					subscription, theRequestDetails, null, theOperation));
 		} else {
@@ -318,16 +319,16 @@ public class SubscriptionValidatingInterceptorTest {
 		}
 	}
 
-public static Stream<Arguments> operationsByRequestType() {
-	return Stream.of(
-		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED, RequestDetailsHelper.newServletRequestDetails()),
-		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED, new SystemRequestDetails()),
-		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED, RequestDetailsHelper.newServletRequestDetails()),
-		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED, new SystemRequestDetails())
-	);
-}
+	public static Stream<Arguments> operationsByRequestType() {
+		return Stream.of(
+			Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED, RequestDetailsHelper.newServletRequestDetails(), false),
+			Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED, new SystemRequestDetails(), false),
+			Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED, RequestDetailsHelper.newServletRequestDetails(), false),
+			Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED, new SystemRequestDetails(), true)
+		);
+	}
 
-@Test
+	@Test
 	public void testInvalidTopic() throws URISyntaxException {
 		when(myDaoRegistry.getResourceDao("SubscriptionTopic")).thenReturn(mySubscriptionTopicDao);
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -21,10 +21,12 @@ import ca.uhn.fhir.jpa.subscription.submit.interceptor.validator.SubscriptionCha
 import ca.uhn.fhir.jpa.subscription.submit.interceptor.validator.SubscriptionQueryValidator;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
+import ca.uhn.fhir.test.utilities.RequestDetailsHelper;
 import ca.uhn.fhir.util.ExtensionUtil;
 import ca.uhn.fhir.util.HapiExtensions;
 import jakarta.annotation.Nonnull;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -61,7 +64,6 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -247,7 +249,7 @@ public class SubscriptionValidatingInterceptorTest {
 		final Subscription subscription = createSubscription();
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
-			public boolean isUserAuthorizedToManageSubscriptions(RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+			public boolean isUserAuthorizedToManageSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 				return false;
 			}
 		};
@@ -268,7 +270,7 @@ public class SubscriptionValidatingInterceptorTest {
 		final Patient patient = new Patient();
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
-			public boolean isUserAuthorizedToManageSubscriptions(RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+			public boolean isUserAuthorizedToManageSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 				return false;
 			}
 		};
@@ -280,7 +282,52 @@ public class SubscriptionValidatingInterceptorTest {
 					patient, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED));
 	}
 
-	@Test
+	/*
+	 * Ensure that, even if the implementer has overridden the authorization rules, the system will still be able to
+	 * update subscriptions in order to activate them
+	 */
+	@ParameterizedTest
+	@MethodSource("operationsByRequestType")
+	void testValidateSubmittedSubscription_operationsByRequestType(Pointcut theOperation, RequestDetails theRequestDetails) {
+		// set up
+		final Subscription subscription = createSubscription();
+
+		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
+			@Override
+			public boolean isUserAuthorizedToManageSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+				return false;
+			}
+		};
+		overrideInterceptor.setFhirContext(myFhirContext);
+		overrideInterceptor.setDaoRegistryForUnitTest(myDaoRegistry);
+		overrideInterceptor.setSubscriptionCanonicalizerForUnitTest(new SubscriptionCanonicalizer(myFhirContext, mySubscriptionSettings, myPartitionSettings));
+		overrideInterceptor.setSubscriptionStrategyEvaluatorForUnitTest(mySubscriptionStrategyEvaluator);
+		overrideInterceptor.setSubscriptionChannelTypeValidatorFactoryForUnitTest(mySubscriptionChannelTypeValidatorFactory);
+		overrideInterceptor.setSubscriptionSettingsForUnitTest(mySubscriptionSettings);
+
+		if (theOperation == Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED && theRequestDetails instanceof SystemRequestDetails) {
+			assertThatNoException().isThrownBy(() -> overrideInterceptor.validateSubmittedSubscription(
+					subscription, theRequestDetails, null, theOperation));
+		} else {
+			// execute and validate
+			assertThatThrownBy(() ->
+				overrideInterceptor.validateSubmittedSubscription(
+					subscription, theRequestDetails, null, theOperation))
+				.isInstanceOf(ForbiddenOperationException.class)
+				.hasMessage(Msg.code(3026) + "User is not authorized to manage subscriptions");
+		}
+	}
+
+public static Stream<Arguments> operationsByRequestType() {
+	return Stream.of(
+		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED, RequestDetailsHelper.newServletRequestDetails()),
+		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED, new SystemRequestDetails()),
+		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED, RequestDetailsHelper.newServletRequestDetails()),
+		Arguments.of(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED, new SystemRequestDetails())
+	);
+}
+
+@Test
 	public void testInvalidTopic() throws URISyntaxException {
 		when(myDaoRegistry.getResourceDao("SubscriptionTopic")).thenReturn(mySubscriptionTopicDao);
 

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -22,6 +22,7 @@ import ca.uhn.fhir.jpa.subscription.submit.interceptor.validator.SubscriptionQue
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
 import ca.uhn.fhir.util.ExtensionUtil;
@@ -42,10 +43,10 @@ import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.net.URI;
@@ -58,6 +59,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -71,20 +73,20 @@ public class SubscriptionValidatingInterceptorTest {
 
 	@Autowired
 	private SubscriptionValidatingInterceptor mySubscriptionValidatingInterceptor;
-	@MockBean
+	@MockitoBean
 	private DaoRegistry myDaoRegistry;
-	@MockBean
+	@MockitoBean
 	private SubscriptionStrategyEvaluator mySubscriptionStrategyEvaluator;
-	@MockBean
+	@MockitoBean
 	private SubscriptionSettings mySubscriptionSettings;
-	@MockBean
+	@MockitoBean
 	private IRequestPartitionHelperSvc myRequestPartitionHelperSvc;
 	@Mock
 	private IFhirResourceDao<SubscriptionTopic> mySubscriptionTopicDao;
 	private FhirContext myFhirContext;
 
 	private PartitionSettings myPartitionSettings = new PartitionSettings();
-	@SpyBean
+	@MockitoSpyBean
 	private SubscriptionChannelTypeValidatorFactory mySubscriptionChannelTypeValidatorFactory;
 
 	@BeforeEach
@@ -235,6 +237,23 @@ public class SubscriptionValidatingInterceptorTest {
 		} catch (UnprocessableEntityException e) {
 			assertEquals(Msg.code(2267) + "Expected Pointcut to be either STORAGE_PRESTORAGE_RESOURCE_CREATED or STORAGE_PRESTORAGE_RESOURCE_UPDATED but was: " + Pointcut.TEST_RB, e.getMessage());
 		}
+	}
+
+	@Test
+	void testValidateSubmittedSubscription_userAuthorizationCanBeDenied() {
+		// set up
+		final Subscription subscription = createSubscription();
+		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
+			@Override
+			public boolean isUserAuthorizedToManageSubscriptions() {
+				return false;
+			}
+		};
+
+		assertThrows(AuthenticationException.class, () ->
+			overrideInterceptor.validateSubmittedSubscription(
+				subscription, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED),
+			Msg.code(3026) + "User is not authorized to manage subscriptions");
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -22,7 +22,7 @@ import ca.uhn.fhir.jpa.subscription.submit.interceptor.validator.SubscriptionQue
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
-import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.subscription.SubscriptionConstants;
 import ca.uhn.fhir.util.ExtensionUtil;
@@ -31,6 +31,7 @@ import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4b.model.CanonicalType;
 import org.hl7.fhir.r4b.model.Enumerations;
+import org.hl7.fhir.r4b.model.Patient;
 import org.hl7.fhir.r4b.model.Subscription;
 import org.hl7.fhir.r4b.model.SubscriptionTopic;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +59,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -245,15 +247,37 @@ public class SubscriptionValidatingInterceptorTest {
 		final Subscription subscription = createSubscription();
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
-			public boolean isUserAuthorizedToManageSubscriptions() {
+			public boolean isUserAuthorizedToManageSubscriptions(RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
 				return false;
 			}
 		};
 
-		assertThrows(AuthenticationException.class, () ->
+		overrideInterceptor.setFhirContext(myFhirContext);
+
+		// execute and validate
+		assertThatThrownBy(() ->
 			overrideInterceptor.validateSubmittedSubscription(
-				subscription, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED),
-			Msg.code(3026) + "User is not authorized to manage subscriptions");
+				subscription, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED))
+			.isInstanceOf(ForbiddenOperationException.class)
+				.hasMessage(Msg.code(3026) + "User is not authorized to manage subscriptions");
+	}
+
+	@Test
+	void testValidateSubmittedSubscription_userAuthorizationDoesNotBlockOtherResourceTypes() {
+		// set up
+		final Patient patient = new Patient();
+		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
+			@Override
+			public boolean isUserAuthorizedToManageSubscriptions(RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
+				return false;
+			}
+		};
+		overrideInterceptor.setFhirContext(myFhirContext);
+
+		// execute and validate
+		assertThatNoException().isThrownBy(
+			() -> overrideInterceptor.validateSubmittedSubscription(
+					patient, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED));
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionValidatingInterceptorTest.java
@@ -243,10 +243,11 @@ public class SubscriptionValidatingInterceptorTest {
 		}
 	}
 
-	@Test
-	void testValidateSubmittedSubscription_userAuthorizationCanBeDenied() {
+	@ParameterizedTest
+	@MethodSource("subscriptionByFhirVersion345")
+	void testValidateSubmittedSubscription_userAuthorizationCanBeDenied(IBaseResource theSubscription) {
 		// set up
-		final Subscription subscription = createSubscription();
+		initSubscription(theSubscription);
 		SubscriptionValidatingInterceptor overrideInterceptor = new SubscriptionValidatingInterceptor() {
 			@Override
 			public boolean isUserAuthorizedToWriteSubscriptions(IBaseResource theSubscription, RequestDetails theRequestDetails, RequestPartitionId theRequestPartitionId, Pointcut thePointcut) {
@@ -259,7 +260,7 @@ public class SubscriptionValidatingInterceptorTest {
 		// execute and validate
 		assertThatThrownBy(() ->
 			overrideInterceptor.validateSubmittedSubscription(
-				subscription, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED))
+				theSubscription, null, null, Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED))
 			.isInstanceOf(ForbiddenOperationException.class)
 				.hasMessage(Msg.code(3026) + "User is not authorized to manage subscriptions");
 	}


### PR DESCRIPTION
This MR introduces a hook in the `SubscriptionValidatingInterceptor` to allow an implementer to control which users are able to create or update Subscription resources. 

Since subscriptions run with system privileges, they can access resources that the user would not normally be allowed to read, and route them to arbitrary endpoints. Depending on the permission to write Subscriptions is not enough, since that permission could be granted through a wildcard. The default behaviour is unchanged for backward compatibility, but the new hook gives implementers the option of writing fine-grained security rules that take into account the user session, the contents of the Subscription, the partition being written to and whether the create or update pointcut was called.

In the edge case where the system itself is updating a Subscription, this must not be denied or the Subscription functionality will break. In this specific case, the user-provided rules will not be invoked. This does leave a residual risk where a user who does not have permission to write Subscriptions can trick a system process into writing the Subscription for them. However, this is a much narrower attack surface and harder to attack.