### PR TITLE
8232 cds hook prefetch template resolution doesnt resolve values from resolved prefetch

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/9139-cds-hook-prefetch-template-resolution-doesn-t-resolve-values-from-resolved-prefetch.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_12_0/9139-cds-hook-prefetch-template-resolution-doesn-t-resolve-values-from-resolved-prefetch.yaml
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 9139
+title: "CDS Hooks prefetch templates using the %prefetchKey.fhirpath syntax to reference a previously-resolved
+  prefetch entry now correctly resolve. Previously, these expressions always produced no result because
+  the template substitution was looking into CDS hook request context."

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 @Service
@@ -165,8 +166,7 @@ public class CdsPrefetchSvc {
 				// The service will manage missing prefetch elements
 				continue;
 			}
-			String url = PrefetchTemplateUtil.substituteTemplate(
-					template, theCdsServiceRequestJson.getContext(), myFhirContext);
+			String url = PrefetchTemplateUtil.substituteTemplate(template, theCdsServiceRequestJson, myFhirContext);
 			ourLog.info("missing: {}.  Fetching with {}", theMissingPrefetch, url);
 
 			CdsHookPrefetchPointcutContextJson cdsHookPrefetchPointcutContext =
@@ -245,9 +245,8 @@ public class CdsPrefetchSvc {
 	private IBaseOperationOutcome extractOrCreateOperationOutcomeFromException(Exception e) {
 		IBaseOperationOutcome oo = null;
 		// check first if we can get an OperationOutcome from the exception
-		if (e instanceof BaseServerResponseException) {
-			BaseServerResponseException serverException = (BaseServerResponseException) e;
-			oo = serverException.getOperationOutcome();
+		if (e instanceof BaseServerResponseException serverResponseException) {
+			oo = serverResponseException.getOperationOutcome();
 		}
 
 		if (oo == null) {
@@ -269,7 +268,7 @@ public class CdsPrefetchSvc {
 			CdsServiceJson theServiceSpec, CdsServiceRequestJson theCdsServiceRequestJson) {
 		Set<String> expectedPrefetchKeys = theServiceSpec.getPrefetch().keySet();
 		Set<String> actualPrefetchKeys = theCdsServiceRequestJson.getPrefetchKeys();
-		Set<String> retval = new HashSet<>(expectedPrefetchKeys);
+		Set<String> retval = new LinkedHashSet<>(expectedPrefetchKeys);
 		retval.removeAll(actualPrefetchKeys);
 		return retval;
 	}

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvc.java
@@ -34,6 +34,7 @@ import ca.uhn.hapi.fhir.cdshooks.api.ICdsHooksDaoAuthorizationSvc;
 import ca.uhn.hapi.fhir.cdshooks.api.ICdsServiceMethod;
 import ca.uhn.hapi.fhir.cdshooks.api.json.CdsServiceJson;
 import ca.uhn.hapi.fhir.cdshooks.api.json.prefetch.CdsHookPrefetchPointcutContextJson;
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -264,8 +265,9 @@ public class CdsPrefetchSvc {
 		return resource;
 	}
 
+	@Nonnull
 	public Set<String> findMissingPrefetch(
-			CdsServiceJson theServiceSpec, CdsServiceRequestJson theCdsServiceRequestJson) {
+			@Nonnull CdsServiceJson theServiceSpec, @Nonnull CdsServiceRequestJson theCdsServiceRequestJson) {
 		Set<String> expectedPrefetchKeys = theServiceSpec.getPrefetch().keySet();
 		Set<String> actualPrefetchKeys = theCdsServiceRequestJson.getPrefetchKeys();
 		Set<String> retval = new LinkedHashSet<>(expectedPrefetchKeys);

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtil.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtil.java
@@ -24,7 +24,9 @@ import ca.uhn.fhir.fhirpath.FhirPathExecutionException;
 import ca.uhn.fhir.fhirpath.IFhirPath;
 import ca.uhn.fhir.fhirpath.IFhirPathEvaluationContext;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestContextJson;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.BundleUtil;
 import jakarta.annotation.Nonnull;
@@ -58,40 +60,53 @@ public class PrefetchTemplateUtil {
 
 		record MissingContextKey(String key, String availableKeys) implements PartResolutionResult {}
 
+		record MissingPrefetchKey(String key, String availableKeys) implements PartResolutionResult {}
+
 		record NoMatch() implements PartResolutionResult {}
 	}
 
 	@Nonnull
 	public static String substituteTemplate(
 			@Nonnull String theTemplate,
-			@Nonnull CdsServiceRequestContextJson theContext,
+			@Nonnull CdsServiceRequestJson theCdsServiceRequestJson,
 			@Nonnull FhirContext theFhirContext) {
 		return SURROUNDING_CURLY_BRACES_PART
 				.matcher(theTemplate)
-				.replaceAll(match ->
-						Matcher.quoteReplacement(resolveExpression(match.group(1), theContext, theFhirContext)));
+				.replaceAll(match -> Matcher.quoteReplacement(resolveExpression(
+						match.group(1),
+						theCdsServiceRequestJson.getContext(),
+						theCdsServiceRequestJson,
+						theFhirContext)));
 	}
 
 	private static String resolveExpression(
 			String theRawExpression,
 			@Nonnull CdsServiceRequestContextJson theContext,
+			@Nonnull CdsServiceRequestJson theCdsServiceRequestJson,
 			@Nonnull FhirContext theFhirContext) {
 		final List<String> results = new ArrayList<>();
-		PartResolutionResult.MissingContextKey firstMissingKey = null;
+		PartResolutionResult firstMissingKey = null;
 		for (String rawPart : theRawExpression.split(UNION_OPERATOR_REGEX)) {
-			final PartResolutionResult partResult = resolvePartResults(rawPart.trim(), theContext, theFhirContext);
+			final PartResolutionResult partResult =
+					resolvePartResults(rawPart.trim(), theContext, theCdsServiceRequestJson, theFhirContext);
 			if (partResult instanceof PartResolutionResult.Success s) {
 				results.addAll(s.values());
-			} else if (partResult instanceof PartResolutionResult.MissingContextKey m && firstMissingKey == null) {
-				firstMissingKey = m;
+			} else if ((partResult instanceof PartResolutionResult.MissingContextKey
+							|| partResult instanceof PartResolutionResult.MissingPrefetchKey)
+					&& firstMissingKey == null) {
+				firstMissingKey = partResult;
 			}
 		}
 		if (!results.isEmpty()) {
 			return String.join(",", results);
 		}
-		if (firstMissingKey != null) {
+		if (firstMissingKey instanceof PartResolutionResult.MissingContextKey m) {
 			throw new InvalidRequestException(Msg.code(2372) + "Request context did not provide a value for key <"
-					+ firstMissingKey.key() + ">.  Available keys in context are: " + firstMissingKey.availableKeys());
+					+ m.key() + ">.  Available keys in context are: " + m.availableKeys());
+		}
+		if (firstMissingKey instanceof PartResolutionResult.MissingPrefetchKey m) {
+			throw new InvalidRequestException(Msg.code(2861) + "Prefetch did not provide a value for key <" + m.key()
+					+ ">.  Available keys in prefetch are: " + m.availableKeys());
 		}
 		throw new InvalidRequestException(Msg.code(2856) + "Unable to resolve prefetch template : " + theRawExpression
 				+ ". No result was found for the prefetch query.");
@@ -99,13 +114,19 @@ public class PrefetchTemplateUtil {
 
 	@Nonnull
 	private static PartResolutionResult resolvePartResults(
-			String thePart, @Nonnull CdsServiceRequestContextJson theContext, @Nonnull FhirContext theFhirContext) {
+			String thePart,
+			@Nonnull CdsServiceRequestContextJson theContext,
+			@Nonnull CdsServiceRequestJson theCdsServiceRequestJson,
+			@Nonnull FhirContext theFhirContext) {
 		PartResolutionResult result = handleDaVinciPart(thePart, theContext, theFhirContext);
 		if (result instanceof PartResolutionResult.NoMatch) {
 			result = handleDefaultPart(thePart, theContext);
 		}
 		if (result instanceof PartResolutionResult.NoMatch) {
-			result = handleFhirPathAndReferencedPrefetchPart(thePart, theContext, theFhirContext);
+			result = handleFhirPathPart(thePart, theContext, theFhirContext);
+		}
+		if (result instanceof PartResolutionResult.NoMatch) {
+			result = handleReferencedPrefetchPart(thePart, theCdsServiceRequestJson, theFhirContext);
 		}
 		return result;
 	}
@@ -167,41 +188,51 @@ public class PrefetchTemplateUtil {
 	}
 
 	@Nonnull
-	private static PartResolutionResult handleFhirPathAndReferencedPrefetchPart(
+	private static PartResolutionResult handleFhirPathPart(
 			String thePart, @Nonnull CdsServiceRequestContextJson theContext, @Nonnull FhirContext theFhirContext) {
-		Matcher m = FHIR_PATH_PART.matcher(thePart);
-		PartResolutionResult partResolutionResult = matchAndCheckKey(m, theContext);
-		if (partResolutionResult instanceof PartResolutionResult.NoMatch) {
-			m = REFERENCED_PREFETCH_PART.matcher(thePart);
-			partResolutionResult = matchAndCheckKey(m, theContext);
-		}
+		final Matcher m = FHIR_PATH_PART.matcher(thePart);
+		final PartResolutionResult partResolutionResult = matchAndCheckKey(m, theContext);
 		if (!(partResolutionResult instanceof PartResolutionResult.Proceed)) {
 			return partResolutionResult;
 		}
 		final String key = m.group(1);
 		final String expression = m.group(2);
-		return new PartResolutionResult.Success(convertPrimitiveResultsToString(
-				evaluateFhirPathOnContextKey(key, expression, theContext, theFhirContext), key));
+		final List<IBase> results = evaluateFhirPathOnKey(theContext.getResource(key), key, expression, theFhirContext);
+		final List<String> values = convertPrimitiveResultsToString(results, key);
+		return new PartResolutionResult.Success(values);
 	}
 
 	@Nonnull
-	private static List<IBase> evaluateFhirPathOnContextKey(
+	private static PartResolutionResult handleReferencedPrefetchPart(
+			String thePart,
+			@Nonnull CdsServiceRequestJson theCdsServiceRequestJson,
+			@Nonnull FhirContext theFhirContext) {
+		final Matcher m = REFERENCED_PREFETCH_PART.matcher(thePart);
+		final PartResolutionResult partResolutionResult = matchAndCheckPrefetchKey(m, theCdsServiceRequestJson);
+		if (!(partResolutionResult instanceof PartResolutionResult.Proceed)) {
+			return partResolutionResult;
+		}
+		final String key = m.group(1);
+		final String expression = m.group(2);
+		final List<IBase> results =
+				evaluateFhirPathOnKey(theCdsServiceRequestJson.getPrefetch(key), key, expression, theFhirContext);
+		final List<String> values = convertPrimitiveResultsToString(results, key);
+		return new PartResolutionResult.Success(values);
+	}
+
+	@Nonnull
+	private static List<IBase> evaluateFhirPathOnKey(
+			@Nonnull IBaseResource theResource,
 			String thePrefetchKey,
 			String theFhirPathExpression,
-			@Nonnull CdsServiceRequestContextJson theContext,
 			@Nonnull FhirContext theFhirContext) {
 		try {
-			final IBaseResource resource = theContext.getResource(thePrefetchKey);
-			final IFhirPath fhirPath = createFhirPathWithReferenceLocalResolution(theFhirContext, resource);
-			final String fullExpression = resource.fhirType() + "." + theFhirPathExpression;
-			return fhirPath.evaluate(resource, fullExpression, IBase.class);
-		} catch (ClassCastException e) {
-			throw new InvalidRequestException(Msg.code(2858) + "Request context did not provide valid "
-					+ theFhirContext.getVersion().getVersion() + " Bundle resource for FHIRPath template key <"
-					+ thePrefetchKey + ">");
+			final IFhirPath fhirPath = createFhirPath(theFhirContext, theResource);
+			final String fullExpression = theResource.fhirType() + "." + theFhirPathExpression;
+			return fhirPath.evaluate(theResource, fullExpression, IBase.class);
 		} catch (FhirPathExecutionException e) {
 			throw new InvalidRequestException(Msg.code(2859)
-					+ "Unable to evaluate FHIRPath for prefetch template key <" + thePrefetchKey + "> for FHIR version "
+					+ "Unable to evaluate FHIRPath for prefetch key <" + thePrefetchKey + "> for FHIR version "
 					+ theFhirContext.getVersion().getVersion());
 		}
 	}
@@ -216,6 +247,20 @@ public class PrefetchTemplateUtil {
 		if (!theContext.containsKey(key)) {
 			return new PartResolutionResult.MissingContextKey(
 					key, theContext.getKeys().toString());
+		}
+		return new PartResolutionResult.Proceed();
+	}
+
+	@Nonnull
+	private static PartResolutionResult matchAndCheckPrefetchKey(
+			Matcher theMatcher, @Nonnull CdsServiceRequestJson theCdsServiceRequestJson) {
+		if (!theMatcher.matches()) {
+			return new PartResolutionResult.NoMatch();
+		}
+		final String key = theMatcher.group(1);
+		if (!theCdsServiceRequestJson.getPrefetchKeys().contains(key)) {
+			return new PartResolutionResult.MissingPrefetchKey(
+					key, theCdsServiceRequestJson.getPrefetchKeys().toString());
 		}
 		return new PartResolutionResult.Proceed();
 	}
@@ -237,15 +282,37 @@ public class PrefetchTemplateUtil {
 				.toList();
 	}
 
-	private static IFhirPath createFhirPathWithReferenceLocalResolution(
-			@Nonnull FhirContext theFhirContext, IBaseResource theResource) {
+	private static IFhirPath createFhirPath(@Nonnull FhirContext theFhirContext, @Nonnull IBaseResource theResource) {
 		final IFhirPath fhirPath = theFhirContext.newFhirPath();
 		fhirPath.setEvaluationContext(new IFhirPathEvaluationContext() {
 			@Override
 			public IBase resolveReference(@Nonnull IIdType theReference, @Nullable IBase theContext) {
-				return BundleUtil.getReferenceInBundle(theFhirContext, theReference.getValue(), theResource);
+				if (theResource instanceof IBaseBundle) {
+					return BundleUtil.getReferenceInBundle(theFhirContext, theReference.getValue(), theResource);
+				}
+				return resolveAsIdOnlyStub(theFhirContext, theReference);
 			}
 		});
 		return fhirPath;
+	}
+
+	@Nullable
+	private static IBaseResource resolveAsIdOnlyStub(
+			@Nonnull FhirContext theFhirContext, @Nonnull IIdType theReference) {
+		String resourceType = theReference.getResourceType();
+		String id = theReference.getIdPart();
+		if (StringUtils.isBlank(resourceType) || StringUtils.isBlank(id)) {
+			return null;
+		}
+		try {
+			IBaseResource stub =
+					theFhirContext.getResourceDefinition(resourceType).newInstance();
+			stub.setId(theReference);
+			return stub;
+		} catch (DataFormatException e) {
+			throw new InvalidRequestException(Msg.code(2862)
+					+ "Unknown resource type '" + resourceType + "' encountered while resolving reference: "
+					+ theReference.getValue());
+		}
 	}
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtil.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtil.java
@@ -37,6 +37,8 @@ import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +46,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class PrefetchTemplateUtil {
+	private static final Logger ourLog = LoggerFactory.getLogger(PrefetchTemplateUtil.class);
 	private static final Pattern SURROUNDING_CURLY_BRACES_PART = Pattern.compile("\\{\\{([^}]+)}}");
 	private static final Pattern DA_VINCI_PART = Pattern.compile("^context\\.(\\w+)\\.(\\w+)\\.id$");
 	private static final Pattern DEFAULT_PART = Pattern.compile("^context\\.(\\w+)$");
@@ -105,7 +108,7 @@ public class PrefetchTemplateUtil {
 					+ m.key() + ">.  Available keys in context are: " + m.availableKeys());
 		}
 		if (firstMissingKey instanceof PartResolutionResult.MissingPrefetchKey m) {
-			throw new InvalidRequestException(Msg.code(2861) + "Prefetch did not provide a value for key <" + m.key()
+			throw new InvalidRequestException(Msg.code(3030) + "Prefetch did not provide a value for key <" + m.key()
 					+ ">.  Available keys in prefetch are: " + m.availableKeys());
 		}
 		throw new InvalidRequestException(Msg.code(2856) + "Unable to resolve prefetch template : " + theRawExpression
@@ -197,9 +200,15 @@ public class PrefetchTemplateUtil {
 		}
 		final String key = m.group(1);
 		final String expression = m.group(2);
-		final List<IBase> results = evaluateFhirPathOnKey(theContext.getResource(key), key, expression, theFhirContext);
-		final List<String> values = convertPrimitiveResultsToString(results, key);
-		return new PartResolutionResult.Success(values);
+		try {
+			final List<IBase> results =
+					evaluateFhirPathOnKey(theContext.getResource(key), key, expression, theFhirContext);
+			final List<String> values = convertPrimitiveResultsToString(results, key);
+			return new PartResolutionResult.Success(values);
+		} catch (ClassCastException e) {
+			throw new InvalidRequestException(Msg.code(2858) + "Request context did not provide a valid "
+					+ theFhirContext.getVersion().getVersion() + " resource for template key <" + key + ">");
+		}
 	}
 
 	@Nonnull
@@ -310,9 +319,11 @@ public class PrefetchTemplateUtil {
 			stub.setId(theReference);
 			return stub;
 		} catch (DataFormatException e) {
-			throw new InvalidRequestException(Msg.code(2862)
-					+ "Unknown resource type '" + resourceType + "' encountered while resolving reference: "
-					+ theReference.getValue());
+			ourLog.warn(
+					"Unknown resource type '{}' encountered while resolving reference: {}. Returning null.",
+					resourceType,
+					theReference.getValue());
+			return null;
 		}
 	}
 }

--- a/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtil.java
+++ b/hapi-fhir-server-cds-hooks/src/main/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtil.java
@@ -201,8 +201,11 @@ public class PrefetchTemplateUtil {
 		final String key = m.group(1);
 		final String expression = m.group(2);
 		try {
-			final List<IBase> results =
-					evaluateFhirPathOnKey(theContext.getResource(key), key, expression, theFhirContext);
+			final IBaseResource resource = theContext.getResource(key);
+			if (resource == null) {
+				return new PartResolutionResult.Success(List.of());
+			}
+			final List<IBase> results = evaluateFhirPathOnKey(resource, key, expression, theFhirContext);
 			final List<String> values = convertPrimitiveResultsToString(results, key);
 			return new PartResolutionResult.Success(values);
 		} catch (ClassCastException e) {

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvcTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/CdsPrefetchSvcTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -74,7 +73,7 @@ class CdsPrefetchSvcTest {
 		CdsServiceRequestJson input = new CdsServiceRequestJson();
 
 		result = myCdsPrefetchSvc.findMissingPrefetch(spec, input);
-		assertThat(result).hasSize(0);
+		assertThat(result).isEmpty();
 
 		spec.addPrefetch("foo", "fooval");
 		result = myCdsPrefetchSvc.findMissingPrefetch(spec, input);
@@ -82,7 +81,7 @@ class CdsPrefetchSvcTest {
 
 		input.addPrefetch("foo", new Patient());
 		result = myCdsPrefetchSvc.findMissingPrefetch(spec, input);
-		assertThat(result).hasSize(0);
+		assertThat(result).isEmpty();
 
 		spec.addPrefetch("bar", "barval");
 		spec.addPrefetch("baz", "bazval");
@@ -104,6 +103,26 @@ class CdsPrefetchSvcTest {
 		input.addPrefetch("baz", null);
 		result = myCdsPrefetchSvc.findMissingPrefetch(spec, input);
 		assertThat(result).containsExactly("bar");
+	}
+
+	@Test
+	void testFindMissingPrefetchMaintainsOrder() {
+		// setup
+		final CdsServiceJson cdsServiceJson = new CdsServiceJson();
+		cdsServiceJson.addPrefetch("foo-1", "some-query-1");
+		cdsServiceJson.addPrefetch("foo-2", "some-query-2");
+		cdsServiceJson.addPrefetch("foo-3", "some-query-3");
+		cdsServiceJson.addPrefetch("foo-4", "some-query-4");
+		cdsServiceJson.addPrefetch("foo-5", "some-query-5");
+		cdsServiceJson.addPrefetch("foo-6", "some-query-6");
+		final CdsServiceRequestJson input = new CdsServiceRequestJson();
+		input.addPrefetch("foo-1", null);
+		input.addPrefetch("foo-3", null);
+		input.addPrefetch("foo-4", null);
+		// execute
+		final Set<String> actual = myCdsPrefetchSvc.findMissingPrefetch(cdsServiceJson, input);
+		// validate
+		assertThat(actual).containsSequence("foo-2", "foo-5", "foo-6");
 	}
 
 

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilCommonTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilCommonTest.java
@@ -118,9 +118,11 @@ class PrefetchTemplateUtilCommonTest {
 		final String template = "Patient?id={{context.encounter.id}}";
 		final CdsServiceRequestJson request = new CdsServiceRequestJson();
 		request.addContext("encounter", "not-a-resource");
-		// execute & validate — getResource() does a raw cast; ClassCastException propagates as-is
+		// execute & validate
 		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
-				.isInstanceOf(ClassCastException.class);
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining("did not provide a valid")
+				.hasMessageContaining("encounter");
 	}
 
 }

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilCommonTest.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilCommonTest.java
@@ -1,7 +1,7 @@
 package ca.uhn.hapi.fhir.cdshooks.svc.prefetch;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestContextJson;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.hl7.fhir.r4.model.Encounter;
 import org.junit.jupiter.api.Test;
@@ -22,19 +22,19 @@ class PrefetchTemplateUtilCommonTest {
 	@Test
 	void substituteTemplateShouldInterpolatePrefetchTokensWithContextValues() {
 		String template = "{{context.userId}} a {{context.patientId}} b {{context.patientId}}";
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("userId", TEST_USER_ID);
-		String result = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("userId", TEST_USER_ID);
+		String result = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		assertThat(result).isEqualTo(TEST_USER_ID + " a " + TEST_PATIENT_ID + " b " + TEST_PATIENT_ID);
 	}
 
 	@Test
 	void substituteTemplateShouldThrowForMissingPrefetchTokens() {
 		String template = "{{context.userId}} a {{context.patientId}}";
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessage(
 						"HAPI-2372: Request context did not provide a value for key <userId>.  Available keys in context are: [patientId]");
@@ -43,10 +43,9 @@ class PrefetchTemplateUtilCommonTest {
 	@Test
 	void substituteTemplateShouldThrow412ForMissingContext() {
 		String template = "{{context.userId}} a {{context.patientId}}";
-		// Leave the context empty for the test.
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
 
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessage(
 						"HAPI-2372: Request context did not provide a value for key <userId>.  Available keys in context are: []");
@@ -55,9 +54,9 @@ class PrefetchTemplateUtilCommonTest {
 	@Test
 	void substituteTemplateShouldThrowForMissingNestedPrefetchTokens() {
 		String template = "{{context.draftOrders.ServiceRequest.id}} a {{context.patientId}}";
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessage(
 						"HAPI-2372: Request context did not provide a value for key <draftOrders>.  Available keys in context are: [patientId]");
@@ -67,11 +66,11 @@ class PrefetchTemplateUtilCommonTest {
 	void substituteTemplateShouldHandleWhitespaceAroundUnionOperator() {
 		// setup
 		final String template = "{{context.userId | context.patientId}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("userId", TEST_USER_ID);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("userId", TEST_USER_ID);
         // execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
         // validate
 		assertThat(actual).isEqualTo(TEST_USER_ID + "," + TEST_PATIENT_ID);
 	}
@@ -80,10 +79,10 @@ class PrefetchTemplateUtilCommonTest {
 	void substituteTemplateShouldThrowWhenDefaultPartKeyHoldsNullValue() {
 		// setup
 		final String template = "Condition?patient={{context.patientId}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, null);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, null);
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessage("HAPI-2375: Request context value for key <patientId> is null or not a string.");
 	}
@@ -92,10 +91,10 @@ class PrefetchTemplateUtilCommonTest {
 	void substituteTemplateShouldThrowWhenDefaultPartKeyHoldsResourceInsteadOfString() {
 		// setup
 		final String template = "Condition?encounter={{context.encounter}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("encounter", new Encounter().setId("enc1"));
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("encounter", new Encounter().setId("enc1"));
         // setup & execute
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining("encounter");
 	}
@@ -104,10 +103,10 @@ class PrefetchTemplateUtilCommonTest {
 	void substituteTemplateShouldThrowWhenExpressionMatchesNoKnownPattern() {
 		// setup
 		final String template = "Patient?id={{unknownPattern}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("patientId", TEST_PATIENT_ID);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("patientId", TEST_PATIENT_ID);
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
 						"Unable to resolve prefetch template : unknownPattern. No result was found for the prefetch query.");
@@ -117,13 +116,11 @@ class PrefetchTemplateUtilCommonTest {
 	void substituteTemplateShouldThrowWhenFhirPathContextKeyHoldsNonResourceValue() {
 		// setup
 		final String template = "Patient?id={{context.encounter.id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("encounter", "not-a-resource");
-		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
-				.isInstanceOf(InvalidRequestException.class)
-				.hasMessageContaining(
-						"Request context did not provide valid R4 Bundle resource for FHIRPath template key <encounter>");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("encounter", "not-a-resource");
+		// execute & validate — getResource() does a raw cast; ClassCastException propagates as-is
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
+				.isInstanceOf(ClassCastException.class);
 	}
 
 }

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilDstu3Test.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilDstu3Test.java
@@ -1,7 +1,7 @@
 package ca.uhn.hapi.fhir.cdshooks.svc.prefetch;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestContextJson;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.BundleBuilder;
 import org.hl7.fhir.dstu3.model.Device;
@@ -33,10 +33,10 @@ class PrefetchTemplateUtilDstu3Test {
 		Observation observation = new Observation();
 		observation.setId(OBSERVATION_ID);
 		builder.addCollectionEntry(observation);
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
-		String result = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		String result = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		assertThat(result).isEqualTo(OBSERVATION_ID + " a " + TEST_PATIENT_ID);
 	}
 
@@ -51,14 +51,14 @@ class PrefetchTemplateUtilDstu3Test {
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new Reference(deviceId1));
 		builder.addCollectionEntry(deviceRequest1);
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
-						"Unable to evaluate FHIRPath for prefetch template key <draftOrders> for FHIR version DSTU3");
+						"Unable to evaluate FHIRPath for prefetch key <draftOrders> for FHIR version DSTU3");
 	}
 
 	@Test
@@ -72,11 +72,11 @@ class PrefetchTemplateUtilDstu3Test {
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(new Device().setId(deviceId1));
 		builder.addCollectionEntry(new Device().setId(deviceId2));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("DeviceRequest?device=" + deviceId1);
 	}
@@ -90,11 +90,11 @@ class PrefetchTemplateUtilDstu3Test {
 				"DeviceRequest?device={{context.draftOrders.entry.resource.where(id = 'Device/2').id}}";
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(new Device().setId(deviceId1));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
 						"Unable to resolve prefetch template : context.draftOrders.entry.resource.where(id = 'Device/2').id. No result was found for the prefetch query.");
@@ -106,11 +106,11 @@ class PrefetchTemplateUtilDstu3Test {
 		// setup
 		final String encounterId = "Encounter/1";
 		final String template = "Condition?patient={{context.patientId}}&context={{context.encounter.id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("encounter", new Encounter().setId(encounterId));
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("encounter", new Encounter().setId(encounterId));
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("Condition?patient=" + TEST_PATIENT_ID + "&context=" + encounterId);
 	}
@@ -120,11 +120,11 @@ class PrefetchTemplateUtilDstu3Test {
 	void substituteTemplateWithFhirPathResourceContextWithInvalidPath() {
 		// setup
 		final String template = "Condition?patient={{context.patientId}}&context={{context.encounter.id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("encounter", new Encounter());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("encounter", new Encounter());
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining("Unable to resolve prefetch template : context.encounter.id. No result was found for the prefetch query.");
 	}

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilR4Test.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilR4Test.java
@@ -2,7 +2,7 @@ package ca.uhn.hapi.fhir.cdshooks.svc.prefetch;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
-import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestContextJson;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.BundleBuilder;
 import org.apache.commons.lang3.time.DateUtils;
@@ -20,6 +20,7 @@ import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import jakarta.annotation.Nonnull;
 
 import java.util.Date;
 import java.util.List;
@@ -38,6 +39,7 @@ class PrefetchTemplateUtilR4Test {
 	private static final String SERVICE_ID2 = "serviceId2";
 	private static final String PATIENT_ID_CONTEXT_KEY = "patientId";
 	private static final String DRAFT_ORDERS_CONTEXT_KEY = "draftOrders";
+	private static final String PRACTITIONER_ROLE_ID = "practitionerRole";
 
 	@Test
 	@DisplayName("Should return all matches for DaVinci prefetch tokens")
@@ -46,10 +48,10 @@ class PrefetchTemplateUtilR4Test {
 		BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(new ServiceRequest().setId(SERVICE_ID1));
 		builder.addCollectionEntry(new ServiceRequest().setId(SERVICE_ID2));
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
-		String result = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		String result = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		assertThat(result).isEqualTo(SERVICE_ID1 + "," + SERVICE_ID2 + " a " + TEST_PATIENT_ID);
 	}
 
@@ -58,10 +60,10 @@ class PrefetchTemplateUtilR4Test {
 	void substituteTemplateDaVinciTemplateResourcesNotFoundInContext() {
 		String template = "{{context.draftOrders.ServiceRequest.id}} a {{context.patientId}}";
 		BundleBuilder builder = new BundleBuilder(ourFhirContext);
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessage("HAPI-2373: Request context did not provide for resource(s) matching template."
 						+ " ResourceType missing is: ServiceRequest");
@@ -71,10 +73,10 @@ class PrefetchTemplateUtilR4Test {
 	@DisplayName("Should throw exception when DaVinci template context is not a Bundle")
 	void substituteTemplateDaVinciTemplateResourceIsNotBundle() {
 		String template = "{{context.draftOrders.ServiceRequest.id}} a {{context.patientId}}";
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, new Observation().setId(OBSERVATION_ID));
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, new Observation().setId(OBSERVATION_ID));
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
 						"Request context did not provide valid "
@@ -97,11 +99,11 @@ class PrefetchTemplateUtilR4Test {
 		deviceRequest2.setCode(new Reference(deviceId2));
 		builder.addCollectionEntry(deviceRequest1);
 		builder.addCollectionEntry(deviceRequest2);
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("Device?_id=" + deviceId1 + "," + deviceId2);
 	}
@@ -123,10 +125,10 @@ class PrefetchTemplateUtilR4Test {
 		builder.addCollectionEntry(deviceRequest2);
 		builder.addCollectionEntry(new Device().setId(deviceId1));
 		builder.addCollectionEntry(new Device().setId(deviceId2));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("Device?_id=" + 1 + "," + 2);
 	}
@@ -141,31 +143,28 @@ class PrefetchTemplateUtilR4Test {
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new Reference("#" + deviceId1));
 		deviceRequest1.addContained(new Device().setId(deviceId1));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(deviceRequestKey, deviceRequest1);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(deviceRequestKey, deviceRequest1);
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("Device?_id=" + 1);
 	}
 
 	@Test
-	@DisplayName("Should fail to resolve external references when resource has only contained resources")
-	void substituteTemplateWithFhirPathResolveMethodWithExternalReferenceFailure() {
+	@DisplayName("Should resolve id from external reference using id-only stub when full resource is unavailable")
+	void substituteTemplateWithFhirPathResolveMethodWithExternalReference() {
 		// setup
 		final String deviceRequestKey = "deviceRequest";
 		final String deviceId1 = "Device/1";
 		final String template = "Device?_id={{context.deviceRequest.code.resolve().as(Device).id}}";
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new Reference(deviceId1));
-		deviceRequest1.addContained(new Device().setId(deviceId1));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(deviceRequestKey, deviceRequest1);
-		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
-				.isInstanceOf(InvalidRequestException.class)
-				.hasMessageContaining(
-						"Unable to resolve prefetch template : context.deviceRequest.code.resolve().as(Device).id. No result was found for the prefetch query.");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(deviceRequestKey, deviceRequest1);
+		// execute & validate — resolve() returns an id-only stub, so .id is resolvable
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
+		assertThat(actual).isEqualTo("Device?_id=1");
 	}
 
 	@Test
@@ -177,10 +176,10 @@ class PrefetchTemplateUtilR4Test {
 		final String template = "Device?_id={{context.deviceRequest.code.resolve().as(Device).id}}";
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new Reference(deviceId1));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(deviceRequestKey, deviceRequest1);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(deviceRequestKey, deviceRequest1);
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 			.isInstanceOf(InvalidRequestException.class)
 			.hasMessageContaining(
 				"Unable to resolve prefetch template : context.deviceRequest.code.resolve().as(Device).id. No result was found for the prefetch query.");
@@ -197,11 +196,11 @@ class PrefetchTemplateUtilR4Test {
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new Reference(deviceId1));
 		builder.addCollectionEntry(deviceRequest1);
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
 						"Unable to resolve prefetch template : context.draftOrders.entry.resource.ofType(DeviceRequest).code.resolve().as(Device).id. No result was found for the prefetch query.");
@@ -218,14 +217,14 @@ class PrefetchTemplateUtilR4Test {
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new Reference(deviceId1));
 		builder.addCollectionEntry(deviceRequest1);
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
-						"Unable to evaluate FHIRPath for prefetch template key <draftOrders> for FHIR version R4");
+						"Unable to evaluate FHIRPath for prefetch key <draftOrders> for FHIR version R4");
 	}
 
 	@Test
@@ -235,16 +234,16 @@ class PrefetchTemplateUtilR4Test {
 		final String encounterId = "Encounter/1";
 		final String template =
 				"Condition?patient={{context.patientId}}&context={{context.encounter.id}}&recorded-date={{context.encounter.period.start + 2 days}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
 		final Encounter encounter = new Encounter();
 		encounter.setId(encounterId);
 		final Date encounterStartDate = new Date();
 		encounter.setPeriod(new Period().setStart(encounterStartDate));
-		context.put("encounter", encounter);
+		request.addContext("encounter", encounter);
 		final DateTimeType expectedDateTime = new DateTimeType(DateUtils.addDays(encounterStartDate, 2));
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual)
 				.isEqualTo("Condition?patient=" + TEST_PATIENT_ID + "&context=" + 1 + "&recorded-date="
@@ -262,8 +261,8 @@ class PrefetchTemplateUtilR4Test {
 		final String pracReference = "Practitioner/P1";
 		final String template =
 				"PractitionerRole?_id={{context.draftOrders.entry.resource.ofType(Encounter).participant.individual.resolve().ofType(PractitionerRole).id|context.draftOrders.entry.resource.ofType(Encounter).serviceProvider.resolve().ofType(PractitionerRole).id|context.draftOrders.entry.resource.performer.resolve().ofType(PractitionerRole).id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
 		final Encounter encounter = new Encounter();
 		encounter.setId(encounterId);
 		encounter.addParticipant(
@@ -279,9 +278,9 @@ class PrefetchTemplateUtilR4Test {
 		builder.addCollectionEntry(new PractitionerRole().setId(pracRoleReference1));
 		builder.addCollectionEntry(new PractitionerRole().setId(pracRoleReference2));
 		builder.addCollectionEntry(new PractitionerRole().setId(pracRoleReference3));
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("PractitionerRole?_id=PR1,PR2,PR3");
 	}
@@ -299,37 +298,80 @@ class PrefetchTemplateUtilR4Test {
 		encounter.addLocation(new Encounter.EncounterLocationComponent().setLocation(new Reference("#" + location2)));
 		encounter.addContained(new Location().setId(location2));
 		final String template = "Location?_id={{%practitionerRoles.location.resolve().id|%encounter.location.location.resolve().ofType(Location).id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("encounter", encounter);
-		context.put("practitionerRoles", practitionerRole);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addPrefetch("encounter", encounter);
+		request.addPrefetch("practitionerRoles", practitionerRole);
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("Location?_id=L1,L2");
 	}
 
 	@Test
-	@DisplayName("Should throw exception when referenced prefetch key is not in context")
-	void substituteTemplateForReferencedPrefetchMissingKey() {
-		// setup
-		final String template = "Location?_id={{%practitionerRoles.location.resolve().id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("some-key", "some-value");
+	@DisplayName("Should resolve in-bundle reference when prefetch is a Bundle and referenced resource is in it")
+	void substituteTemplate_forBundlePrefetchWithInBundleReference_shouldResolveViaBundle() {
+		// setup — practitionerRoles Bundle contains both the role and the referenced Practitioner
+		final String practitionerRoleId = "PractitionerRole/PR1";
+		final String practitionerId = "Practitioner/P1";
+		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
+		final PractitionerRole role = new PractitionerRole();
+		role.setId(practitionerRoleId);
+		role.setPractitioner(new Reference(practitionerId));
+		builder.addCollectionEntry(role);
+		builder.addCollectionEntry(new org.hl7.fhir.r4.model.Practitioner().setId(practitionerId));
+		final String template =
+				"Practitioner?_id={{%practitionerRoles.entry.resource.ofType(PractitionerRole).practitioner.resolve().id}}";
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addPrefetch("practitionerRoles", builder.getBundle());
 		// execute
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
-			.isInstanceOf(InvalidRequestException.class)
-			.hasMessageContaining("Request context did not provide a value for key <practitionerRoles>.  Available keys in context are: [some-key]");
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
+		// validate
+		assertThat(actual).isEqualTo("Practitioner?_id=P1");
 	}
 
 	@Test
-	@DisplayName("Should resolve when referenced prefetch key is not in context but the other expression is valid")
+	@DisplayName("Should throw when prefetch is a Bundle and referenced resource is not in it")
+	void substituteTemplate_forBundlePrefetchWithExternalReference_shouldThrow() {
+		// setup — practitionerRoles Bundle has a reference to Practitioner/P1, but P1 is not in the Bundle
+		final String practitionerRoleId = "PractitionerRole/PR1";
+		final String practitionerId = "Practitioner/P1";
+		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
+		final PractitionerRole role = new PractitionerRole();
+		role.setId(practitionerRoleId);
+		role.setPractitioner(new Reference(practitionerId));
+		builder.addCollectionEntry(role);
+		final String template =
+				"Practitioner?_id={{%practitionerRoles.entry.resource.ofType(PractitionerRole).practitioner.resolve().id}}";
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addPrefetch("practitionerRoles", builder.getBundle());
+		// execute & validate
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining("No result was found for the prefetch query.");
+	}
+
+	@Test
+	@DisplayName("Should throw exception when referenced prefetch key is not in prefetch")
+	void substituteTemplateForReferencedPrefetchMissingKey() {
+		// setup
+		final String template = "Location?_id={{%practitionerRoles.location.resolve().id}}";
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addPrefetch("some-key", new Location().setId("some-id"));
+		// execute
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("Prefetch did not provide a value for key <practitionerRoles>.  Available keys in prefetch are: [some-key]");
+	}
+
+	@Test
+	@DisplayName("Should resolve when referenced prefetch key is not in prefetch but the other expression is valid")
 	void substituteTemplate_forReferencedPrefetchMissingKeyUnionValidContextKey_shouldResolvePrefetchKeyWithValidContextKey() {
 		// setup
 		final String template = "Location?_id={{%practitionerRoles.location.resolve().id|context.locationId}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("locationId", "Location/1");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("locationId", "Location/1");
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		assertThat(actual).isEqualTo("Location?_id=Location/1");
 	}
 
@@ -338,10 +380,10 @@ class PrefetchTemplateUtilR4Test {
 	void substituteTemplate_withDaVinciMissingKeyUnionValidContextKey_shouldResolvePrefetchKeyWithValidContextKey() {
 		// setup
 		final String template = "ServiceRequest?_id={{context.missingDraftOrders.ServiceRequest.id|context.patientId}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("ServiceRequest?_id=" + TEST_PATIENT_ID);
 	}
@@ -351,10 +393,10 @@ class PrefetchTemplateUtilR4Test {
 	void substituteTemplate_withAllUnionExpressionsMissingContextKey_shouldThrowError() {
 		// setup
 		final String template = "ServiceRequest?_id={{context.missingDraftOrders.ServiceRequest.id|context.missingPatientId}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("someOtherKey", "someValue");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("someOtherKey", "someValue");
 		// execute & validate - should report the missing key error (2372), not the generic no-result error (2856)
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 			.isInstanceOf(InvalidRequestException.class)
 			.hasMessageContaining(Msg.code(2372))
 			.hasMessageContaining("missingDraftOrders");
@@ -370,9 +412,9 @@ class PrefetchTemplateUtilR4Test {
 		final String pracRoleReference3 = "PractitionerRole/PR3";
 		final String template =
 			"PractitionerRole?_id={{context.draftOrders.entry.resource.ofType(Encounter).participant.individual.resolve().ofType(PractitionerRole).id|%observation.performer.reference|context.mandatoryPracRole}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("mandatoryPracRole", "PractitionerRole/PR4");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("mandatoryPracRole", "PractitionerRole/PR4");
 		final Encounter encounter = new Encounter();
 		encounter.setId(encounterId);
 		encounter.addParticipant(
@@ -384,10 +426,10 @@ class PrefetchTemplateUtilR4Test {
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(encounter);
 		builder.addCollectionEntry(new PractitionerRole().setId(pracRoleReference1));
-		context.put("observation", observation);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addPrefetch("observation", observation);
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("PractitionerRole?_id=PR1,PractitionerRole/PR2,PractitionerRole/PR3,PractitionerRole/PR4");
 	}
@@ -402,8 +444,8 @@ class PrefetchTemplateUtilR4Test {
 		final String pracRoleReference3 = "PractitionerRole/PR3";
 		final String template =
 			"PractitionerRole?_id={{%observation.performer.reference|context.draftOrders.entry.resource.ofType(Encounter).participant.individual.resolve().ofType(PractitionerRole).id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
 		final Encounter encounter = new Encounter();
 		encounter.setId(encounterId);
 		encounter.addParticipant(
@@ -415,10 +457,10 @@ class PrefetchTemplateUtilR4Test {
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(encounter);
 		builder.addCollectionEntry(new PractitionerRole().setId(pracRoleReference1));
-		context.put("observation", observation);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addPrefetch("observation", observation);
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("PractitionerRole?_id=PractitionerRole/PR2,PractitionerRole/PR3,PR1");
 	}
@@ -429,11 +471,11 @@ class PrefetchTemplateUtilR4Test {
 		// setup
 		final Patient patient = new Patient();
 		patient.addName(new HumanName().setFamily("Smith").addGiven("John"));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("patient", patient);
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("patient", patient);
 		final String template = "Patient?name={{context.patient.name}}";
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining("FHIR path expression returned a non-primitive result: HumanName for Prefetch Key : <patient>");
 	}
@@ -444,12 +486,12 @@ class PrefetchTemplateUtilR4Test {
 		// setup - first part returns a complex type (HumanName), not a primitive; second part is valid
 		final Patient patient = new Patient();
 		patient.addName(new HumanName().setFamily("Smith").addGiven("John"));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put("patient", patient);
-		context.put("locationId", "Location/1");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addPrefetch("patient", patient);
+		request.addContext("locationId", "Location/1");
 		final String template = "Patient?name={{%patient.name|context.locationId}}";
 		// execute & validate - must throw for the invalid part, must not silently fall through to context.locationId
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 			.isInstanceOf(InvalidRequestException.class)
 			.hasMessageContaining(Msg.code(2860));
 	}
@@ -460,13 +502,38 @@ class PrefetchTemplateUtilR4Test {
 		// setup 
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(new ServiceRequest().setId(SERVICE_ID1));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		final String template = "ServiceRequest?_id={{context.draftOrders.entry.resource}}";
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining("FHIR path expression returned a non-primitive result: ServiceRequest for Prefetch Key : <draftOrders>");
+	}
+
+	@Test
+	@DisplayName("Should resolve when prefetch key is referenced")
+	void substituteTemplate_withValidPrefetchKey_shouldResolvePrefetchKeyWithValidKey() {
+		// setup
+		final String template = "PractitionerRole?_id={{%encounter.participant.individual.resolve().ofType(PractitionerRole).id}}";
+		final CdsServiceRequestJson cdsServiceRequestJson = new CdsServiceRequestJson();
+		cdsServiceRequestJson.addPrefetch("encounter", withEncounter());
+		// execute
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, cdsServiceRequestJson, ourFhirContext);
+		// validate
+		assertThat(actual).isEqualTo("PractitionerRole?_id=" + PRACTITIONER_ROLE_ID);
+	}
+
+	@Nonnull
+	private Encounter withEncounter() {
+		final PractitionerRole role = new PractitionerRole();
+		role.setId(PRACTITIONER_ROLE_ID);
+
+		final Encounter encounter = new Encounter();
+		encounter.addContained(role);
+		encounter.addParticipant(new Encounter.EncounterParticipantComponent()
+				.setIndividual(new Reference("#" + PRACTITIONER_ROLE_ID)));
+		return encounter;
 	}
 }
 

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilR4Test.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilR4Test.java
@@ -347,6 +347,7 @@ class PrefetchTemplateUtilR4Test {
 		// execute & validate
 		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining(Msg.code(2856))
 				.hasMessageContaining("No result was found for the prefetch query.");
 	}
 
@@ -522,6 +523,24 @@ class PrefetchTemplateUtilR4Test {
 		final String actual = PrefetchTemplateUtil.substituteTemplate(template, cdsServiceRequestJson, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("PractitionerRole?_id=" + PRACTITIONER_ROLE_ID);
+	}
+
+	@Test
+	@DisplayName("Should throw no-result error when a resolve() reference contains an unknown resource type")
+	void substituteTemplate_withContextResourceReferencingUnknownResourceType_shouldThrow() {
+		// setup — DeviceRequest references UnknownResource/1; resolve() triggers resolveAsIdOnlyStub
+		// which returns null for unknown types (matching the IFhirPathEvaluationContext contract),
+		// so the FhirPath engine produces no result and the template throws the generic no-result error.
+		final DeviceRequest deviceRequest = new DeviceRequest();
+		deviceRequest.setCode(new Reference("UnknownResource/1"));
+		final String template = "Device?_id={{context.deviceRequest.code.resolve().as(Device).id}}";
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext("deviceRequest", deviceRequest);
+		// execute & validate
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
+				.isInstanceOf(InvalidRequestException.class)
+				.hasMessageContaining(Msg.code(2856))
+				.hasMessageContaining("No result was found for the prefetch query.");
 	}
 
 	@Nonnull

--- a/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilR5Test.java
+++ b/hapi-fhir-server-cds-hooks/src/test/java/ca/uhn/hapi/fhir/cdshooks/svc/prefetch/PrefetchTemplateUtilR5Test.java
@@ -1,7 +1,7 @@
 package ca.uhn.hapi.fhir.cdshooks.svc.prefetch;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestContextJson;
+import ca.uhn.fhir.rest.api.server.cdshooks.CdsServiceRequestJson;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.BundleBuilder;
 import org.hl7.fhir.r5.model.CodeableReference;
@@ -41,11 +41,11 @@ class PrefetchTemplateUtilR5Test {
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(new Device().setId(deviceId1));
 		builder.addCollectionEntry(new Device().setId(deviceId2));
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("DeviceRequest?device=1");
 	}
@@ -56,11 +56,11 @@ class PrefetchTemplateUtilR5Test {
 		// setup
 		final String encounterId = "Encounter/1";
 		final String template = "Condition?patient={{context.patientId}}&context={{context.encounter.id}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("encounter", new Encounter().setId(encounterId));
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("encounter", new Encounter().setId(encounterId));
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual).isEqualTo("Condition?patient=" + TEST_PATIENT_ID + "&context=1");
 	}
@@ -75,9 +75,9 @@ class PrefetchTemplateUtilR5Test {
 		final String pracRoleReference3 = "PractitionerRole/PR3";
 		final String template =
 				"PractitionerRole?_id={{context.draftOrders.entry.resource.ofType(Encounter).participant.actor.resolve().ofType(PractitionerRole).id|%observation.performer.reference|context.mandatoryPracRole}}";
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put("mandatoryPracRole", "PractitionerRole/PR4");
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext("mandatoryPracRole", "PractitionerRole/PR4");
 		final Encounter encounter = new Encounter();
 		encounter.setId(encounterId);
 		encounter.addParticipant(
@@ -89,10 +89,10 @@ class PrefetchTemplateUtilR5Test {
 		final BundleBuilder builder = new BundleBuilder(ourFhirContext);
 		builder.addCollectionEntry(encounter);
 		builder.addCollectionEntry(new PractitionerRole().setId(pracRoleReference1));
-		context.put("observation", observation);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		request.addPrefetch("observation", observation);
 		// execute
-		final String actual = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		final String actual = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		// validate
 		assertThat(actual)
 				.isEqualTo("PractitionerRole?_id=PR1,PractitionerRole/PR2,PractitionerRole/PR3,PractitionerRole/PR4");
@@ -109,11 +109,11 @@ class PrefetchTemplateUtilR5Test {
 		final DeviceRequest deviceRequest1 = new DeviceRequest();
 		deviceRequest1.setCode(new CodeableReference().setReference(new Reference(deviceId1)));
 		builder.addCollectionEntry(deviceRequest1);
-		final CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		final CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
 		// execute & validate
-		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext))
+		assertThatThrownBy(() -> PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext))
 				.isInstanceOf(InvalidRequestException.class)
 				.hasMessageContaining(
 						"Unable to resolve prefetch template : context.draftOrders.entry.resource.ofType(DeviceRequest).code.reference.resolve().as(Device).id. No result was found for the prefetch query.");
@@ -128,10 +128,10 @@ class PrefetchTemplateUtilR5Test {
 		builder.addCollectionEntry(new ServiceRequest().setId(SERVICE_ID1));
 		builder.addCollectionEntry(new ServiceRequest().setId(SERVICE_ID2));
 		builder.addCollectionEntry(new Observation().setId(OBSERVATION_ID));
-		CdsServiceRequestContextJson context = new CdsServiceRequestContextJson();
-		context.put(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
-		context.put(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
-		String result = PrefetchTemplateUtil.substituteTemplate(template, context, ourFhirContext);
+		CdsServiceRequestJson request = new CdsServiceRequestJson();
+		request.addContext(PATIENT_ID_CONTEXT_KEY, TEST_PATIENT_ID);
+		request.addContext(DRAFT_ORDERS_CONTEXT_KEY, builder.getBundle());
+		String result = PrefetchTemplateUtil.substituteTemplate(template, request, ourFhirContext);
 		assertThat(result).isEqualTo(SERVICE_ID1 + "," + SERVICE_ID2 + " a " + OBSERVATION_ID + " a " + TEST_PATIENT_ID);
 	}
 }


### PR DESCRIPTION
Bug issue :  
 
 - `%prefetchKey.fhirpath` expressions in prefetch templates never resolved because CdsPrefetchSvc was calling the context of substituteTemplate, which had no access to the request's prefetch map.
  - Changed `findMissingPrefetch()` to use LinkedHashSet (preserving declaration order), ensuring a prefetch entry that depends on an earlier entry is always resolved after it.
  - Wrapped ClassCastException in handleFhirPathPart with a descriptive InvalidRequestException; changed resolveAsIdOnlyStub to log-and-return-null on unknown resource types instead of throwing (the FhirPath engine swallows exceptions from resolveReference callbacks, making the throw unreachable).