### PR TITLE
Fix NPE encoding contained Bundle/Parameters/Binary with extension on a root-level primitive (#8238)

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -1358,7 +1358,7 @@ public abstract class BaseParser implements IParser {
 			if (retVal && myEncodeContext.myDontEncodeElementPaths != null) {
 				retVal = !checkIfParentShouldNotBeEncodedAndBuildPath();
 			}
-			if (theContainedResource) {
+			if (theContainedResource && myDef != null) {
 				retVal = !notEncodeForContainedResource.contains(myDef.getElementName());
 			}
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8238-fix-npe-contained-bundle-extension.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8238-fix-npe-contained-bundle-extension.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 8238
+title: "Previously, storing a resource whose `contained[]` array held a Bundle (or Parameters/Binary) with an extension on one of that resource's root-level primitive elements (e.g. `Bundle.timestamp`) threw an uncaught NullPointerException while encoding. This affected any resource type that extends `Resource` directly instead of `DomainResource`, since such resources have no declared `extension` child element. The JSON parser now handles this case correctly."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
@@ -121,6 +121,43 @@ public class JsonParserR4Test extends BaseTest {
 		ourCtx.setStoreRawJson(false);
 	}
 
+	/**
+	 * See #8238
+	 * <p>
+	 * Bundle (and other resources that extend Resource directly instead of DomainResource, e.g. Parameters
+	 * and Binary) has no "extension" child, so BaseRuntimeElementCompositeDefinition#getChildByName("extension")
+	 * legitimately returns null for it. Storing any resource with a contained Bundle that has an extension on
+	 * one of the Bundle's root-level primitive elements (e.g. Bundle.timestamp) used to throw an NPE while
+	 * encoding, even though parsing the identical payload succeeded.
+	 */
+	@Test
+	public void testEncode_containedBundleWithExtensionOnPrimitiveElement_doesNotThrowNpe() {
+		Bundle containedBundle = new Bundle();
+		containedBundle.setId("contained-bundle");
+		containedBundle.setType(Bundle.BundleType.COLLECTION);
+		containedBundle.getTimestampElement().setValueAsString("2024-01-01T00:00:00Z");
+		containedBundle
+				.getTimestampElement()
+				.addExtension(new Extension("http://example.org/some-extension", new StringType("some-value")));
+
+		Patient patient = new Patient();
+		patient.getContained().add(containedBundle);
+		patient.addName().setFamily("Test");
+
+		IParser parser = ourCtx.newJsonParser();
+		String encoded = parser.encodeResourceToString(patient);
+
+		assertThat(encoded).contains("\"timestamp\":\"2024-01-01T00:00:00Z\"");
+		assertThat(encoded).contains("http://example.org/some-extension");
+
+		Patient reparsed = parser.parseResource(Patient.class, encoded);
+		Bundle reparsedContainedBundle = (Bundle) reparsed.getContained().get(0);
+		assertEquals(1, reparsedContainedBundle.getTimestampElement().getExtension().size());
+		assertEquals(
+				"http://example.org/some-extension",
+				reparsedContainedBundle.getTimestampElement().getExtensionFirstRep().getUrl());
+	}
+
 	@ParameterizedTest
 	@MethodSource("patientStrs")
 	public void parseResource_withStoreRawJsonTrue_willStoreTheRawJsonOnTheResource(String thePatientStr) {


### PR DESCRIPTION
## Description

Fixes a NullPointerException thrown when encoding (to JSON) a resource whose `contained[]` array holds a `Bundle`, `Parameters`, or `Binary` resource that has an extension on one of that contained resource's root-level primitive elements (e.g. `Bundle.timestamp`).

### Root cause

`Bundle`, `Parameters`, and `Binary` extend `Resource` directly instead of `DomainResource`, so — unlike most resource types — they have no declared `extension` child element.

`JsonParser#isEncodeExtension()` looks that child up via `definition.getChildByName("extension")`, which is a plain map lookup and legitimately returns `null` for these types (not an exception — by design, since they genuinely have no such child). That `null` becomes `CompositeChildElement#myDef`, which then reaches an unguarded `myDef.getElementName()` call in `CompositeChildElement#shouldBeEncoded()`'s contained-resource branch:

```java
if (theContainedResource) {
    retVal = !notEncodeForContainedResource.contains(myDef.getElementName()); // NPE
}
```

Every other branch in `CompositeChildElement` that touches `myDef` already null-guards it (`buildPath()`, `checkIfPathMatchesForEncoding()`, `hashCode()`, `equals()`, the trace-logging block in the constructor) — this was the one exception.

### Fix

One-line null guard matching the class's own existing convention:

```java
if (theContainedResource && myDef != null) {
    retVal = !notEncodeForContainedResource.contains(myDef.getElementName());
}
```

When `myDef` is null, `retVal` keeps its method-top default of `true` (encode) — the same behavior the method already falls back to elsewhere. This is also provably the *exact* value the branch would produce if `myDef` were non-null here: on this call path `myDef`, when non-null, is always the `"extension"` child definition, and `"extension"` is never a member of `notEncodeForContainedResource` (`{security, versionId, lastUpdated}`), so the branch was always a no-op for this call site regardless of null-ness. No behavior changes for any resource type that previously worked correctly.

### Testing

- Reproduced against the public reference server (`hapi.fhir.org/baseR4`) before making any change: the exact payload from the issue returns HTTP 500 (`HAPI-2223`/`HAPI-0389`) on save, and the control case (identical payload minus the extension) returns a clean `201`.
- Reproduced locally with a debugger: NPE lands exactly at the predicted line, `BaseParser$CompositeChildElement.shouldBeEncoded()`, `myDef.getElementName()`, called from `JsonParser.isEncodeExtension()`.
- Added `JsonParserR4Test#testEncode_containedBundleWithExtensionOnPrimitiveElement_doesNotThrowNpe`, which encodes a `Patient` with a contained `Bundle` carrying an extension on `Bundle.timestamp`, asserts the extension round-trips correctly (not just "no crash"), and re-parses the output to confirm data integrity.
- Ran the full `ca.uhn.fhir.parser` test package (2,832 tests) before and after the fix — 0 failures, 0 errors in both runs; the new test is the only one that changes outcome (previously erroring, now passing).
- `mvn spotless:check` passes clean on the touched modules.

Fixes #8238
