### PR TITLE
Do not mutate shared resource id on subscription delete matching

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8262-subscription-matcher-delete-id-mutation.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8262-subscription-matcher-delete-id-mutation.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 8262
+title: "Previously, SubscriptionMatcherInterceptor.resourceDeleted rewrote the id of the
+    shared STORAGE_PRECOMMIT_RESOURCE_DELETED resource, so later hooks and the DELETE
+    response saw the pre-delete version id. Matching now uses a clone, and the shared
+    instance keeps the deletion version."

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionMatcherInterceptor.java
@@ -90,8 +90,11 @@ public class SubscriptionMatcherInterceptor {
 
 		// When matching for deleted resources, we want to match for the version before it was deleted because
 		// the resource version record for the deleted resource doesn't contain a body.
-		theResource.setId(previousId);
-		processResourceModifiedEvent(theResource, ResourceModifiedMessage.OperationTypeEnum.DELETE, theRequest);
+		// Clone first so other STORAGE_PRECOMMIT_RESOURCE_DELETED hooks and the DELETE response
+		// keep the deletion version id on the shared instance.
+		IBaseResource resourceForMatching = myFhirContext.newTerser().clone(theResource);
+		resourceForMatching.setId(previousId);
+		processResourceModifiedEvent(resourceForMatching, ResourceModifiedMessage.OperationTypeEnum.DELETE, theRequest);
 	}
 
 	@Hook(Pointcut.STORAGE_PRECOMMIT_RESOURCE_UPDATED)

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionMatcherInterceptorTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/submit/interceptor/SubscriptionMatcherInterceptorTest.java
@@ -5,13 +5,18 @@ import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.jpa.subscription.match.matcher.matching.IResourceModifiedConsumer;
 import ca.uhn.fhir.jpa.subscription.model.ResourceModifiedMessage;
 import ca.uhn.fhir.subscription.api.IResourceModifiedMessagePersistenceSvc;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.MessageDeliveryException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,5 +80,27 @@ class SubscriptionMatcherInterceptorTest {
 		// Assert
 		verify(myResourceModifiedConsumer, never()).submitResourceModified(any());
 		verify(myResourceModifiedMessagePersistenceSvc, times(1)).persist(theResourceModifiedMessage);
+	}
+
+	@Test
+	void resourceDeletedDoesNotMutateSharedResourceId() {
+		FhirContext ctx = FhirContext.forR4Cached();
+		SubscriptionMatcherInterceptor interceptor = spy(new SubscriptionMatcherInterceptor());
+		interceptor.setFhirContext(ctx);
+		doNothing().when(interceptor).processResourceModifiedEvent(any(), any(), any());
+
+		Patient patient = new Patient();
+		patient.setId("Patient/123/_history/2");
+		IdType previousId = new IdType("Patient/123/_history/1");
+
+		interceptor.resourceDeleted(patient, null, previousId);
+
+		assertThat(patient.getIdElement().getValue()).isEqualTo("Patient/123/_history/2");
+		ArgumentCaptor<IBaseResource> matchingResource = ArgumentCaptor.forClass(IBaseResource.class);
+		verify(interceptor)
+				.processResourceModifiedEvent(
+						matchingResource.capture(), eq(ResourceModifiedMessage.OperationTypeEnum.DELETE), isNull());
+		assertThat(matchingResource.getValue()).isNotSameAs(patient);
+		assertThat(matchingResource.getValue().getIdElement().getValue()).isEqualTo("Patient/123/_history/1");
 	}
 }


### PR DESCRIPTION
`SubscriptionMatcherInterceptor.resourceDeleted` rewrote `theResource.setId(previousId)` on the shared `STORAGE_PRECOMMIT_RESOURCE_DELETED` instance. Later hooks and the DELETE response then saw the pre-delete version id (`_history/1`) instead of the deletion version (`_history/2`).

Matching still needs the version-before-delete because the deleted version has no body. This change clones the resource first, rewrites the id on the clone, and leaves the shared instance unchanged.

Fixes #8262

## Tests
- `mvn test -pl hapi-fhir-jpaserver-subscription -Dtest=SubscriptionMatcherInterceptorTest` — 4/4 GREEN (new test RED then GREEN)
- `mvn test -pl hapi-fhir-jpaserver-subscription -Dtest=SubscriptionMatcherInterceptorTest,SubscriptionSubmitInterceptorLoaderTest,SubscriptionValidatingInterceptorTest` — 39/39 GREEN