### PR TITLE
[8271] Fix ConcurrentModification error that happens randomly during …

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModifications.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModifications.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * This class is used in RuleBuilder, as a way to allow adding or removing certain Search Parameters
  * to the compartment.
  * For example, if you were to add as additional SPs
- * [device -> ["patient", "subject"]
+ * [device -> ["patient", "subject"]]
  * and apply it to compartment Patient/123, then any device with Patient/123 as its patient would be considered "in"
  * the compartment, despite the fact that device is technically not part of the compartment definition for patient.
  * <p>
@@ -53,7 +53,7 @@ public class CompartmentSearchParameterModifications {
 	 * @param theResourceType the resource type the SPs are based on
 	 * @param theAdditionalSPs the additional SP names
 	 * @param theOmittedSps the omitted SP names
-	 * @return
+	 * @return a new instance with the given SP names registered against the given resource type
 	 */
 	public static CompartmentSearchParameterModifications fromAdditionalAndOmittedSPNames(
 			@Nonnull String theResourceType,
@@ -69,8 +69,9 @@ public class CompartmentSearchParameterModifications {
 		return modifications;
 	}
 
+	@Nonnull
 	public static CompartmentSearchParameterModifications fromAdditionalCompartmentParamNames(
-			String theResourceType, @Nonnull Set<String> theAdditionalCompartmentParamNames) {
+			@Nonnull String theResourceType, @Nonnull Set<String> theAdditionalCompartmentParamNames) {
 		return fromAdditionalAndOmittedSPNames(theResourceType, theAdditionalCompartmentParamNames, Set.of());
 	}
 
@@ -89,7 +90,7 @@ public class CompartmentSearchParameterModifications {
 	 * @param theResourceType the resource type on which the SP exists
 	 * @param theSPName the name of the search parameter
 	 */
-	public void addSPToOmitFromCompartment(String theResourceType, String theSPName) {
+	public void addSPToOmitFromCompartment(@Nonnull String theResourceType, @Nonnull String theSPName) {
 		addSPName(myOmittedResourceTypeToParameterCodeMap, theResourceType, theSPName);
 	}
 
@@ -98,7 +99,7 @@ public class CompartmentSearchParameterModifications {
 	 * @param theResourceType the resource type on which the SP exists
 	 * @param theSPName the name of the search parameter
 	 */
-	public void addSPToIncludeInCompartment(String theResourceType, String theSPName) {
+	public void addSPToIncludeInCompartment(@Nonnull String theResourceType, @Nonnull String theSPName) {
 		addSPName(myAdditionalResourceTypeToParameterCodeMap, theResourceType, theSPName);
 	}
 
@@ -140,7 +141,6 @@ public class CompartmentSearchParameterModifications {
 	@Nonnull
 	private static Set<String> getSPNames(
 			Map<String, Set<String>> theResourceTypeToParameterCodeMap, String theResourceType) {
-		// can be called concurrently by every thread evaluating a shared authorization rule list.
 		String normalizedResourceType = normalizeResourceType(theResourceType);
 		return theResourceTypeToParameterCodeMap.getOrDefault(normalizedResourceType, Collections.emptySet());
 	}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModifications.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModifications.java
@@ -21,10 +21,12 @@ package ca.uhn.fhir.interceptor.auth;
 
 import jakarta.annotation.Nonnull;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class is used in RuleBuilder, as a way to allow adding or removing certain Search Parameters
@@ -33,6 +35,16 @@ import java.util.Set;
  * [device -> ["patient", "subject"]
  * and apply it to compartment Patient/123, then any device with Patient/123 as its patient would be considered "in"
  * the compartment, despite the fact that device is technically not part of the compartment definition for patient.
+ * <p>
+ * Instances of this class are thread safe. A single instance is typically populated once while an
+ * authorization rule list is being built, and is then read concurrently by every thread that evaluates
+ * that rule list. The getters never modify any internal state, and the {@link Set}s they return are
+ * immutable.
+ * </p>
+ * <p>
+ * Resource type names are matched case-insensitively. Search parameter names are matched case-sensitively,
+ * since FHIR SearchParameter codes are case sensitive.
+ * </p>
  */
 public class CompartmentSearchParameterModifications {
 
@@ -67,8 +79,8 @@ public class CompartmentSearchParameterModifications {
 	private final Map<String, Set<String>> myOmittedResourceTypeToParameterCodeMap;
 
 	public CompartmentSearchParameterModifications() {
-		myAdditionalResourceTypeToParameterCodeMap = new HashMap<>();
-		myOmittedResourceTypeToParameterCodeMap = new HashMap<>();
+		myAdditionalResourceTypeToParameterCodeMap = new ConcurrentHashMap<>();
+		myOmittedResourceTypeToParameterCodeMap = new ConcurrentHashMap<>();
 	}
 
 	/**
@@ -78,9 +90,7 @@ public class CompartmentSearchParameterModifications {
 	 * @param theSPName the name of the search parameter
 	 */
 	public void addSPToOmitFromCompartment(String theResourceType, String theSPName) {
-		myOmittedResourceTypeToParameterCodeMap
-				.computeIfAbsent(theResourceType.toLowerCase(), (key) -> new HashSet<>())
-				.add(theSPName);
+		addSPName(myOmittedResourceTypeToParameterCodeMap, theResourceType, theSPName);
 	}
 
 	/**
@@ -89,18 +99,53 @@ public class CompartmentSearchParameterModifications {
 	 * @param theSPName the name of the search parameter
 	 */
 	public void addSPToIncludeInCompartment(String theResourceType, String theSPName) {
-		myAdditionalResourceTypeToParameterCodeMap
-				.computeIfAbsent(theResourceType.toLowerCase(), (key) -> new HashSet<>())
-				.add(theSPName);
+		addSPName(myAdditionalResourceTypeToParameterCodeMap, theResourceType, theSPName);
 	}
 
+	/**
+	 * Returns the search parameters which should be treated as part of the compartment for the given
+	 * resource type, in addition to the ones in the compartment definition.
+	 *
+	 * @param theResourceType the resource type to look up, matched case-insensitively
+	 * @return an immutable Set, empty if no additional SPs are registered for this resource type
+	 */
+	@Nonnull
 	public Set<String> getAdditionalSearchParamNamesForResourceType(@Nonnull String theResourceType) {
-		return myAdditionalResourceTypeToParameterCodeMap.computeIfAbsent(
-				theResourceType.toLowerCase(), (key) -> new HashSet<>());
+		return getSPNames(myAdditionalResourceTypeToParameterCodeMap, theResourceType);
 	}
 
-	public Set<String> getOmittedSPNamesForResourceType(String theResourceType) {
-		return myOmittedResourceTypeToParameterCodeMap.computeIfAbsent(
-				theResourceType.toLowerCase(), (key) -> new HashSet<>());
+	/**
+	 * Returns the search parameters which should be excluded from the compartment for the given resource
+	 * type, even though the compartment definition includes them.
+	 *
+	 * @param theResourceType the resource type to look up, matched case-insensitively
+	 * @return an immutable Set, empty if no omitted SPs are registered for this resource type
+	 */
+	@Nonnull
+	public Set<String> getOmittedSPNamesForResourceType(@Nonnull String theResourceType) {
+		return getSPNames(myOmittedResourceTypeToParameterCodeMap, theResourceType);
+	}
+
+	private static void addSPName(
+			Map<String, Set<String>> theResourceTypeToParameterCodeMap, String theResourceType, String theSPName) {
+		// Copy-on-write, so that a reader holding a previously returned Set is unaffected by this update
+		String normalizedResourceType = normalizeResourceType(theResourceType);
+		theResourceTypeToParameterCodeMap.compute(normalizedResourceType, (key, existingSPNames) -> {
+			Set<String> updatedSPNames = existingSPNames == null ? new HashSet<>() : new HashSet<>(existingSPNames);
+			updatedSPNames.add(theSPName);
+			return Collections.unmodifiableSet(updatedSPNames);
+		});
+	}
+
+	@Nonnull
+	private static Set<String> getSPNames(
+			Map<String, Set<String>> theResourceTypeToParameterCodeMap, String theResourceType) {
+		// can be called concurrently by every thread evaluating a shared authorization rule list.
+		String normalizedResourceType = normalizeResourceType(theResourceType);
+		return theResourceTypeToParameterCodeMap.getOrDefault(normalizedResourceType, Collections.emptySet());
+	}
+
+	private static String normalizeResourceType(String theResourceType) {
+		return theResourceType.toLowerCase(Locale.ROOT);
 	}
 }

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModificationsTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModificationsTest.java
@@ -1,0 +1,251 @@
+package ca.uhn.fhir.interceptor.auth;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+// Created by claude-opus-5
+class CompartmentSearchParameterModificationsTest {
+
+	private static final int THREAD_COUNT = 16;
+	private static final int ITERATIONS_PER_THREAD = 5_000;
+	private static final int RESOURCE_TYPE_COUNT = 500;
+
+	private final CompartmentSearchParameterModifications myModifications =
+			new CompartmentSearchParameterModifications();
+
+	@Test
+	void getOmittedSPNamesForResourceType_whenNothingRegistered_returnsEmptyImmutableSet() {
+		Set<String> actual = myModifications.getOmittedSPNamesForResourceType("Group");
+
+		assertThat(actual).isEmpty();
+		assertThatThrownBy(() -> actual.add("member")).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	@Test
+	void getAdditionalSearchParamNamesForResourceType_whenNothingRegistered_returnsEmptyImmutableSet() {
+		Set<String> actual = myModifications.getAdditionalSearchParamNamesForResourceType("Device");
+
+		assertThat(actual).isEmpty();
+		assertThatThrownBy(() -> actual.add("patient")).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	@Test
+	void getOmittedSPNamesForResourceType_whenRegistered_returnsImmutableSetWithValues() {
+		myModifications.addSPToOmitFromCompartment("Group", "member");
+
+		Set<String> actual = myModifications.getOmittedSPNamesForResourceType("Group");
+
+		assertThat(actual).containsExactly("member");
+		assertThatThrownBy(() -> actual.add("managingEntity")).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	@Test
+	void getAdditionalSearchParamNamesForResourceType_whenRegistered_returnsImmutableSetWithValues() {
+		myModifications.addSPToIncludeInCompartment("Device", "patient");
+		myModifications.addSPToIncludeInCompartment("Device", "subject");
+
+		Set<String> actual = myModifications.getAdditionalSearchParamNamesForResourceType("Device");
+
+		assertThat(actual).containsExactlyInAnyOrder("patient", "subject");
+		assertThatThrownBy(() -> actual.add("owner")).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	/**
+	 * The root cause of the reported ConcurrentModificationException: the getters used to call
+	 * computeIfAbsent, so a logical read structurally modified the backing map. This asserts the
+	 * getters are side effect free, deterministically and without relying on thread interleaving.
+	 */
+	@Test
+	void getSPNames_doNotStructurallyModifyInternalState() throws Exception {
+		for (int i = 0; i < 1_000; i++) {
+			myModifications.getOmittedSPNamesForResourceType("UnregisteredType" + i);
+			myModifications.getAdditionalSearchParamNamesForResourceType("UnregisteredType" + i);
+		}
+
+		assertThat(readBackingMap("myOmittedResourceTypeToParameterCodeMap")).isEmpty();
+		assertThat(readBackingMap("myAdditionalResourceTypeToParameterCodeMap")).isEmpty();
+
+		myModifications.addSPToOmitFromCompartment("Group", "member");
+
+		assertThat(readBackingMap("myOmittedResourceTypeToParameterCodeMap")).containsOnlyKeys("group");
+		assertThat(readBackingMap("myAdditionalResourceTypeToParameterCodeMap")).isEmpty();
+	}
+
+	@Test
+	void getSPNames_areMatchedCaseInsensitivelyOnResourceType() {
+		myModifications.addSPToOmitFromCompartment("Group", "member");
+		myModifications.addSPToIncludeInCompartment("DEVICE", "patient");
+
+		assertThat(myModifications.getOmittedSPNamesForResourceType("group")).containsExactly("member");
+		assertThat(myModifications.getOmittedSPNamesForResourceType("GROUP")).containsExactly("member");
+		assertThat(myModifications.getOmittedSPNamesForResourceType("GrOuP")).containsExactly("member");
+		assertThat(myModifications.getAdditionalSearchParamNamesForResourceType("device"))
+				.containsExactly("patient");
+	}
+
+	@Test
+	void addSPToOmitFromCompartment_doesNotAffectAdditionalSPNames() {
+		myModifications.addSPToOmitFromCompartment("Group", "member");
+
+		assertThat(myModifications.getAdditionalSearchParamNamesForResourceType("Group")).isEmpty();
+	}
+
+	@Test
+	void fromAdditionalAndOmittedSPNames_populatesBothMaps() {
+		CompartmentSearchParameterModifications actual =
+				CompartmentSearchParameterModifications.fromAdditionalAndOmittedSPNames(
+						"List", Set.of("subject"), Set.of("source", "patient"));
+
+		assertThat(actual.getAdditionalSearchParamNamesForResourceType("List")).containsExactly("subject");
+		assertThat(actual.getOmittedSPNamesForResourceType("List"))
+				.containsExactlyInAnyOrder("source", "patient");
+	}
+
+	@Test
+	void fromAdditionalCompartmentParamNames_populatesAdditionalOnly() {
+		CompartmentSearchParameterModifications actual =
+				CompartmentSearchParameterModifications.fromAdditionalCompartmentParamNames(
+						"Device", Set.of("patient", "subject"));
+
+		assertThat(actual.getAdditionalSearchParamNamesForResourceType("Device"))
+				.containsExactlyInAnyOrder("patient", "subject");
+		assertThat(actual.getOmittedSPNamesForResourceType("Device")).isEmpty();
+	}
+
+	/**
+	 * Reproduces the customer scenario from CDR #8555: a single instance is built once while an
+	 * AuthorizationInterceptor rule list is assembled, then read by every thread that evaluates that
+	 * rule list. Most of the resource types looked up here are absent from the maps, since an absent
+	 * key is what used to trigger the structural write.
+	 */
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void getSPNames_underConcurrentReads_neverThrowAndPreserveState() throws Exception {
+		seedPatientCompartmentOmissions();
+
+		List<Throwable> failures = runConcurrently(theThreadIndex -> {
+			for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+				String resourceType = "ResourceType" + ((theThreadIndex + i) % RESOURCE_TYPE_COUNT);
+				myModifications.getOmittedSPNamesForResourceType(resourceType).contains("member");
+				myModifications
+						.getAdditionalSearchParamNamesForResourceType(resourceType)
+						.stream()
+						.count();
+			}
+		});
+
+		assertThat(failures).as("Concurrent reads must not modify shared state").isEmpty();
+		assertSeededStateIntact();
+	}
+
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void addAndGetSPNames_underConcurrentReadsAndWrites_neverThrowAndPreserveState() throws Exception {
+		seedPatientCompartmentOmissions();
+
+		List<Throwable> failures = runConcurrently(theThreadIndex -> {
+			boolean writer = theThreadIndex < 2;
+			for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+				String resourceType = "ResourceType" + ((theThreadIndex + i) % RESOURCE_TYPE_COUNT);
+				if (writer) {
+					myModifications.addSPToOmitFromCompartment(resourceType, "sp" + theThreadIndex);
+					myModifications.addSPToIncludeInCompartment(resourceType, "sp" + theThreadIndex);
+				} else {
+					myModifications.getOmittedSPNamesForResourceType(resourceType).contains("member");
+					myModifications
+							.getAdditionalSearchParamNamesForResourceType(resourceType)
+							.stream()
+							.count();
+				}
+			}
+		});
+
+		assertThat(failures)
+				.as("Concurrent reads and writes must not corrupt shared state")
+				.isEmpty();
+		assertSeededStateIntact();
+		for (int i = 0; i < RESOURCE_TYPE_COUNT; i++) {
+			assertThat(myModifications.getOmittedSPNamesForResourceType("ResourceType" + i))
+					.containsExactlyInAnyOrder("sp0", "sp1");
+			assertThat(myModifications.getAdditionalSearchParamNamesForResourceType("ResourceType" + i))
+					.containsExactlyInAnyOrder("sp0", "sp1");
+		}
+	}
+
+	/**
+	 * Mirrors {@literal SearchParameterUtil.RESOURCE_TYPES_TO_SP_TO_OMIT_FROM_PATIENT_COMPARTMENT},
+	 * which is what CdrAuthorizationInterceptor copies into this object in production.
+	 */
+	private void seedPatientCompartmentOmissions() {
+		myModifications.addSPToOmitFromCompartment("Group", "member");
+		myModifications.addSPToOmitFromCompartment("List", "subject");
+		myModifications.addSPToOmitFromCompartment("List", "source");
+		myModifications.addSPToOmitFromCompartment("List", "patient");
+	}
+
+	private void assertSeededStateIntact() {
+		assertThat(myModifications.getOmittedSPNamesForResourceType("Group")).contains("member");
+		assertThat(myModifications.getOmittedSPNamesForResourceType("List"))
+				.contains("subject", "source", "patient");
+	}
+
+	/**
+	 * Runs the given task on {@link #THREAD_COUNT} threads that all start hammering at the same moment,
+	 * and returns everything that was thrown. The tasks deliberately do not assert - assertions belong
+	 * on the calling thread.
+	 */
+	private List<Throwable> runConcurrently(ThreadTask theTask) throws Exception {
+		List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+		CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
+		ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+		try {
+			List<Future<?>> futures = new ArrayList<>();
+			for (int threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++) {
+				int index = threadIndex;
+				futures.add(executor.submit(() -> {
+					try {
+						barrier.await(30, TimeUnit.SECONDS);
+						theTask.run(index);
+					} catch (Throwable t) {
+						failures.add(t);
+					}
+				}));
+			}
+			for (Future<?> future : futures) {
+				// A corrupted HashMap can hang a reader rather than throw, so bound the wait
+				future.get(60, TimeUnit.SECONDS);
+			}
+		} finally {
+			executor.shutdownNow();
+		}
+		return failures;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Set<String>> readBackingMap(String theFieldName) throws Exception {
+		// Reflection because there is no API to observe whether a read inserted an entry
+		Field field = CompartmentSearchParameterModifications.class.getDeclaredField(theFieldName);
+		field.setAccessible(true);
+		return (Map<String, Set<String>>) field.get(myModifications);
+	}
+
+	@FunctionalInterface
+	private interface ThreadTask {
+		void run(int theThreadIndex);
+	}
+}

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModificationsTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/interceptor/auth/CompartmentSearchParameterModificationsTest.java
@@ -24,6 +24,8 @@ class CompartmentSearchParameterModificationsTest {
 	private static final int THREAD_COUNT = 16;
 	private static final int ITERATIONS_PER_THREAD = 5_000;
 	private static final int RESOURCE_TYPE_COUNT = 500;
+	private static final Set<String> SEEDED_OMITTED_SPS = Set.of("subject", "source");
+	private static final Set<String> SEEDED_ADDITIONAL_SPS = Set.of("performer", "patient");
 
 	private final CompartmentSearchParameterModifications myModifications =
 			new CompartmentSearchParameterModifications();
@@ -66,7 +68,7 @@ class CompartmentSearchParameterModificationsTest {
 	}
 
 	/**
-	 * The root cause of the reported ConcurrentModificationException: the getters used to call
+	 * The root cause of the reported ConcurrentModificationException(gitlab-8555): the getters used to call
 	 * computeIfAbsent, so a logical read structurally modified the backing map. This asserts the
 	 * getters are side effect free, deterministically and without relying on thread interleaving.
 	 */
@@ -127,25 +129,19 @@ class CompartmentSearchParameterModificationsTest {
 		assertThat(actual.getOmittedSPNamesForResourceType("Device")).isEmpty();
 	}
 
-	/**
-	 * Reproduces the customer scenario from CDR #8555: a single instance is built once while an
-	 * AuthorizationInterceptor rule list is assembled, then read by every thread that evaluates that
-	 * rule list. Most of the resource types looked up here are absent from the maps, since an absent
-	 * key is what used to trigger the structural write.
-	 */
 	@Test
 	@Timeout(value = 120, unit = TimeUnit.SECONDS)
 	void getSPNames_underConcurrentReads_neverThrowAndPreserveState() throws Exception {
 		seedPatientCompartmentOmissions();
+		seedEverySecondResourceType();
 
 		List<Throwable> failures = runConcurrently(theThreadIndex -> {
 			for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
 				String resourceType = "ResourceType" + ((theThreadIndex + i) % RESOURCE_TYPE_COUNT);
-				myModifications.getOmittedSPNamesForResourceType(resourceType).contains("member");
-				myModifications
-						.getAdditionalSearchParamNamesForResourceType(resourceType)
-						.stream()
-						.count();
+				// forEach rather than contains() or count(), neither of which iterates the Set, and
+				// iteration is where a concurrently mutated Set throws
+				myModifications.getOmittedSPNamesForResourceType(resourceType).forEach(spName -> {});
+				myModifications.getAdditionalSearchParamNamesForResourceType(resourceType).forEach(spName -> {});
 			}
 		});
 
@@ -166,11 +162,10 @@ class CompartmentSearchParameterModificationsTest {
 					myModifications.addSPToOmitFromCompartment(resourceType, "sp" + theThreadIndex);
 					myModifications.addSPToIncludeInCompartment(resourceType, "sp" + theThreadIndex);
 				} else {
-					myModifications.getOmittedSPNamesForResourceType(resourceType).contains("member");
+					myModifications.getOmittedSPNamesForResourceType(resourceType).forEach(spName -> {});
 					myModifications
 							.getAdditionalSearchParamNamesForResourceType(resourceType)
-							.stream()
-							.count();
+							.forEach(spName -> {});
 				}
 			}
 		});
@@ -187,15 +182,24 @@ class CompartmentSearchParameterModificationsTest {
 		}
 	}
 
-	/**
-	 * Mirrors {@literal SearchParameterUtil.RESOURCE_TYPES_TO_SP_TO_OMIT_FROM_PATIENT_COMPARTMENT},
-	 * which is what CdrAuthorizationInterceptor copies into this object in production.
-	 */
 	private void seedPatientCompartmentOmissions() {
 		myModifications.addSPToOmitFromCompartment("Group", "member");
 		myModifications.addSPToOmitFromCompartment("List", "subject");
 		myModifications.addSPToOmitFromCompartment("List", "source");
 		myModifications.addSPToOmitFromCompartment("List", "patient");
+	}
+
+	/**
+	 * Registers SPs on every second resource type, so concurrent reads hit a mix of populated keys - where
+	 * traversal does real work - and absent keys.
+	 */
+	private void seedEverySecondResourceType() {
+		for (int i = 0; i < RESOURCE_TYPE_COUNT; i += 2) {
+			String resourceType = "ResourceType" + i;
+			SEEDED_OMITTED_SPS.forEach(spName -> myModifications.addSPToOmitFromCompartment(resourceType, spName));
+			SEEDED_ADDITIONAL_SPS.forEach(
+					spName -> myModifications.addSPToIncludeInCompartment(resourceType, spName));
+		}
 	}
 
 	private void assertSeededStateIntact() {

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8271-fix-concurrent-modification-exception-in-batch-request.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8271-fix-concurrent-modification-exception-in-batch-request.yaml
@@ -2,11 +2,5 @@
 type: fix
 issue: 8271
 jira: SMILE-11895
-title: "Previously, the getter methods on `CompartmentSearchParameterModifications` inserted an empty entry
-  into their backing map when asked about a resource type that had no modifications registered. Because a
-  single instance is shared by every thread evaluating an AuthorizationInterceptor rule list for a given
-  request, this could throw a `ConcurrentModificationException`, corrupt the shared map, or accumulate empty
-  entries. The getters no longer modify any state, the backing maps are now concurrent, and the returned Sets
-  are immutable. Note that callers who previously mutated a Set returned by
-  `getAdditionalSearchParamNamesForResourceType(..)` or `getOmittedSPNamesForResourceType(..)` must instead
-  use `addSPToIncludeInCompartment(..)` or `addSPToOmitFromCompartment(..)`."
+title: "Fixed a `ConcurrentModificationException` that could be thrown when concurrent threads evaluated a
+  shared AuthorizationInterceptor rule list."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8271-fix-concurrent-modification-exception-in-batch-request.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8271-fix-concurrent-modification-exception-in-batch-request.yaml
@@ -1,0 +1,12 @@
+---
+type: fix
+issue: 8271
+jira: SMILE-11895
+title: "Previously, the getter methods on `CompartmentSearchParameterModifications` inserted an empty entry
+  into their backing map when asked about a resource type that had no modifications registered. Because a
+  single instance is shared by every thread evaluating an AuthorizationInterceptor rule list for a given
+  request, this could throw a `ConcurrentModificationException`, corrupt the shared map, or accumulate empty
+  entries. The getters no longer modify any state, the backing maps are now concurrent, and the returned Sets
+  are immutable. Note that callers who previously mutated a Set returned by
+  `getAdditionalSearchParamNamesForResourceType(..)` or `getOmittedSPNamesForResourceType(..)` must instead
+  use `addSPToIncludeInCompartment(..)` or `addSPToOmitFromCompartment(..)`."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8271-fix-concurrent-modification-exception-in-batch-request.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8271-fix-concurrent-modification-exception-in-batch-request.yaml
@@ -3,4 +3,7 @@ type: fix
 issue: 8271
 jira: SMILE-11895
 title: "Fixed a `ConcurrentModificationException` that could be thrown when concurrent threads evaluated a
-  shared AuthorizationInterceptor rule list."
+  shared AuthorizationInterceptor rule list. Note that the Sets returned by
+  `CompartmentSearchParameterModifications.getAdditionalSearchParamNamesForResourceType(..)` and
+  `getOmittedSPNamesForResourceType(..)` are now immutable. Callers that previously mutated a returned Set
+  must use `addSPToIncludeInCompartment(..)` or `addSPToOmitFromCompartment(..)` instead."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -1601,13 +1601,6 @@ public class FhirTerserR4Test {
 		}
 	}
 
-	/**
-	 * Unlike {@link #testConcurrentTerserCalls()}, which goes through the deprecated Set overload and so
-	 * builds a fresh CompartmentSearchParameterModifications per call, this shares a single instance across
-	 * all the threads. That is what production does: AuthorizationInterceptor caches its rule list on the
-	 * RequestDetails, and each rule holds one CompartmentSearchParameterModifications.
-	 * See CDR #8555 / SMILE-11895.
-	 */
 	@Test
 	public void testConcurrentTerserCallsWithSharedCompartmentModifications()
 			throws ExecutionException, InterruptedException {

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -7,13 +7,10 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.auth.CompartmentSearchParameterModifications;
 import ca.uhn.fhir.model.api.annotation.Block;
 import ca.uhn.fhir.parser.DataFormatException;
-import ca.uhn.fhir.parser.IParser;
-import ca.uhn.fhir.parser.JsonParser;
 
 import static ca.uhn.fhir.test.utilities.UuidUtils.UUID_PATTERN;
 
 import com.google.common.collect.Lists;
-import org.apache.jena.base.Sys;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
@@ -24,10 +21,10 @@ import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DocumentReference;
-import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Enumeration;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Library;
@@ -57,8 +54,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -74,7 +69,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import static ca.uhn.fhir.test.utilities.UuidUtils.HASH_UUID_PATTERN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1601,48 +1595,35 @@ public class FhirTerserR4Test {
 		}
 	}
 
+	/**
+	 * Thread safety of the shared modifications object itself is covered deterministically by
+	 * CompartmentSearchParameterModificationsTest; this asserts the compartment semantics that the
+	 * modifications overload is supposed to apply.
+	 */
 	@Test
-	public void testConcurrentTerserCallsWithSharedCompartmentModifications()
-			throws ExecutionException, InterruptedException {
+	void testIsSourceInCompartmentForTarget_appliesCompartmentModifications_returnsProperValue() {
 		FhirContext ctx = FhirContext.forR4();
-		CompartmentSearchParameterModifications sharedModifications = new CompartmentSearchParameterModifications();
-		sharedModifications.addSPToOmitFromCompartment("Group", "member");
-		sharedModifications.addSPToIncludeInCompartment("Observation", "performer");
+		FhirTerser terser = ctx.newTerser();
+		IdType patientId = new IdType("Patient/123");
 
-		ExecutorService executor = Executors.newFixedThreadPool(10);
-		try {
-			List<Future<?>> futures = new ArrayList<>();
-			for (int i = 0; i < 10; i++) {
-				Runnable runnable = () -> {
-					for (int j = 0; j < 500; j++) {
-						Observation observation = new Observation();
-						observation.setSubject(new Reference("Patient/123"));
-						boolean outcome = ctx.newTerser()
-								.isSourceInCompartmentForTarget(
-										"Patient", observation, new IdType("Patient/123"), sharedModifications);
-						assertTrue(outcome);
+		// Group.member is in the Patient compartment definition, so the Group is in until "member" is omitted
+		Group groupWithMember = new Group();
+		groupWithMember.addMember().setEntity(new Reference("Patient/123"));
+		assertTrue(terser.isSourceInCompartmentForTarget("Patient", groupWithMember, patientId, new CompartmentSearchParameterModifications()));
 
-						Encounter encounter = new Encounter();
-						encounter.setSubject(new Reference("Patient/456"));
-						boolean encounterOutcome = ctx.newTerser()
-								.isSourceInCompartmentForTarget(
-										"Patient", encounter, new IdType("Patient/123"), sharedModifications);
-						assertFalse(encounterOutcome);
-					}
-				};
-				futures.add(executor.submit(runnable));
-			}
+		CompartmentSearchParameterModifications withOmittedSP = new CompartmentSearchParameterModifications();
+		withOmittedSP.addSPToOmitFromCompartment("Group", "member");
+		assertFalse(terser.isSourceInCompartmentForTarget("Patient", groupWithMember, patientId, withOmittedSP));
 
-			for (var next : futures) {
-				next.get();
-			}
-		} finally {
-			executor.shutdown();
-		}
+		// Group.managingEntity is not in the Patient compartment definition, so the Group is out until it is added
+		Group groupWithManagingEntity = new Group();
+		groupWithManagingEntity.setManagingEntity(new Reference("Patient/123"));
+		assertFalse(terser.isSourceInCompartmentForTarget(
+				"Patient", groupWithManagingEntity, patientId, new CompartmentSearchParameterModifications()));
 
-		assertThat(sharedModifications.getOmittedSPNamesForResourceType("Group")).containsExactly("member");
-		assertThat(sharedModifications.getAdditionalSearchParamNamesForResourceType("Observation"))
-				.containsExactly("performer");
+		CompartmentSearchParameterModifications withAdditionalSP = new CompartmentSearchParameterModifications();
+		withAdditionalSP.addSPToIncludeInCompartment("Group", "managing-entity");
+		assertTrue(terser.isSourceInCompartmentForTarget("Patient", groupWithManagingEntity, patientId, withAdditionalSP));
 	}
 
 	@Test

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/util/FhirTerserR4Test.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.auth.CompartmentSearchParameterModifications;
 import ca.uhn.fhir.model.api.annotation.Block;
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParser;
@@ -23,6 +24,7 @@ import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Enumeration;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;
@@ -1597,6 +1599,57 @@ public class FhirTerserR4Test {
 		}finally {
 			executor.shutdown();
 		}
+	}
+
+	/**
+	 * Unlike {@link #testConcurrentTerserCalls()}, which goes through the deprecated Set overload and so
+	 * builds a fresh CompartmentSearchParameterModifications per call, this shares a single instance across
+	 * all the threads. That is what production does: AuthorizationInterceptor caches its rule list on the
+	 * RequestDetails, and each rule holds one CompartmentSearchParameterModifications.
+	 * See CDR #8555 / SMILE-11895.
+	 */
+	@Test
+	public void testConcurrentTerserCallsWithSharedCompartmentModifications()
+			throws ExecutionException, InterruptedException {
+		FhirContext ctx = FhirContext.forR4();
+		CompartmentSearchParameterModifications sharedModifications = new CompartmentSearchParameterModifications();
+		sharedModifications.addSPToOmitFromCompartment("Group", "member");
+		sharedModifications.addSPToIncludeInCompartment("Observation", "performer");
+
+		ExecutorService executor = Executors.newFixedThreadPool(10);
+		try {
+			List<Future<?>> futures = new ArrayList<>();
+			for (int i = 0; i < 10; i++) {
+				Runnable runnable = () -> {
+					for (int j = 0; j < 500; j++) {
+						Observation observation = new Observation();
+						observation.setSubject(new Reference("Patient/123"));
+						boolean outcome = ctx.newTerser()
+								.isSourceInCompartmentForTarget(
+										"Patient", observation, new IdType("Patient/123"), sharedModifications);
+						assertTrue(outcome);
+
+						Encounter encounter = new Encounter();
+						encounter.setSubject(new Reference("Patient/456"));
+						boolean encounterOutcome = ctx.newTerser()
+								.isSourceInCompartmentForTarget(
+										"Patient", encounter, new IdType("Patient/123"), sharedModifications);
+						assertFalse(encounterOutcome);
+					}
+				};
+				futures.add(executor.submit(runnable));
+			}
+
+			for (var next : futures) {
+				next.get();
+			}
+		} finally {
+			executor.shutdown();
+		}
+
+		assertThat(sharedModifications.getOmittedSPNamesForResourceType("Group")).containsExactly("member");
+		assertThat(sharedModifications.getAdditionalSearchParamNamesForResourceType("Observation"))
+				.containsExactly("performer");
 	}
 
 	@Test


### PR DESCRIPTION
Closes #8271

### Issue

`CompartmentSearchParameterModifications` is populated once when an `AuthorizationInterceptor` rule list is built, then read concurrently by every thread evaluating that list. Both getters used `computeIfAbsent` on a plain `HashMap`, so a *read* for an unregistered resource type structurally modified the shared map — causing intermittent `ConcurrentModificationException` during batch requests. It also leaked one empty entry per resource type queried.

### For Code Reviewer

- Getters are now pure reads (`getOrDefault` → `Collections.emptySet()`), returning `unmodifiableSet`.
- Backing maps are `ConcurrentHashMap`; writes are copy-on-write inside `compute(..)`, so readers holding a previously returned `Set` never see it mutated. Chosen over a synchronized `Set` to keep reads lock-free; writes are build-time only and rare.
- Resource-type lookup normalizes with `toLowerCase(Locale.ROOT)` to avoid locale-dependent casing (e.g. Turkish `I`). Search parameter names stay case-sensitive, matching FHIR.

**Behaviour change:** the getters previously returned a live, mutable `Set` that callers could add to. That now throws `UnsupportedOperationException`. No such caller exists in this repo, but it is public API — downstream callers must use `addSPToIncludeInCompartment(..)` / `addSPToOmitFromCompartment(..)`. Noted in the changelog.

### For QA

1. Batch/transaction requests against a rule list using compartment SP modifications no longer intermittently fail with `ConcurrentModificationException` — verify under concurrent load, repeated runs.
2. Compartment authorization decisions unchanged: SPs added via `addSPToIncludeInCompartment(..)` still include, SPs omitted via `addSPToOmitFromCompartment(..)` still exclude.
3. Resource types with no registered modifications still use the stock compartment definition.
4. Resource type names match case-insensitively; search parameter names remain case-sensitive.
5. Repeated authorization evaluations do not grow memory over time.
