### PR TITLE
chore(unused global variable) : remove unused constant as duplicate exists in fhir.rest.api.Constraints.java

### DIFF
--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/util/JpaConstants.java
@@ -341,11 +341,6 @@ public class JpaConstants {
 	public static final String HEADER_UPSERT_EXISTENCE_CHECK = "X-Upsert-Extistence-Check";
 	public static final String HEADER_UPSERT_EXISTENCE_CHECK_DISABLED = "disabled";
 
-	/**
-	 * Parameters for the rewrite history operation
-	 */
-	public static final String HEADER_REWRITE_HISTORY = "X-Rewrite-History";
-
 	public static final String SKIP_REINDEX_ON_UPDATE = "SKIP-REINDEX-ON-UPDATE";
 	/**
 	 * IPS Generation operation name


### PR DESCRIPTION
This constant in `JpaConstants.java` is completely unused. There's an exact copy of it in `/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java` which is more globally accessible as the base dependency to the project [permalink](https://github.com/hapifhir/hapi-fhir/blob/0d7494bf98fa1e5c9686bf43c3b04c0b447272ff/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java#L109)