### PR TITLE
R4 validation issue text should not contains code+inferSystem

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8282-remote-terminology-validate-code-infersystem-message.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8282-remote-terminology-validate-code-infersystem-message.yaml
@@ -1,0 +1,5 @@
+---
+type: fix
+issue: 8282
+title: "Fixed an issue where validating a code against an older (R4/DSTU3) terminology server could show an error 
+message meant for a newer FHIR version."

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/ValidateCodeWithRemoteTerminologyR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/validation/ValidateCodeWithRemoteTerminologyR4Test.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.jpa.config.JpaConfig;
 import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.provider.BaseResourceProviderR4Test;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.test.utilities.server.RestfulServerExtension;
 import ca.uhn.fhir.test.utilities.validation.IValidationProviders;
 import ca.uhn.fhir.test.utilities.validation.IValidationProvidersR4;
@@ -232,6 +233,37 @@ public class ValidateCodeWithRemoteTerminologyR4Test extends BaseResourceProvide
 		assertFalse(((BooleanType) respParam.getParameterValue("result")).booleanValue());
 		assertThat(respParam.getParameterValue("message").toString()).isEqualTo("Validator is unable to provide validation for P#" + CODE_SYSTEM_V2_0247_URI +
 			" - Unknown or unusable ValueSet[" + UNKNOWN_VALUE_SYSTEM_URI + "]");
+	}
+
+	@Test
+	void validateCodeOperationOnValueSet_byCodeOnlyNoSystem_doesNotLeakR5OnlyInferSystemWordingInMessage() {
+		final String code = "male";
+		final String valueSetUrl = "http://hl7.org/fhir/ValueSet/administrative-gender";
+
+		// Simulates a strict remote R4 terminology server (e.g. tx.fhir.org) rejecting a
+		// code-only lookup with an HTTP 422 whose message references inferSystem -- an R5+
+		// $validate-code parameter this client never sends for R4 (see
+		// RemoteTerminologyServiceValidationSupport#shouldInferSystem).
+		myValueSetProvider.addTerminologyResource(valueSetUrl);
+		myValueSetProvider.addException(
+			OPERATION_VALIDATE_CODE,
+			valueSetUrl,
+			code,
+			new UnprocessableEntityException(
+				"Unable to find code to validate (looked for coding | codeableConcept | code+system | code+inferSystem in parameters"));
+
+		Parameters inputParam = new Parameters()
+			.addParameter("code", code)
+			.addParameter("url", new UriType(valueSetUrl));
+
+		Parameters respParam = myClient.operation()
+			.onType(ValueSet.class)
+			.named(JpaConstants.OPERATION_VALIDATE_CODE)
+			.withParameters(inputParam)
+			.execute();
+
+		assertFalse(((BooleanType) respParam.getParameterValue("result")).booleanValue());
+		assertThat(respParam.getParameterValue("message").toString()).doesNotContain("inferSystem");
 	}
 
 	@Test

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/RemoteTerminologyServiceValidationSupport.java
@@ -16,6 +16,7 @@ import ca.uhn.fhir.rest.gclient.IQuery;
 import ca.uhn.fhir.rest.gclient.StringClientParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.util.BundleUtil;
 import ca.uhn.fhir.util.Logs;
 import ca.uhn.fhir.util.ParametersUtil;
@@ -687,9 +688,19 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 					.withParameters(input)
 					.execute();
 			return createCodeValidationResult(output, errorMessageBuilder, theCode, theDisplay);
-		} catch (ResourceNotFoundException | InvalidRequestException ex) {
+		} catch (ResourceNotFoundException | InvalidRequestException | UnprocessableEntityException ex) {
 			ourLog.error(ex.getMessage(), ex);
-			String errorMessage = errorMessageBuilder.buildErrorMessage(ex.getMessage());
+			// A remote server can reference a parameter that doesn't apply to this FHIR version
+			// (e.g. the R5-only code+inferSystem) even when talking to an R4/DSTU3 endpoint that
+			// never received it. In that specific case, describe our own supported parameter
+			// combinations instead of relaying the remote server's message verbatim. Any other
+			// failure (e.g. a genuine "code not found") still surfaces the remote's real message.
+			boolean referencesUnsupportedInferSystem =
+					!shouldInferSystem(getFhirContext()) && containsInferSystemWord(ex.getMessage());
+			String errorMessage = referencesUnsupportedInferSystem
+					? "Unable to find code to validate " + theCode + " (looked for "
+							+ getSupportedValidateCodeParameterCombinations(getFhirContext()) + " in parameters)"
+					: errorMessageBuilder.buildErrorMessage(ex.getMessage());
 			CodeValidationIssueCode issueCode = ex instanceof ResourceNotFoundException
 					? CodeValidationIssueCode.NOT_FOUND
 					: CodeValidationIssueCode.CODE_INVALID;
@@ -989,6 +1000,10 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 		return theText != null && Strings.CI.contains(theText, "display");
 	}
 
+	private static boolean containsInferSystemWord(String theText) {
+		return theText != null && Strings.CI.contains(theText, "inferSystem");
+	}
+
 	/**
 	 * Returns true if any of the supplied extensions matches the per-issue display-mismatch contract:
 	 * URL equals {@link #DISPLAY_MISMATCH_EXTENSION_URL}, or URL equals {@link #MESSAGE_ID_EXTENSION_URL}
@@ -1059,6 +1074,18 @@ public class RemoteTerminologyServiceValidationSupport extends BaseTerminologySe
 			return myInferSystemEnabled;
 		}
 		return theFhirContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.R4);
+	}
+
+	/**
+	 * Parameter combinations this client can populate on a {@code $validate-code} request.
+	 * {@code code+inferSystem} is only included when {@link #shouldInferSystem} is true for
+	 * this context, since {@code inferSystem} is never sent otherwise.
+	 */
+	private String getSupportedValidateCodeParameterCombinations(FhirContext theFhirContext) {
+		if (shouldInferSystem(theFhirContext)) {
+			return "coding | codeableConcept | code+system | code+inferSystem";
+		}
+		return "coding | codeableConcept | code+system";
 	}
 
 	@Nullable


### PR DESCRIPTION
- Added failing test.  
- Added fix (exception is caught and doesn't mention inferSystem anymore in R4-).  
- Added changelog.