### PR TITLE
Fix Upload Terminology intermittent test failures

### DIFF
--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIntegrationDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIntegrationDstu3Test.java
@@ -213,7 +213,7 @@ public class TerminologyLoaderSvcIntegrationDstu3Test extends BaseJpaDstu3Test {
 
 		IValidationSupport.CodeValidationResult result = myValueSetDao.validateCode(new UriType("http://loinc.org/vs"), null, new StringType("10013-1-9999999999"), new StringType(TerminologyConstants.LOINC_URI), null, null, null, mySrd);
 		assertFalse(result.isOk());
-		assertThat(result.getMessage()).contains("Unknown code 'http://loinc.org#10013-1-9999999999' for in-memory expansion");
+		assertThat(result.getMessage()).contains("Unknown code 'http://loinc.org#10013-1-9999999999'");
 	}
 
 	private Set<String> toExpandedCodes(ValueSet theExpanded) {

--- a/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIntegrationDstu3Test.java
+++ b/hapi-fhir-jpaserver-test-dstu3/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIntegrationDstu3Test.java
@@ -213,7 +213,7 @@ public class TerminologyLoaderSvcIntegrationDstu3Test extends BaseJpaDstu3Test {
 
 		IValidationSupport.CodeValidationResult result = myValueSetDao.validateCode(new UriType("http://loinc.org/vs"), null, new StringType("10013-1-9999999999"), new StringType(TerminologyConstants.LOINC_URI), null, null, null, mySrd);
 		assertFalse(result.isOk());
-		assertThat(result.getMessage()).contains("Unknown code 'http://loinc.org#10013-1-9999999999'");
+		assertThat(result.getMessage()).contains("Unknown code \"http://loinc.org#10013-1-9999999999\"");
 	}
 
 	private Set<String> toExpandedCodes(ValueSet theExpanded) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10JpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10JpaTest.java
@@ -38,7 +38,7 @@ class TerminologyLoaderSvcIcd10JpaTest extends BaseJpaR4Test {
 		// Verify
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count());
 			assertEquals(0, myTermValueSetDao.count());
 			assertEquals(0, myTermConceptMapDao.count());
 			assertEquals(1, myResourceTableDao.count(), () -> myResourceTableDao.findAll().stream().map(t -> "\n * " + t.toString()).collect(Collectors.joining("\n * ")));

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10JpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10JpaTest.java
@@ -38,7 +38,7 @@ class TerminologyLoaderSvcIcd10JpaTest extends BaseJpaR4Test {
 		// Verify
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(1, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(0, myTermValueSetDao.count());
 			assertEquals(0, myTermConceptMapDao.count());
 			assertEquals(1, myResourceTableDao.count(), () -> myResourceTableDao.findAll().stream().map(t -> "\n * " + t.toString()).collect(Collectors.joining("\n * ")));

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10cmJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10cmJpaTest.java
@@ -33,7 +33,7 @@ class TerminologyLoaderSvcIcd10cmJpaTest extends BaseJpaR4Test {
 		// Verify
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(1, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(0, myTermValueSetDao.count());
 			assertEquals(0, myTermConceptMapDao.count());
 			assertEquals(1, myResourceTableDao.count(), () -> myResourceTableDao.findAll().stream().map(t -> "\n * " + t.toString()).collect(Collectors.joining("\n * ")));

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10cmJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcIcd10cmJpaTest.java
@@ -33,7 +33,7 @@ class TerminologyLoaderSvcIcd10cmJpaTest extends BaseJpaR4Test {
 		// Verify
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count());
 			assertEquals(0, myTermValueSetDao.count());
 			assertEquals(0, myTermConceptMapDao.count());
 			assertEquals(1, myResourceTableDao.count(), () -> myResourceTableDao.findAll().stream().map(t -> "\n * " + t.toString()).collect(Collectors.joining("\n * ")));

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -65,7 +65,8 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertEquals(82, myTermConceptDao.count());
 			assertEquals(8, myTermConceptParentChildLinkDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count(),
+				"the placeholder version superseded during activation must have been deleted");
 			assertEquals(10, myTermValueSetDao.count());
 			assertEquals(5, myTermConceptMapDao.count());
 			assertEquals(16, myResourceTableDao.count());
@@ -109,7 +110,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertEquals(82 * 2, myTermConceptDao.count());
 			assertEquals(8 * 2, myTermConceptParentChildLinkDao.count());
-			assertEquals(2 * 2, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count());
 			assertEquals(10 * 2, myTermValueSetDao.count());
 			assertEquals(5 * 2, myTermConceptMapDao.count());
 			assertEquals(16 * 2, myResourceTableDao.count());
@@ -135,7 +136,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertEquals(82 * 3, myTermConceptDao.count());
 			assertEquals(8 * 3, myTermConceptParentChildLinkDao.count());
-			assertEquals(2 * 3, myTermCodeSystemVersionDao.count());
+			assertEquals(3, myTermCodeSystemVersionDao.count());
 			assertEquals(10 * 3, myTermValueSetDao.count());
 			assertEquals(5 * 3, myTermConceptMapDao.count());
 			assertEquals(16 * 3, myResourceTableDao.count());
@@ -191,7 +192,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(4, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count());
 			TermCodeSystem myTermCodeSystem = myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org");
 
 			TermCodeSystemVersion myTermCodeSystemVersion_new =

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -57,7 +57,6 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		files = new ZipCollectionBuilder(true);
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
 		String instanceId = myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion("2.66", files);
-		myBatch2JobHelper.awaitNoJobsRunning();
 
 		logAllValueSets();
 
@@ -65,8 +64,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertEquals(82, myTermConceptDao.count());
 			assertEquals(8, myTermConceptParentChildLinkDao.count());
-			assertEquals(1, myTermCodeSystemVersionDao.count(),
-				"the placeholder version superseded during activation must have been deleted");
+			assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(10, myTermValueSetDao.count());
 			assertEquals(5, myTermConceptMapDao.count());
 			assertEquals(16, myResourceTableDao.count());
@@ -101,7 +99,6 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		files = new ZipCollectionBuilder(true);
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion("2.67", files);
-		myBatch2JobHelper.awaitNoJobsRunning();
 
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
 
@@ -110,7 +107,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertEquals(82 * 2, myTermConceptDao.count());
 			assertEquals(8 * 2, myTermConceptParentChildLinkDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(10 * 2, myTermValueSetDao.count());
 			assertEquals(5 * 2, myTermConceptMapDao.count());
 			assertEquals(16 * 2, myResourceTableDao.count());
@@ -130,13 +127,12 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		files = new ZipCollectionBuilder(true);
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v268_loincupload.properties");
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion("2.68", files);
-		myBatch2JobHelper.awaitNoJobsRunning();
 
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertEquals(82 * 3, myTermConceptDao.count());
 			assertEquals(8 * 3, myTermConceptParentChildLinkDao.count());
-			assertEquals(3, myTermCodeSystemVersionDao.count());
+			assertEquals(3, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(10 * 3, myTermValueSetDao.count());
 			assertEquals(5 * 3, myTermConceptMapDao.count());
 			assertEquals(16 * 3, myResourceTableDao.count());
@@ -192,7 +188,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			TermCodeSystem myTermCodeSystem = myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org");
 
 			TermCodeSystemVersion myTermCodeSystemVersion_new =
@@ -209,7 +205,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 
 	@Test
 	public void testValueSetExpansion() throws IOException {
-		// Load LOINC marked as version 2.66
+		// Load LOINC marked as version 2.67
 
 		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
@@ -225,17 +221,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		assertEquals("Never", outcome.getExpansion().getContains().get(0).getDisplay());
 
 		String expansionMessage = outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE);
-		assertThat(expansionMessage).contains("has not yet been pre-expanded");
-
-		// Now run the pre-expansion
-
-		logAllValueSets();
-		myBatch2JobHelper.awaitNoJobsRunning();
-
-		outcome = myValueSetDao.expand(new IdType("ValueSet/LL1001-8-2.67"), options, newSrd());
-		expansionMessage = outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE);
 		assertThat(expansionMessage).contains("using an expansion that was pre-calculated");
-
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -6,6 +6,8 @@ import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyResultJson;
 import ca.uhn.fhir.jpa.entity.TermCodeSystem;
 import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
 import ca.uhn.fhir.jpa.entity.TermConcept;
+import ca.uhn.fhir.jpa.entity.TermValueSet;
+import ca.uhn.fhir.jpa.entity.TermValueSetPreExpansionStatusEnum;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.util.JsonUtil;
 import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
@@ -15,6 +17,7 @@ import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -219,6 +222,15 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		assertEquals("2.67", outcome.getExpansion().getContains().get(0).getVersion());
 		assertEquals("LA6270-8", outcome.getExpansion().getContains().get(0).getCode());
 		assertEquals("Never", outcome.getExpansion().getContains().get(0).getDisplay());
+
+		String valueSetUrl = outcome.getUrl();
+
+		runInTransaction(() -> {
+			List<TermValueSet> valueSets = myTermValueSetDao.findTermValueSetByUrl(PageRequest.of(0, 10), valueSetUrl);
+			assertThat(valueSets).hasSize(1);
+			assertEquals(valueSetUrl, valueSets.get(0).getUrl());
+			assertEquals(TermValueSetPreExpansionStatusEnum.EXPANDED, valueSets.get(0).getExpansionStatus());
+		});
 
 		outcome = myValueSetDao.expand(new IdType("ValueSet/LL1001-8-2.67"), options, newSrd());
 		String expansionMessage = outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -209,6 +209,8 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion("2.67", files);
 
+		logAllValueSets();
+
 		ValueSetExpansionOptions options = new ValueSetExpansionOptions();
 		ValueSet outcome = myValueSetDao.expand(new IdType("ValueSet/LL1001-8-2.67"), options, newSrd());
 		ourLog.info("Expansion outcome: {}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
@@ -218,6 +220,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		assertEquals("LA6270-8", outcome.getExpansion().getContains().get(0).getCode());
 		assertEquals("Never", outcome.getExpansion().getContains().get(0).getDisplay());
 
+		outcome = myValueSetDao.expand(new IdType("ValueSet/LL1001-8-2.67"), options, newSrd());
 		String expansionMessage = outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE);
 		assertThat(expansionMessage).contains("using an expansion that was pre-calculated");
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -12,7 +12,6 @@ import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.ValueSet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcSnomedCtJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcSnomedCtJpaTest.java
@@ -51,7 +51,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(()->{
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count());
 			assertEquals(15, myTermConceptDao.count());
 			assertEquals(3, myTermConceptParentChildLinkDao.count());
 		});
@@ -93,7 +93,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 			runInTransaction(()->{
 				assertEquals(1, myTermCodeSystemDao.count());
-				assertEquals(2, myTermCodeSystemVersionDao.count());
+				assertEquals(1, myTermCodeSystemVersionDao.count());
 				assertEquals(16, myTermConceptDao.count());
 				assertEquals(5, myTermConceptParentChildLinkDao.count());
 			});
@@ -149,7 +149,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(()->{
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count());
 			assertEquals(15, myTermConceptDao.count());
 			assertEquals(3, myTermConceptParentChildLinkDao.count());
 		});
@@ -180,7 +180,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(()->{
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count());
 			assertEquals(5, myTermConceptDao.count());
 			assertEquals(3, myTermConceptParentChildLinkDao.count());
 		});

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcSnomedCtJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcSnomedCtJpaTest.java
@@ -51,7 +51,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(()->{
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(1, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(15, myTermConceptDao.count());
 			assertEquals(3, myTermConceptParentChildLinkDao.count());
 		});
@@ -93,7 +93,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 			runInTransaction(()->{
 				assertEquals(1, myTermCodeSystemDao.count());
-				assertEquals(1, myTermCodeSystemVersionDao.count());
+				assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 				assertEquals(16, myTermConceptDao.count());
 				assertEquals(5, myTermConceptParentChildLinkDao.count());
 			});
@@ -149,7 +149,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(()->{
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(1, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(15, myTermConceptDao.count());
 			assertEquals(3, myTermConceptParentChildLinkDao.count());
 		});
@@ -180,7 +180,7 @@ public class TerminologyLoaderSvcSnomedCtJpaTest extends BaseJpaR4Test {
 
 		runInTransaction(()->{
 			assertEquals(1, myTermCodeSystemDao.count());
-			assertEquals(1, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(5, myTermConceptDao.count());
 			assertEquals(3, myTermConceptParentChildLinkDao.count());
 		});

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -261,7 +260,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		List<IBaseResource> noUploadVerValueSets = noUploadVerResult.getAllResources();
 		assertThat(noUploadVerValueSets).hasSize(expectedResultQty);
 
-		matchUnqualifiedIds(noUploadVerValueSets, theExpectedIdVersions);
+		matchUnqualifiedIds(noUploadVerValueSets, theExpectedIdVersions, VS_NO_VERSIONED_ON_UPLOAD_ID);
 
 		// now  validate search for CS ver = null VS ver != null
 		for (String version : theExpectedIdVersions) {
@@ -318,24 +317,26 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 	/**
 	 * Validates that the collection of unqualified IDs of each element of theValueSets matches the expected
-	 * unqualifiedIds corresponding to the uploaded versions plus one with no version
+	 * unqualifiedIds corresponding to the uploaded versions — one per version, each id being
+	 * theUnqualifiedIdPrefix suffixed with its version. Since the loader was converted to a Batch2 job
+	 * there is no longer an extra version-less ValueSet in these results.
 	 *
-	 * @param theValueSets          the ValueSet collection
-	 * @param theExpectedIdVersions the collection of expected versions
+	 * @param theValueSets            the ValueSet collection
+	 * @param theExpectedIdVersions   the collection of expected versions
+	 * @param theUnqualifiedIdPrefix  the id prefix the searched ValueSets are stored under, which differs per
+	 *                                ValueSet URL — hence a parameter rather than a constant
 	 */
-	private void matchUnqualifiedIds(List<IBaseResource> theValueSets, Collection<String> theExpectedIdVersions) {
+	private void matchUnqualifiedIds(
+			List<IBaseResource> theValueSets, Collection<String> theExpectedIdVersions, String theUnqualifiedIdPrefix) {
 		// set should contain one entry per expectedVersion
-		List<String> expectedNoVersionUnqualifiedIds = theExpectedIdVersions.stream()
-			.map(expVer -> VS_NO_VERSIONED_ON_UPLOAD_ID + "-" + expVer)
-			.collect(Collectors.toList());
-
-		// plus one entry for null version
-		expectedNoVersionUnqualifiedIds.add(VS_NO_VERSIONED_ON_UPLOAD_ID);
+		List<String> expectedUnqualifiedIds = theExpectedIdVersions.stream()
+			.map(expVer -> theUnqualifiedIdPrefix + "-" + expVer)
+			.toList();
 
 		List<String> resultUnqualifiedIds = theValueSets.stream()
 			.map(r -> r.getIdElement().getIdPart()).toList();
 
-		assertThat(resultUnqualifiedIds).containsExactlyInAnyOrderElementsOf(expectedNoVersionUnqualifiedIds);
+		assertThat(resultUnqualifiedIds).containsExactlyInAnyOrderElementsOf(expectedUnqualifiedIds);
 
 		List<String> valueSetVersions = theValueSets.stream().map(r -> ((ValueSet) r).getVersion()).toList();
 		assertThat(valueSetVersions).containsExactlyInAnyOrderElementsOf(theExpectedIdVersions);
@@ -439,7 +440,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		List<IBaseResource> valueSets = result.getAllResources();
 		assertThat(valueSets).hasSize(expectedResultQty);
 
-		matchUnqualifiedIds(valueSets, theExpectedIdVersions);
+		matchUnqualifiedIds(valueSets, theExpectedIdVersions, LOINC_ALL_VALUESET_ID);
 
 		// now validate each specific uploaded version
 		theExpectedIdVersions.forEach(this::validateValueSetSearchForVersionLoincAllVS);
@@ -516,9 +517,12 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		Map<String, String> versionToDisplay = new HashMap<>();
 		for (TermConcept termConcept : termConcepts) {
 			String version = termConcept.getCodeSystemVersion().getCodeSystemVersionId();
-			assertThat(versionToDisplay.put(version, termConcept.getDisplay()))
+			// Asserted on the map rather than on put()'s return value: put() returns null both for a new key
+			// and for a duplicate whose display was null, which would let a real duplicate through.
+			assertThat(versionToDisplay)
 				.as("Duplicate TermConcept for code: " + theCode + ", version: " + version)
-				.isNull();
+				.doesNotContainKey(version);
+			versionToDisplay.put(version, termConcept.getDisplay());
 		}
 
 		for (String version : theExpectedVersions) {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -4,12 +4,8 @@ import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.context.support.LookupCodeRequest;
 import ca.uhn.fhir.context.support.ValidationSupportContext;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
-import ca.uhn.fhir.jpa.config.JpaConfig;
-import ca.uhn.fhir.jpa.entity.TermCodeSystem;
-import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
-import ca.uhn.fhir.jpa.term.api.ITermReadSvc;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
@@ -17,7 +13,6 @@ import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import jakarta.persistence.EntityManager;
 import jakarta.servlet.http.HttpServletResponse;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -32,21 +27,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME;
-import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_ALL_VALUESET_ID;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_LOW;
@@ -58,9 +48,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests load and validate CodeSystem and ValueSet so test names as uploadFirstCurrent... mean uploadCodeSystemAndValueSetCurrent...
  */
-public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
-	private static final Logger ourLog = LoggerFactory.getLogger(TerminologySvcImplCurrentVersionR4Test.class);
-
+class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	private static final String BASE_LOINC_URL = "http://loinc.org";
 	private static final String BASE_LOINC_VS_URL = BASE_LOINC_URL + "/vs/";
 
@@ -78,10 +66,6 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	private static final String VS_VERSIONED_ON_UPLOAD_FIRST_CODE = "LA13825-7";
 	private static final String VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY = "1 slice or 1 dinner roll";
 
-	private static final Set<String> possibleVersions = Sets.newHashSet("2.67", "2.68", "2.69");
-
-	private static final int ALL_VS_QTY = 81;
-
 	@Mock
 	private HttpServletResponse mockServletResponse;
 
@@ -95,12 +79,6 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	private TerminologyTestHelper myTerminologyTestHelper;
 
 	@Autowired
-	private ITermReadSvc myITermReadSvc;
-
-	@Autowired @Qualifier(JpaConfig.JPA_VALIDATION_SUPPORT)
-	private IValidationSupport myJpaPersistedResourceValidationSupport;
-
-	@Autowired
 	private Batch2JobHelper myBatchJobHelper;
 
 	private final ServletRequestDetails myRequestDetails = new ServletRequestDetails();
@@ -109,14 +87,14 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 
 	@BeforeEach
-	public void beforeEach() throws Exception {
+	void beforeEach() {
 		myValueSetIFhirResourceDao = myDaoRegistry.getResourceDao(ValueSet.class);
 
 		when(mockRequestDetails.getServer().getDefaultPageSize()).thenReturn(25);
 	}
 
 	@AfterEach
-	public void afterEach() {
+	void afterEach() {
 		myBatchJobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 	}
 
@@ -216,28 +194,35 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		assertEquals(prefixWithVersion(currentVersion, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY), vs1.getExpansion().getContains().iterator().next().getDisplay());
 
 
-		validateExpandedTermConceptsForVersion(currentVersion);
+		validateTermConceptForVersion(currentVersion);
 		for (String version : theAllVersions) {
-			validateExpandedTermConceptsForVersion(version);
+			validateTermConceptForVersion(version);
 		}
 
 		// now for each uploaded version
 		theAllVersions.forEach(this::validateValueExpandForVersion);
 	}
 
-	private void validateExpandedTermConceptsForVersion(String theVersion) {
+	/**
+	 * Validates the TermConcepts for both test codes exist for the given version, and their
+	 * displays match that version. Concepts are matched to a version via
+	 * {@code tcsv.myCodeSystemVersionId} rather than by insertion order (e.g. {@code myId.myId}),
+	 * since concept persistence goes through an asynchronous deferred-storage queue and is not
+	 * guaranteed to happen in upload order.
+	 */
+	private void validateTermConceptForVersion(String theVersion) {
 		runInTransaction(()->{
 			TermConcept termConceptNoVer = (TermConcept) myEntityManager.createQuery(
 				"select tc from TermConcept tc join fetch tc.myCodeSystem tcsv where tc.myCode = '" +
 					VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE + "' and tcsv.myCodeSystemVersionId = '" + theVersion + "'").getSingleResult();
-			assertNotNull(termConceptNoVer);
-			assertEquals(prefixWithVersion(theVersion, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY), termConceptNoVer.getDisplay());
+			assertEquals(prefixWithVersion(theVersion, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY),
+				termConceptNoVer.getDisplay(), "TermCode for code system version: " + theVersion);
 
 			TermConcept termConceptVer = (TermConcept) myEntityManager.createQuery(
 				"select tc from TermConcept tc join fetch tc.myCodeSystem tcsv where tc.myCode = '" +
 					VS_VERSIONED_ON_UPLOAD_FIRST_CODE + "' and tcsv.myCodeSystemVersionId = '" + theVersion + "'").getSingleResult();
-			assertNotNull(termConceptVer);
-			assertEquals(prefixWithVersion(theVersion, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY), termConceptVer.getDisplay());
+			assertEquals(prefixWithVersion(theVersion, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY),
+				termConceptVer.getDisplay(), "TermCode for code system version: " + theVersion);
 		});
 	}
 
@@ -345,8 +330,7 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		expectedNoVersionUnqualifiedIds.add(VS_NO_VERSIONED_ON_UPLOAD_ID);
 
 		List<String> resultUnqualifiedIds = theValueSets.stream()
-			.map(r -> r.getIdElement().getIdPart())
-			.collect(Collectors.toList());
+			.map(r -> r.getIdElement().getIdPart()).toList();
 
 		assertThat(resultUnqualifiedIds).containsExactlyInAnyOrderElementsOf(resultUnqualifiedIds);
 
@@ -374,6 +358,7 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 			// Fetch from validation context
 			codeSystem = (CodeSystem) myValidationSupport.fetchCodeSystem(BASE_LOINC_URL + "|" + version);
+			assertNotNull(codeSystem);
 			assertEquals(version, codeSystem.getVersion());
 
 			// for ValueSet resource
@@ -386,7 +371,7 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	}
 
 	@Test()
-	public void uploadWithVersion() throws Exception {
+	void uploadWithVersion() throws Exception {
 		String ver = "2.67";
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(ver, true);
 
@@ -401,7 +386,7 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 
 	@Test
-	public void uploadWithVersionThenNoCurrent() throws Exception {
+	void uploadWithVersionThenNoCurrent() throws Exception {
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
 
 		String currentVer = "2.67";
@@ -508,34 +493,16 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	}
 
 	/**
-	 * Validates TermConcepts were created in the sequence indicated by the parameters,
-	 * and their displays match the expected versions
+	 * Validates a TermConcept exists for each expected version, and its display matches
+	 * that version. See {@link #validateTermConceptForVersion(String)}.
 	 */
 	private void validateTermConcepts(ArrayList<String> theExpectedVersions) {
-		runInTransaction(() -> {
-		@SuppressWarnings("unchecked")
-			List<TermConcept> termConceptNoVerList = (List<TermConcept>) myEntityManager.createQuery(
-				"from TermConcept where myCode = '" + VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE + "' order by myId.myId").getResultList();
-			assertEquals(theExpectedVersions.size(), termConceptNoVerList.size());
-			for (int i = 0; i < theExpectedVersions.size(); i++) {
-				assertEquals( prefixWithVersion(theExpectedVersions.get(i), VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY),
-					termConceptNoVerList.get(i).getDisplay(), "TermCode with id: " + i + " display");
-			}
-
-			@SuppressWarnings("unchecked")
-			List<TermConcept> termConceptWithVerList = (List<TermConcept>) myEntityManager.createQuery(
-				"from TermConcept where myCode = '" + VS_VERSIONED_ON_UPLOAD_FIRST_CODE + "' order by myId.myId").getResultList();
-			assertEquals(theExpectedVersions.size(), termConceptWithVerList.size());
-			for (int i = 0; i < theExpectedVersions.size(); i++) {
-				assertEquals( prefixWithVersion(theExpectedVersions.get(i), VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY),
-					termConceptWithVerList.get(i).getDisplay(), "TermCode with id: " + i + " display");
-			}
-		});
+		theExpectedVersions.forEach(this::validateTermConceptForVersion);
 	}
 
 
 	@Test
-	public void uploadWithVersionThenNoCurrentThenCurrent() throws Exception {
+	void uploadWithVersionThenNoCurrentThenCurrent() throws Exception {
 		String firstCurrentVer = "2.67";
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(firstCurrentVer, true);
 
@@ -554,33 +521,4 @@ public class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		//	tests conditions which were failing after VS expansion (before fix for issue-2995)
 		validateTermConcepts(Lists.newArrayList(firstCurrentVer, noCurrentVer, lastCurrentVer));
 	}
-
-
-
-	private TermCodeSystemVersion fetchCurrentCodeSystemVersion() {
-		runInTransaction(() -> {
-			@SuppressWarnings("unchecked")
-			List<TermCodeSystem> tcsList = myEntityManager.createQuery("from TermCodeSystem").getResultList();
-			@SuppressWarnings("unchecked")
-			List<TermCodeSystemVersion> tcsvList = myEntityManager.createQuery("from TermCodeSystemVersion").getResultList();
-			ourLog.error("tcslist: {}", tcsList.stream().map(TermCodeSystem::toString).collect(joining("\n", "\n", "")));
-			ourLog.error("tcsvlist: {}", tcsvList.stream().map(TermCodeSystemVersion::toString).collect(joining("\n", "\n", "")));
-
-			if (tcsList.size() != 1) {
-				throw new IllegalStateException("More than one TCS: " +
-					tcsList.stream().map(tcs -> String.valueOf(tcs.getPid())).collect(joining()));
-			}
-			if (tcsList.get(0).getCurrentVersion() == null) {
-				throw new IllegalStateException("Current version is null in TCS: " + tcsList.get(0).getPid());
-			}
-		});
-
-		return runInTransaction(() -> (TermCodeSystemVersion) myEntityManager.createQuery(
-				"select tcsv from TermCodeSystemVersion tcsv join fetch tcsv.myCodeSystem tcs " +
-					"where tcs.myCurrentVersion = tcsv").getSingleResult());
-	}
-
-
-
-
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -29,7 +29,6 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -399,7 +398,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
 
 		String nonCurrentVer = "2.68";
-		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(nonCurrentVer, false);
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(nonCurrentVer, false, true);
 
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
 		logAllUriIndexes();
@@ -501,17 +500,18 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	 * matching display. This validation also ensures there are no other version (e.g. DELETED_ ones).
 	 * Concepts are matched to a version by FK, not insertion order, since persistence is async and not upload-ordered.
 	 */
-	private void validateTermConcepts(ArrayList<String> theExpectedVersions) {
+	private void validateTermConcepts(Collection<String> theExpectedVersions) {
 		runInTransaction(() -> {
 			assertTermConceptsForCode(VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
 			assertTermConceptsForCode(VS_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
 		});
 	}
 
-	private void assertTermConceptsForCode(String theCode, String theExpectedDisplaySuffix, ArrayList<String> theExpectedVersions) {
-		@SuppressWarnings("unchecked")
-		List<TermConcept> termConcepts = (List<TermConcept>) myEntityManager.createQuery(
-			"select tc from TermConcept tc join fetch tc.myCodeSystem where tc.myCode = '" + theCode + "'").getResultList();
+	private void assertTermConceptsForCode(String theCode, String theExpectedDisplaySuffix, Collection<String> theExpectedVersions) {
+		List<TermConcept> termConcepts = myEntityManager
+			.createQuery("select tc from TermConcept tc join fetch tc.myCodeSystem where tc.myCode = :code", TermConcept.class)
+			.setParameter("code", theCode)
+			.getResultList();
 		assertThat(termConcepts).as("TermConcept count for code: " + theCode).hasSize(theExpectedVersions.size());
 
 		Map<String, String> versionToDisplay = new HashMap<>();
@@ -542,8 +542,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(noCurrentVer, false);
 
 		String lastCurrentVer = "2.69";
-		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(lastCurrentVer, true);
-		myBatchJobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(lastCurrentVer, true, true);
 
 		runCommonValidations(Lists.newArrayList(firstCurrentVer, noCurrentVer, lastCurrentVer));
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_ALL_VALUESET_ID;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_LOW;

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -29,10 +29,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_ALL_VALUESET_ID;
@@ -276,7 +276,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 	/**
 	 * Validates that the collection of unqualified IDs of each element of theValueSets matches the expected
-	 * unqualifiedIds corresponding to the uploaded versions — one per version, each id being
+	 * unqualifiedIds corresponding to the uploaded versions - one per version, each id being
 	 * theUnqualifiedIdPrefix suffixed with its version.
 	 *
 	 * @param theValueSets            the ValueSet collection
@@ -358,8 +358,6 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(nonCurrentVer, false);
 
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
-		logAllValueSets();
-		logAllValueSetConcepts();
 		logAllUriIndexes();
 		logAllTokenIndexes("version");
 		logAllConcepts();
@@ -455,38 +453,51 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	}
 
 	/**
-	 * Validates that, for each test code, exactly one TermConcept exists per expected version and no others,
-	 * with the display matching that version. A TermConcept belonging to a superseded (DELETED_) version
-	 * therefore fails this check.
+	 * Validates that exactly one TermConcept exists per expected CodeSystem version, and that each one's
+	 * display matches its version. A TermConcept belonging to a superseded (DELETED_) version therefore
+	 * fails this check.
+	 * <p>
+	 * Concepts are keyed by CodeSystem version rather than by PID, because the
+	 * {@link ca.uhn.fhir.jpa.term.TermDeferredStorageSvcImpl} drain persists them in a separate transaction
+	 * from the import job. PID order therefore does not necessarily follow upload order.
 	 */
-	private void validateTermConcepts(Collection<String> theExpectedVersions) {
-		runInTransaction(() -> {
-			assertTermConceptsForCode(VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
-			assertTermConceptsForCode(VS_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
-		});
+	private void validateTermConcepts(List<String> theExpectedVersions) {
+		validateTermConceptDisplaysByVersion(
+			VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
+
+		validateTermConceptDisplaysByVersion(
+			VS_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
 	}
 
-	private void assertTermConceptsForCode(String theCode, String theExpectedDisplaySuffix, Collection<String> theExpectedVersions) {
-		List<TermConcept> termConcepts = myEntityManager
-			.createQuery("select tc from TermConcept tc join fetch tc.myCodeSystem where tc.myCode = :code", TermConcept.class)
-			.setParameter("code", theCode)
-			.getResultList();
-		assertThat(termConcepts).as("TermConcept count for code: " + theCode).hasSize(theExpectedVersions.size());
+	/**
+	 * Asserts that the TermConcepts for theCode are exactly one per expected version, each displaying
+	 * theDisplay prefixed with its own version. Displays are collected into lists per version so that a
+	 * duplicated version surfaces as a readable map difference rather than an exception.
+	 */
+	private void validateTermConceptDisplaysByVersion(
+			String theCode, String theDisplay, List<String> theExpectedVersions) {
 
-		Map<String, String> versionToDisplay = new HashMap<>();
-		for (TermConcept termConcept : termConcepts) {
-			String version = termConcept.getCodeSystemVersion().getCodeSystemVersionId();
-			assertThat(versionToDisplay)
-				.as("Duplicate TermConcept for code: " + theCode + ", version: " + version)
-				.doesNotContainKey(version);
-			versionToDisplay.put(version, termConcept.getDisplay());
-		}
+		Map<String, List<String>> expectedDisplaysByVersion = theExpectedVersions.stream()
+			.collect(Collectors.toMap(
+				version -> version,
+				version -> List.of(prefixWithVersion(version, theDisplay))));
 
-		for (String version : theExpectedVersions) {
-			assertThat(versionToDisplay)
-				.as("TermConcept for code: " + theCode + ", version: " + version)
-				.containsEntry(version, prefixWithVersion(version, theExpectedDisplaySuffix));
-		}
+		Map<String, List<String>> actualDisplaysByVersion = runInTransaction(() -> {
+			List<TermConcept> concepts = myEntityManager.createQuery(
+					"select tc from TermConcept tc join fetch tc.myCodeSystem tcsv where tc.myCode = :code",
+					TermConcept.class)
+				.setParameter("code", theCode)
+				.getResultList();
+
+			return concepts.stream()
+				.collect(Collectors.groupingBy(
+					concept -> concept.getCodeSystemVersion().getCodeSystemVersionId(),
+					Collectors.mapping(TermConcept::getDisplay, Collectors.toList())));
+		});
+
+		assertThat(actualDisplaysByVersion)
+			.as("TermConcept displays by CodeSystem version for code: %s", theCode)
+			.containsExactlyInAnyOrderEntriesOf(expectedDisplaysByVersion);
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -32,7 +32,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -177,6 +179,9 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 	}
 
+	/**
+	 * @param theAllVersions must include currentVersion; the TermConcept check below relies on this to also cover currentVersion
+	 */
 	private void validateValueExpand(String currentVersion, Collection<String> theAllVersions) {
 		// for CS ver = null, VS ver = null
 		ValueSet vs = myValueSetDao.expandByIdentifier(VS_NO_VERSIONED_ON_UPLOAD, null);
@@ -194,10 +199,8 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		assertEquals(prefixWithVersion(currentVersion, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY), vs1.getExpansion().getContains().iterator().next().getDisplay());
 
 
-		validateTermConceptForVersion(currentVersion);
-		for (String version : theAllVersions) {
-			validateTermConceptForVersion(version);
-		}
+		// currentVersion is always included in theAllVersions at every call site, so this also covers it
+		theAllVersions.forEach(this::validateTermConceptForVersion);
 
 		// now for each uploaded version
 		theAllVersions.forEach(this::validateValueExpandForVersion);
@@ -332,7 +335,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		List<String> resultUnqualifiedIds = theValueSets.stream()
 			.map(r -> r.getIdElement().getIdPart()).toList();
 
-		assertThat(resultUnqualifiedIds).containsExactlyInAnyOrderElementsOf(resultUnqualifiedIds);
+		assertThat(resultUnqualifiedIds).containsExactlyInAnyOrderElementsOf(expectedNoVersionUnqualifiedIds);
 
 		List<String> valueSetVersions = theValueSets.stream().map(r -> ((ValueSet) r).getVersion()).toList();
 		assertThat(valueSetVersions).containsExactlyInAnyOrderElementsOf(theExpectedIdVersions);
@@ -493,11 +496,36 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	}
 
 	/**
-	 * Validates a TermConcept exists for each expected version, and its display matches
-	 * that version. See {@link #validateTermConceptForVersion(String)}.
+	 * Validates exactly one TermConcept exists for the expected versions only, per test code, with the
+	 * matching display. This validation also ensures there are no other version (e.g. DELETED_ ones).
+	 * Concepts are matched to a version by FK, not insertion order, since persistence is async and not upload-ordered.
 	 */
 	private void validateTermConcepts(ArrayList<String> theExpectedVersions) {
-		theExpectedVersions.forEach(this::validateTermConceptForVersion);
+		runInTransaction(() -> {
+			assertTermConceptsForCode(VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
+			assertTermConceptsForCode(VS_VERSIONED_ON_UPLOAD_FIRST_CODE, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY, theExpectedVersions);
+		});
+	}
+
+	private void assertTermConceptsForCode(String theCode, String theExpectedDisplaySuffix, ArrayList<String> theExpectedVersions) {
+		@SuppressWarnings("unchecked")
+		List<TermConcept> termConcepts = (List<TermConcept>) myEntityManager.createQuery(
+			"select tc from TermConcept tc join fetch tc.myCodeSystem where tc.myCode = '" + theCode + "'").getResultList();
+		assertThat(termConcepts).as("TermConcept count for code: " + theCode).hasSize(theExpectedVersions.size());
+
+		Map<String, String> versionToDisplay = new HashMap<>();
+		for (TermConcept termConcept : termConcepts) {
+			String version = termConcept.getCodeSystemVersion().getCodeSystemVersionId();
+			assertThat(versionToDisplay.put(version, termConcept.getDisplay()))
+				.as("Duplicate TermConcept for code: " + theCode + ", version: " + version)
+				.isNull();
+		}
+
+		for (String version : theExpectedVersions) {
+			assertThat(versionToDisplay.get(version))
+				.as("TermConcept for code: " + theCode + ", version: " + version)
+				.isEqualTo(prefixWithVersion(version, theExpectedDisplaySuffix));
+		}
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -7,7 +7,6 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
-import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
@@ -22,7 +21,6 @@ import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.ValueSet;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
@@ -36,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_ALL_VALUESET_ID;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_LOW;
@@ -78,9 +75,6 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	@Autowired
 	private TerminologyTestHelper myTerminologyTestHelper;
 
-	@Autowired
-	private Batch2JobHelper myBatchJobHelper;
-
 	private final ServletRequestDetails myRequestDetails = new ServletRequestDetails();
 
 	private IFhirResourceDao<ValueSet> myValueSetIFhirResourceDao;
@@ -91,11 +85,6 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		myValueSetIFhirResourceDao = myDaoRegistry.getResourceDao(ValueSet.class);
 
 		when(mockRequestDetails.getServer().getDefaultPageSize()).thenReturn(25);
-	}
-
-	@AfterEach
-	void afterEach() {
-		myBatchJobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 	}
 
 	/**
@@ -177,9 +166,6 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 	}
 
-	/**
-	 * @param theAllVersions must include currentVersion; the TermConcept check below relies on this to also cover currentVersion
-	 */
 	private void validateValueExpand(String currentVersion, Collection<String> theAllVersions) {
 		// for CS ver = null, VS ver = null
 		ValueSet vs = myValueSetDao.expandByIdentifier(VS_NO_VERSIONED_ON_UPLOAD, null);
@@ -197,34 +183,8 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		assertEquals(prefixWithVersion(currentVersion, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY), vs1.getExpansion().getContains().iterator().next().getDisplay());
 
 
-		// currentVersion is always included in theAllVersions at every call site, so this also covers it
-		theAllVersions.forEach(this::validateTermConceptForVersion);
-
 		// now for each uploaded version
 		theAllVersions.forEach(this::validateValueExpandForVersion);
-	}
-
-	/**
-	 * Validates the TermConcepts for both test codes exist for the given version, and their
-	 * displays match that version. Concepts are matched to a version via
-	 * {@code tcsv.myCodeSystemVersionId} rather than by insertion order (e.g. {@code myId.myId}),
-	 * since concept persistence goes through an asynchronous deferred-storage queue and is not
-	 * guaranteed to happen in upload order.
-	 */
-	private void validateTermConceptForVersion(String theVersion) {
-		runInTransaction(()->{
-			TermConcept termConceptNoVer = (TermConcept) myEntityManager.createQuery(
-				"select tc from TermConcept tc join fetch tc.myCodeSystem tcsv where tc.myCode = '" +
-					VS_NO_VERSIONED_ON_UPLOAD_FIRST_CODE + "' and tcsv.myCodeSystemVersionId = '" + theVersion + "'").getSingleResult();
-			assertEquals(prefixWithVersion(theVersion, VS_NO_VERSIONED_ON_UPLOAD_FIRST_DISPLAY),
-				termConceptNoVer.getDisplay(), "TermCode for code system version: " + theVersion);
-
-			TermConcept termConceptVer = (TermConcept) myEntityManager.createQuery(
-				"select tc from TermConcept tc join fetch tc.myCodeSystem tcsv where tc.myCode = '" +
-					VS_VERSIONED_ON_UPLOAD_FIRST_CODE + "' and tcsv.myCodeSystemVersionId = '" + theVersion + "'").getSingleResult();
-			assertEquals(prefixWithVersion(theVersion, VS_VERSIONED_ON_UPLOAD_FIRST_DISPLAY),
-				termConceptVer.getDisplay(), "TermCode for code system version: " + theVersion);
-		});
 	}
 
 
@@ -317,17 +277,14 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	/**
 	 * Validates that the collection of unqualified IDs of each element of theValueSets matches the expected
 	 * unqualifiedIds corresponding to the uploaded versions — one per version, each id being
-	 * theUnqualifiedIdPrefix suffixed with its version. Since the loader was converted to a Batch2 job
-	 * there is no longer an extra version-less ValueSet in these results.
+	 * theUnqualifiedIdPrefix suffixed with its version.
 	 *
 	 * @param theValueSets            the ValueSet collection
 	 * @param theExpectedIdVersions   the collection of expected versions
-	 * @param theUnqualifiedIdPrefix  the id prefix the searched ValueSets are stored under, which differs per
-	 *                                ValueSet URL — hence a parameter rather than a constant
+	 * @param theUnqualifiedIdPrefix  the id prefix the searched ValueSets are stored under
 	 */
 	private void matchUnqualifiedIds(
 			List<IBaseResource> theValueSets, Collection<String> theExpectedIdVersions, String theUnqualifiedIdPrefix) {
-		// set should contain one entry per expectedVersion
 		List<String> expectedUnqualifiedIds = theExpectedIdVersions.stream()
 			.map(expVer -> theUnqualifiedIdPrefix + "-" + expVer)
 			.toList();
@@ -373,7 +330,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 	}
 
-	@Test()
+	@Test
 	void uploadWithVersion() throws Exception {
 		String ver = "2.67";
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(ver, true);
@@ -398,9 +355,11 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
 
 		String nonCurrentVer = "2.68";
-		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(nonCurrentVer, false, true);
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(nonCurrentVer, false);
 
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
+		logAllValueSets();
+		logAllValueSetConcepts();
 		logAllUriIndexes();
 		logAllTokenIndexes("version");
 		logAllConcepts();
@@ -496,9 +455,9 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 	}
 
 	/**
-	 * Validates exactly one TermConcept exists for the expected versions only, per test code, with the
-	 * matching display. This validation also ensures there are no other version (e.g. DELETED_ ones).
-	 * Concepts are matched to a version by FK, not insertion order, since persistence is async and not upload-ordered.
+	 * Validates that, for each test code, exactly one TermConcept exists per expected version and no others,
+	 * with the display matching that version. A TermConcept belonging to a superseded (DELETED_) version
+	 * therefore fails this check.
 	 */
 	private void validateTermConcepts(Collection<String> theExpectedVersions) {
 		runInTransaction(() -> {
@@ -517,8 +476,6 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		Map<String, String> versionToDisplay = new HashMap<>();
 		for (TermConcept termConcept : termConcepts) {
 			String version = termConcept.getCodeSystemVersion().getCodeSystemVersionId();
-			// Asserted on the map rather than on put()'s return value: put() returns null both for a new key
-			// and for a duplicate whose display was null, which would let a real duplicate through.
 			assertThat(versionToDisplay)
 				.as("Duplicate TermConcept for code: " + theCode + ", version: " + version)
 				.doesNotContainKey(version);
@@ -526,9 +483,9 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		}
 
 		for (String version : theExpectedVersions) {
-			assertThat(versionToDisplay.get(version))
+			assertThat(versionToDisplay)
 				.as("TermConcept for code: " + theCode + ", version: " + version)
-				.isEqualTo(prefixWithVersion(version, theExpectedDisplaySuffix));
+				.containsEntry(version, prefixWithVersion(version, theExpectedDisplaySuffix));
 		}
 	}
 
@@ -542,7 +499,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(noCurrentVer, false);
 
 		String lastCurrentVer = "2.69";
-		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(lastCurrentVer, true, true);
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(lastCurrentVer, true);
 
 		runCommonValidations(Lists.newArrayList(firstCurrentVer, noCurrentVer, lastCurrentVer));
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemDeleteJobTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemDeleteJobTest.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.batch2.api.IJobCoordinator;
 import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
 import ca.uhn.fhir.jpa.batch.models.Batch2JobStartResponse;
 import ca.uhn.fhir.jpa.entity.TermCodeSystem;
+import ca.uhn.fhir.jpa.term.TermTestUtil;
 import ca.uhn.fhir.jpa.term.TerminologyTestHelper;
 import ca.uhn.fhir.jpa.term.models.TermCodeSystemDeleteJobParameters;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
@@ -69,7 +70,7 @@ public class TermCodeSystemDeleteJobTest extends BaseJpaR4Test {
 			assertNotNull(termCodeSystem);
 			termCodeSystemPidVect[0] = termCodeSystem.getPid();
 
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(82 * 2, myTermConceptDao.count());
 		});
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemDeleteJobTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemDeleteJobTest.java
@@ -33,13 +33,8 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.util.JsonUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
-
-import java.io.InputStream;
-import java.util.Properties;
 
 import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_DELETE_JOB_NAME;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum.LOINC_UPLOAD_PROPERTIES_FILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,8 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class TermCodeSystemDeleteJobTest extends BaseJpaR4Test {
-
-	private Properties uploadProperties;
 
 	@Autowired
 	private TerminologyTestHelper myTerminologyTestHelper;
@@ -60,19 +53,13 @@ public class TermCodeSystemDeleteJobTest extends BaseJpaR4Test {
 	@Autowired
 	private IJobCoordinator myJobCoordinator;
 
-	private void initMultipleVersionLoad() throws Exception {
-		InputStream is = new ClassPathResource("loinc-ver/" + LOINC_UPLOAD_PROPERTIES_FILE.getCode()).getInputStream();
-		uploadProperties = new Properties();
-		uploadProperties.load(is);
-	}
-
 	@Test
 	public void runDeleteJobMultipleVersions() throws Exception {
-		initMultipleVersionLoad();
-
-		// loading a loinc CS with version loads two versions (second one with null version)
 		String firstCurrentVer = "2.67";
 		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(firstCurrentVer, true);
+
+		String secondCurrentVer = "2.68";
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion(secondCurrentVer, true);
 
 		long[] termCodeSystemPidVect = new long[1];  //bypass final restriction
 		runInTransaction(() -> {
@@ -83,7 +70,7 @@ public class TermCodeSystemDeleteJobTest extends BaseJpaR4Test {
 			termCodeSystemPidVect[0] = termCodeSystem.getPid();
 
 			assertEquals(2, myTermCodeSystemVersionDao.count());
-			assertEquals(82, myTermConceptDao.count());
+			assertEquals(82 * 2, myTermConceptDao.count());
 		});
 
 		TermCodeSystemDeleteJobParameters parameters = new TermCodeSystemDeleteJobParameters();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemVersionDeleteJobTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemVersionDeleteJobTest.java
@@ -70,7 +70,7 @@ public class TermCodeSystemVersionDeleteJobTest extends BaseJpaR4Test {
 			assertNotNull(termCodeSystemVersion);
 			termCodeSystemVersionPidVect[0] = requireNonNull(termCodeSystemVersion.getPid());
 
-			assertEquals(2 * 2, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count());
 			assertEquals(82 * 2, myTermConceptDao.count());
 		});
 
@@ -89,7 +89,7 @@ public class TermCodeSystemVersionDeleteJobTest extends BaseJpaR4Test {
 		runInTransaction(() -> {
 			assertEquals(1, myTermCodeSystemDao.count());
 			assertNotNull(myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org"));
-			assertEquals(3, myTermCodeSystemVersionDao.count());
+			assertEquals(1, myTermCodeSystemVersionDao.count());
 			assertEquals(82, myTermConceptDao.count());
 		});
 	}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemVersionDeleteJobTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/job/TermCodeSystemVersionDeleteJobTest.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.batch2.model.JobInstanceStartRequest;
 import ca.uhn.fhir.jpa.batch.models.Batch2JobStartResponse;
 import ca.uhn.fhir.jpa.entity.TermCodeSystem;
 import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
+import ca.uhn.fhir.jpa.term.TermTestUtil;
 import ca.uhn.fhir.jpa.term.TerminologyTestHelper;
 import ca.uhn.fhir.jpa.term.models.TermCodeSystemDeleteVersionJobParameters;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
@@ -70,7 +71,7 @@ public class TermCodeSystemVersionDeleteJobTest extends BaseJpaR4Test {
 			assertNotNull(termCodeSystemVersion);
 			termCodeSystemVersionPidVect[0] = requireNonNull(termCodeSystemVersion.getPid());
 
-			assertEquals(2, myTermCodeSystemVersionDao.count());
+			assertEquals(2, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			assertEquals(82 * 2, myTermConceptDao.count());
 		});
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TermTestUtil.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TermTestUtil.java
@@ -58,6 +58,14 @@ public final class TermTestUtil {
 	public static final String URL_MY_CODE_SYSTEM = "http://example.com/my_code_system";
 	public static final String URL_MY_VALUE_SET = "http://example.com/my_value_set";
 
+	/**
+	 * Message for assertions on the surviving {@code TermCodeSystemVersion} count. An upload creates a
+	 * placeholder version and then supersedes it when the real version is activated, so each upload leaves
+	 * exactly one version behind once the batch2 deletion of the superseded one has run.
+	 */
+	public static final String MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD =
+			"each upload leaves exactly one CodeSystem version once the superseded placeholder is deleted";
+
 	private TermTestUtil() {}
 
 	public static void addLoincMandatoryFilesAndSinglePartLinkToZip(ZipCollectionBuilder theFiles) throws IOException {

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TermTestUtil.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TermTestUtil.java
@@ -63,8 +63,7 @@ public final class TermTestUtil {
 	 * placeholder version and then supersedes it when the real version is activated, so each upload leaves
 	 * exactly one version behind once the batch2 deletion of the superseded one has run.
 	 */
-	public static final String MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD =
-			"each upload leaves exactly one CodeSystem version once the superseded placeholder is deleted";
+	public static final String MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD = "one CodeSystemVersion per upload";
 
 	private TermTestUtil() {}
 

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -44,6 +44,7 @@ import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.util.JsonUtil;
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayInputStream;
@@ -51,6 +52,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.FILENAME_LOINC_DISTRIBUTION_FILE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.FILENAME_SNOMED_CT_DISTRIBUTION_FILE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum.LOINC_ANSWERLIST_DUPLICATE_FILE_DEFAULT;
@@ -196,6 +198,27 @@ public class TerminologyTestHelper {
 	public String startImportLoincJobAndWaitForCompletion(
 			String versionId, ZipCollectionBuilder theFiles, boolean theDontMakeCurrent) {
 		return startImportLoincJobAndWaitForCompletion(versionId, theFiles, theDontMakeCurrent, null);
+	}
+
+	/**
+	 * @param theAwaitVersionDelete if this upload replaces an existing TermCodeSystemVersion for the same version
+	 *                              string, activation deletes the old row asynchronously (see
+	 *                              {@link ca.uhn.fhir.jpa.term.TermCodeSystemStorageSvcImpl#activateStagingCodeSystemVersion}).
+	 *                              Pass {@code true} to await that deletion job before returning, so callers that
+	 *                              assert exact TermConcept/TermCodeSystemVersion counts don't race a pending
+	 *                              DELETED_ row. Callers asserting on the pre-deletion state (e.g. delete-job tests)
+	 *                              should keep using the three-arg overload instead.
+	 */
+	public String startImportLoincJobAndWaitForCompletion(
+			String versionId,
+			ZipCollectionBuilder theFiles,
+			boolean theDontMakeCurrent,
+			boolean theAwaitVersionDelete) {
+		String jobInstanceId = startImportLoincJobAndWaitForCompletion(versionId, theFiles, theDontMakeCurrent, null);
+		if (theAwaitVersionDelete) {
+			myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
+		}
+		return jobInstanceId;
 	}
 
 	public String startImportLoincJobAndWaitForCompletion(
@@ -368,6 +391,16 @@ public class TerminologyTestHelper {
 	}
 
 	public void startImportLoincJobAndWaitForCompletion(String theVersion, boolean theMakeItCurrent) throws Exception {
+		startImportLoincJobAndWaitForCompletion(theVersion, theMakeItCurrent, false);
+	}
+
+	/**
+	 * @param theAwaitVersionDelete see {@link #startImportLoincJobAndWaitForCompletion(String, ZipCollectionBuilder, boolean, boolean)},
+	 *                              which this delegates to. Defaults to {@code false} via the two-arg overload since
+	 *                              some callers (e.g. delete-job tests) intentionally assert on the pre-deletion state.
+	 */
+	public void startImportLoincJobAndWaitForCompletion(
+			@Nullable String theVersion, boolean theMakeItCurrent, boolean theAwaitVersionDelete) throws Exception {
 		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
 
 		assertThat(theVersion == null
@@ -379,7 +412,7 @@ public class TerminologyTestHelper {
 
 		addLoincMandatoryFilesToZip(files, theVersion);
 
-		startImportLoincJobAndWaitForCompletion(theVersion, files, !theMakeItCurrent);
+		startImportLoincJobAndWaitForCompletion(theVersion, files, !theMakeItCurrent, theAwaitVersionDelete);
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -38,13 +38,13 @@ import ca.uhn.fhir.jpa.batch2.jobs.term.icd.ImportIcdJobAppCtx;
 import ca.uhn.fhir.jpa.batch2.jobs.term.loinc.ImportLoincJobAppCtx;
 import ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum;
 import ca.uhn.fhir.jpa.batch2.jobs.term.snomedct.ImportSnomedCtJobAppCtx;
-import ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx;
 import ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetParameters;
+import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
 import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.jpa.util.MemoryCacheService;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.util.JsonUtil;
-import jakarta.annotation.Nullable;
+import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayInputStream;
@@ -52,6 +52,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_DELETE_JOB_NAME;
 import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.FILENAME_LOINC_DISTRIBUTION_FILE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.FILENAME_SNOMED_CT_DISTRIBUTION_FILE;
@@ -76,6 +77,7 @@ import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum.L
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum.LOINC_RSNA_PLAYBOOK_FILE_DEFAULT;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum.LOINC_UNIVERSAL_LAB_ORDER_VALUESET_FILE_DEFAULT;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.loinc.LoincUploadPropertiesEnum.LOINC_XML_FILE;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET;
 import static ca.uhn.fhir.jpa.test.BaseJpaTest.newSrd;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -85,23 +87,56 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TerminologyTestHelper {
 
+	/**
+	 * Maximum number of {@link ITermDeferredStorageSvc#saveDeferred()} passes made when draining the deferred
+	 * queue. Each pass itself makes up to 10 internal passes of 1000 concepts, so this is far beyond what any
+	 * test fixture needs. The bound exists so that a queue which can never drain - a paused
+	 * {@link ITermDeferredStorageSvc} - fails the assertion in {@link #awaitDeferredTerminologyWork()} rather
+	 * than spinning forever.
+	 */
+	private static final int MAX_SAVE_DEFERRED_PASSES = 10;
+
 	private final IJobPersistence myJobPersistence;
 	private final IJobCoordinator myJobCoordinator;
 	private final Batch2JobHelper myBatch2JobHelper;
 	private final MemoryCacheService myMemoryCacheService;
 	private final IValidationSupport myValidationSupport;
+	private final ITermDeferredStorageSvc myTermDeferredStorageSvc;
 
 	public TerminologyTestHelper(
-			IJobPersistence theJobPersistence,
-			IJobCoordinator theJobCoordinator,
-			Batch2JobHelper theBatch2JobHelper,
-			MemoryCacheService theMemoryCacheService,
-			IValidationSupport theValidationSupport) {
+			@Nonnull IJobPersistence theJobPersistence,
+			@Nonnull IJobCoordinator theJobCoordinator,
+			@Nonnull Batch2JobHelper theBatch2JobHelper,
+			@Nonnull MemoryCacheService theMemoryCacheService,
+			@Nonnull IValidationSupport theValidationSupport,
+			@Nonnull ITermDeferredStorageSvc theTermDeferredStorageSvc) {
 		myJobPersistence = theJobPersistence;
 		myJobCoordinator = theJobCoordinator;
 		myBatch2JobHelper = theBatch2JobHelper;
 		myMemoryCacheService = theMemoryCacheService;
 		myValidationSupport = theValidationSupport;
+		myTermDeferredStorageSvc = theTermDeferredStorageSvc;
+	}
+
+	/**
+	 * Waits for the async work an import leaves behind: the deferred storage queue, the deletion of the
+	 * CodeSystem version it supersedes, and the ValueSet pre-expansions.
+	 */
+	private void awaitDeferredTerminologyWork() {
+		for (int i = 0; i < MAX_SAVE_DEFERRED_PASSES && !myTermDeferredStorageSvc.isStorageQueueEmpty(false); i++) {
+			myTermDeferredStorageSvc.saveDeferred();
+		}
+
+		assertThat(myTermDeferredStorageSvc.isStorageQueueEmpty(false))
+				.as(
+						"Deferred queue must be drained before awaiting the deletion jobs - either deferred "
+								+ "processing is paused, or %s saveDeferred() passes were not enough to reach the deletions",
+						MAX_SAVE_DEFERRED_PASSES)
+				.isTrue();
+
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
 	}
 
 	public String startImportCustomJobAndWaitForCompletion(
@@ -198,27 +233,6 @@ public class TerminologyTestHelper {
 	public String startImportLoincJobAndWaitForCompletion(
 			String versionId, ZipCollectionBuilder theFiles, boolean theDontMakeCurrent) {
 		return startImportLoincJobAndWaitForCompletion(versionId, theFiles, theDontMakeCurrent, null);
-	}
-
-	/**
-	 * @param theAwaitVersionDelete if this upload replaces an existing TermCodeSystemVersion for the same version
-	 *                              string, activation deletes the old row asynchronously (see
-	 *                              {@link ca.uhn.fhir.jpa.term.TermCodeSystemStorageSvcImpl#activateStagingCodeSystemVersion}).
-	 *                              Pass {@code true} to await that deletion job before returning, so callers that
-	 *                              assert exact TermConcept/TermCodeSystemVersion counts don't race a pending
-	 *                              DELETED_ row. Callers asserting on the pre-deletion state (e.g. delete-job tests)
-	 *                              should keep using the three-arg overload instead.
-	 */
-	public String startImportLoincJobAndWaitForCompletion(
-			String versionId,
-			ZipCollectionBuilder theFiles,
-			boolean theDontMakeCurrent,
-			boolean theAwaitVersionDelete) {
-		String jobInstanceId = startImportLoincJobAndWaitForCompletion(versionId, theFiles, theDontMakeCurrent, null);
-		if (theAwaitVersionDelete) {
-			myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
-		}
-		return jobInstanceId;
 	}
 
 	public String startImportLoincJobAndWaitForCompletion(
@@ -349,6 +363,7 @@ public class TerminologyTestHelper {
 		} else {
 			myBatch2JobHelper.awaitJobFailure(instanceId);
 		}
+		awaitDeferredTerminologyWork();
 
 		return instanceId.getInstanceId();
 	}
@@ -391,16 +406,6 @@ public class TerminologyTestHelper {
 	}
 
 	public void startImportLoincJobAndWaitForCompletion(String theVersion, boolean theMakeItCurrent) throws Exception {
-		startImportLoincJobAndWaitForCompletion(theVersion, theMakeItCurrent, false);
-	}
-
-	/**
-	 * @param theAwaitVersionDelete see {@link #startImportLoincJobAndWaitForCompletion(String, ZipCollectionBuilder, boolean, boolean)},
-	 *                              which this delegates to. Defaults to {@code false} via the two-arg overload since
-	 *                              some callers (e.g. delete-job tests) intentionally assert on the pre-deletion state.
-	 */
-	public void startImportLoincJobAndWaitForCompletion(
-			@Nullable String theVersion, boolean theMakeItCurrent, boolean theAwaitVersionDelete) throws Exception {
 		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
 
 		assertThat(theVersion == null
@@ -412,7 +417,7 @@ public class TerminologyTestHelper {
 
 		addLoincMandatoryFilesToZip(files, theVersion);
 
-		startImportLoincJobAndWaitForCompletion(theVersion, files, !theMakeItCurrent, theAwaitVersionDelete);
+		startImportLoincJobAndWaitForCompletion(theVersion, files, !theMakeItCurrent);
 	}
 
 	/**
@@ -505,7 +510,7 @@ public class TerminologyTestHelper {
 		parameters.setVersion(theVersion);
 
 		JobInstanceStartRequest startRequest = new JobInstanceStartRequest();
-		startRequest.setJobDefinitionId(PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET);
+		startRequest.setJobDefinitionId(JOB_ID_PRE_EXPAND_VALUESET);
 		startRequest.setParameters(parameters);
 
 		String instanceId =

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -88,11 +88,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TerminologyTestHelper {
 
 	/**
-	 * Maximum number of {@link ITermDeferredStorageSvc#saveDeferred()} passes made when draining the deferred
-	 * queue. Each pass itself makes up to 10 internal passes of 1000 concepts, so this is far beyond what any
-	 * test fixture needs. The bound exists so that a queue which can never drain - a paused
-	 * {@link ITermDeferredStorageSvc} - fails the assertion in {@link #awaitDeferredTerminologyWork()} rather
-	 * than spinning forever.
+	 * Bound on the {@link ITermDeferredStorageSvc#saveDeferred()} passes used to drain the deferred queue.
+	 * Each pass itself makes up to 10 internal passes of 1000 concepts.
+	 * <p>
+	 * {@link ITermDeferredStorageSvc#saveAllDeferred()} is the equivalent production API, but it loops until
+	 * {@link ITermDeferredStorageSvc#isStorageQueueEmpty(boolean)} reports empty, and that never reports
+	 * empty while deferred processing is paused - so it would spin forever against a paused service.
 	 */
 	private static final int MAX_SAVE_DEFERRED_PASSES = 10;
 
@@ -119,20 +120,26 @@ public class TerminologyTestHelper {
 	}
 
 	/**
-	 * Waits for the async work an import leaves behind: the deferred storage queue, the deletion of the
-	 * CodeSystem version it supersedes, and the ValueSet pre-expansions.
+	 * Waits for the async work a successful import leaves behind: the deferred storage queue, the deletion of
+	 * the CodeSystem version it supersedes, and the ValueSet pre-expansions. The drain also starts any
+	 * whole-CodeSystem deletion queued earlier in the same context, so that job is awaited as well.
+	 * <p>
+	 * The queue must be drained before the deletion jobs are awaited: the superseded version is only enqueued
+	 * for batch2 deletion once the drain reaches it, so awaiting first would find no job instance and return
+	 * immediately.
 	 */
 	private void awaitDeferredTerminologyWork() {
 		for (int i = 0; i < MAX_SAVE_DEFERRED_PASSES && !myTermDeferredStorageSvc.isStorageQueueEmpty(false); i++) {
 			myTermDeferredStorageSvc.saveDeferred();
 		}
 
-		assertThat(myTermDeferredStorageSvc.isStorageQueueEmpty(false))
-				.as(
-						"Deferred queue must be drained before awaiting the deletion jobs - either deferred "
-								+ "processing is paused, or %s saveDeferred() passes were not enough to reach the deletions",
-						MAX_SAVE_DEFERRED_PASSES)
-				.isTrue();
+		if (!myTermDeferredStorageSvc.isStorageQueueEmpty(false)) {
+			myTermDeferredStorageSvc.logQueueForUnitTest();
+			fail("Deferred queue was not drained after " + MAX_SAVE_DEFERRED_PASSES
+					+ " saveDeferred() passes. Note that isStorageQueueEmpty() also reports non-empty when "
+					+ "deferred processing is paused, so check setProcessDeferred(false) callers as well as "
+					+ "the queue contents logged above.");
+		}
 
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
@@ -360,10 +367,10 @@ public class TerminologyTestHelper {
 
 		if (expectSuccess) {
 			myBatch2JobHelper.awaitJobCompletion(instanceId);
+			awaitDeferredTerminologyWork();
 		} else {
 			myBatch2JobHelper.awaitJobFailure(instanceId);
 		}
-		awaitDeferredTerminologyWork();
 
 		return instanceId.getInstanceId();
 	}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -124,13 +124,14 @@ public class TerminologyTestHelper {
 	 * Only successful imports call this. A failed import leaves whatever it queued behind for the per-test
 	 * terminology cleanup to discard.
 	 */
-	private void awaitDeferredTerminologyWork() {
+	private void awaitImportDeferredTerminologyWork() {
 		myTermDeferredStorageSvc.setProcessDeferred(true);
 		myTermDeferredStorageSvc.saveAllDeferred();
 
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
-		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
+		// adding this revealed a Prod bug which will be fixed separately
+		// myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
 	}
 
 	public String startImportCustomJobAndWaitForCompletion(
@@ -354,7 +355,7 @@ public class TerminologyTestHelper {
 
 		if (expectSuccess) {
 			myBatch2JobHelper.awaitJobCompletion(instanceId);
-			awaitDeferredTerminologyWork();
+			awaitImportDeferredTerminologyWork();
 		} else {
 			myBatch2JobHelper.awaitJobFailure(instanceId);
 		}

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -115,17 +115,10 @@ public class TerminologyTestHelper {
 	 * earlier in the test, and the ValueSet pre-expansions. Every instance of those job definitions is
 	 * awaited, not only the ones this import produced.
 	 * <p>
-	 * Order matters: the drain is what enqueues the superseded version for batch2 deletion, so awaiting the
-	 * delete jobs first would find no instances and return immediately. Deferred processing is re-enabled
-	 * before draining because {@link ITermDeferredStorageSvc#isStorageQueueEmpty(boolean)} reports non-empty
-	 * while processing is paused, which would leave {@link ITermDeferredStorageSvc#saveAllDeferred()} looping
-	 * forever.
-	 * <p>
 	 * Only successful imports call this. A failed import leaves whatever it queued behind for the per-test
 	 * terminology cleanup to discard.
 	 */
 	private void awaitImportDeferredTerminologyWork() {
-		myTermDeferredStorageSvc.setProcessDeferred(true);
 		myTermDeferredStorageSvc.saveAllDeferred();
 
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -130,8 +130,10 @@ public class TerminologyTestHelper {
 
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
-		// adding this revealed a Prod bug which will be fixed separately
-		// myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
+
+		// adding a second saveAllDeferred call until https://github.com/hapifhir/hapi-fhir/issues/8321 is fixed
+		myTermDeferredStorageSvc.saveAllDeferred();
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
 	}
 
 	public String startImportCustomJobAndWaitForCompletion(

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -87,16 +87,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TerminologyTestHelper {
 
-	/**
-	 * Bound on the {@link ITermDeferredStorageSvc#saveDeferred()} passes used to drain the deferred queue.
-	 * Each pass itself makes up to 10 internal passes of 1000 concepts.
-	 * <p>
-	 * {@link ITermDeferredStorageSvc#saveAllDeferred()} is the equivalent production API, but it loops until
-	 * {@link ITermDeferredStorageSvc#isStorageQueueEmpty(boolean)} reports empty, and that never reports
-	 * empty while deferred processing is paused - so it would spin forever against a paused service.
-	 */
-	private static final int MAX_SAVE_DEFERRED_PASSES = 10;
-
 	private final IJobPersistence myJobPersistence;
 	private final IJobCoordinator myJobCoordinator;
 	private final Batch2JobHelper myBatch2JobHelper;
@@ -120,26 +110,23 @@ public class TerminologyTestHelper {
 	}
 
 	/**
-	 * Waits for the async work a successful import leaves behind: the deferred storage queue, the deletion of
-	 * the CodeSystem version it supersedes, and the ValueSet pre-expansions. The drain also starts any
-	 * whole-CodeSystem deletion queued earlier in the same context, so that job is awaited as well.
+	 * Drains the deferred storage queue and waits for the batch2 jobs a successful import leaves behind:
+	 * deletion of the CodeSystem version this import supersedes, deletion of any whole CodeSystem queued
+	 * earlier in the test, and the ValueSet pre-expansions. Every instance of those job definitions is
+	 * awaited, not only the ones this import produced.
 	 * <p>
-	 * The queue must be drained before the deletion jobs are awaited: the superseded version is only enqueued
-	 * for batch2 deletion once the drain reaches it, so awaiting first would find no job instance and return
-	 * immediately.
+	 * Order matters: the drain is what enqueues the superseded version for batch2 deletion, so awaiting the
+	 * delete jobs first would find no instances and return immediately. Deferred processing is re-enabled
+	 * before draining because {@link ITermDeferredStorageSvc#isStorageQueueEmpty(boolean)} reports non-empty
+	 * while processing is paused, which would leave {@link ITermDeferredStorageSvc#saveAllDeferred()} looping
+	 * forever.
+	 * <p>
+	 * Only successful imports call this. A failed import leaves whatever it queued behind for the per-test
+	 * terminology cleanup to discard.
 	 */
 	private void awaitDeferredTerminologyWork() {
-		for (int i = 0; i < MAX_SAVE_DEFERRED_PASSES && !myTermDeferredStorageSvc.isStorageQueueEmpty(false); i++) {
-			myTermDeferredStorageSvc.saveDeferred();
-		}
-
-		if (!myTermDeferredStorageSvc.isStorageQueueEmpty(false)) {
-			myTermDeferredStorageSvc.logQueueForUnitTest();
-			fail("Deferred queue was not drained after " + MAX_SAVE_DEFERRED_PASSES
-					+ " saveDeferred() passes. Note that isStorageQueueEmpty() also reports non-empty when "
-					+ "deferred processing is paused, so check setProcessDeferred(false) callers as well as "
-					+ "the queue contents logged above.");
-		}
+		myTermDeferredStorageSvc.setProcessDeferred(true);
+		myTermDeferredStorageSvc.saveAllDeferred();
 
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestJPAConfig.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestJPAConfig.java
@@ -40,6 +40,7 @@ import ca.uhn.fhir.jpa.subscription.submit.config.SubscriptionSubmitterConfig;
 import ca.uhn.fhir.jpa.term.TermCodeSystemDeleteJobSvcWithUniTestFailures;
 import ca.uhn.fhir.jpa.term.TerminologyTestHelper;
 import ca.uhn.fhir.jpa.term.api.ITermCodeSystemDeleteJobSvc;
+import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
 import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.jpa.test.util.StoppableSubscriptionDeliveringRestHookListener;
 import ca.uhn.fhir.jpa.test.util.SubscriptionTestUtil;
@@ -88,8 +89,20 @@ public class TestJPAConfig {
 	}
 
 	@Bean
-	public TerminologyTestHelper terminologyTestHelper(IJobPersistence theJobPersistence, IJobCoordinator theJobCoordinator, Batch2JobHelper theBatch2JobHelper, MemoryCacheService theMemoryCacheSvc, IValidationSupport theValidationSupport) {
-		return new TerminologyTestHelper(theJobPersistence, theJobCoordinator, theBatch2JobHelper, theMemoryCacheSvc, theValidationSupport);
+	public TerminologyTestHelper terminologyTestHelper(
+			IJobPersistence theJobPersistence,
+			IJobCoordinator theJobCoordinator,
+			Batch2JobHelper theBatch2JobHelper,
+			MemoryCacheService theMemoryCacheSvc,
+			IValidationSupport theValidationSupport,
+			ITermDeferredStorageSvc theTermDeferredStorageSvc) {
+		return new TerminologyTestHelper(
+			theJobPersistence,
+			theJobCoordinator,
+			theBatch2JobHelper,
+			theMemoryCacheSvc,
+			theValidationSupport,
+			theTermDeferredStorageSvc);
 	}
 
 	@Bean

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestJPAConfig.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/test/config/TestJPAConfig.java
@@ -90,19 +90,14 @@ public class TestJPAConfig {
 
 	@Bean
 	public TerminologyTestHelper terminologyTestHelper(
-			IJobPersistence theJobPersistence,
-			IJobCoordinator theJobCoordinator,
-			Batch2JobHelper theBatch2JobHelper,
-			MemoryCacheService theMemoryCacheSvc,
-			IValidationSupport theValidationSupport,
-			ITermDeferredStorageSvc theTermDeferredStorageSvc) {
-		return new TerminologyTestHelper(
-			theJobPersistence,
-			theJobCoordinator,
-			theBatch2JobHelper,
-			theMemoryCacheSvc,
-			theValidationSupport,
-			theTermDeferredStorageSvc);
+		IJobPersistence theJobPersistence,
+		IJobCoordinator theJobCoordinator,
+		Batch2JobHelper theBatch2JobHelper,
+		MemoryCacheService theMemoryCacheSvc,
+		IValidationSupport theValidationSupport,
+		ITermDeferredStorageSvc theITermDeferredStorageSvc) {
+		return new TerminologyTestHelper(theJobPersistence,
+			theJobCoordinator, theBatch2JobHelper, theMemoryCacheSvc, theValidationSupport, theITermDeferredStorageSvc);
 	}
 
 	@Bean


### PR DESCRIPTION
Fixes #8291

**Root Cause**

The new terminology upload uses a `CodeSystem` staging mechanism which uses a placeholder `TermCodeSystemVersion` which is replaced with the actual `TermCodeSystemVersion` once all concepts and all related information to a CodeSystem are persisted. This adds records to the delete deferred queue which queues a delete job for the obsolete `TermCodeSystemVersion`. The terminology can also contain ValueSets which can trigger `ValueSet` async pre-expansion jobs. 

Upload terminology tests do not wait for the async processes to finish before doing the assertions. This results in intermittent test failures.

**Changes**

- `TerminologyTestHelper` successful imports now settle their own async work via a new private `awaitImportDeferredTerminologyWork()`: re-enable deferred processing, `saveAllDeferred()`, then await the version-delete, CodeSystem-delete, and pre-expansion jobs. Callers no longer need to know what an import leaves behind.                                                                                                                                       
                                                                                                                                                                                                              
- `TerminologySvcImplCurrentVersionR4Test` — fixed the self-comparing assertion in matchUnqualifiedIds and gave it the ID prefix as a parameter so both call sites assert against the right set.        

- replaced `validateExpandedTermConceptsForVersion` with `validateTermConcepts`, which keys concepts by `CodeSystem` version and asserts exactly one per version, so a leftover `DELETED_` version shows up as a readable map diff instead of an exception. Removed the `@AfterEach` job wait, dead helpers, and unused fields now that the helper handles the waiting.                                                                      
                                                                                                                                                                                                               
- updated the version-count assertions across the terminology upload tests e.g. `TerminologyLoaderSvcLoincJpaTest` such that each upload now leaves exactly one `TermCodeSystemVersion`. That is the correct final number once the replaced one is deleted, so counts drop from 2 per upload to 1. The reasoning is     captured once in `TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD` and used as the assertion message. 
- `TermCodeSystemDeleteJobTest.runDeleteJobMultipleVersions` now genuinely loads two versions instead of relying on the placeholder version to make up the count.     

**Note**

Another cause for intermittence was related to the scenario with multiple upload terminology operations executed sequentially. The tests relied on the fact that upload order is the same as persistence order for `TermCodeSystemVersion` records which is not necessarily the case. The queries in the test assertions were fixed already as part of #8274.
  
**Known issue**
  
Awaiting the pre-expansion jobs exposed a pre-existing production race condition in `TermDeferredStorageSvcImpl.saveAllDeferred`. `ValueSet` pre-expansion can start while the replaced `CodeSystem` version is still being deleted, and an expansion that runs in that window falls back to an unvalidated in-memory path. Filed as #8321. Worked included here is a second `saveAllDeferred()` call after the delete jobs complete, commented and linked to the issue.