### PR TITLE
Fix ValueSet pre-expansion running before terminology is ready

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TimeoutManager.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/TimeoutManager.java
@@ -51,7 +51,7 @@ public class TimeoutManager {
 	public boolean checkTimeout() {
 		boolean retval = false;
 		if (myStopWatch.getMillis() > myWarningTimeout.toMillis() && !warned) {
-			ourLog.warn(myServiceName + " has run for {}", myStopWatch);
+			ourLog.warn("{} has run for {}", myServiceName, myStopWatch);
 			warned = true;
 			retval = true;
 		}
@@ -60,7 +60,7 @@ public class TimeoutManager {
 				throw new TimeoutException(
 						Msg.code(2133) + myServiceName + " timed out after running for " + myStopWatch);
 			} else {
-				ourLog.error(myServiceName + " has run for {}", myStopWatch);
+				ourLog.error("{} has run for {}", myServiceName, myStopWatch);
 				errored = true;
 				retval = true;
 			}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8321-valueset-pre-expansion-ordering.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8321-valueset-pre-expansion-ordering.yaml
@@ -1,0 +1,9 @@
+---
+type: fix
+issue: 8321
+title: "When a `CodeSystem` was loaded alongside the `ValueSet`s that reference it, such as during an
+  implementation guide install or a terminology import, a `ValueSet` could be pre-expanded before the
+  `CodeSystem` was fully stored and still marked `EXPANDED`, so `$expand` and `$validate-code` omitted
+  valid codes. Introduced when terminology operations moved to batch2 jobs; pre-expansion now waits for
+  deferred terminology entities to be processed, and an import makes the `CodeSystem` version current
+  before activating the `ValueSet`s it generates."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/valueset_expansion.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/server_jpa/valueset_expansion.md
@@ -64,8 +64,9 @@ Whichever way it is queued, the job performs the same steps:
 4. On failure, sets the status to `FAILED_TO_EXPAND` and persists the failure reason in the
    `EXPANSION_ERROR` column of `TRM_VALUESET`.
 
-The job is skipped while deferred terminology entities (e.g. a large CodeSystem still being loaded)
-are being processed, so that ValueSets are not expanded against incomplete CodeSystems.
+The job waits while deferred terminology entities (e.g. a large CodeSystem still being loaded) are
+still queued, retrying until they have been processed, so that ValueSets are not expanded against
+incomplete CodeSystems.
 
 The expanded data lives in the database and is reused across server restarts.
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/ImportTerminologyStepFinalize.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/base/ImportTerminologyStepFinalize.java
@@ -111,17 +111,21 @@ public class ImportTerminologyStepFinalize<PT extends ImportTerminologyJobParame
 		String codeSystemVersion = jobMetadata.getCodeSystem().getVersion();
 		String stagingVersionId = jobMetadata.getCodeSystemStagingVersionId();
 
-		for (String resourceToActivate : myResourcesToActivate) {
-			updateResourceStatusToActive(theStepExecutionDetails, resourceToActivate);
-		}
-
 		boolean makeCurrent =
 				!Boolean.TRUE.equals(theStepExecutionDetails.getParameters().getDontMakeCurrent());
 
+		/*
+		 * Must precede the ValueSet activation below: that patch starts a pre-expansion job on
+		 * commit, and the job resolves its CodeSystem through the current version.
+		 */
 		if (theStepExecutionDetails.getParameters().getMode() == ImportTerminologyModeEnum.SNAPSHOT) {
 			myTermCodeSystemStorageSvc.activateStagingCodeSystemVersion(codeSystemUrl, stagingVersionId, makeCurrent);
 		} else if (makeCurrent) {
 			myTermCodeSystemStorageSvc.makeCodeSystemCurrent(codeSystemUrl, codeSystemVersion);
+		}
+
+		for (String resourceToActivate : myResourcesToActivate) {
+			updateResourceStatusToActive(theStepExecutionDetails, resourceToActivate);
 		}
 
 		ImportTerminologyResultJson resultJson = new ImportTerminologyResultJson();

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJob.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJob.java
@@ -22,11 +22,14 @@ package ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand;
 import ca.uhn.fhir.batch2.api.IJobDataSink;
 import ca.uhn.fhir.batch2.api.IJobStepWorker;
 import ca.uhn.fhir.batch2.api.JobExecutionFailedException;
+import ca.uhn.fhir.batch2.api.RetryChunkLaterException;
 import ca.uhn.fhir.batch2.api.RunOutcome;
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.api.VoidModel;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.entity.TermValueSetConcept;
+import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
 import ca.uhn.fhir.jpa.term.api.ITermValueSetStorageSvc;
 import ca.uhn.fhir.util.IntCounter;
 import ca.uhn.fhir.util.UrlUtil;
@@ -38,6 +41,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class Step1InitiateJob
@@ -52,8 +57,16 @@ public class Step1InitiateJob
 	 */
 	private static final int MAX_CONCEPTS_PER_COMPOSE = 1_000_000;
 
+	/**
+	 * The delay before the next poll for the deferred terminology storage queue to empty.
+	 */
+	private static final Duration RETRY_DELAY = Duration.of(30, ChronoUnit.SECONDS);
+
 	@Autowired
 	private ITermValueSetStorageSvc myTermValueSetStorageSvc;
+
+	@Autowired
+	private ITermDeferredStorageSvc myDeferredStorageSvc;
 
 	@Autowired
 	private VersionCanonicalizer myVersionCanonicalizer;
@@ -71,6 +84,25 @@ public class Step1InitiateJob
 		PreExpandValueSetParameters parameters = theStepExecutionDetails.getParameters();
 		String url = parameters.getUrl();
 		String version = parameters.getVersion();
+
+		/*
+		 * Expanding while concepts are still queued would resolve the compose rules against a
+		 * partially stored CodeSystem. Process the deferred entities here rather than waiting for the
+		 * scheduled task, which may be suppressed on this node. Must precede startStagingVersion(..),
+		 * which creates a new staging TermValueSet row on every call.
+		 */
+		if (!myDeferredStorageSvc.isStorageQueueEmpty(false)) {
+			myDeferredStorageSvc.saveDeferred();
+
+			if (!myDeferredStorageSvc.isStorageQueueEmpty(false)) {
+				ourLog.info(
+						"Deferred terminology storage is still in progress, delaying pre-expansion of ValueSet[url={}, version={}]",
+						url,
+						version);
+				throw new RetryChunkLaterException(Msg.code(3043), RETRY_DELAY);
+			}
+		}
+
 		String stagingVersion = myTermValueSetStorageSvc.startStagingVersion(url, version);
 
 		UrlUtil.CanonicalUrlParts canonicalUrl = UrlUtil.parseCanonicalUrl(url, version);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJob.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJob.java
@@ -34,6 +34,7 @@ import ca.uhn.fhir.jpa.term.api.ITermValueSetStorageSvc;
 import ca.uhn.fhir.util.IntCounter;
 import ca.uhn.fhir.util.UrlUtil;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -61,6 +62,8 @@ public class Step1InitiateJob
 	 * The delay before the next poll for the deferred terminology storage queue to empty.
 	 */
 	private static final Duration RETRY_DELAY = Duration.of(30, ChronoUnit.SECONDS);
+
+	private static Duration ourRetryDelay;
 
 	@Autowired
 	private ITermValueSetStorageSvc myTermValueSetStorageSvc;
@@ -99,7 +102,7 @@ public class Step1InitiateJob
 						"Deferred terminology storage is still in progress, delaying pre-expansion of ValueSet[url={}, version={}]",
 						url,
 						version);
-				throw new RetryChunkLaterException(Msg.code(3043), RETRY_DELAY);
+				throw new RetryChunkLaterException(Msg.code(3047), getRetryLaterDelay());
 			}
 		}
 
@@ -173,5 +176,23 @@ public class Step1InitiateJob
 		}
 
 		return retVal;
+	}
+
+	private static Duration getRetryLaterDelay() {
+		if (ourRetryDelay != null) {
+			return ourRetryDelay;
+		}
+		return RETRY_DELAY;
+	}
+
+	/**
+	 * Sets the delay before the next poll for the deferred terminology storage queue to empty.
+	 * Do not use this in production code! Only test code.
+	 *
+	 * @param theRetryDelay the delay to use, or {@literal null} to restore the default
+	 */
+	@VisibleForTesting
+	public static void setRetryDelay(Duration theRetryDelay) {
+		ourRetryDelay = theRetryDelay;
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJob.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJob.java
@@ -99,7 +99,7 @@ public class Step1InitiateJob
 
 			if (!myDeferredStorageSvc.isStorageQueueEmpty(false)) {
 				ourLog.info(
-						"Deferred terminology storage is still in progress, delaying pre-expansion of ValueSet[url={}, version={}]",
+						"Deferred terminology storage is not ready, delaying pre-expansion of ValueSet[url={}, version={}]",
 						url,
 						version);
 				throw new RetryChunkLaterException(Msg.code(3047), getRetryLaterDelay());

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermValueSetPreExpansionStatusEnum.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermValueSetPreExpansionStatusEnum.java
@@ -33,13 +33,11 @@ public enum TermValueSetPreExpansionStatusEnum {
 	 */
 
 	NOT_ACTIVE("notActive", "The ValueSet is not active and will not be pre-expanded until it is activated."),
-	NOT_EXPANDED("notExpanded", "The ValueSet is waiting to be picked up and pre-expanded by a scheduled task."),
+	NOT_EXPANDED("notExpanded", "The ValueSet is waiting to be picked up and pre-expanded by a batch job."),
 	EXPANSION_IN_PROGRESS(
-			"expansionInProgress",
-			"The ValueSet has been picked up by a scheduled task and pre-expansion is in progress."),
-	EXPANDED("expanded", "The ValueSet has been picked up by a scheduled task and pre-expansion is complete."),
-	FAILED_TO_EXPAND(
-			"failedToExpand", "The ValueSet has been picked up by a scheduled task and pre-expansion has failed.");
+			"expansionInProgress", "The ValueSet has been picked up by a batch job and pre-expansion is in progress."),
+	EXPANDED("expanded", "The ValueSet has been picked up by a batch job and pre-expansion is complete."),
+	FAILED_TO_EXPAND("failedToExpand", "The ValueSet has been picked up by a batch job and pre-expansion has failed.");
 
 	private static Map<String, TermValueSetPreExpansionStatusEnum> ourValues;
 	private String myCode;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermDeferredStorageSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermDeferredStorageSvcImpl.java
@@ -320,10 +320,13 @@ public class TermDeferredStorageSvcImpl implements ITermDeferredStorageSvc, IHas
 		// Don't include executing jobs here since there's no point in thrashing over and over
 		// in a busy wait while we wait for batch2 job processes to finish
 		while (!isStorageQueueEmpty(false)) {
-			if (myAllowDeferredTasksTimeout) {
-				if (timeoutManager.checkTimeout()) {
-					ourLog.info(toString());
-				}
+			if (isProcessDeferredPaused()) {
+				ourLog.warn("Deferred storage processing is paused - not saving the deferred entities");
+				return;
+			}
+
+			if (myAllowDeferredTasksTimeout && timeoutManager != null) {
+				timeoutManager.checkTimeout();
 			}
 			saveDeferred();
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithHSearchDisabledTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4SearchWithHSearchDisabledTest.java
@@ -242,7 +242,7 @@ public class FhirResourceDaoR4SearchWithHSearchDisabledTest extends BaseJpaTest 
 
 		// Non Pre-Expanded
 		ValueSet outcome = myValueSetDao.expand(vs, new ValueSetExpansionOptions());
-		assertEquals("ValueSet \"ValueSet.url[http://vs]\" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: NOT_EXPANDED | The ValueSet is waiting to be picked up and pre-expanded by a scheduled task.", outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE));
+		assertEquals("ValueSet \"ValueSet.url[http://vs]\" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: NOT_EXPANDED | The ValueSet is waiting to be picked up and pre-expanded by a batch job.", outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE));
 		assertThat(myValueSetTestUtil.toCodes(outcome)).as(myValueSetTestUtil.toCodes(outcome).toString()).containsExactly("code5", "code4", "code3", "code2", "code1");
 
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4ValueSetNoVerCSNoVerTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/provider/r4/ResourceProviderR4ValueSetNoVerCSNoVerTest.java
@@ -1063,7 +1063,7 @@ public class ResourceProviderR4ValueSetNoVerCSNoVerTest extends BaseResourceProv
 			onAllThreads()
 				.selectCount(11)
 		);
-		assertEquals("ValueSet \"ValueSet.url[http://example.com/my_value_set]\" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: NOT_EXPANDED | The ValueSet is waiting to be picked up and pre-expanded by a scheduled task.", expansion.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE));
+		assertEquals("ValueSet \"ValueSet.url[http://example.com/my_value_set]\" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: NOT_EXPANDED | The ValueSet is waiting to be picked up and pre-expanded by a batch job.", expansion.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE));
 
 		// Hierarchical
 		myCaptureQueriesListener.clear();

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TermValueSetPreExpansionLifecycleR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TermValueSetPreExpansionLifecycleR4Test.java
@@ -19,24 +19,41 @@
  */
 package ca.uhn.fhir.jpa.term;
 
+import ca.uhn.fhir.batch2.api.RetryChunkLaterException;
+import ca.uhn.fhir.batch2.model.JobInstance;
+import ca.uhn.fhir.batch2.model.WorkChunkStatusEnum;
+import ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.Step1InitiateJob;
+import ca.uhn.fhir.jpa.entity.Batch2WorkChunkEntity;
 import ca.uhn.fhir.jpa.entity.TermValueSet;
 import ca.uhn.fhir.jpa.entity.TermValueSetPreExpansionStatusEnum;
+import ca.uhn.fhir.jpa.test.Batch2JobHelper;
+import org.awaitility.core.ConditionTimeoutException;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Covers {@link TermValueSet} pre-expansion lifecycle transitions — how {@code expansionStatus},
  * {@code expansionError}, and {@code expansionTimestamp} change across failure/retry, success/breakage,
- * CodeSystem-content invalidation, and ValueSet activate/deactivate. {@link ValueSetExpansionR4Test} covers
- * {@code $expand} content/query behavior instead.
+ * CodeSystem-content invalidation, and ValueSet activate/deactivate, and when a pre-expansion job is
+ * allowed to start at all. {@link ValueSetExpansionR4Test} covers {@code $expand} content/query
+ * behavior instead.
  */
 // Created by claude-sonnet-5
 class TermValueSetPreExpansionLifecycleR4Test extends BaseTermR4Test {
@@ -296,6 +313,136 @@ class TermValueSetPreExpansionLifecycleR4Test extends BaseTermR4Test {
 			assertThat(termValueSet.getExpansionError()).isNull();
 			assertThat(termValueSet.getExpansionTimestamp()).isNotNull();
 		});
+	}
+
+	/**
+	 * Covers https://github.com/hapifhir/hapi-fhir/issues/8321 on the resource storage path, which is
+	 * what a package or IG upload uses. A CodeSystem big enough for its concept storage to be
+	 * deferred, followed by a ValueSet that includes it, must not pre-expand until those deferred
+	 * concepts have been processed, otherwise the expansion is written against a partially stored
+	 * CodeSystem.
+	 * <p>
+	 * Scheduling is disabled in these tests, so nothing processes the deferred concepts except the
+	 * pre-expansion job itself. Processing them before the await would empty the queue first and the
+	 * test would pass with or without the readiness check.
+	 */
+	@Test
+	void preExpansion_onCodeSystemConceptStorageDeferred_expandsAllConcepts() {
+		myStorageSettings.setPreExpandValueSets(true);
+		int conceptCount = myStorageSettings.getDeferIndexingForCodesystemsOfSize() + 50;
+
+		myCodeSystemDao.create(newDeferredCodeSystem(conceptCount), newSrd());
+
+		assertFalse(myTerminologyDeferredStorageSvc.isStorageQueueEmpty(false),
+			"Test setup expects the CodeSystem to be big enough for its storage to be deferred");
+
+		// storing the ValueSet starts the pre-expansion job on commit
+		myValueSetDao.create(newValueSetIncludingWholeCodeSystem(), newSrd());
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
+
+		// the job processes the deferred concepts itself, so this should find nothing left
+		myTerminologyDeferredStorageSvc.saveAllDeferred();
+
+		assertThat(runInTransaction(() -> myTermConceptDao.count())).isEqualTo(conceptCount);
+
+		TermValueSet termValueSet = runInTransaction(() -> myTermValueSetDao.findTermValueSetByUrlAndNullVersion(VS_URL).orElseThrow());
+		assertThat(termValueSet.getTotalConcepts()).isEqualTo(conceptCount);
+	}
+
+	/**
+	 * As above, but with deferred processing paused, so the pre-expansion job cannot drain the queue
+	 * itself and has to fall through to {@link RetryChunkLaterException}. The work chunk must park in
+	 * {@link WorkChunkStatusEnum#POLL_WAITING} with nothing expanded, and the expansion must only be
+	 * written once processing resumes.
+	 *
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">GH-8321</a>
+	 */
+	@Test
+	void preExpansion_onDeferredStorageProcessingPaused_waitsForTheQueueThenExpandsAllConcepts() {
+		myStorageSettings.setPreExpandValueSets(true);
+		int conceptCount = myStorageSettings.getDeferIndexingForCodesystemsOfSize() + 50;
+
+		// keep the poll short enough that this test doesn't run long, but long enough that the chunk is
+		// reliably observed parked between the maintenance passes below
+		Step1InitiateJob.setRetryDelay(Duration.of(1, ChronoUnit.SECONDS));
+		try {
+			myCodeSystemDao.create(newDeferredCodeSystem(conceptCount), newSrd());
+
+			assertFalse(myTerminologyDeferredStorageSvc.isStorageQueueEmpty(false),
+				"Test setup expects the CodeSystem to be big enough for its storage to be deferred");
+
+			// pausing makes the job's own saveDeferred() a no-op, so it has no way to drain the queue
+			myTerminologyDeferredStorageSvc.setProcessDeferred(false);
+
+			// storing the ValueSet starts the pre-expansion job on commit
+			myValueSetDao.create(newValueSetIncludingWholeCodeSystem(), newSrd());
+
+			awaitPollWaitingPreExpansionWorkChunk();
+
+			TermValueSet parkedValueSet = runInTransaction(() -> myTermValueSetDao.findTermValueSetByUrlAndNullVersion(VS_URL).orElseThrow());
+			assertEquals(TermValueSetPreExpansionStatusEnum.NOT_EXPANDED, parkedValueSet.getExpansionStatus());
+			assertThat(parkedValueSet.getTotalConcepts()).isZero();
+
+			myTerminologyDeferredStorageSvc.setProcessDeferred(true);
+			myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
+
+			assertThat(runInTransaction(() -> myTermConceptDao.count())).isEqualTo(conceptCount);
+
+			TermValueSet termValueSet = runInTransaction(() -> myTermValueSetDao.findTermValueSetByUrlAndNullVersion(VS_URL).orElseThrow());
+			assertThat(termValueSet.getTotalConcepts()).isEqualTo(conceptCount);
+		} finally {
+			Step1InitiateJob.setRetryDelay(null);
+			myTerminologyDeferredStorageSvc.setProcessDeferred(true);
+		}
+	}
+
+	/**
+	 * Scheduling is disabled in these tests, so a job only advances when a maintenance pass is forced.
+	 */
+	private void awaitPollWaitingPreExpansionWorkChunk() {
+		try {
+			await().atMost(Batch2JobHelper.DEFAULT_WAIT_DURATION).until(() -> {
+				myBatch2JobHelper.forceRunActiveJobMaintenancePass();
+				return preExpansionWorkChunkStatuses().contains(WorkChunkStatusEnum.POLL_WAITING);
+			});
+		} catch (ConditionTimeoutException e) {
+			fail("No pre-expansion work chunk reached POLL_WAITING. Chunk statuses: " + preExpansionWorkChunkStatuses());
+		}
+	}
+
+	private List<WorkChunkStatusEnum> preExpansionWorkChunkStatuses() {
+		Set<String> instanceIds = myBatch2JobHelper.findJobsByDefinition(JOB_ID_PRE_EXPAND_VALUESET).stream()
+			.map(JobInstance::getInstanceId)
+			.collect(Collectors.toSet());
+
+		return runInTransaction(() -> myWorkChunkRepository.findAll().stream()
+			.filter(chunk -> instanceIds.contains(chunk.getInstanceId()))
+			.map(Batch2WorkChunkEntity::getStatus)
+			.toList());
+	}
+
+	/**
+	 * A hierarchy bigger than the deferred storage threshold. Top-level concepts are always persisted
+	 * as the resource is stored, so only a hierarchy leaves anything on the deferred queue.
+	 */
+	private CodeSystem newDeferredCodeSystem(int theConceptCount) {
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl(CS_URL);
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		CodeSystem.ConceptDefinitionComponent root = cs.addConcept().setCode("root").setDisplay("Root");
+		for (int i = 1; i < theConceptCount; i++) {
+			root.addConcept().setCode("code-" + i).setDisplay("Code " + i);
+		}
+		return cs;
+	}
+
+	private ValueSet newValueSetIncludingWholeCodeSystem() {
+		ValueSet vs = new ValueSet();
+		vs.setUrl(VS_URL);
+		vs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		vs.getCompose().addInclude().setSystem(CS_URL);
+		return vs;
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TermValueSetPreExpansionLifecycleR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TermValueSetPreExpansionLifecycleR4Test.java
@@ -316,15 +316,15 @@ class TermValueSetPreExpansionLifecycleR4Test extends BaseTermR4Test {
 	}
 
 	/**
-	 * Covers https://github.com/hapifhir/hapi-fhir/issues/8321 on the resource storage path, which is
-	 * what a package or IG upload uses. A CodeSystem big enough for its concept storage to be
-	 * deferred, followed by a ValueSet that includes it, must not pre-expand until those deferred
-	 * concepts have been processed, otherwise the expansion is written against a partially stored
-	 * CodeSystem.
+	 * A CodeSystem large enough for its concept storage to be deferred, then a ValueSet that includes
+	 * it: the pre-expansion job has to process the deferred concepts itself before it stages the
+	 * expansion, otherwise the expansion is written against a partially stored CodeSystem. Covers the
+	 * resource storage path rather than the terminology import job.
 	 * <p>
-	 * Scheduling is disabled in these tests, so nothing processes the deferred concepts except the
-	 * pre-expansion job itself. Processing them before the await would empty the queue first and the
-	 * test would pass with or without the readiness check.
+	 * Scheduling is disabled in these tests, so the pre-expansion job is the only thing that can drain
+	 * the deferred queue.
+	 *
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">Issue #8321</a>
 	 */
 	@Test
 	void preExpansion_onCodeSystemConceptStorageDeferred_expandsAllConcepts() {
@@ -340,7 +340,8 @@ class TermValueSetPreExpansionLifecycleR4Test extends BaseTermR4Test {
 		myValueSetDao.create(newValueSetIncludingWholeCodeSystem(), newSrd());
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
 
-		// the job processes the deferred concepts itself, so this should find nothing left
+		// must stay after the await - draining the queue first would leave this passing whether or not
+		// the job waits for the deferred concepts
 		myTerminologyDeferredStorageSvc.saveAllDeferred();
 
 		assertThat(runInTransaction(() -> myTermConceptDao.count())).isEqualTo(conceptCount);
@@ -355,7 +356,7 @@ class TermValueSetPreExpansionLifecycleR4Test extends BaseTermR4Test {
 	 * {@link WorkChunkStatusEnum#POLL_WAITING} with nothing expanded, and the expansion must only be
 	 * written once processing resumes.
 	 *
-	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">GH-8321</a>
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">Issue #8321</a>
 	 */
 	@Test
 	void preExpansion_onDeferredStorageProcessingPaused_waitsForTheQueueThenExpandsAllConcepts() {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.jpa.entity.TermCodeSystem;
 import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.entity.TermValueSet;
+import ca.uhn.fhir.jpa.entity.TermValueSetConcept;
 import ca.uhn.fhir.jpa.entity.TermValueSetPreExpansionStatusEnum;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
 import ca.uhn.fhir.util.JsonUtil;
@@ -21,6 +22,10 @@ import org.springframework.data.domain.PageRequest;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyConstants.LOINC_URI;
 import static ca.uhn.fhir.util.HapiExtensions.EXT_VALUESET_EXPANSION_MESSAGE;
@@ -30,6 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
+
+	private static final String LOINC_IMAGING_DOCUMENT_CODES_VS_URL =
+		"http://loinc.org/vs/loinc-imaging-document-codes";
 
 	@Autowired
 	private TerminologyTestHelper myTerminologyTestHelper;
@@ -235,6 +243,98 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 		outcome = myValueSetDao.expand(new IdType("ValueSet/LL1001-8-2.67"), options, newSrd());
 		String expansionMessage = outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE);
 		assertThat(expansionMessage).contains("using an expansion that was pre-calculated");
+	}
+
+	/**
+	 * Reproduces https://github.com/hapifhir/hapi-fhir/issues/8321 on the terminology upload path.
+	 * <p>
+	 * An import activates the ValueSets it generated before it activates the CodeSystem version it
+	 * staged ({@code ImportTerminologyStepFinalize.run} patches each ValueSet to ACTIVE, which fires
+	 * a pre-expansion job on commit, and only afterwards calls
+	 * {@code activateStagingCodeSystemVersion}). A pre-expansion that runs inside that window cannot
+	 * resolve the CodeSystem version, so it falls back to an in-memory expansion that adds every
+	 * enumerated {@code compose.include.concept} without checking it against the CodeSystem.
+	 * <p>
+	 * The assertion is deliberately an invariant rather than a code count, so it holds for any
+	 * LOINC test dataset: a pre-expansion may only contain codes the import actually stored.
+	 */
+	@Test
+	public void testLoadLoinc_PreExpansionsContainOnlyCodesStoredByTheImport() throws IOException {
+		// first import - nothing is being replaced, so no CodeSystem version deletion is in flight
+		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
+		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion("2.66", files);
+
+		assertPreExpansionsContainOnlyStoredCodes();
+		assertImagingDocumentCodesPreExpansionHasOnlyTheStoredCode();
+
+		// second import - this one replaces the version above, so a version deletion runs alongside it
+		files = new ZipCollectionBuilder(true);
+		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
+		myTerminologyTestHelper.startImportLoincJobAndWaitForCompletion("2.67", files);
+
+		assertPreExpansionsContainOnlyStoredCodes();
+		assertImagingDocumentCodesPreExpansionHasOnlyTheStoredCode();
+	}
+
+	/**
+	 * The imaging document ValueSet enumerates the nine LOINC codes listed in
+	 * {@code AccessoryFiles/ImagingDocuments/ImagingDocumentCodes.csv}, of which only
+	 * {@code 17787-3} is present in {@code LoincTable/Loinc.csv}. A correct pre-expansion therefore
+	 * holds exactly one concept. The unvalidated in-memory fallback would hold all nine, and a
+	 * pre-expansion resolved against a CodeSystem version that has no concepts yet would hold none,
+	 * so this catches the failure in both directions.
+	 * <p>
+	 * Note that rows are not filtered on intendedVersionId. A pre-expanded ValueSet keeps a
+	 * non-null one: {@code TermValueSetStorageSvcImpl.activateStagingVersion} promotes the staging
+	 * row and deletes the row it replaces, but never clears the staging marker.
+	 */
+	private void assertImagingDocumentCodesPreExpansionHasOnlyTheStoredCode() {
+		runInTransaction(() -> {
+			List<TermValueSet> allValueSets = myTermValueSetDao.findAll();
+			String storedValueSets = allValueSets.stream()
+				.map(valueSet -> valueSet.getUrl() + "|" + valueSet.getVersion() + " concepts="
+					+ valueSet.getTotalConcepts() + " status=" + valueSet.getExpansionStatus())
+				.sorted()
+				.collect(Collectors.joining("\n  "));
+
+			List<TermValueSet> valueSets = allValueSets.stream()
+				.filter(valueSet -> LOINC_IMAGING_DOCUMENT_CODES_VS_URL.equals(valueSet.getUrl()))
+				.toList();
+
+			assertThat(valueSets)
+				.as("Expected the import to have generated %s. Stored ValueSets:\n  %s",
+					LOINC_IMAGING_DOCUMENT_CODES_VS_URL, storedValueSets)
+				.isNotEmpty();
+
+			assertThat(valueSets)
+				.allSatisfy(valueSet -> assertThat(valueSet.getTotalConcepts())
+					.as("Pre-expansion of %s|%s", valueSet.getUrl(), valueSet.getVersion())
+					.isEqualTo(1L));
+		});
+	}
+
+	/**
+	 * Fails with the ValueSets that hold LOINC codes absent from every stored CodeSystem version,
+	 * which is what the unvalidated in-memory expansion fallback produces.
+	 */
+	private void assertPreExpansionsContainOnlyStoredCodes() {
+		runInTransaction(() -> {
+			Set<String> storedCodes =
+				myTermConceptDao.findAll().stream().map(TermConcept::getCode).collect(Collectors.toSet());
+
+			Map<String, List<String>> unknownCodesByValueSet = myTermValueSetConceptDao.findAll().stream()
+				.filter(concept -> LOINC_URI.equals(concept.getSystem()))
+				.filter(concept -> !storedCodes.contains(concept.getCode()))
+				.collect(Collectors.groupingBy(
+					concept -> concept.getValueSet().getUrl(),
+					TreeMap::new,
+					Collectors.mapping(TermValueSetConcept::getCode, Collectors.toList())));
+
+			assertThat(unknownCodesByValueSet)
+				.as("Pre-expanded ValueSets must not contain LOINC codes that the import never stored")
+				.isEmpty();
+		});
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologyLoaderSvcLoincJpaTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
+class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 
 	private static final String LOINC_IMAGING_DOCUMENT_CODES_VS_URL =
 		"http://loinc.org/vs/loinc-imaging-document-codes";
@@ -59,7 +59,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void testLoadLoincMultipleVersions() throws IOException {
+	void testLoadLoincMultipleVersions() throws IOException {
 		// Load LOINC marked as version 2.66
 
 		ZipCollectionBuilder files;
@@ -79,12 +79,12 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(16, myResourceTableDao.count());
 			TermCodeSystem myTermCodeSystem = myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org");
 
-			TermCodeSystemVersion myTermCodeSystemVersion_versioned = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
-			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_versioned.getPid());
-			assertEquals(myTermCodeSystem.getResource().getId(), myTermCodeSystemVersion_versioned.getResource().getId());
+			TermCodeSystemVersion versionedTermCodeSystemVersion = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
+			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), versionedTermCodeSystemVersion.getPid());
+			assertEquals(myTermCodeSystem.getResource().getId(), versionedTermCodeSystemVersion.getResource().getId());
 
 			// Make sure we calculated the concept closure
-			TermConcept concept = myTermConceptDao.findByCodeSystemAndCodeList(myTermCodeSystemVersion_versioned.getPid(), List.of(
+			TermConcept concept = myTermConceptDao.findByCodeSystemAndCodeList(versionedTermCodeSystemVersion.getPid(), List.of(
 				"LP52258-8"
 				)).get(0);
 			assertThat(concept.getParentPidsAsString()).matches("[0-9]+ [0-9]+ [0-9]+ [0-9]+");
@@ -122,13 +122,13 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(16 * 2, myResourceTableDao.count());
 			TermCodeSystem myTermCodeSystem = myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org");
 
-			TermCodeSystemVersion myTermCodeSystemVersion_versioned = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
-			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_versioned.getPid());
-			assertNotEquals(myTermCodeSystem.getResource().getId(), myTermCodeSystemVersion_versioned.getResource().getId());
+			TermCodeSystemVersion versionedTermCodeSystem = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
+			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), versionedTermCodeSystem.getPid());
+			assertNotEquals(myTermCodeSystem.getResource().getId(), versionedTermCodeSystem.getResource().getId());
 
-			TermCodeSystemVersion myTermCodeSystemVersion_current = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.67");
-			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_current.getPid());
-			assertEquals(myTermCodeSystem.getResource().getId(), myTermCodeSystemVersion_current.getResource().getId());
+			TermCodeSystemVersion currentTermCodeSystemVersion = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.67");
+			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), currentTermCodeSystemVersion.getPid());
+			assertEquals(myTermCodeSystem.getResource().getId(), currentTermCodeSystemVersion.getResource().getId());
 		});
 
 
@@ -147,17 +147,17 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(16 * 3, myResourceTableDao.count());
 			TermCodeSystem myTermCodeSystem = myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org");
 
-			TermCodeSystemVersion mySecondTermCodeSystemVersion_versioned = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
-			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), mySecondTermCodeSystemVersion_versioned.getPid());
-			assertNotEquals(myTermCodeSystem.getResource().getId(), mySecondTermCodeSystemVersion_versioned.getResource().getId());
+			TermCodeSystemVersion secondVersionedTermCodeSystem = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
+			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), secondVersionedTermCodeSystem.getPid());
+			assertNotEquals(myTermCodeSystem.getResource().getId(), secondVersionedTermCodeSystem.getResource().getId());
 
-			TermCodeSystemVersion myTermCodeSystemVersion_versioned = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.67");
-			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_versioned.getPid());
-			assertNotEquals(myTermCodeSystem.getResource().getId(), myTermCodeSystemVersion_versioned.getResource().getId());
+			TermCodeSystemVersion versionedTermCodeSystemVersion = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.67");
+			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), versionedTermCodeSystemVersion.getPid());
+			assertNotEquals(myTermCodeSystem.getResource().getId(), versionedTermCodeSystemVersion.getResource().getId());
 
-			TermCodeSystemVersion myTermCodeSystemVersion_current = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.68");
-			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_current.getPid());
-			assertEquals(myTermCodeSystem.getResource().getId(), myTermCodeSystemVersion_current.getResource().getId());
+			TermCodeSystemVersion currentTermCodeSystemVersion = myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.68");
+			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), currentTermCodeSystemVersion.getPid());
+			assertEquals(myTermCodeSystem.getResource().getId(), currentTermCodeSystemVersion.getResource().getId());
 		});
 
 		logAllCodeSystemsAndVersionsCodeSystemsAndVersions();
@@ -181,7 +181,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 	}
 
 	@Test
-	public void testLoadLoincVersionNotCurrent() throws IOException {
+	void testLoadLoincVersionNotCurrent() throws IOException {
 		// Load LOINC marked as version 2.66
 		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
@@ -200,20 +200,20 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 			assertEquals(2, myTermCodeSystemVersionDao.count(), TermTestUtil.MSG_ONE_CODE_SYSTEM_VERSION_PER_UPLOAD);
 			TermCodeSystem myTermCodeSystem = myTermCodeSystemDao.findByCodeSystemUri("http://loinc.org");
 
-			TermCodeSystemVersion myTermCodeSystemVersion_new =
+			TermCodeSystemVersion newTermCodeSystemVersion =
 				myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.67");
-			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_new.getPid());
+			assertNotEquals(myTermCodeSystem.getCurrentVersion().getPid(), newTermCodeSystemVersion.getPid());
 
-			TermCodeSystemVersion myTermCodeSystemVersion_old =
+			TermCodeSystemVersion oldTermCodeSystemVersion =
 				myTermCodeSystemVersionDao.findByCodeSystemPidAndVersion(myTermCodeSystem.getPid(), "2.66");
-			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), myTermCodeSystemVersion_old.getPid());
+			assertEquals(myTermCodeSystem.getCurrentVersion().getPid(), oldTermCodeSystemVersion.getPid());
 		});
 
 
 	}
 
 	@Test
-	public void testValueSetExpansion() throws IOException {
+	void testValueSetExpansion() throws IOException {
 		// Load LOINC marked as version 2.67
 
 		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
@@ -246,20 +246,11 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 	}
 
 	/**
-	 * Reproduces https://github.com/hapifhir/hapi-fhir/issues/8321 on the terminology upload path.
-	 * <p>
-	 * An import activates the ValueSets it generated before it activates the CodeSystem version it
-	 * staged ({@code ImportTerminologyStepFinalize.run} patches each ValueSet to ACTIVE, which fires
-	 * a pre-expansion job on commit, and only afterwards calls
-	 * {@code activateStagingCodeSystemVersion}). A pre-expansion that runs inside that window cannot
-	 * resolve the CodeSystem version, so it falls back to an in-memory expansion that adds every
-	 * enumerated {@code compose.include.concept} without checking it against the CodeSystem.
-	 * <p>
-	 * The assertion is deliberately an invariant rather than a code count, so it holds for any
-	 * LOINC test dataset: a pre-expansion may only contain codes the import actually stored.
+	 * Asserts an invariant rather than a code count, so that it holds for any LOINC test dataset: a
+	 * pre-expansion may only contain codes the import actually stored.
 	 */
 	@Test
-	public void testLoadLoinc_PreExpansionsContainOnlyCodesStoredByTheImport() throws IOException {
+	void importLoinc_twoVersions_PreExpansionsContainOnlyCodesStoredByTheImport() throws IOException {
 		// first import - nothing is being replaced, so no CodeSystem version deletion is in flight
 		ZipCollectionBuilder files = new ZipCollectionBuilder(true);
 		TermTestUtil.addLoincMandatoryFilesWithPropertiesFileToZip(files, "v267_loincupload.properties");
@@ -281,9 +272,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 	 * The imaging document ValueSet enumerates the nine LOINC codes listed in
 	 * {@code AccessoryFiles/ImagingDocuments/ImagingDocumentCodes.csv}, of which only
 	 * {@code 17787-3} is present in {@code LoincTable/Loinc.csv}. A correct pre-expansion therefore
-	 * holds exactly one concept. The unvalidated in-memory fallback would hold all nine, and a
-	 * pre-expansion resolved against a CodeSystem version that has no concepts yet would hold none,
-	 * so this catches the failure in both directions.
+	 * holds exactly one concept.
 	 * <p>
 	 * Note that rows are not filtered on intendedVersionId. A pre-expanded ValueSet keeps a
 	 * non-null one: {@code TermValueSetStorageSvcImpl.activateStagingVersion} promotes the staging
@@ -315,8 +304,7 @@ public class TerminologyLoaderSvcLoincJpaTest extends BaseJpaR4Test {
 	}
 
 	/**
-	 * Fails with the ValueSets that hold LOINC codes absent from every stored CodeSystem version,
-	 * which is what the unvalidated in-memory expansion fallback produces.
+	 * Fails with the ValueSets that hold LOINC codes absent from every stored CodeSystem version.
 	 */
 	private void assertPreExpansionsContainOnlyStoredCodes() {
 		runInTransaction(() -> {

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/TerminologySvcImplCurrentVersionR4Test.java
@@ -7,7 +7,6 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
-import ca.uhn.fhir.jpa.test.Batch2JobHelper;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.UriParam;
@@ -35,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_ALL_VALUESET_ID;
 import static org.hl7.fhir.common.hapi.validation.support.ValidationConstants.LOINC_LOW;
@@ -242,7 +240,7 @@ class TerminologySvcImplCurrentVersionR4Test extends BaseJpaR4Test {
 
 
 	/**
-	 * Some ValueSets (IE: AnswerLists), can have a specific version, different than the version of the
+	 * Some ValueSets (IE: AnswerLists), can have a specific version, different from the version of the
 	 * CodeSystem with which they were uploaded. That version is what we distinguish in both sets of tests here,
 	 * no the CodeSystem version.
 	 */

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
@@ -75,7 +75,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.batch2.jobs.reindex.ReindexUtils.JOB_REINDEX;
-import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET;
 import static ca.uhn.fhir.jpa.term.TerminologySvcDeltaR4Test.newDeltaCodeSystem;
 import static ca.uhn.fhir.util.HapiExtensions.EXT_VALUESET_EXPANSION_MESSAGE;
 import static java.util.Objects.requireNonNull;
@@ -2449,55 +2448,6 @@ public class ValueSetExpansionR4Test extends BaseTermR4Test implements IValueSet
 			myStorageSettings.setDeferIndexingForCodesystemsOfSize(deferredIndexingDefault);
 			ReindexUtils.setRetryDelay(null);
 		}
-	}
-
-	/**
-	 * Covers https://github.com/hapifhir/hapi-fhir/issues/8321 on the resource storage path, which is
-	 * what a package or IG upload uses. A CodeSystem big enough for its concept storage to be
-	 * deferred, followed by a ValueSet that includes it, must not pre-expand until those deferred
-	 * concepts have been processed, otherwise the expansion is written against a partially stored
-	 * CodeSystem.
-	 * <p>
-	 * Scheduling is disabled in these tests, so nothing processes the deferred concepts except the
-	 * pre-expansion job itself. Processing them before the await would empty the queue first and the
-	 * test would pass with or without the readiness check.
-	 */
-	@Test
-	void preExpand_CodeSystemConceptStorageDeferred_ExpandsAllConcepts() {
-		// setup - a hierarchy bigger than the deferred storage threshold, so the child concepts
-		// past the threshold are left on the deferred queue by the create below
-		int conceptCount = myStorageSettings.getDeferIndexingForCodesystemsOfSize() + 50;
-
-		CodeSystem cs = new CodeSystem();
-		cs.setUrl(CS_URL);
-		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
-		cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		CodeSystem.ConceptDefinitionComponent root = cs.addConcept().setCode("root").setDisplay("Root");
-		for (int i = 1; i < conceptCount; i++) {
-			root.addConcept().setCode("code-" + i).setDisplay("Code " + i);
-		}
-		myCodeSystemDao.create(cs, newSrd());
-
-		assertFalse(myTerminologyDeferredStorageSvc.isStorageQueueEmpty(false),
-			"Test setup expects the CodeSystem to be big enough for its storage to be deferred");
-
-		ValueSet vs = new ValueSet();
-		vs.setUrl(VS_URL);
-		vs.setStatus(Enumerations.PublicationStatus.ACTIVE);
-		vs.getCompose().addInclude().setSystem(CS_URL);
-
-		// execute - creating the ValueSet starts the pre-expansion job on commit
-		myValueSetDao.create(vs, newSrd());
-		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
-
-		// the job processes the deferred concepts itself, so this should find nothing left
-		myTerminologyDeferredStorageSvc.saveAllDeferred();
-
-		// validate - the CodeSystem is complete in the database
-		assertThat(runInTransaction(() -> myTermConceptDao.count())).isEqualTo(conceptCount);
-
-		TermValueSet termValueSet = runInTransaction(() -> myTermValueSetDao.findTermValueSetByUrlAndNullVersion(VS_URL).orElseThrow());
-		assertThat(termValueSet.getTotalConcepts()).isEqualTo(conceptCount);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
@@ -75,6 +75,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static ca.uhn.fhir.batch2.jobs.reindex.ReindexUtils.JOB_REINDEX;
+import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.JOB_ID_PRE_EXPAND_VALUESET;
 import static ca.uhn.fhir.jpa.term.TerminologySvcDeltaR4Test.newDeltaCodeSystem;
 import static ca.uhn.fhir.util.HapiExtensions.EXT_VALUESET_EXPANSION_MESSAGE;
 import static java.util.Objects.requireNonNull;
@@ -2448,6 +2449,53 @@ public class ValueSetExpansionR4Test extends BaseTermR4Test implements IValueSet
 			myStorageSettings.setDeferIndexingForCodesystemsOfSize(deferredIndexingDefault);
 			ReindexUtils.setRetryDelay(null);
 		}
+	}
+
+	/**
+	 * Reproduces https://github.com/hapifhir/hapi-fhir/issues/8321 on the resource storage path,
+	 * which is what a package or IG upload uses. A CodeSystem big enough for its concept storage to
+	 * be deferred, followed by a ValueSet that includes it, pre-expands against a partially stored
+	 * CodeSystem: storing the ValueSet fires the pre-expansion job on transaction commit, and
+	 * nothing gates that on the deferred terminology storage queue being drained first.
+	 */
+	@Test
+	void preExpand_CodeSystemConceptStorageDeferred_ExpandsAllConcepts() {
+		// setup - a hierarchy bigger than the deferred storage threshold, so the child concepts
+		// past the threshold are left on the deferred queue by the create below
+		int conceptCount = myStorageSettings.getDeferIndexingForCodesystemsOfSize() + 50;
+
+		CodeSystem cs = new CodeSystem();
+		cs.setUrl(CS_URL);
+		cs.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		CodeSystem.ConceptDefinitionComponent root = cs.addConcept().setCode("root").setDisplay("Root");
+		for (int i = 1; i < conceptCount; i++) {
+			root.addConcept().setCode("code-" + i).setDisplay("Code " + i);
+		}
+		myCodeSystemDao.create(cs, newSrd());
+
+		assertFalse(myTerminologyDeferredStorageSvc.isStorageQueueEmpty(false),
+			"Test setup expects the CodeSystem to be big enough for its storage to be deferred");
+
+		ValueSet vs = new ValueSet();
+		vs.setUrl(VS_URL);
+		vs.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		vs.getCompose().addInclude().setSystem(CS_URL);
+
+		// execute - creating the ValueSet starts the pre-expansion job on commit
+		myValueSetDao.create(vs, newSrd());
+		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
+
+		// drain the rest of the deferred queue before asserting, so that a failure below can not be
+		// explained away as the assertion running too early - nothing re-expands the ValueSet, so a
+		// pre-expansion built against the half stored CodeSystem stays wrong once the queue drains
+		myTerminologyDeferredStorageSvc.saveAllDeferred();
+
+		// validate - the CodeSystem is now complete in the database
+		assertThat(runInTransaction(() -> myTermConceptDao.count())).isEqualTo(conceptCount);
+
+		TermValueSet termValueSet = runInTransaction(() -> myTermValueSetDao.findByUrl(VS_URL).orElseThrow());
+		assertThat(termValueSet.getTotalConcepts()).isEqualTo(conceptCount);
 	}
 
 	@Test

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/ValueSetExpansionR4Test.java
@@ -1223,7 +1223,7 @@ public class ValueSetExpansionR4Test extends BaseTermR4Test implements IValueSet
 
 		// Non Pre-Expanded
 		ValueSet outcome = myValueSetDao.expand(vs, new ValueSetExpansionOptions());
-		assertEquals("ValueSet \"ValueSet.url[http://vs]\" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: NOT_EXPANDED | The ValueSet is waiting to be picked up and pre-expanded by a scheduled task.", outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE));
+		assertEquals("ValueSet \"ValueSet.url[http://vs]\" has not yet been pre-expanded. Performing in-memory expansion without parameters. Current status: NOT_EXPANDED | The ValueSet is waiting to be picked up and pre-expanded by a batch job.", outcome.getMeta().getExtensionString(EXT_VALUESET_EXPANSION_MESSAGE));
 		assertThat(myValueSetTestUtil.toCodes(outcome)).as(myValueSetTestUtil.toCodes(outcome).toString()).containsExactly("code5", "code4", "code3", "code2", "code1");
 
 		// Perform pre-expansion
@@ -2452,11 +2452,15 @@ public class ValueSetExpansionR4Test extends BaseTermR4Test implements IValueSet
 	}
 
 	/**
-	 * Reproduces https://github.com/hapifhir/hapi-fhir/issues/8321 on the resource storage path,
-	 * which is what a package or IG upload uses. A CodeSystem big enough for its concept storage to
-	 * be deferred, followed by a ValueSet that includes it, pre-expands against a partially stored
-	 * CodeSystem: storing the ValueSet fires the pre-expansion job on transaction commit, and
-	 * nothing gates that on the deferred terminology storage queue being drained first.
+	 * Covers https://github.com/hapifhir/hapi-fhir/issues/8321 on the resource storage path, which is
+	 * what a package or IG upload uses. A CodeSystem big enough for its concept storage to be
+	 * deferred, followed by a ValueSet that includes it, must not pre-expand until those deferred
+	 * concepts have been processed, otherwise the expansion is written against a partially stored
+	 * CodeSystem.
+	 * <p>
+	 * Scheduling is disabled in these tests, so nothing processes the deferred concepts except the
+	 * pre-expansion job itself. Processing them before the await would empty the queue first and the
+	 * test would pass with or without the readiness check.
 	 */
 	@Test
 	void preExpand_CodeSystemConceptStorageDeferred_ExpandsAllConcepts() {
@@ -2486,15 +2490,13 @@ public class ValueSetExpansionR4Test extends BaseTermR4Test implements IValueSet
 		myValueSetDao.create(vs, newSrd());
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
 
-		// drain the rest of the deferred queue before asserting, so that a failure below can not be
-		// explained away as the assertion running too early - nothing re-expands the ValueSet, so a
-		// pre-expansion built against the half stored CodeSystem stays wrong once the queue drains
+		// the job processes the deferred concepts itself, so this should find nothing left
 		myTerminologyDeferredStorageSvc.saveAllDeferred();
 
-		// validate - the CodeSystem is now complete in the database
+		// validate - the CodeSystem is complete in the database
 		assertThat(runInTransaction(() -> myTermConceptDao.count())).isEqualTo(conceptCount);
 
-		TermValueSet termValueSet = runInTransaction(() -> myTermValueSetDao.findByUrl(VS_URL).orElseThrow());
+		TermValueSet termValueSet = runInTransaction(() -> myTermValueSetDao.findTermValueSetByUrlAndNullVersion(VS_URL).orElseThrow());
 		assertThat(termValueSet.getTotalConcepts()).isEqualTo(conceptCount);
 	}
 

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyJobParameters;
+import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyModeEnum;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyResultJson;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyStepFinalize;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyFileSetJson;
@@ -20,8 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.InOrder;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
+class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(ImportTerminologyStepFinalizeTest.class);
 	@Mock
@@ -61,7 +62,7 @@ public class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 	@Test
 	void testProcess_GenerateReport() {
 		mockFetchJobMetadataAttachment();
-		when(myJobPersistence.calculateStepStatistics(eq("my-instance-id"))).thenReturn(new BatchInstanceStepStatisticsDTO(Map.of(
+		when(myJobPersistence.calculateStepStatistics("my-instance-id")).thenReturn(new BatchInstanceStepStatisticsDTO(Map.of(
 			"import-concepts", new BatchInstanceStepStatisticsDTO.StepStatistics(10, 20),
 			"import-hierarchy", new BatchInstanceStepStatisticsDTO.StepStatistics(20, 30),
 			"import-answer-lists", new BatchInstanceStepStatisticsDTO.StepStatistics(40, 50)
@@ -107,7 +108,7 @@ public class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 		when(myJobPersistence.calculateStepStatistics(any())).thenReturn(new BatchInstanceStepStatisticsDTO(Map.of()));
 		mockFetchJobMetadataAttachment();
 		when(myDaoRegistry.getFhirContext()).thenReturn(FhirContext.forR4Cached());
-		when(myDaoRegistry.getResourceDao(eq("ValueSet"))).thenReturn(myValueSetDao);
+		when(myDaoRegistry.getResourceDao("ValueSet")).thenReturn(myValueSetDao);
 
 		// Test
 		ImportTerminologyJobParameters parameters = new ImportTerminologyJobParameters();
@@ -149,7 +150,7 @@ public class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 		when(myJobPersistence.calculateStepStatistics(any())).thenReturn(new BatchInstanceStepStatisticsDTO(Map.of()));
 		mockFetchJobMetadataAttachment();
 		when(myDaoRegistry.getFhirContext()).thenReturn(FhirContext.forR4Cached());
-		when(myDaoRegistry.getResourceDao(eq("ValueSet"))).thenReturn(myValueSetDao);
+		when(myDaoRegistry.getResourceDao("ValueSet")).thenReturn(myValueSetDao);
 
 		ImportTerminologyJobParameters parameters = new ImportTerminologyJobParameters();
 		TerminologyFileSetJson data = newData();
@@ -166,6 +167,39 @@ public class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 		// Verify
 		InOrder inOrder = inOrder(myTermCodeSystemStorageSvc, myValueSetDao);
 		inOrder.verify(myTermCodeSystemStorageSvc).activateStagingCodeSystemVersion(any(), eq("my-staging-version-id"), eq(true));
+		inOrder.verify(myValueSetDao).patch(any(), isNull(), eq(PatchTypeEnum.FHIR_PATCH_JSON), any(), any(), any());
+	}
+
+	/**
+	 * As above, for a non-SNAPSHOT import, which makes the existing CodeSystem version current
+	 * instead of activating a staged one.
+	 *
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">GH-8321</a>
+	 */
+	@Test
+	void run_addModeWithValueSetsToActivate_makesCodeSystemCurrentBeforeValueSets() {
+		// Setup
+		when(myJobPersistence.calculateStepStatistics(any())).thenReturn(new BatchInstanceStepStatisticsDTO(Map.of()));
+		mockFetchJobMetadataAttachment();
+		when(myDaoRegistry.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+		when(myDaoRegistry.getResourceDao(eq("ValueSet"))).thenReturn(myValueSetDao);
+
+		ImportTerminologyJobParameters parameters = new ImportTerminologyJobParameters();
+		parameters.setMode(ImportTerminologyModeEnum.ADD);
+		TerminologyFileSetJson data = newData();
+		data.addResourceToActivate("ValueSet/A");
+		myStep.consume(new ChunkExecutionDetails<>(data, parameters, "instance-id", "chunk-id"));
+
+		JobDefinition<ImportTerminologyJobParameters> jobDefinition = new ImportLoincJobAppCtx(myDaoRegistry, myTermCodeSystemStorageSvc, myJobPersistence, myTransactionService).importLoincJobDefinition();
+		JobInstance instance = new JobInstance();
+		instance.setInstanceId("my-instance-id");
+
+		// Test
+		myStep.run(new StepExecutionDetails<>(parameters, null, instance, new WorkChunk(), myStepExecutionSvc, jobDefinition, null, null), myDataSink);
+
+		// Verify
+		InOrder inOrder = inOrder(myTermCodeSystemStorageSvc, myValueSetDao);
+		inOrder.verify(myTermCodeSystemStorageSvc).makeCodeSystemCurrent(any(), eq("1.234"));
 		inOrder.verify(myValueSetDao).patch(any(), isNull(), eq(PatchTypeEnum.FHIR_PATCH_JSON), any(), any(), any());
 	}
 

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -130,6 +132,41 @@ public class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 
 		String expectedPatchBody = "{\"resourceType\":\"Parameters\",\"parameter\":[{\"name\":\"operation\",\"part\":[{\"name\":\"type\",\"valueString\":\"replace\"},{\"name\":\"path\",\"valueString\":\"status\"},{\"name\":\"value\",\"valueCode\":\"active\"}]}]}";
 		assertEquals(expectedPatchBody, myPatchBodyCaptor.getAllValues().get(0));
+	}
+
+	/**
+	 * Patching a ValueSet to ACTIVE starts a pre-expansion job as soon as that patch commits, and the
+	 * pre-expansion resolves its CodeSystem through the current version. The imported CodeSystem
+	 * version therefore has to be activated and made current before any ValueSet is activated,
+	 * otherwise the pre-expansion runs against a CodeSystem that has no current version and falls
+	 * back to an unvalidated in-memory expansion.
+	 *
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">GH-8321</a>
+	 */
+	@Test
+	void run_valueSetsToActivate_activatesCodeSystemVersionBeforeValueSets() {
+		// Setup
+		when(myJobPersistence.calculateStepStatistics(any())).thenReturn(new BatchInstanceStepStatisticsDTO(Map.of()));
+		mockFetchJobMetadataAttachment();
+		when(myDaoRegistry.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+		when(myDaoRegistry.getResourceDao(eq("ValueSet"))).thenReturn(myValueSetDao);
+
+		ImportTerminologyJobParameters parameters = new ImportTerminologyJobParameters();
+		TerminologyFileSetJson data = newData();
+		data.addResourceToActivate("ValueSet/A");
+		myStep.consume(new ChunkExecutionDetails<>(data, parameters, "instance-id", "chunk-id"));
+
+		JobDefinition<ImportTerminologyJobParameters> jobDefinition = new ImportLoincJobAppCtx(myDaoRegistry, myTermCodeSystemStorageSvc, myJobPersistence, myTransactionService).importLoincJobDefinition();
+		JobInstance instance = new JobInstance();
+		instance.setInstanceId("my-instance-id");
+
+		// Test
+		myStep.run(new StepExecutionDetails<>(parameters, null, instance, new WorkChunk(), myStepExecutionSvc, jobDefinition, null, null), myDataSink);
+
+		// Verify
+		InOrder inOrder = inOrder(myTermCodeSystemStorageSvc, myValueSetDao);
+		inOrder.verify(myTermCodeSystemStorageSvc).activateStagingCodeSystemVersion(any(), eq("my-staging-version-id"), eq(true));
+		inOrder.verify(myValueSetDao).patch(any(), isNull(), eq(PatchTypeEnum.FHIR_PATCH_JSON), any(), any(), any());
 	}
 
 }

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
@@ -139,7 +139,7 @@ class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 	 * otherwise the pre-expansion runs against a CodeSystem that has no current version and falls
 	 * back to an unvalidated in-memory expansion.
 	 *
-	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">GH-8321</a>
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">Issue #8321</a>
 	 */
 	@Test
 	void run_valueSetsToActivate_activatesCodeSystemVersionBeforeValueSets() {
@@ -171,7 +171,7 @@ class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 	 * As above, for a non-SNAPSHOT import, which makes the existing CodeSystem version current
 	 * instead of activating a staged one.
 	 *
-	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">GH-8321</a>
+	 * @see <a href="https://github.com/hapifhir/hapi-fhir/issues/8321">Issue #8321</a>
 	 */
 	@Test
 	void run_addModeWithValueSetsToActivate_makesCodeSystemCurrentBeforeValueSets() {

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/loinc/ImportTerminologyStepFinalizeTest.java
@@ -14,7 +14,6 @@ import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyModeEnum;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyResultJson;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.ImportTerminologyStepFinalize;
 import ca.uhn.fhir.jpa.batch2.jobs.term.base.TerminologyFileSetJson;
-import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import ca.uhn.fhir.rest.api.PatchTypeEnum;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.Test;
@@ -46,8 +45,6 @@ class ImportTerminologyStepFinalizeTest extends BaseImportLoincStepTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(ImportTerminologyStepFinalizeTest.class);
 	@Mock
 	private IJobStepExecutionServices myStepExecutionSvc;
-	@Mock
-	private ITermCodeSystemStorageSvc myTermCodeSystemStorageSvc;
 	@Mock
 	private IJobDataSink<ImportTerminologyResultJson> myDataSink;
 	@InjectMocks

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJobTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJobTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand;
 
 import ca.uhn.fhir.batch2.api.IJobDataSink;
 import ca.uhn.fhir.batch2.api.IJobStepExecutionServices;
+import ca.uhn.fhir.batch2.api.RetryChunkLaterException;
 import ca.uhn.fhir.batch2.api.StepExecutionDetails;
 import ca.uhn.fhir.batch2.api.VoidModel;
 import ca.uhn.fhir.batch2.model.JobDefinition;
@@ -11,6 +12,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.svc.MockHapiTransactionService;
+import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
 import ca.uhn.fhir.jpa.term.api.ITermValueSetStorageSvc;
 import ca.uhn.fhir.model.api.IModelJson;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
@@ -27,9 +29,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.STEP_ID_EXPAND_CONCEPTS_EXCLUDE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.STEP_ID_EXPAND_CONCEPTS_INCLUDE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.STEP_ID_INITIATE_JOB;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -50,6 +54,8 @@ class Step1InitiateJobTest {
 	VersionCanonicalizer myVersionCanonicalizer = new VersionCanonicalizer(myFhirContext);
 	@Mock
 	private ITermValueSetStorageSvc myValueSetStorageSvc;
+	@Mock
+	private ITermDeferredStorageSvc myDeferredStorageSvc;
 	@Mock
 	private IValidationSupport myValidationSupport;
 	@Mock
@@ -76,6 +82,7 @@ class Step1InitiateJobTest {
 		inputVs.getCompose()
 			.addExclude()
 			.setSystem("http://system-2");
+		when(myDeferredStorageSvc.isStorageQueueEmpty(false)).thenReturn(true);
 		when(myValidationSupport.fetchValueSet(eq("http://foo|1.0"))).thenReturn(inputVs);
 		when(myValueSetStorageSvc.startStagingVersion(eq(THE_VS_URL), eq(THE_VS_VERSION))).thenReturn(THE_STAGING_VERSION);
 
@@ -115,5 +122,49 @@ class Step1InitiateJobTest {
 		verifyNoMoreInteractions(myDataSink);
 	}
 
+	@Test
+	void run_deferredStorageQueueNotEmpty_retriesChunkLaterWithoutStagingAnything() {
+		// Setup
+		when(myDeferredStorageSvc.isStorageQueueEmpty(false)).thenReturn(false);
+
+		PreExpandValueSetParameters params = new PreExpandValueSetParameters();
+		params.setUrl(THE_VS_URL);
+		params.setVersion(THE_VS_VERSION);
+
+		// Test & Verify
+		assertThatThrownBy(() -> mySvc.run(
+			new StepExecutionDetails<>(params, new VoidModel(), new JobInstance(), new WorkChunk(), myJobStepExecutionServices, myJobDefinition, STEP_ID_INITIATE_JOB, STEP_ID_EXPAND_CONCEPTS_INCLUDE),
+			myDataSink))
+			.isInstanceOf(RetryChunkLaterException.class);
+
+		verify(myDeferredStorageSvc).saveDeferred();
+		verify(myValueSetStorageSvc, never()).startStagingVersion(any(), any());
+		verifyNoMoreInteractions(myDataSink);
+	}
+
+	@Test
+	void run_deferredEntitiesProcessedOnDemand_expandsWithoutRetrying() {
+		// Setup - deferred entities on entry, none left once they are processed
+		when(myDeferredStorageSvc.isStorageQueueEmpty(false)).thenReturn(false, true);
+
+		ValueSet inputVs = new ValueSet();
+		inputVs.getCompose()
+			.addInclude()
+			.setSystem("http://system-0");
+		when(myValidationSupport.fetchValueSet(eq("http://foo|1.0"))).thenReturn(inputVs);
+		when(myValueSetStorageSvc.startStagingVersion(eq(THE_VS_URL), eq(THE_VS_VERSION))).thenReturn(THE_STAGING_VERSION);
+
+		PreExpandValueSetParameters params = new PreExpandValueSetParameters();
+		params.setUrl(THE_VS_URL);
+		params.setVersion(THE_VS_VERSION);
+
+		// Test
+		mySvc.run(new StepExecutionDetails<>(params, new VoidModel(), new JobInstance(), new WorkChunk(), myJobStepExecutionServices, myJobDefinition, STEP_ID_INITIATE_JOB, STEP_ID_EXPAND_CONCEPTS_INCLUDE), myDataSink);
+
+		// Verify
+		verify(myDeferredStorageSvc).saveDeferred();
+		verify(myValueSetStorageSvc).startStagingVersion(eq(THE_VS_URL), eq(THE_VS_VERSION));
+		verify(myDataSink).acceptForFutureStep(eq(STEP_ID_EXPAND_CONCEPTS_INCLUDE), any(ExpandConceptsWorkChunkJson.class));
+	}
 
 }

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJobTest.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/batch2/jobs/term/valueset/preexpand/Step1InitiateJobTest.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.batch2.model.JobInstance;
 import ca.uhn.fhir.batch2.model.WorkChunk;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.jpa.dao.tx.IHapiTransactionService;
 import ca.uhn.fhir.jpa.svc.MockHapiTransactionService;
 import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
@@ -17,6 +18,7 @@ import ca.uhn.fhir.jpa.term.api.ITermValueSetStorageSvc;
 import ca.uhn.fhir.model.api.IModelJson;
 import ca.uhn.hapi.converters.canonical.VersionCanonicalizer;
 import org.hl7.fhir.r5.model.ValueSet;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -26,9 +28,13 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.STEP_ID_EXPAND_CONCEPTS_EXCLUDE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.STEP_ID_EXPAND_CONCEPTS_INCLUDE;
 import static ca.uhn.fhir.jpa.batch2.jobs.term.valueset.preexpand.PreExpandValueSetJobAppCtx.STEP_ID_INITIATE_JOB;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +49,7 @@ import static org.mockito.Mockito.when;
 class Step1InitiateJobTest {
 
 	private static final String THE_STAGING_VERSION = "the-staging-version";
+	private static final Duration RETRY_DELAY = Duration.of(3, ChronoUnit.SECONDS);
 	static final String THE_VS_URL = "http://foo";
 	static final String THE_VS_VERSION = "1.0";
 
@@ -68,6 +75,11 @@ class Step1InitiateJobTest {
 	private Step1InitiateJob mySvc;
 	@Captor
 	private ArgumentCaptor<IModelJson> myWorkChunkCaptor;
+
+	@AfterEach
+	void afterResetRetryDelay() {
+		Step1InitiateJob.setRetryDelay(null);
+	}
 
 	@Test
 	void testRun() {
@@ -126,6 +138,7 @@ class Step1InitiateJobTest {
 	void run_deferredStorageQueueNotEmpty_retriesChunkLaterWithoutStagingAnything() {
 		// Setup
 		when(myDeferredStorageSvc.isStorageQueueEmpty(false)).thenReturn(false);
+		Step1InitiateJob.setRetryDelay(RETRY_DELAY);
 
 		PreExpandValueSetParameters params = new PreExpandValueSetParameters();
 		params.setUrl(THE_VS_URL);
@@ -135,7 +148,9 @@ class Step1InitiateJobTest {
 		assertThatThrownBy(() -> mySvc.run(
 			new StepExecutionDetails<>(params, new VoidModel(), new JobInstance(), new WorkChunk(), myJobStepExecutionServices, myJobDefinition, STEP_ID_INITIATE_JOB, STEP_ID_EXPAND_CONCEPTS_INCLUDE),
 			myDataSink))
-			.isInstanceOf(RetryChunkLaterException.class);
+			.isInstanceOfSatisfying(RetryChunkLaterException.class, e ->
+				assertThat(e.getNextPollDuration()).isEqualTo(RETRY_DELAY))
+			.hasMessage(Msg.code(3047));
 
 		verify(myDeferredStorageSvc).saveDeferred();
 		verify(myValueSetStorageSvc, never()).startStagingVersion(any(), any());

--- a/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/main/java/ca/uhn/fhir/jpa/term/TerminologyTestHelper.java
@@ -124,7 +124,6 @@ public class TerminologyTestHelper {
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_VERSION_DELETE_JOB_NAME);
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(TERM_CODE_SYSTEM_DELETE_JOB_NAME);
 
-		// adding a second saveAllDeferred call until https://github.com/hapifhir/hapi-fhir/issues/8321 is fixed
 		myTermDeferredStorageSvc.saveAllDeferred();
 		myBatch2JobHelper.awaitAllJobsOfJobDefinitionIdToComplete(JOB_ID_PRE_EXPAND_VALUESET);
 	}

--- a/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/term/TermDeferredStorageSvcImplTest.java
+++ b/hapi-fhir-jpaserver-test-utilities/src/test/java/ca/uhn/fhir/jpa/term/TermDeferredStorageSvcImplTest.java
@@ -16,26 +16,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static ca.uhn.fhir.batch2.jobs.termcodesystem.TermCodeSystemJobConfig.TERM_CODE_SYSTEM_DELETE_JOB_NAME;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TermDeferredStorageSvcImplTest {
+class TermDeferredStorageSvcImplTest {
 
 	@Mock
 	private PlatformTransactionManager myTxManager;
@@ -53,15 +54,44 @@ public class TermDeferredStorageSvcImplTest {
 	private TermDeferredStorageSvcImpl mySvc;
 
 	@Test
-	public void testSaveDeferredWithExecutionSuspended() {
+	void saveDeferred_processingIsPaused_holdsTheQueuedConceptUntilProcessingResumes() {
+		TermConcept concept = new TermConcept();
+		concept.setCode("CODE_A");
+		TermCodeSystemVersion codeSystemVersion = new TermCodeSystemVersion();
+		codeSystemVersion.setId(1L);
+		concept.setCodeSystemVersion(codeSystemVersion);
+
 		TermDeferredStorageSvcImpl svc = new TermDeferredStorageSvcImpl();
+		svc.setTransactionManagerForUnitTest(myTxManager);
+		svc.setTermConceptDaoSvc(myTermConceptDaoSvc);
+		svc.setCodeSystemVersionDaoForUnitTest(myTermCodeSystemVersionDao);
+		svc.addConceptToStorageQueue(concept);
+
 		svc.setProcessDeferred(false);
 		svc.saveDeferred();
+		verifyNoInteractions(myTermConceptDaoSvc);
+
+		// the queued concept must survive the pause, not be dropped by it
+		when(myTermCodeSystemVersionDao.findById(any())).thenReturn(Optional.of(codeSystemVersion));
+		svc.setProcessDeferred(true);
+		svc.saveDeferred();
+		verify(myTermConceptDaoSvc).saveConcept(same(concept));
+	}
+
+	@Test
+	void saveAllDeferred_processingIsPaused_returnsInsteadOfLoopingForever() {
+		TermDeferredStorageSvcImpl svc = new TermDeferredStorageSvcImpl();
+		svc.setProcessDeferred(false);
+
+		// a paused queue reports itself as non-empty, so the save loop has no exit condition of its own
+		assertFalse(svc.isStorageQueueEmpty(false));
+
+		assertTimeoutPreemptively(Duration.ofSeconds(5), svc::saveAllDeferred);
 	}
 
 
 	@Test
-	public void testStorageNotEmptyWhileJobsExecuting() {
+	void testStorageNotEmptyWhileJobsExecuting() {
 		String jobId = "jobId";
 		JobInstance instance = new JobInstance();
 		instance.setInstanceId(jobId);
@@ -88,7 +118,7 @@ public class TermDeferredStorageSvcImplTest {
 
 
 	@Test
-	public void testSaveDeferred_Concept() {
+	void testSaveDeferred_Concept() {
 		TermConcept concept = new TermConcept();
 		concept.setCode("CODE_A");
 
@@ -111,7 +141,7 @@ public class TermDeferredStorageSvcImplTest {
 	}
 
 	@Test
-	public void testSaveDeferred_Concept_StaleCodeSystemVersion() {
+	void testSaveDeferred_Concept_StaleCodeSystemVersion() {
 		TermConcept concept = new TermConcept();
 		concept.setCode("CODE_A");
 
@@ -135,7 +165,7 @@ public class TermDeferredStorageSvcImplTest {
 	}
 
 	@Test
-	public void testSaveDeferred_Concept_Exception() {
+	void testSaveDeferred_Concept_Exception() {
 		// There is a small
 		TermConcept concept = new TermConcept();
 		concept.setCode("CODE_A");
@@ -162,7 +192,7 @@ public class TermDeferredStorageSvcImplTest {
 	}
 
 	@Test
-	public void testSaveDeferred_ConceptParentChildLink_ConceptsMissing() {
+	void testSaveDeferred_ConceptParentChildLink_ConceptsMissing() {
 		TermConceptParentChildLink conceptLink = new TermConceptParentChildLink();
 		conceptLink.setChild(new TermConcept().setId(111L));
 		conceptLink.setParent(new TermConcept().setId(222L));

--- a/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepExecutorServiceImpl.java
+++ b/hapi-fhir-storage-batch2/src/main/java/ca/uhn/fhir/batch2/coordinator/ReductionStepExecutorServiceImpl.java
@@ -297,10 +297,12 @@ public class ReductionStepExecutorServiceImpl implements IReductionStepExecutorS
 		try {
 			processChunksAndCompleteJob(theJobWorkCursor, step, instance, parameters, reductionStepWorker, response);
 		} catch (Exception ex) {
-			ourLog.error("Job completion failed for Job {}", instance.getInstanceId(), ex);
-
+			String msg = String.format(
+					"Failed to execute reduction step for instance %s: %s", instance.getInstanceId(), ex.getMessage());
+			ourLog.error(msg, ex);
 			executeInTransactionWithSynchronization(() -> {
 				myJobPersistence.updateInstance(instance.getInstanceId(), theInstance -> {
+					theInstance.setErrorMessage(msg);
 					theInstance.setEndTime(new Date());
 					myJobInstanceStatusUpdater.updateInstanceStatus(theInstance, StatusEnum.FAILED);
 					return true;

--- a/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/ReductionStepExecutorServiceImplTest.java
+++ b/hapi-fhir-storage-batch2/src/test/java/ca/uhn/fhir/batch2/coordinator/ReductionStepExecutorServiceImplTest.java
@@ -54,14 +54,13 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ReductionStepExecutorServiceImplTest {
+class ReductionStepExecutorServiceImplTest {
 
 	private final IHapiTransactionService myTransactionService = new NonTransactionalHapiTransactionService();
 	@Mock
@@ -83,7 +82,7 @@ public class ReductionStepExecutorServiceImplTest {
 	private final JobDefinitionRegistry myJobDefinitionRegistry = new JobDefinitionRegistry();
 
 	@BeforeEach
-	public void before() {
+	void before() {
 		mySvc = new ReductionStepExecutorServiceImpl(myJobPersistence, myTransactionService, myJobDefinitionRegistry, myJobStepExecutionServices , myInterceptorService, myWorkChunkHeartbeatService);
 	}
 
@@ -92,7 +91,7 @@ public class ReductionStepExecutorServiceImplTest {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@ParameterizedTest
 	@EnumSource(value = WorkChunkStatusEnum.class, names = { "REDUCTION_READY", "QUEUED", "IN_PROGRESS" })
-	public void doExecution_reductionWithChunkFailed_marksAllFutureChunksAsFailedButPreviousAsSuccess() {
+	void doExecution_reductionWithChunkFailed_marksAllFutureChunksAsFailedButPreviousAsSuccess() {
 		// setup
 		List<String> chunkIds = Arrays.asList("chunk1", "chunk2");
 		List<WorkChunk> chunks = new ArrayList<>();
@@ -107,9 +106,9 @@ public class ReductionStepExecutorServiceImplTest {
 		// when
 		when(workCursor.getCurrentStep()).thenReturn((JobDefinitionStep<TestJobParameters, StepInputData, StepOutputData>) createJobDefinition().getSteps().get(1));
 		when(workCursor.getJobDefinition()).thenReturn(createJobDefinition());
-		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(jobInstance));
-		when(myJobPersistence.markInstanceAsStatusWhenStatusIn(INSTANCE_ID, StatusEnum.FINALIZE, EnumSet.of(StatusEnum.IN_PROGRESS, StatusEnum.ERRORED))).thenReturn(true);
-		when(myJobPersistence.fetchAllWorkChunksForStepStream(eq(INSTANCE_ID), eq(REDUCTION_STEP_ID)))
+		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(jobInstance));
+		when(myJobPersistence.markInstanceAsStatusWhenStatusIn(INSTANCE_ID, StatusEnum.FINALIZE, EnumSet.of(StatusEnum.IN_PROGRESS, ERRORED))).thenReturn(true);
+		when(myJobPersistence.fetchAllWorkChunksForStepStream(INSTANCE_ID, REDUCTION_STEP_ID))
 			.thenReturn(chunks.stream());
 		when(myReductionStepWorker.consume(any(ChunkExecutionDetails.class)))
 			.thenReturn(ChunkOutcome.SUCCESS())
@@ -146,7 +145,7 @@ public class ReductionStepExecutorServiceImplTest {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Test
-	public void doExecution_reductionStepWithValidInput_executesAsExpected() {
+	void doExecution_reductionStepWithValidInput_executesAsExpected() {
 		// setup
 		List<String> chunkIds = Arrays.asList("chunk1", "chunk2");
 		List<WorkChunk> chunks = new ArrayList<>();
@@ -161,9 +160,9 @@ public class ReductionStepExecutorServiceImplTest {
 		// when
 		when(workCursor.getCurrentStep()).thenReturn((JobDefinitionStep<TestJobParameters, StepInputData, StepOutputData>) createJobDefinition().getSteps().get(1));
 		when(workCursor.getJobDefinition()).thenReturn(createJobDefinition());
-		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(jobInstance));
+		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(jobInstance));
 		when(myJobPersistence.markInstanceAsStatusWhenStatusIn(INSTANCE_ID, StatusEnum.FINALIZE, EnumSet.of(IN_PROGRESS, ERRORED))).thenReturn(true);
-		when(myJobPersistence.fetchAllWorkChunksForStepStream(eq(INSTANCE_ID), eq(REDUCTION_STEP_ID)))
+		when(myJobPersistence.fetchAllWorkChunksForStepStream(INSTANCE_ID, REDUCTION_STEP_ID))
 			.thenReturn(chunks.stream());
 		when(myReductionStepWorker.consume(any(ChunkExecutionDetails.class)))
 			.thenReturn(ChunkOutcome.SUCCESS());
@@ -196,9 +195,9 @@ public class ReductionStepExecutorServiceImplTest {
 
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({"unchecked"})
 	@Test
-	public void doExecution_reductionStepWithErrors_returnsFalseAndMarksPreviousChunksFailed() {
+	void doExecution_reductionStepWithErrors_returnsFalseAndMarksPreviousChunksFailed() {
 		// setup
 		List<String> chunkIds = Arrays.asList("chunk1", "chunk2");
 		List<WorkChunk> chunks = new ArrayList<>();
@@ -214,9 +213,9 @@ public class ReductionStepExecutorServiceImplTest {
 		// when
 		when(workCursor.getCurrentStep()).thenReturn((JobDefinitionStep<TestJobParameters, StepInputData, StepOutputData>) createJobDefinition().getSteps().get(1));
 		when(workCursor.getJobDefinition()).thenReturn(createJobDefinition());
-		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.of(jobInstance));
-		when(myJobPersistence.fetchAllWorkChunksForStepStream(eq(INSTANCE_ID), eq(REDUCTION_STEP_ID))).thenReturn(chunks.stream());
-		when(myJobPersistence.markInstanceAsStatusWhenStatusIn(INSTANCE_ID, StatusEnum.FINALIZE, EnumSet.of(StatusEnum.IN_PROGRESS, StatusEnum.ERRORED))).thenReturn(true);
+		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(jobInstance));
+		when(myJobPersistence.fetchAllWorkChunksForStepStream(INSTANCE_ID, REDUCTION_STEP_ID)).thenReturn(chunks.stream());
+		when(myJobPersistence.markInstanceAsStatusWhenStatusIn(INSTANCE_ID, StatusEnum.FINALIZE, EnumSet.of(StatusEnum.IN_PROGRESS, ERRORED))).thenReturn(true);
 		doThrow(new RuntimeException("This is an error")).when(myReductionStepWorker).consume(any(ChunkExecutionDetails.class));
 		when(myReductionStepWorker.newInstance()).thenReturn(myReductionStepWorker);
 
@@ -244,14 +243,60 @@ public class ReductionStepExecutorServiceImplTest {
 			.run(any(), any());
 	}
 
+	@SuppressWarnings({"unchecked"})
 	@Test
-	public void doExecution_reductionStep_NotFound() {
+	void executeReductionStep_reductionWorkerThrows_marksInstanceFailedWithTheErrorMessage() {
+		// setup
+		List<WorkChunk> chunks = new ArrayList<>();
+		WorkChunk chunk = createWorkChunk("chunk1");
+		chunk.setStatus(WorkChunkStatusEnum.REDUCTION_READY);
+		chunks.add(chunk);
+		JobInstance jobInstance = getTestJobInstance();
+		jobInstance.setStatus(StatusEnum.IN_PROGRESS);
+		myJobDefinitionRegistry.addJobDefinitionIfNotRegistered(createJobDefinition());
+
+		// when
+		when(workCursor.getCurrentStep()).thenReturn((JobDefinitionStep<TestJobParameters, StepInputData, StepOutputData>) createJobDefinition().getSteps().get(1));
+		when(workCursor.getJobDefinition()).thenReturn(createJobDefinition());
+		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.of(jobInstance));
+		when(myJobPersistence.markInstanceAsStatusWhenStatusIn(INSTANCE_ID, StatusEnum.FINALIZE, EnumSet.of(IN_PROGRESS, ERRORED))).thenReturn(true);
+		when(myJobPersistence.fetchAllWorkChunksForStepStream(INSTANCE_ID, REDUCTION_STEP_ID))
+			.thenReturn(chunks.stream());
+		when(myReductionStepWorker.consume(any(ChunkExecutionDetails.class)))
+			.thenReturn(ChunkOutcome.SUCCESS());
+		when(myReductionStepWorker.newInstance()).thenReturn(myReductionStepWorker);
+		when(myReductionStepWorker.run(any(StepExecutionDetails.class), any(BaseDataSink.class)))
+			.thenThrow(new RuntimeException("This is an error"));
+
+		// test
+		ReductionStepChunkProcessingResponse result = mySvc.executeReductionStep(INSTANCE_ID, workCursor);
+
+		// verify
+		assertFalse(result.isSuccessful());
+
+		ArgumentCaptor<IJobPersistence.JobInstanceUpdateCallback> callbackCaptor =
+			ArgumentCaptor.forClass(IJobPersistence.JobInstanceUpdateCallback.class);
+		verify(myJobPersistence).updateInstance(eq(INSTANCE_ID), callbackCaptor.capture());
+
+		// the callback carries the failure detail that the job instance is left with
+		JobInstance failedInstance = getTestJobInstance();
+		failedInstance.setJobDefinitionId(JOB_DEFINITION_ID);
+		failedInstance.setJobDefinitionVersion(1);
+		failedInstance.setStatus(StatusEnum.FINALIZE);
+		assertTrue(callbackCaptor.getValue().doUpdate(failedInstance));
+
+		assertEquals(StatusEnum.FAILED, failedInstance.getStatus());
+		assertThat(failedInstance.getErrorMessage()).contains("This is an error");
+	}
+
+	@Test
+	void doExecution_reductionStep_NotFound() {
 		// setup
 
 		// when
 		when(workCursor.getCurrentStep()).thenReturn((JobDefinitionStep<TestJobParameters, StepInputData, StepOutputData>) createJobDefinition().getSteps().get(1));
 		when(workCursor.getJobDefinition()).thenReturn(createJobDefinition());
-		when(myJobPersistence.fetchInstance(eq(INSTANCE_ID))).thenReturn(Optional.empty());
+		when(myJobPersistence.fetchInstance(INSTANCE_ID)).thenReturn(Optional.empty());
 
 		// test
 		ReductionStepChunkProcessingResponse result = mySvc.executeReductionStep(INSTANCE_ID, workCursor);
@@ -260,7 +305,6 @@ public class ReductionStepExecutorServiceImplTest {
 		assertFalse(result.isSuccessful());
 	}
 
-	@SuppressWarnings("unchecked")
 	private JobDefinition<TestJobParameters> createJobDefinition() {
 		return JobDefinition.newBuilder()
 			.setJobDefinitionId(JOB_DEFINITION_ID)


### PR DESCRIPTION
Fixes #8321

A `ValueSet` could be pre-expanded before the `CodeSystem` it references was fully stored, and the partial result was then marked `EXPANDED`. Nothing re-runs it, so `$expand` and `$validate-code` silently omit valid codes. Two independent defects caused this.

## 1. Pre-expansion ran against concepts still on the deferred queue

Storing an active `ValueSet` starts the `PRE_EXPAND_VALUESET` job on commit, with no check that the terminology it needs is stored. Concepts past `deferIndexingForCodesystemsOfSize` (default 100) are still on `TermDeferredStorageSvcImpl`'s in-memory queue at that point, so the expansion is written from whatever is already in the database. The equivalent check used to live in `TermReadSvcImpl.preExpandDeferredValueSetsToTerminologyTables()`, removed by #8127 along with the scheduled task that called it.

**Fix** — `Step1InitiateJob.run()` checks `isStorageQueueEmpty(false)` before staging anything. If concepts are still queued it drains them with `saveDeferred()`; if any remain it throws `RetryChunkLaterException`, parking the work chunk in `POLL_WAITING` until they are stored. The check has to precede `startStagingVersion()`, which inserts a `TermValueSet` staging row on every call.

## 2. Import finalize activated ValueSets before the CodeSystem version

`ImportTerminologyStepFinalize.run()` patched `ValueSet`s to `ACTIVE` — firing the trigger above — and only then made the new `CodeSystem` version current. Pre-expansion therefore resolved the empty placeholder on a first upload, or the previous release on an upgrade. A full LOINC release starts one such job per `ValueSet`, all inside that window.

**Fix** — the activation block moves above the `updateResourceStatusToActive` loop.

## Two defects found while investigating a CI failure

- `TermDeferredStorageSvcImpl.saveAllDeferred()` spun forever while deferred processing was paused. `isStorageQueueEmpty()` reports a paused queue as non-empty — that is how a terminology reindex holds off pre-expansion — and `saveDeferred()` is a no-op in that state, so the loop had no exit condition. It now returns.
- `ReductionStepExecutorServiceImpl` left a job `FAILED` with a blank error message unless the reduction worker threw `ReductionStepFailureException`. Every other exception was logged but never recorded on the instance, so the cause was invisible to the admin API and to tests. The generic catch now records it.

## Tests

- `TermValueSetPreExpansionLifecycleR4Test#preExpansion_onCodeSystemConceptStorageDeferred_expandsAllConcepts` — a `CodeSystem` larger than `deferIndexingForCodesystemsOfSize`, so the queue cannot be empty when the job starts. Fails with `expected 150, was 100` before the fix.
- `TermValueSetPreExpansionLifecycleR4Test#preExpansion_onDeferredStorageProcessingPaused_waitsForTheQueueThenExpandsAllConcepts` — pauses deferred processing so the step cannot drain the queue itself, and asserts the chunk parks in `POLL_WAITING` with the `ValueSet` still `NOT_EXPANDED`, then completes once processing resumes. This is what exercises `RetryChunkLaterException` end to end.
- `ImportTerminologyStepFinalizeTest` — Mockito `InOrder` on the two activation calls, for both SNAPSHOT and ADD modes.
- `Step1InitiateJobTest` — `RetryChunkLaterException` with the configured delay and `Msg.code(3047)` when the queue does not empty, and no call to `startStagingVersion` in that case.
- `TerminologyLoaderSvcLoincJpaTest#importLoinc_twoVersions_PreExpansionsContainOnlyCodesStoredByTheImport` — asserts a pre-expansion holds only codes the import actually stored.
- `TermDeferredStorageSvcImplTest` and `ReductionStepExecutorServiceImplTest` cover the two defects above.

Also updated `server_jpa/valueset_expansion.md` and the `TermValueSetPreExpansionStatusEnum` descriptions, which still described a scheduled task.

## Known limitation, not fixed here

The deferred queue is in-memory and per-node, so the readiness check only describes the node it runs on; a job dispatched elsewhere still sees an empty queue. Not a regression — the check removed by #8127 read the same in-memory queue — and fixing it needs a `MigrationTask` for a load-state column on `TRM_CODESYSTEM_VER`, after which it is a one-line change at the same call site. Tracked in #8354.
