### PR TITLE
Consider a CodeableConcept valid if any coding is in the bound ValueSet

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/support/IValidationSupport.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/support/IValidationSupport.java
@@ -1638,24 +1638,26 @@ public interface IValidationSupport {
 	}
 
 	/**
-	 * When validating a CodeableConcept containing multiple codings, this method can be used to control whether
-	 * the validator requires all codings in the CodeableConcept to be valid in order to consider the
-	 * CodeableConcept valid.
+	 * When validating a CodeableConcept containing multiple codings against a ValueSet binding,
+	 * this setting controls whether all codings need to be members of the ValueSet in order to
+	 * consider the CodeableConcept valid, or whether a single matching coding is sufficient.
 	 * <p>
-	 * See VersionSpecificWorkerContextWrapper#validateCode in hapi-fhir-validation, and the refer to the values below
-	 * for the behaviour associated with each value.
+	 * See WorkerContextValidationSupportAdapter#validateCode in hapi-fhir-validation for the
+	 * behaviour associated with each value:
 	 * </p>
-	 * <p>
-	 *   <ul>
-	 *     <li>If <code>false</code> (default setting) the validation for codings will return a positive result only if
-	 *     ALL codings are valid.</li>
-	 * 	   <li>If <code>true</code> the validation for codings will return a positive result if ANY codings are valid.
-	 * 	   </li>
-	 * 	  </ul>
-	 * </p>
+	 * <ul>
+	 *   <li>If <code>false</code>, the validation returns a positive result only if ALL codings
+	 *   are members of the ValueSet.</li>
+	 *   <li>If <code>true</code> (default setting), the validation returns a positive result if
+	 *   ANY coding is a member of the ValueSet, matching the FHIR specification and the HL7
+	 *   reference validator. Issues about ValueSet membership of the remaining codings are
+	 *   downgraded to warnings, while other findings (such as a code that does not exist in its
+	 *   CodeSystem) keep their severity.</li>
+	 * </ul>
+	 *
 	 * @return true or false depending on the desired coding validation behaviour.
 	 */
 	default boolean isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid() {
-		return false;
+		return true;
 	}
 }

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8345-codeableconcept-validation-any-coding-default.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8345-codeableconcept-validation-any-coding-default.yaml
@@ -1,0 +1,11 @@
+---
+type: change
+issue: 8345
+title: "When validating a CodeableConcept against a ValueSet binding, the concept is now considered
+valid by default if at least one of its codings is a member of the ValueSet, matching the FHIR
+specification and the HL7 reference validator. Previously all codings had to be members. The
+previous behavior can be restored with
+ValidationSupportChain#setCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid(false).
+A coding that is invalid in its CodeSystem is still reported as an error even when another
+coding satisfies the binding.
+Thanks to Patrick Werner (@patrick-werner) for the contribution!"

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChain.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChain.java
@@ -146,7 +146,7 @@ public class ValidationSupportChain implements IValidationSupport {
 
 	private final ThreadPoolExecutor myBackgroundExecutor;
 	private final CacheConfiguration myCacheConfiguration;
-	private boolean myEnabledValidationForCodingsLogicalAnd;
+	private boolean myEnabledValidationForCodingsLogicalAnd = true;
 	private String myName = getClass().getSimpleName();
 	private ValidationSupportChainMetrics myMetrics;
 	private volatile boolean myHaveFetchedAllStructureDefinitions = false;
@@ -284,23 +284,23 @@ public class ValidationSupportChain implements IValidationSupport {
 	}
 
 	/**
-	 * When validating a CodeableConcept containing multiple codings, this method can be used to control whether
-	 * the validator requires all codings in the CodeableConcept to be valid in order to consider the
-	 * CodeableConcept valid.
+	 * When validating a CodeableConcept containing multiple codings against a ValueSet binding,
+	 * this method controls whether the validator requires all codings to be members of the
+	 * ValueSet in order to consider the CodeableConcept valid, or whether a single matching
+	 * coding is sufficient.
 	 * <p>
-	 * See VersionSpecificWorkerContextWrapper#validateCode in hapi-fhir-validation, and the refer to the values below
-	 * for the behaviour associated with each value.
+	 * See WorkerContextValidationSupportAdapter#validateCode in hapi-fhir-validation for the
+	 * behaviour associated with each value:
 	 * </p>
-	 * <p>
-	 *   <ul>
-	 *     <li>If <code>false</code> (default setting) the validation for codings will return a positive result only if
-	 *     ALL codings are valid.</li>
-	 * 	   <li>If <code>true</code> the validation for codings will return a positive result if ANY codings are valid.
-	 * 	   </li>
-	 * 	  </ul>
-	 * </p>
-	 *
-	 * @return true or false depending on the desired coding validation behaviour.
+	 * <ul>
+	 *   <li>If <code>false</code>, the validation returns a positive result only if ALL codings
+	 *   are members of the ValueSet.</li>
+	 *   <li>If <code>true</code> (default setting), the validation returns a positive result if
+	 *   ANY coding is a member of the ValueSet, matching the FHIR specification and the HL7
+	 *   reference validator. Issues about ValueSet membership of the remaining codings are
+	 *   downgraded to warnings, while other findings (such as a code that does not exist in its
+	 *   CodeSystem) keep their severity.</li>
+	 * </ul>
 	 */
 	public ValidationSupportChain setCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid(
 			boolean theEnabledValidationForCodingsLogicalAnd) {

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapter.java
@@ -976,7 +976,24 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 				}
 			} else {
 				if (!validationResultsOk.isEmpty()) {
-					return validationResultsOk.get(0);
+					if (issues.isEmpty()) {
+						return validationResultsOk.get(0);
+					}
+					/* The CodeableConcept is valid because at least one coding is in the ValueSet.
+					ValueSet membership issues of the other codings are downgraded to warnings, but
+					all other findings (such as a code that does not exist in its CodeSystem) keep
+					their severity, matching the behavior of the HL7 reference validator. */
+					ValidationResult retVal = new ValidationResult(validationResultsOk.get(0));
+					for (OperationOutcome.OperationOutcomeIssueComponent issue : issues) {
+						OperationOutcome.OperationOutcomeIssueComponent issueCopy = issue.copy();
+						if (isValueSetMembershipIssue(issueCopy)
+								&& (issueCopy.getSeverity() == OperationOutcome.IssueSeverity.ERROR
+										|| issueCopy.getSeverity() == OperationOutcome.IssueSeverity.FATAL)) {
+							issueCopy.setSeverity(OperationOutcome.IssueSeverity.WARNING);
+						}
+						retVal.getIssues().add(issueCopy);
+					}
+					return retVal;
 				}
 			}
 		}
@@ -1147,6 +1164,13 @@ public class WorkerContextValidationSupportAdapter extends I18nBase implements I
 
 	private static boolean hasInvalidDisplayDetailCode(IValidationSupport.CodeValidationIssue theIssue) {
 		return theIssue.hasIssueDetailCode(INVALID_DISPLAY.getCode());
+	}
+
+	private static boolean isValueSetMembershipIssue(OperationOutcome.OperationOutcomeIssueComponent theIssue) {
+		return theIssue.getDetails()
+						.hasCoding(IValidationSupport.CodeValidationIssueCoding.TX_ISSUE_SYSTEM, "not-in-vs")
+				|| theIssue.getDetails()
+						.hasCoding(IValidationSupport.CodeValidationIssueCoding.TX_ISSUE_SYSTEM, "this-code-not-in-vs");
 	}
 
 	public static ConceptValidationOptions convertConceptValidationOptions(ValidationOptions theOptions) {

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChainTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/support/ValidationSupportChainTest.java
@@ -76,6 +76,16 @@ public class ValidationSupportChainTest extends BaseTest {
 	private IValidationSupport myValidationSupport2;
 
 	@Test
+	public void testCodeableConceptValidationSuccessfulIfNotAllCodingsAreValidDefaultsToTrue() {
+		DefaultProfileValidationSupport ctx = new DefaultProfileValidationSupport(FhirContext.forR4Cached());
+		ValidationSupportChain chain = new ValidationSupportChain(ctx);
+
+		assertTrue(chain.isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid());
+		chain.setCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid(false);
+		assertFalse(chain.isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid());
+	}
+
+	@Test
 	public void testVersionCheck() {
 		DefaultProfileValidationSupport ctx3 = new DefaultProfileValidationSupport(FhirContext.forDstu3Cached());
 		DefaultProfileValidationSupport ctx4 = new DefaultProfileValidationSupport(FhirContext.forR4Cached());

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapterTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/common/hapi/validation/validator/WorkerContextValidationSupportAdapterTest.java
@@ -13,6 +13,7 @@ import ca.uhn.fhir.fhirpath.BaseValidationTestWithInlineMocks;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r5.model.CodeableConcept;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.Resource;
@@ -159,6 +160,98 @@ public class WorkerContextValidationSupportAdapterTest extends BaseValidationTes
 		for(ForkJoinTask<?> f : futures) {
 			f.join();
 		}
+	}
+
+	@Test
+	public void validateCode_codeableConceptAnyCodingValid_downgradesNotInVsIssuesToWarnings() {
+		// setup
+		setupValidation();
+		when(myValidationSupport.isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid()).thenReturn(true);
+
+		String system = "http://codesystems.com/system";
+		ValueSet valueSet = new ValueSet();
+		valueSet.getCompose().addInclude().setSystem(system).addConcept().setCode("code0");
+
+		CodeValidationResult goodResult = new CodeValidationResult().setCode("code0").setCodeSystemName(system);
+		when(myValidationSupport.validateCodeInValueSet(any(), any(), eq(system), eq("code0"), any(), any())).thenReturn(goodResult);
+
+		CodeValidationIssue badIssue = new CodeValidationIssue("Code not in ValueSet", IssueSeverity.ERROR, CodeValidationIssueCode.CODE_INVALID, CodeValidationIssueCoding.NOT_IN_VS);
+		CodeValidationResult badResult = new CodeValidationResult().setMessage("Code not in ValueSet").setSeverity(IssueSeverity.ERROR).addIssue(badIssue);
+		when(myValidationSupport.validateCodeInValueSet(any(), any(), eq(system), eq("otherCode"), any(), any())).thenReturn(badResult);
+
+		CodeableConcept codeableConcept = new CodeableConcept();
+		codeableConcept.addCoding(new Coding(system, "code0", null));
+		codeableConcept.addCoding(new Coding(system, "otherCode", null));
+
+		// execute
+		ValidationResult result = myWorkerContextWrapper.validateCode(new ValidationOptions(), codeableConcept, valueSet);
+
+		// verify
+		assertThat(result.isOk()).isTrue();
+		assertThat(result.getIssues()).hasSize(1);
+		assertThat(result.getIssues().get(0).getSeverity()).isEqualTo(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.WARNING);
+		assertThat(result.getIssues().get(0).getDiagnostics()).isEqualTo("Code not in ValueSet");
+	}
+
+	@Test
+	public void validateCode_codeableConceptAnyCodingValid_keepsCodeSystemIssuesAsErrors() {
+		// setup
+		setupValidation();
+		when(myValidationSupport.isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid()).thenReturn(true);
+
+		String system = "http://codesystems.com/system";
+		ValueSet valueSet = new ValueSet();
+		valueSet.getCompose().addInclude().setSystem(system).addConcept().setCode("code0");
+
+		CodeValidationResult goodResult = new CodeValidationResult().setCode("code0").setCodeSystemName(system);
+		when(myValidationSupport.validateCodeInValueSet(any(), any(), eq(system), eq("code0"), any(), any())).thenReturn(goodResult);
+
+		CodeValidationIssue badIssue = new CodeValidationIssue("Unknown code", IssueSeverity.ERROR, CodeValidationIssueCode.CODE_INVALID, CodeValidationIssueCoding.INVALID_CODE);
+		CodeValidationResult badResult = new CodeValidationResult().setMessage("Unknown code").setSeverity(IssueSeverity.ERROR).addIssue(badIssue);
+		when(myValidationSupport.validateCodeInValueSet(any(), any(), eq(system), eq("badCode"), any(), any())).thenReturn(badResult);
+
+		CodeableConcept codeableConcept = new CodeableConcept();
+		codeableConcept.addCoding(new Coding(system, "code0", null));
+		codeableConcept.addCoding(new Coding(system, "badCode", null));
+
+		// execute
+		ValidationResult result = myWorkerContextWrapper.validateCode(new ValidationOptions(), codeableConcept, valueSet);
+
+		// verify
+		assertThat(result.isOk()).isTrue();
+		assertThat(result.getIssues()).hasSize(1);
+		assertThat(result.getIssues().get(0).getSeverity()).isEqualTo(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+		assertThat(result.getIssues().get(0).getDiagnostics()).isEqualTo("Unknown code");
+	}
+
+	@Test
+	public void validateCode_codeableConceptAllCodingsMustBeValid_invalidCodingFailsConcept() {
+		// setup
+		setupValidation();
+		when(myValidationSupport.isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid()).thenReturn(false);
+
+		String system = "http://codesystems.com/system";
+		ValueSet valueSet = new ValueSet();
+		valueSet.getCompose().addInclude().setSystem(system).addConcept().setCode("code0");
+
+		CodeValidationResult goodResult = new CodeValidationResult().setCode("code0").setCodeSystemName(system);
+		when(myValidationSupport.validateCodeInValueSet(any(), any(), eq(system), eq("code0"), any(), any())).thenReturn(goodResult);
+
+		CodeValidationIssue badIssue = new CodeValidationIssue("Unknown code", IssueSeverity.ERROR, CodeValidationIssueCode.NOT_FOUND, CodeValidationIssueCoding.NOT_FOUND);
+		CodeValidationResult badResult = new CodeValidationResult().setMessage("Unknown code").setSeverity(IssueSeverity.ERROR).addIssue(badIssue);
+		when(myValidationSupport.validateCodeInValueSet(any(), any(), eq(system), eq("badCode"), any(), any())).thenReturn(badResult);
+
+		CodeableConcept codeableConcept = new CodeableConcept();
+		codeableConcept.addCoding(new Coding(system, "code0", null));
+		codeableConcept.addCoding(new Coding(system, "badCode", null));
+
+		// execute
+		ValidationResult result = myWorkerContextWrapper.validateCode(new ValidationOptions(), codeableConcept, valueSet);
+
+		// verify
+		assertThat(result.isOk()).isFalse();
+		assertThat(result.getIssues()).hasSize(1);
+		assertThat(result.getIssues().get(0).getSeverity()).isEqualTo(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
 	}
 
 	@Test

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/FhirInstanceValidatorR4Test.java
@@ -1735,9 +1735,12 @@ public class FhirInstanceValidatorR4Test extends BaseTest {
 		final String encoded = loadResource("patient-with-multiple-comm-langs-en_US-and-en-UNDERSCORE.json");
 
 		final ValidationResult output = myFhirValidator.validateWithResult(encoded);
-		final List<SingleValidationMessage> errors = logResultsAndReturnNonInformationalOnes(output);
+		final List<SingleValidationMessage> errors = logResultsAndReturnErrorOnes(output);
 
-		assertThat(errors).isEmpty();
+		// The concept satisfies the binding through the valid "en" coding, but the invalid
+		// en_US coding still fails against its CodeSystem, matching the reference validator
+		assertThat(errors).hasSize(1);
+		assertThat(errors.get(0).getMessage()).contains("en_US");
 	}
 
 	@Test

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4b/validation/FhirInstanceValidatorR4BTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4b/validation/FhirInstanceValidatorR4BTest.java
@@ -1484,9 +1484,12 @@ public class FhirInstanceValidatorR4BTest extends BaseTest {
 		final String encoded = loadResource("patient-with-multiple-comm-langs-en_US-and-en-UNDERSCORE.json");
 
 		final ValidationResult output = myFhirValidator.validateWithResult(encoded);
-		final List<SingleValidationMessage> errors = logResultsAndReturnNonInformationalOnes(output);
+		final List<SingleValidationMessage> errors = logResultsAndReturnErrorOnes(output);
 
-		assertThat(errors).isEmpty();
+		// The concept satisfies the binding through the valid "en" coding, but the invalid
+		// en_US coding still fails against its CodeSystem, matching the reference validator
+		assertThat(errors).hasSize(1);
+		assertThat(errors.get(0).getMessage()).contains("en_US");
 	}
 
 	@Test


### PR DESCRIPTION
Closes #8345.

Flips the default of `isCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid` from `false` to `true`, so a CodeableConcept validated against a ValueSet binding is accepted when at least one coding is a member — matching the FHIR spec ("one of the Coding values SHALL be from the specified value set") and the HL7 reference validator. The stricter ALL-codings check stays available via `ValidationSupportChain#setCodeableConceptValidationSuccessfulIfNotAllCodingsAreValid(false)`.

With the ANY behavior, issues collected for the codings that did not validate were previously discarded entirely. They are now retained on the successful result: ValueSet-membership findings are downgraded to warnings, while other findings — such as a code that does not exist in its CodeSystem — keep their severity, so an invalid sibling coding still fails validation. This matches the reference validator (verified with validator_cli against tx.fhir.org).

- `IValidationSupport`: interface default flipped, javadoc updated
- `ValidationSupportChain`: field default flipped, javadoc updated
- `WorkerContextValidationSupportAdapter`: non-matching codings' issues retained (membership findings as warnings, everything else with original severity)
- Tests for the new default and both severity behaviors
- Changelog entry (8_14_0)
