### PR TITLE
fix(8350): Prevent stored CodeSystems from shadowing built-in core terminology when allowDatabaseValidationOverride=false

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8350-core-terminology-shadowed-by-database-codesystems.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8350-core-terminology-shadowed-by-database-codesystems.yaml
@@ -1,0 +1,13 @@
+---
+type: fix
+issue: 8350
+title: "Previously, a CodeSystem stored in the JPA server with same canonical URL as a built-in FHIR definition was used for code validation and for
+ValueSet pre-expansion even when JpaStorageSettings#isAllowDatabaseValidationOverride() was false. 
+This meant that if the stored CodeSystem diverges from the built-in (as happens when installing e.g. hl7.fhir.uv.xver-r5.r4 that contains R5 terminology 
+that exist at same core canonical URLs as in R4 (e.g. http://hl7.org/fhir/item-type),
+then instance validation and pre-expanded ValueSets were based on the stored backported R5 CodeSystem rather on the built-in R4 version. 
+This has been fixed such that when allowDatabaseValidationOverride is false (which is the default), the JPA terminology
+service no longer answers for code systems that is part of the core specification namespace (http://hl7.org/fhir/*) of the active FHIR version the server is running (e.g. R4). 
+Terminology stored at other URLs (e.g. LOINC, SNOMED CT, terminology.hl7.org content), 
+or are not defined in the active FHIR context (e.g. the R5 CodeSystem http://hl7.org/fhir/version-algorithmon an R4 server), are unaffected. 
+Fix submitted by Tue Toft Nørgård (@ttnTrifork)"

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/introduction/changelog.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/introduction/changelog.md
@@ -1,4 +1,0 @@
-# Changelog: 2025
-
-<th:block th:insert="~{fragment_changelog.md :: changelog('2025', '')}"/>
-

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermReadSvcImpl.java
@@ -22,6 +22,7 @@ package ca.uhn.fhir.jpa.term;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.support.ConceptValidationOptions;
+import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.context.support.IValidationSupport;
 import ca.uhn.fhir.context.support.LookupCodeRequest;
 import ca.uhn.fhir.context.support.ValidationSupportContext;
@@ -276,9 +277,15 @@ public class TermReadSvcImpl implements ITermReadSvc {
 	@Autowired
 	private MemoryCacheService myMemoryCache;
 
+	private volatile IValidationSupport myBuiltInValidationSupportForProtectionCheck;
+
 	@Override
 	public boolean isCodeSystemSupported(ValidationSupportContext theValidationSupportContext, String theSystem) {
 		if (isBlank(theSystem)) {
+			return false;
+		}
+		if (isProtectedBuiltInCodeSystem(theSystem)) {
+			// Defer to the chain, so the built-in definition is used
 			return false;
 		}
 		TermCodeSystemVersionDetails cs = getCurrentCodeSystemVersion(theSystem);
@@ -886,8 +893,11 @@ public class TermReadSvcImpl implements ITermReadSvc {
 
 			ourLog.debug("Starting {} expansion around CodeSystem: {}", (theAdd ? "inclusion" : "exclusion"), system);
 
-			Optional<TermCodeSystemVersion> termCodeSystemVersion =
-					optionalFindTermCodeSystemVersion(theIncludeOrExclude);
+			Optional<TermCodeSystemVersion> termCodeSystemVersion = isProtectedBuiltInCodeSystem(system)
+					// Protected built-in code systems should be expanded by the in-memory path instead, to ensure the
+					// built-in definitions take precedence over any overriding definitions in the database
+					? Optional.empty()
+					: optionalFindTermCodeSystemVersion(theIncludeOrExclude);
 			if (termCodeSystemVersion.isPresent()) {
 
 				expandValueSetHandleIncludeOrExcludeUsingDatabase(
@@ -2237,10 +2247,11 @@ public class TermReadSvcImpl implements ITermReadSvc {
 		}
 
 		if (isNotBlank(theSystem)
-				&& isCodeSystemNotPresentAndHasNoLocalContent(theValidationSupportContext, theSystem)) {
-			// The included CodeSystem is content=not-present with no local concepts, so fall
-			// through to the next validator in the chain rather than short-circuiting with a
-			// non-null "not found".
+				&& (isCodeSystemNotPresentAndHasNoLocalContent(theValidationSupportContext, theSystem)
+						|| isProtectedBuiltInCodeSystem(theSystem))) {
+			// The included CodeSystem is content=not-present with no local concepts,
+			// or the built-in definition is authoritative for it, so fall through
+			// to the next validator in the chain rather than short-circuiting with a non-null "not found".
 			return null;
 		}
 
@@ -2710,6 +2721,12 @@ public class TermReadSvcImpl implements ITermReadSvc {
 					theValidationSupportContext, theOptions, theValueSetUrl, theCodeSystemUrl, theCode, theDisplay);
 		}
 
+		if (isProtectedBuiltInCodeSystem(theCodeSystemUrl)) {
+			// Fall through to the next validator in the chain, so the code is validated against the built-in definition
+			// rather than the database-stored copy
+			return null;
+		}
+
 		TransactionTemplate txTemplate = new TransactionTemplate(myTransactionManager);
 		txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRED);
 		txTemplate.setReadOnly(true);
@@ -2801,6 +2818,47 @@ public class TermReadSvcImpl implements ITermReadSvc {
 			return false;
 		}
 		return myCodeSystemDao.findByCodeSystemUri(theCodeSystemUrl) != null;
+	}
+
+	/**
+	 * Returns <code>true</code> when the given CodeSystem identifier must not be answered from the
+	 * terminology tables because the built-in default profile definitions are authoritative for it.
+	 * <p>
+	 * The check is deliberately narrow:
+	 * <ul>
+	 *     <li>Only the core specification namespace is protected. Content at other URLs - e.g.
+	 *     <code>terminology.hl7.org</code> (THO, v2, v3), LOINC, SNOMED CT - stored in the terminology
+	 *     tables keeps winning even though the built-in definitions carry partial snapshots of some of
+	 *     it.</li>
+	 *     <li>Only built-in definitions from the current FHIR context are protected.
+	 *     Code systems stored in the database that are not part of the current context
+	 *     (e.g.<code>http://hl7.org/fhir/version-algorithm</code> on an R4 server) will not be considered protected.</li>
+	 *     <li>Setting {@link JpaStorageSettings#setAllowDatabaseValidationOverride(boolean)} to
+	 *     <code>true</code> disables the protection entirely.</li>
+	 * </ul>
+	 * </p>
+	 */
+	private boolean isProtectedBuiltInCodeSystem(String theCodeSystemIdentifier) {
+		if (myStorageSettings.isAllowDatabaseValidationOverride()) {
+			return false;
+		}
+		if (isBlank(theCodeSystemIdentifier)) {
+			return false;
+		}
+		String url = getUrlFromIdentifier(theCodeSystemIdentifier);
+		if (!url.startsWith("http://hl7.org/fhir/")) {
+			return false;
+		}
+		return getDefaultProfileValidationSupport().fetchCodeSystem(url) != null;
+	}
+
+	private IValidationSupport getDefaultProfileValidationSupport() {
+		IValidationSupport retVal = myBuiltInValidationSupportForProtectionCheck;
+		if (retVal == null) {
+			retVal = new DefaultProfileValidationSupport(myContext);
+			myBuiltInValidationSupportForProtectionCheck = retVal;
+		}
+		return retVal;
 	}
 
 	IValidationSupport.CodeValidationResult validateCodeInValueSet(

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
@@ -851,11 +851,11 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 			fail(myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(e.getOperationOutcome()));
 		}
 		myCaptureQueriesListener.logSelectQueriesForCurrentThread();
-		assertEquals(7, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
+		assertEquals(5, myCaptureQueriesListener.getSelectQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getUpdateQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getInsertQueriesForCurrentThread().size());
 		assertEquals(0, myCaptureQueriesListener.getDeleteQueriesForCurrentThread().size());
-		assertEquals(7, myCaptureQueriesListener.countCommits());
+		assertEquals(5, myCaptureQueriesListener.countCommits());
 
 		// Validate again (should rely only on caches)
 		myCaptureQueriesListener.clear();
@@ -4864,17 +4864,17 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 		if (theStoredInRepository) {
 			assertThat(myCaptureQueriesListener).has(
 				onAllThreads()
-					.connectionCount(5)
-					.selectCount(5)
-					.commitCount(5)
+					.connectionCount(3)
+					.selectCount(3)
+					.commitCount(3)
 					.noOtherCounts()
 			);
 		} else {
 			assertThat(myCaptureQueriesListener).has(
 				onAllThreads()
-					.connectionCount(6)
-					.selectCount(6)
-					.commitCount(6)
+					.connectionCount(4)
+					.selectCount(4)
+					.commitCount(4)
 					.noOtherCounts()
 			);
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/RemoteTerminologyServiceJpaR4Test.java
@@ -122,7 +122,7 @@ public class RemoteTerminologyServiceJpaR4Test extends BaseJpaR4Test {
 		assertSuccess(outcome);
 
 		// Verify 1
-		Assertions.assertEquals(2, myCaptureQueriesListener.countGetConnections());
+		Assertions.assertEquals(1, myCaptureQueriesListener.countGetConnections());
 		assertThat(ourValueSetProvider.mySearchParams).asList().containsExactlyInAnyOrder(
 			"http://hl7.org/fhir/ValueSet/administrative-gender", "4.0.1",
 			"http://hl7.org/fhir/ValueSet/administrative-gender","http://hl7.org/fhir/ValueSet/administrative-gender"

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/CoreTerminologyOverrideTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/term/CoreTerminologyOverrideTest.java
@@ -1,0 +1,195 @@
+package ca.uhn.fhir.jpa.term;
+
+import ca.uhn.fhir.context.support.IValidationSupport;
+import ca.uhn.fhir.context.support.ValueSetExpansionOptions;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.entity.TermValueSet;
+import ca.uhn.fhir.jpa.entity.TermValueSetPreExpansionStatusEnum;
+import ca.uhn.fhir.jpa.test.BaseJpaR4Test;
+import ca.uhn.fhir.jpa.validation.JpaValidationSupportChain;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test checking that a CodeSystem stored in the database with a canonical URL that matches a built-in definition
+ * (e.g. {@code http://hl7.org/fhir/item-type}) should not take precedence during instance validation or during ValueSet pre-expansion when {@link JpaStorageSettings#isAllowDatabaseValidationOverride()} is {@code false}.
+ * <p>
+ * These tests assert that the built-in R4 terminology keeps winning when the setting is {@code false} and gives way to the database stored terminology wins when the setting is {@code true}
+ */
+class CoreTerminologyOverrideTest extends BaseJpaR4Test {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(CoreTerminologyOverrideTest.class);
+
+	private static final String CORE_ITEM_TYPE_SYSTEM = "http://hl7.org/fhir/item-type";
+	private static final String MY_ITEM_TYPE_VS = "http://example.org/fhir/ValueSet/my-item-type";
+
+	@Autowired
+	private IValidationSupport myJpaValidationSupportChain;
+
+	@AfterEach
+	public void after() {
+		JpaStorageSettings defaults = new JpaStorageSettings();
+		myStorageSettings.setAllowDatabaseValidationOverride(defaults.isAllowDatabaseValidationOverride());
+		myStorageSettings.setPreExpandValueSets(defaults.isPreExpandValueSets());
+		((JpaValidationSupportChain) myJpaValidationSupportChain).rebuildChainForUnitTest();
+	}
+
+	@Test
+	void instanceValidation_codeSystemAtCoreUrl_doesNotShadowBuiltInDefinitions_whenOverrideDisabled() {
+		// Setup
+		myStorageSettings.setAllowDatabaseValidationOverride(false);
+		createR5ItemTypeBackportCodeSystem();
+		// Make sure no previously cached validation results mask the behavior under test
+		((JpaValidationSupportChain) myJpaValidationSupportChain).rebuildChainForUnitTest();
+
+		Questionnaire questionnaire = new Questionnaire();
+		questionnaire.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		questionnaire.addItem()
+			.setLinkId("1")
+			.setText("Pick one")
+			.setType(Questionnaire.QuestionnaireItemType.CHOICE);
+
+		// Execute
+		OperationOutcome outcome = (OperationOutcome) myQuestionnaireDao
+			.validate(questionnaire, null, null, null, null, null, mySrd)
+			.getOperationOutcome();
+		ourLog.info("Validation outcome:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+
+		// Verify: "choice" is a valid R4 item-type code, so the built-in definition must win over
+		// the R5 backport stored in the database while allowDatabaseValidationOverride=false
+		List<String> errors = outcome.getIssue().stream()
+			.filter(t -> t.getSeverity() == OperationOutcome.IssueSeverity.ERROR || t.getSeverity() == OperationOutcome.IssueSeverity.FATAL)
+			.map(OperationOutcome.OperationOutcomeIssueComponent::getDiagnostics)
+			.collect(Collectors.toList());
+		assertThat(errors).isEmpty();
+	}
+
+	@Test
+	void preExpansion_valueSetIncludingCoreSystem_expandsAgainstBuiltInDefinitions_whenOverrideDisabled() {
+		// Setup
+		myStorageSettings.setAllowDatabaseValidationOverride(false);
+		myStorageSettings.setPreExpandValueSets(true);
+		createR5ItemTypeBackportCodeSystem();
+
+		ValueSet valueSet = new ValueSet();
+		valueSet.setUrl(MY_ITEM_TYPE_VS);
+		valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		valueSet.getCompose().addInclude().setSystem(CORE_ITEM_TYPE_SYSTEM);
+		myValueSetDao.create(valueSet, mySrd);
+		myBatch2JobHelper.awaitNoJobsRunning();
+
+		// Confirm we pre-expanded successfully
+		runInTransaction(() -> {
+			List<TermValueSet> valueSets = myTermValueSetDao.findTermValueSetByUrl(Pageable.unpaged(), MY_ITEM_TYPE_VS);
+			assertEquals(1, valueSets.size());
+			assertEquals(TermValueSetPreExpansionStatusEnum.EXPANDED, valueSets.get(0).getExpansionStatus());
+		});
+
+		// Execute
+		ValueSet expanded = myTermSvc.expandValueSet(new ValueSetExpansionOptions(), valueSet);
+		List<String> codes = expanded.getExpansion().getContains().stream()
+			.map(ValueSet.ValueSetExpansionContainsComponent::getCode)
+			.collect(Collectors.toList());
+		ourLog.info("Expanded ValueSet contains {} codes: {}", codes.size(), codes);
+
+		// Verify: the expansion must reflect the built-in R4 item-type definition (17 codes incl. "choice"), not the override stored in the database (3 codes, no "choice")
+		assertThat(codes).hasSize(17);
+		assertThat(codes).contains("choice");
+	}
+
+	@Test
+	void instanceValidation_codeSystemAtCoreUrl_shadowsBuiltInDefinitions_whenOverrideEnabled() {
+		// Setup
+		myStorageSettings.setAllowDatabaseValidationOverride(true);
+		createR5ItemTypeBackportCodeSystem();
+		// Rebuild so the chain reflects the flipped setting and no cached validation results interfere
+		((JpaValidationSupportChain) myJpaValidationSupportChain).rebuildChainForUnitTest();
+
+		Questionnaire questionnaire = new Questionnaire();
+		questionnaire.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		questionnaire.addItem()
+			.setLinkId("1")
+			.setText("Pick one")
+			.setType(Questionnaire.QuestionnaireItemType.CHOICE);
+
+		// Execute
+		OperationOutcome outcome = (OperationOutcome) myQuestionnaireDao
+			.validate(questionnaire, null, null, null, null, null, mySrd)
+			.getOperationOutcome();
+		ourLog.info("Validation outcome:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(outcome));
+
+		// Verify: with allowDatabaseValidationOverride=true the database-stored R5 backport is authoritative, so "choice" (absent from it) must be rejected
+		List<String> errors = outcome.getIssue().stream()
+			.filter(t -> t.getSeverity() == OperationOutcome.IssueSeverity.ERROR || t.getSeverity() == OperationOutcome.IssueSeverity.FATAL)
+			.map(OperationOutcome.OperationOutcomeIssueComponent::getDiagnostics)
+			.collect(Collectors.toList());
+		assertThat(errors).anySatisfy(t -> assertThat(t).contains("Code is not found in CodeSystem: " + CORE_ITEM_TYPE_SYSTEM));
+	}
+
+	@Test
+	void preExpansion_valueSetIncludingCoreSystem_expandsAgainstDatabaseCodeSystem_whenOverrideEnabled() {
+		// Setup
+		myStorageSettings.setAllowDatabaseValidationOverride(true);
+		myStorageSettings.setPreExpandValueSets(true);
+		((JpaValidationSupportChain) myJpaValidationSupportChain).rebuildChainForUnitTest();
+		createR5ItemTypeBackportCodeSystem();
+
+		ValueSet valueSet = new ValueSet();
+		valueSet.setUrl(MY_ITEM_TYPE_VS);
+		valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		valueSet.getCompose().addInclude().setSystem(CORE_ITEM_TYPE_SYSTEM);
+		myValueSetDao.create(valueSet, mySrd);
+		myBatch2JobHelper.awaitNoJobsRunning();
+
+		// Confirm we pre-expanded successfully
+		runInTransaction(() -> {
+			List<TermValueSet> valueSets = myTermValueSetDao.findTermValueSetByUrl(Pageable.unpaged(), MY_ITEM_TYPE_VS);
+			assertEquals(1, valueSets.size());
+			assertEquals(TermValueSetPreExpansionStatusEnum.EXPANDED, valueSets.get(0).getExpansionStatus());
+		});
+
+		// Execute
+		ValueSet expanded = myTermSvc.expandValueSet(new ValueSetExpansionOptions(), valueSet);
+		List<String> codes = expanded.getExpansion().getContains().stream()
+			.map(ValueSet.ValueSetExpansionContainsComponent::getCode)
+			.collect(Collectors.toList());
+		ourLog.info("Expanded ValueSet contains {} codes: {}", codes.size(), codes);
+
+		// Verify: with allowDatabaseValidationOverride=true the expansion must reflect the database-stored R5 backport (3 codes), not the built-in R4 definition (17 codes)
+		assertThat(codes).containsExactlyInAnyOrder("group", "display", "question");
+	}
+
+	/**
+	 * Mirrors the {@code item-type} CodeSystem shipped by {@code hl7.fhir.uv.xver-r5.r4#0.1.0}: same
+	 * canonical URL as the built-in R4 definition, but with the R5 code set, where {@code choice} no
+	 * longer exists.
+	 */
+	private void createR5ItemTypeBackportCodeSystem() {
+		CodeSystem codeSystem = new CodeSystem();
+		codeSystem.setUrl(CORE_ITEM_TYPE_SYSTEM);
+		codeSystem.setVersion("5.0.0");
+		codeSystem.setName("QuestionnaireItemTypeR5Backport");
+		codeSystem.setStatus(Enumerations.PublicationStatus.ACTIVE);
+		codeSystem.setContent(CodeSystem.CodeSystemContentMode.COMPLETE);
+		codeSystem.addConcept().setCode("group").setDisplay("Group");
+		codeSystem.addConcept().setCode("display").setDisplay("Display");
+		codeSystem.addConcept().setCode("question").setDisplay("Question");
+		myCodeSystemDao.create(codeSystem, mySrd);
+		myTerminologyDeferredStorageSvc.saveAllDeferred();
+	}
+}


### PR DESCRIPTION
Make TermReadSvcImpl respect when JpaStorageSettings#isAllowDatabaseValidationOverride() is `false` - which is the default setting.

This fixes #8350