### PR TITLE
8270 partition conditional url placeholder

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8270-patient-id-partition-conditional-url-placeholder.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8270-patient-id-partition-conditional-url-placeholder.yaml
@@ -1,0 +1,13 @@
+---
+type: fix
+issue: 8270
+title: "In Patient ID partition mode, a transaction entry whose conditional URL (the If-None-Exist
+  of a conditional create, or the URL of a conditional update) referenced another entry's placeholder
+  fullUrl was incorrectly rejected with error HAPI-0539. Placeholder references inside conditional
+  URLs are now resolved before the entries are processed, matching the behaviour outside of Patient
+  ID partition mode. In addition, conditional creates whose If-None-Exist omits the resource type
+  (the form shown by the FHIR specification) are now included in the transaction conditional URL
+  pre-fetch, giving them the same behaviour and query cost as the type-qualified form, and
+  conditional URLs answered from the match URL cache are now recorded in the transaction details so
+  that repeated conditional creates work correctly in Patient ID partition mode when the match URL
+  cache is enabled."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8270-patient-id-partition-conditional-url-placeholder.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8270-patient-id-partition-conditional-url-placeholder.yaml
@@ -1,13 +1,10 @@
 ---
 type: fix
 issue: 8270
-title: "In Patient ID partition mode, a transaction entry whose conditional URL (the If-None-Exist
-  of a conditional create, or the URL of a conditional update) referenced another entry's placeholder
-  fullUrl was incorrectly rejected with error HAPI-0539. Placeholder references inside conditional
-  URLs are now resolved before the entries are processed, matching the behaviour outside of Patient
-  ID partition mode. In addition, conditional creates whose If-None-Exist omits the resource type
-  (the form shown by the FHIR specification) are now included in the transaction conditional URL
-  pre-fetch, giving them the same behaviour and query cost as the type-qualified form, and
-  conditional URLs answered from the match URL cache are now recorded in the transaction details so
-  that repeated conditional creates work correctly in Patient ID partition mode when the match URL
-  cache is enabled."
+title: "In Patient ID partition mode, a transaction entry whose conditional URL (an If-None-Exist
+value or a conditional update URL) referenced another entry's placeholder fullUrl was incorrectly
+rejected with error HAPI-0539. This has been fixed: placeholder references inside conditional URLs
+are now resolved before the entries are processed, matching the behaviour outside of partition
+mode. In addition, conditional creates whose If-None-Exist omits the resource type are now included
+in the transaction pre-fetch optimization, and repeated conditional creates no longer fail in
+Patient ID partition mode when the match URL cache is enabled."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8270-patient-id-partition-conditional-url-placeholder.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8270-patient-id-partition-conditional-url-placeholder.yaml
@@ -1,10 +1,5 @@
 ---
 type: fix
 issue: 8270
-title: "In Patient ID partition mode, a transaction entry whose conditional URL (an If-None-Exist
-value or a conditional update URL) referenced another entry's placeholder fullUrl was incorrectly
-rejected with error HAPI-0539. This has been fixed: placeholder references inside conditional URLs
-are now resolved before the entries are processed, matching the behaviour outside of partition
-mode. In addition, conditional creates whose If-None-Exist omits the resource type are now included
-in the transaction pre-fetch optimization, and repeated conditional creates no longer fail in
-Patient ID partition mode when the match URL cache is enabled."
+title: "In Patient ID partition mode, a transaction entry whose conditional URL referenced another 
+entry's placeholder fullUrl was incorrectly rejected with error HAPI-0539. This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -1112,6 +1112,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 	 * </p>
 	 *
 	 * @param thePartitionId                        The partition ID of the associated resource (can be null)
+	 * @param theTransactionDetails                 The active transaction details, in which cache-answered resolutions are recorded
 	 * @param theResourceType                       The resource type associated with the match URL (ie what resource type should it resolve to)
 	 * @param theRequestUrl                         The actual match URL, which could be as simple as just parameters or could include the resource type too
 	 * @param theShouldPreFetchResourceBody         Should we also fetch the actual resource body, or just figure out the PID associated with it? See the method javadoc above for some context.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -657,12 +657,16 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 							theIdsToPreFetchBodiesFor,
 							theIdsToPreFetchFhirIdsFor,
 							searchParameterMapsToResolve);
-				} else if ("POST".equals(verb) && requestIfNoneExist != null && requestIfNoneExist.contains("?")) {
+				} else if ("POST".equals(verb) && isNotBlank(requestIfNoneExist)) {
+					// If-None-Exist may legally omit the resource type ("identifier=..." or "?identifier=...").
+					// Qualify it so it pre-fetches — and is recorded in the transaction details — under the
+					// same canonical form the write path looks match URLs up by.
+					String ifNoneExist = MatchResourceUrlService.massageForStorage(resourceType, requestIfNoneExist);
 					processConditionalUrlForPreFetching(
 							theRequestPartitionId,
 							resourceType,
 							resource,
-							requestIfNoneExist,
+							ifNoneExist,
 							false,
 							true,
 							theIdsToPreFetchBodiesFor,

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -1111,8 +1111,8 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 	 * a reference in it for example) so it's not really possible to doing anything useful with this.
 	 * </p>
 	 *
-	 * @param thePartitionId                        The partition ID of the associated resource (can be null)
 	 * @param theTransactionDetails                 The active transaction details, in which cache-answered resolutions are recorded
+	 * @param thePartitionId                        The partition ID of the associated resource (can be null)
 	 * @param theResourceType                       The resource type associated with the match URL (ie what resource type should it resolve to)
 	 * @param theRequestUrl                         The actual match URL, which could be as simple as just parameters or could include the resource type too
 	 * @param theShouldPreFetchResourceBody         Should we also fetch the actual resource body, or just figure out the PID associated with it? See the method javadoc above for some context.

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/TransactionProcessor.java
@@ -648,6 +648,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 						associatedResource = resource;
 					}
 					processConditionalUrlForPreFetching(
+							theTransactionDetails,
 							theRequestPartitionId,
 							resourceType,
 							associatedResource,
@@ -663,6 +664,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 					// same canonical form the write path looks match URLs up by.
 					String ifNoneExist = MatchResourceUrlService.massageForStorage(resourceType, requestIfNoneExist);
 					processConditionalUrlForPreFetching(
+							theTransactionDetails,
 							theRequestPartitionId,
 							resourceType,
 							resource,
@@ -684,6 +686,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 						String refResourceType = determineResourceTypeInResourceUrl(myFhirContext, referenceUrl);
 						if (refResourceType != null) {
 							processConditionalUrlForPreFetching(
+									theTransactionDetails,
 									theRequestPartitionId,
 									refResourceType,
 									null,
@@ -1117,6 +1120,7 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 	 * @param theOutputSearchParameterMapsToResolve This will be populated with any {@link SearchParameterMap} instances corresponding to match URLs we need to resolve
 	 */
 	private void processConditionalUrlForPreFetching(
+			TransactionDetails theTransactionDetails,
 			RequestPartitionId thePartitionId,
 			String theResourceType,
 			@Nullable IBaseResource theAssociatedResource,
@@ -1129,6 +1133,10 @@ public class TransactionProcessor extends BaseTransactionProcessor {
 		JpaPid cachedId =
 				myMatchResourceUrlService.processMatchUrlUsingCacheOnly(theResourceType, theRequestUrl, thePartitionId);
 		if (cachedId != null) {
+			// Record the resolution the same way the live pre-fetch would: consumers of the transaction
+			// details' resolved match URLs (the write path's lookup, partition-mode interceptors) must not
+			// see a known-matched URL as never-attempted just because it was answered from the cache.
+			myMatchResourceUrlService.matchUrlResolved(theTransactionDetails, theResourceType, theRequestUrl, cachedId);
 			if (theShouldPreFetchResourceBody) {
 				theOutputIdsToPreFetchBodiesFor.add(cachedId);
 			} else {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlServiceTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -108,6 +109,7 @@ class MatchResourceUrlServiceTest {
 		SearchParameterMap sp = new SearchParameterMap();
 		sp.setLastUpdated(new DateRangeParam().setLowerBound("2024").setUpperBound("2025"));
 
+		when(myCtx.getResourceType(Patient.class)).thenReturn("Patient");
 		when(myDaoRegistry.getResourceDao(Patient.class)).thenReturn(myFhirResourceDao);
 		when(myFhirResourceDao.searchForIds(any(), any(), any())).thenReturn(List.of(cachedPid));
 		when(myMatchUrlSvc.translateMatchUrl(any(), any())).thenReturn(sp);
@@ -118,6 +120,16 @@ class MatchResourceUrlServiceTest {
 		assertNotNull(pid);
 		assertThat(pid.getPartitionId()).isEqualTo(partitionId);
 		assertThat(pid.getId()).isEqualTo(1L);
+	}
+
+	@Test
+	void testMassageForStorage_nullOrBlankResourceType_throws() {
+		assertThatThrownBy(() -> MatchResourceUrlService.massageForStorage(null, "identifier=foo|bar"))
+			.isInstanceOf(NullPointerException.class)
+			.hasMessageContaining("theResourceType");
+		assertThatThrownBy(() -> MatchResourceUrlService.massageForStorage(" ", "identifier=foo|bar"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("theResourceType");
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/TransactionProcessorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/TransactionProcessorTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -365,6 +366,39 @@ public class TransactionProcessorTest {
 		verifyNoMoreInteractions(myRequestPartitionHelperSvc);
 
 		// Only 1 pre-fetch covering all 3 URLs
+		verify(myEntityManager, times(1)).createQuery(anyCriteriaQuery());
+		verify(myCriteriaBuilder, times(1)).equal(any(), myLongCaptor.capture());
+		assertEquals(PATIENT_MATCH_URL_FOO_123_HASH, myLongCaptor.getValue());
+	}
+
+	/**
+	 * The If-None-Exist header may legally omit the resource type — {@code identifier=...}, the form the FHIR
+	 * specification itself shows, or {@code ?identifier=...} — since the type is implied by the entry. A
+	 * type-less conditional create must be pre-fetched exactly like the type-qualified form: the same single
+	 * batched token-hash query.
+	 */
+	// Created by Claude Fable 5
+	@ParameterizedTest
+	@ValueSource(strings = {PATIENT_MATCH_URL_FOO_123, "identifier=http://foo|123", "?identifier=http://foo|123"})
+	public void testPreFetch_ConditionalCreate_typelessIfNoneExistPrefetchedLikeQualified(String theIfNoneExist) {
+		// Setup
+		when(myPartitionSettings.isPartitioningEnabled()).thenReturn(true);
+		when(myRequestPartitionHelperSvc.determineCreatePartitionForRequest(any(), any(), any())).thenReturn(RequestPartitionId.fromPartitionId(100));
+		when(myRequestPartitionHelperSvc.determineReadPartitionForRequestForSearchType(any(), any(), any(), any())).thenReturn(RequestPartitionId.fromPartitionId(100));
+
+		BundleBuilder bb = new BundleBuilder(myFhirContext);
+		bb.addTransactionCreateEntry(new Patient().setActive(true)).conditional(theIfNoneExist);
+		Bundle input = bb.getBundleTyped();
+
+		when(myInMemoryResourceMatcher.canBeEvaluatedInMemory(any())).thenReturn(InMemoryMatchResult.unsupportedFromReason("Foo"));
+
+		mockPreFetchHashCapture();
+		mockPatientDaoCreate();
+
+		// Test
+		myTransactionProcessor.transaction(newSrd(), input, false);
+
+		// Verify
 		verify(myEntityManager, times(1)).createQuery(anyCriteriaQuery());
 		verify(myCriteriaBuilder, times(1)).equal(any(), myLongCaptor.capture());
 		assertEquals(PATIENT_MATCH_URL_FOO_123_HASH, myLongCaptor.getValue());

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirResourceDaoR4QueryCountTest.java
@@ -2839,15 +2839,22 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 	 * for an explanation of why only SINGLE_TOKEN has a small number of SELECTS.
 	 * Others could potentially be optimized in the future so that they have a small number
 	 * of selects too, but this is tricky and may not be worth the effort.
+	 * <p>
+	 * The SINGLE_TOKEN_BARE_URL and SINGLE_TOKEN_LEADING_QMARK modes are the type-less If-None-Exist
+	 * spellings; they must cost exactly the same as the type-qualified SINGLE_TOKEN form.
 	 */
 	@ParameterizedTest
 	@CsvSource({
-		"SINGLE_TOKEN   , false, 1  2  1",
-		"SINGLE_TOKEN   , true,  1  0  0",
-		"MULTIPLE_TOKEN , false, 10 31 30",
-		"MULTIPLE_TOKEN , true,  10 0  0",
-		"STRING         , false, 10 31 30",
-		"STRING         , true,  10 0  0",
+		"SINGLE_TOKEN               , false, 1  2  1",
+		"SINGLE_TOKEN               , true,  1  0  0",
+		"SINGLE_TOKEN_BARE_URL      , false, 1  2  1",
+		"SINGLE_TOKEN_BARE_URL      , true,  1  0  0",
+		"SINGLE_TOKEN_LEADING_QMARK , false, 1  2  1",
+		"SINGLE_TOKEN_LEADING_QMARK , true,  1  0  0",
+		"MULTIPLE_TOKEN             , false, 10 31 30",
+		"MULTIPLE_TOKEN             , true,  10 0  0",
+		"STRING                     , false, 10 31 30",
+		"STRING                     , true,  10 0  0",
 	})
 	public void testTransactionWithMultipleConditionalCreateUrls(String theMatchMode, boolean theMatchUrlCacheEnabled, String theExpectedCounts) {
 		registerNoOpAuthorizationAndConsentInterceptors();
@@ -2870,6 +2877,8 @@ public class FhirResourceDaoR4QueryCountTest extends BaseResourceProviderR4Test 
 
 				String conditionalUrl = switch(theMatchMode) {
 					case "SINGLE_TOKEN" -> "Patient?identifier=http://foo|" + identifier;
+					case "SINGLE_TOKEN_BARE_URL" -> "identifier=http://foo|" + identifier;
+					case "SINGLE_TOKEN_LEADING_QMARK" -> "?identifier=http://foo|" + identifier;
 					case "MULTIPLE_TOKEN" -> "Patient?identifier=http://bar|" + identifier + "&active=true";
 					case "STRING" -> "Patient?name=FAM" + identifier;
 					default -> throw new IllegalStateException("Unexpected value: " + theMatchMode);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
@@ -2167,11 +2167,13 @@ public class FhirSystemDaoR4Test extends BaseJpaR4SystemTest {
 	}
 
 	/**
-	 * A conditional create (POST + If-None-Exist) and a conditional update (PUT) sharing one match URL, with
-	 * nothing pre-existing that matches it. The create runs first and the update's match URL then resolves to
-	 * the resource the create just made. With an identical update body the update no-ops and the transaction
-	 * succeeds against the single created resource; with a differing body, two writes both match the one
-	 * conditional URL and the transaction is rejected.
+	 * A conditional create and an update sharing one match URL, with nothing pre-existing that matches it.
+	 * The create runs first and the update's match URL then resolves to the resource the create just made.
+	 * With an identical update body the update no-ops and the transaction succeeds against the single created
+	 * resource; with a differing body, two writes both match the one conditional URL and the transaction is rejected.
+	 * <p>
+	 * Note that this is technically a bad request per the FHIR spec since the entries should not be depended on each
+	 * other. Pinning down the behavior here.
 	 */
 	// Created by Claude Fable 5
 	@ParameterizedTest

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
@@ -106,6 +106,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.slf4j.LoggerFactory;
@@ -2163,6 +2164,67 @@ public class FhirSystemDaoR4Test extends BaseJpaR4SystemTest {
 			.map(t -> new IdType(t.getResponse().getLocation()).getResourceType())
 			.collect(Collectors.toList());
 		assertThat(responseTypes).as(responseTypes.toString()).containsExactly("Practitioner", "Observation", "Observation");
+	}
+
+	/**
+	 * A conditional create (POST + If-None-Exist) and a conditional update (PUT) sharing one match URL, with
+	 * nothing pre-existing that matches it. The create runs first and the update's match URL then resolves to
+	 * the resource the create just made. With an identical update body the update no-ops and the transaction
+	 * succeeds against the single created resource; with a differing body, two writes both match the one
+	 * conditional URL and the transaction is rejected.
+	 */
+	// Created by Claude Fable 5
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	public void testTransactionWithConditionalCreateAndConditionalUpdateOnSameMatchUrl(boolean theUpdateBodyDiffers) {
+		Bundle request = new Bundle();
+		request.setType(BundleType.TRANSACTION);
+
+		Practitioner p = new Practitioner();
+		p.setId(IdType.newRandomUuid());
+		p.addIdentifier().setSystem("http://foo").setValue("mixed");
+		request.addEntry()
+			.setFullUrl(p.getId())
+			.setResource(p)
+			.getRequest()
+			.setMethod(HTTPVerb.POST)
+			.setUrl("Practitioner/")
+			.setIfNoneExist("Practitioner?identifier=http://foo|mixed");
+
+		Practitioner p2 = new Practitioner();
+		p2.setId(IdType.newRandomUuid());
+		p2.addIdentifier().setSystem("http://foo").setValue("mixed");
+		if (theUpdateBodyDiffers) {
+			p2.setActive(true);
+		}
+		request.addEntry()
+			.setFullUrl(p2.getId())
+			.setResource(p2)
+			.getRequest()
+			.setMethod(HTTPVerb.PUT)
+			.setUrl("Practitioner?identifier=http://foo|mixed");
+
+		if (theUpdateBodyDiffers) {
+			try {
+				mySystemDao.transaction(mySrd, request);
+				fail();
+			} catch (InvalidRequestException e) {
+				assertEquals(
+					Msg.code(542) + "Unable to process Transaction - Request would cause multiple resources to match URL: "
+						+ "\"Practitioner?identifier=http://foo|mixed\". Does transaction request contain duplicates?",
+					e.getMessage());
+			}
+		} else {
+			Bundle response = mySystemDao.transaction(mySrd, request);
+			ourLog.debug("Response:\n{}", myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(response));
+
+			assertEquals(2, response.getEntry().size());
+			assertThat(response.getEntry().get(0).getResponse().getStatus()).startsWith("201");
+			assertThat(response.getEntry().get(1).getResponse().getStatus()).startsWith("200");
+			IdType createdId = new IdType(response.getEntry().get(0).getResponse().getLocation());
+			IdType updatedId = new IdType(response.getEntry().get(1).getResponse().getLocation());
+			assertEquals(createdId.toUnqualifiedVersionless().getValue(), updatedId.toUnqualifiedVersionless().getValue());
+		}
 	}
 
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/dao/r4/FhirSystemDaoR4Test.java
@@ -2178,7 +2178,7 @@ public class FhirSystemDaoR4Test extends BaseJpaR4SystemTest {
 	// Created by Claude Fable 5
 	@ParameterizedTest
 	@ValueSource(booleans = {false, true})
-	public void testTransactionWithConditionalCreateAndConditionalUpdateOnSameMatchUrl(boolean theUpdateBodyDiffers) {
+	public void testTransaction_conditionalCreateAndConditionalUpdateOnSameMatchUrl_succeedsOnlyIfUpdateIsNoOp(boolean theUpdateBodyDiffers) {
 		Bundle request = new Bundle();
 		request.setType(BundleType.TRANSACTION);
 
@@ -2209,7 +2209,7 @@ public class FhirSystemDaoR4Test extends BaseJpaR4SystemTest {
 		if (theUpdateBodyDiffers) {
 			try {
 				mySystemDao.transaction(mySrd, request);
-				fail();
+				fail("Expected the transaction to be rejected because the created resource and the differing update both match the same conditional URL");
 			} catch (InvalidRequestException e) {
 				assertEquals(
 					Msg.code(542) + "Unable to process Transaction - Request would cause multiple resources to match URL: "

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -1731,14 +1731,14 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 		assertEquals(theSplitTransaction ? 27 : 26, myCaptureQueriesListener.countSelectQueries());
 		// this is so high because we limit Hibernate to batches of 30 rows.
 		if (theSplitTransaction) {
-			assertEquals(328, myCaptureQueriesListener.getInsertQueries().size());
+			assertEquals(326, myCaptureQueriesListener.getInsertQueries().size());
 			assertEquals(9379, myCaptureQueriesListener.countInsertQueries());
 			assertEquals(36, myCaptureQueriesListener.getUpdateQueries().size());
 			assertEquals(1016, myCaptureQueriesListener.countUpdateQueries());
 			assertEquals(0, myCaptureQueriesListener.countDeleteQueries());
 			assertEquals(2, myCaptureQueriesListener.countCommits());
 		} else {
-			assertEquals(322, myCaptureQueriesListener.getInsertQueries().size());
+			assertEquals(319, myCaptureQueriesListener.getInsertQueries().size());
 			assertEquals(9379, myCaptureQueriesListener.countInsertQueries());
 			assertEquals(35, myCaptureQueriesListener.getUpdateQueries().size());
 			assertEquals(1016, myCaptureQueriesListener.countUpdateQueries());
@@ -2715,15 +2715,21 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 	}
 
 	/**
-	 * A conditional create and a conditional update sharing one match URL consolidate too (both are rewritten to
-	 * the same conditional PUT), keeping the first entry's outcome. Stock HAPI would not consolidate across verbs;
-	 * in patient-id partition mode both target the same logical patient, so one create is the correct result.
+	 * A conditional create and a conditional update sharing one match URL behave exactly as outside patient id
+	 * partition mode (cf. {@code FhirSystemDaoR4Test#testTransactionWithConditionalCreateAndConditionalUpdateOnSameMatchUrl}):
+	 * the create runs first, the update's match URL resolves to the patient the create just made. An identical
+	 * update body no-ops against it and the transaction succeeds; a differing body means two writes match the
+	 * one conditional URL, and the transaction is rejected with nothing persisted.
 	 */
-	@Test
-	void testTransaction_mixedDuplicateConditionalWritesInBundle_dedup() {
+	// Created by Claude Fable 5
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void testTransaction_mixedConditionalCreateAndUpdateOnSameMatchUrl_behavesLikeUnpartitionedMode(
+			boolean theUpdateBodyDiffers) {
 		myStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);
 		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
 
+		String updateBodyExtra = theUpdateBodyDiffers ? "\"active\" : true," : "";
 		String bundle =
 				"""
 				{ "resourceType" : "Bundle", "type" : "transaction",
@@ -2737,21 +2743,37 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 						}, {
 							"resource" : {
 								"resourceType" : "Patient",
+								%s
 								"identifier" : [ { "system" : "old-sys", "value" : "dup-mixed"} ]
 							},
 							"request" : { "method" : "PUT", "url" : "Patient?identifier=old-sys|dup-mixed"}
 						}
 					]
 				}
-				""";
+				"""
+						.formatted(updateBodyExtra);
 
 		Bundle requestBundle = myFhirContext.newJsonParser().parseResource(Bundle.class, bundle);
-		Bundle resultBundle = mySystemDao.transaction(mySrd, requestBundle);
 
-		assertReferenceScenario(
-				resultBundle,
-				List.of(inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH)));
-		assertPatientCountInDatabase(1);
+		if (theUpdateBodyDiffers) {
+			assertThatThrownBy(() -> mySystemDao.transaction(mySrd, requestBundle))
+					.isInstanceOf(InvalidRequestException.class)
+					.hasMessage("HAPI-0542: Unable to process Transaction - Request would cause multiple resources to "
+							+ "match URL: \"Patient?identifier=old-sys|dup-mixed\". Does transaction request contain duplicates?");
+			assertPatientCountInDatabase(0);
+		} else {
+			Bundle resultBundle = mySystemDao.transaction(mySrd, requestBundle);
+
+			assertReferenceScenario(
+					resultBundle,
+					List.of(
+							inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+							inSamePartitionAsEntry(
+									"Patient",
+									StorageResponseCodeEnum.SUCCESSFUL_UPDATE_WITH_CONDITIONAL_MATCH_NO_CHANGE,
+									0)));
+			assertPatientCountInDatabase(1);
+		}
 	}
 
 	/**

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -2818,6 +2818,72 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 	}
 
 	/**
+	 * With the match URL cache enabled, a repeat of a conditional-create bundle must still no-op to the patient
+	 * the first run created: the pre-fetch cache-hit shortcut must record its resolution where the partition
+	 * AFTER_PREFETCH hook's match reads it, which otherwise treats the known-matched URL as unresolved, mints a fresh
+	 * id, and gets rejected at write time.
+	 */
+	// Created by Claude Fable 5
+	@Test
+	void testTransaction_conditionalCreateRepeatedWithMatchUrlCacheEnabled_noOpsToExistingPatient() {
+		myStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+		myStorageSettings.setMatchUrlCacheEnabled(true);
+
+		String bundle =
+				"""
+				{ "resourceType" : "Bundle", "type" : "transaction",
+					"entry" : [
+						{
+							"fullUrl" : "urn:uuid:c4c4e0f1-0000-0000-0000-000000000c4c",
+							"resource" : {
+								"resourceType" : "Patient",
+								"identifier" : [ { "system" : "old-sys", "value" : "cachedCondCreate"} ]
+							},
+							"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|cachedCondCreate"}
+						}, {
+							"resource" : {
+								"resourceType" : "Observation",
+								"identifier" : [ { "system" : "observation-system", "value" : "obsWithUrnRef"} ],
+								"subject" : { "reference" : "urn:uuid:c4c4e0f1-0000-0000-0000-000000000c4c" }
+							},
+							"request" : { "method" : "POST", "url" : "Observation"}
+						}
+					]
+				}
+				""";
+
+		Bundle firstResponse = mySystemDao.transaction(
+				mySrd, myFhirContext.newJsonParser().parseResource(Bundle.class, bundle));
+		assertReferenceScenario(
+				firstResponse,
+				List.of(
+						inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+						inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, 0)));
+
+		// The commit of the first transaction has populated the match URL cache; the repeat must NOP to the
+		// same patient rather than minting a new id for a URL the cache already knows is matched.
+		Bundle secondResponse = mySystemDao.transaction(
+				mySrd, myFhirContext.newJsonParser().parseResource(Bundle.class, bundle));
+		assertReferenceScenario(
+				secondResponse,
+				List.of(
+						inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH),
+						inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, 0)));
+
+		String firstPatientId = new IdType(
+						firstResponse.getEntry().get(0).getResponse().getLocation())
+				.toUnqualifiedVersionless()
+				.getValue();
+		String secondPatientId = new IdType(
+						secondResponse.getEntry().get(0).getResponse().getLocation())
+				.toUnqualifiedVersionless()
+				.getValue();
+		assertEquals(firstPatientId, secondPatientId);
+		assertPatientCountInDatabase(1);
+	}
+
+	/**
 	 * The concurrency-guard row must also be written for a conditional create whose ifNoneExist embeds another
 	 * entry's placeholder fullUrl: once the placeholder resolves, the substituted URL — not the raw
 	 * urn form — is what the guard row must record, since that is the URL a concurrent transaction would

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -2716,7 +2716,7 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 
 	/**
 	 * A conditional create and a conditional update sharing one match URL behave exactly as outside patient id
-	 * partition mode (cf. {@code FhirSystemDaoR4Test#testTransactionWithConditionalCreateAndConditionalUpdateOnSameMatchUrl}):
+	 * partition mode (cf. {@code FhirSystemDaoR4Test#testTransaction_conditionalCreateAndConditionalUpdateOnSameMatchUrl_succeedsOnlyIfUpdateIsNoOp}):
 	 * the create runs first, the update's match URL resolves to the patient the create just made. An identical
 	 * update body no-ops against it and the transaction succeeds; a differing body means two writes match the
 	 * one conditional URL, and the transaction is rejected with nothing persisted.

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptorR4Test.java
@@ -2795,6 +2795,70 @@ public class PatientIdPartitionInterceptorR4Test extends BaseResourceProviderR4T
 				.containsExactly("Patient?identifier=old-sys%7Crace-guard");
 	}
 
+	/**
+	 * The concurrency-guard row must also be written for a conditional create whose ifNoneExist embeds another
+	 * entry's placeholder fullUrl: once the placeholder resolves, the substituted URL — not the raw
+	 * urn form — is what the guard row must record, since that is the URL a concurrent transaction would
+	 * collide on.
+	 */
+	// Created by Claude Fable 5
+	@Test
+	void testTransaction_conditionalCreateWithPlaceholderInIfNoneExist_leavesSearchUrlRowForSubstitutedUrl() {
+		myStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);
+		myStorageSettings.setAutoCreatePlaceholderReferenceTargets(true);
+
+		String bundle =
+				"""
+				{ "resourceType" : "Bundle", "type" : "transaction",
+					"entry" : [
+						{
+							"fullUrl" : "urn:uuid:b7c10c0c-0000-0000-0000-000000000c0c",
+							"resource" : {
+								"resourceType" : "Patient",
+								"identifier" : [ { "system" : "old-sys", "value" : "race-guard-urn"} ]
+							},
+							"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|race-guard-urn"}
+						}, {
+							"resource" : {
+								"resourceType" : "Observation",
+								"identifier" : [ { "system" : "observation-system", "value" : "race-guard-obs"} ],
+								"subject" : { "reference" : "urn:uuid:b7c10c0c-0000-0000-0000-000000000c0c" }
+							},
+							"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|race-guard-obs&subject=urn:uuid:b7c10c0c-0000-0000-0000-000000000c0c"}
+						}
+					]
+				}
+				""";
+
+		Bundle requestBundle = myFhirContext.newJsonParser().parseResource(Bundle.class, bundle);
+		Bundle resultBundle = mySystemDao.transaction(mySrd, requestBundle);
+
+		assertReferenceScenario(
+				resultBundle,
+				List.of(
+						inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+						inSamePartitionAsEntry(
+								"Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 0)));
+
+		String patientIdPart = new IdType(
+						resultBundle.getEntry().get(0).getResponse().getLocation())
+				.getIdPart();
+		List<String> searchUrls = runInTransaction(() -> myResourceSearchUrlDao.findAll().stream()
+				.map(ResourceSearchUrlEntity::getSearchUrl)
+				.toList());
+		assertThat(searchUrls)
+				.as("conditional-create concurrency guard rows")
+				.hasSize(2)
+				.contains("Patient?identifier=old-sys%7Crace-guard-urn");
+		assertThat(searchUrls)
+				.filteredOn(t -> t.startsWith("Observation?"))
+				.singleElement()
+				.asString()
+				.contains("race-guard-obs")
+				.contains(patientIdPart)
+				.doesNotContain("urn:");
+	}
+
 	@Test
 	void testTransaction_rewrittenPatientOutcomeKeepsAutoCreatedPlaceholderIssue() {
 		myStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionNormalizerOffScenarios.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionNormalizerOffScenarios.java
@@ -158,6 +158,64 @@ class PatientIdPartitionNormalizerOffScenarios {
 					List.of(
 						inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE)
 					)
+				),
+				Arguments.of(
+					"Conditionally Create Patient + Conditionally Create Observation | placeholder inside the observation's ifNoneExist",
+					"""
+						{ "resourceType" : "Bundle", "type" : "transaction",
+							"entry" : [
+								{
+									"fullUrl" : "urn:uuid:1f9e2b44-0000-0000-0000-000000000d01",
+									"resource" : {
+										"resourceType" : "Patient",
+										"identifier" : [ { "system" : "old-sys", "value" : "condCreatePatient"} ]
+									},
+									"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|condCreatePatient"}
+								}, {
+									"resource" : {
+										"resourceType" : "Observation",
+										"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+										"subject" : { "reference" : "urn:uuid:1f9e2b44-0000-0000-0000-000000000d01" }
+									},
+									"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:1f9e2b44-0000-0000-0000-000000000d01"}
+								}
+							]
+						}
+						""",
+					"A conditional URL embedding a client-supplied urn fullUrl must resolve without the normalizer — the placeholder resolution lives in the post-prefetch hook.",
+					List.of(
+						inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+						inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 0)
+					)
+				),
+				Arguments.of(
+					"Conditionally Create Patient (bare spec-form ifNoneExist) + Observation | placeholder reference, patient matches existing",
+					"""
+						{ "resourceType" : "Bundle", "type" : "transaction",
+							"entry" : [
+								{
+									"fullUrl" : "urn:uuid:1f9e2b44-0000-0000-0000-000000000d02",
+									"resource" : {
+										"resourceType" : "Patient",
+										"identifier" : [ { "system" : "old-sys", "value" : "existingPat1Ident1"} ]
+									},
+									"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "identifier=old-sys|existingPat1Ident1"}
+								}, {
+									"resource" : {
+										"resourceType" : "Observation",
+										"identifier" : [ { "system" : "observation-system", "value" : "obsWithUrnRef"} ],
+										"subject" : { "reference" : "urn:uuid:1f9e2b44-0000-0000-0000-000000000d02" }
+									},
+									"request" : { "method" : "POST", "url" : "Observation"}
+								}
+							]
+						}
+						""",
+					"The spec allows If-None-Exist to omit the type prefix; a bare URL must still resolve to the existing patient without the normalizer's synthetics.",
+					List.of(
+						inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1"),
+						inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, "pat1")
+					)
 				)
 			);
 		}

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionReferenceScenarios.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionReferenceScenarios.java
@@ -1158,6 +1158,384 @@ class PatientIdPartitionReferenceScenarios implements ArgumentsProvider {
 				allPartitionSearchOffModeRejectNoCompartment("Observation")
 			),
 
+			// --- Placeholder (urn) references inside conditional URLs ---
+			Arguments.of(
+				"Conditionally Create Patient + Conditionally Create Observation | placeholder reference inside the observation's ifNoneExist, neither matches",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10001-0000-0000-0000-000000000001",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "condCreatePatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|condCreatePatient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10001-0000-0000-0000-000000000001" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:b7c10001-0000-0000-0000-000000000001"}
+							}
+						]
+					}
+					""",
+				"The Observation's ifNoneExist embeds the Patient entry's placeholder fullUrl: the placeholder must resolve to the minted patient id before the conditional-create match search and the post-write URL verification run. Neither conditional matches → both create, co-located.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 0)
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Create Patient + Conditionally Create Observation | placeholder reference inside the observation's ifNoneExist",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10002-0000-0000-0000-000000000002",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "newPatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10002-0000-0000-0000-000000000002" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:b7c10002-0000-0000-0000-000000000002"}
+							}
+						]
+					}
+					""",
+				"Same conditional-URL placeholder, but the Patient is an unconditional create: the minted id must reach the Observation's ifNoneExist too.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 0)
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Patient + Conditionally Create Observation | placeholder in the observation's ifNoneExist, patient matches existing",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10003-0000-0000-0000-000000000003",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "existingPat1Ident1"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|existingPat1Ident1"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10003-0000-0000-0000-000000000003" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:b7c10003-0000-0000-0000-000000000003"}
+							}
+						]
+					}
+					""",
+				"The Patient conditional create NOPs to pat1, so the placeholder in the Observation's ifNoneExist must resolve to Patient/pat1; the Observation conditional finds no match → created in pat1's compartment.",
+				List.of(
+					inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1"),
+					inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, "pat1")
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Patient + Conditionally Create Observation | placeholder in the observation's ifNoneExist, both match existing",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10004-0000-0000-0000-000000000004",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "existingPat1Ident1"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|existingPat1Ident1"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "obsExisting"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10004-0000-0000-0000-000000000004" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|obsExisting&subject=urn:uuid:b7c10004-0000-0000-0000-000000000004"}
+							}
+						]
+					}
+					""",
+				"With the placeholder resolved to Patient/pat1, the Observation's ifNoneExist matches the fixture Observation → native no-op conditional-match outcomes for both entries.",
+				List.of(
+					inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1"),
+					inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1")
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Patient + Conditionally Update Observation | placeholder inside the conditional update URL, no observation match",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10005-0000-0000-0000-000000000005",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "condCreatePatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|condCreatePatient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condUpdateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10005-0000-0000-0000-000000000005" }
+								},
+								"request" : { "method" : "PUT", "url" : "Observation?identifier=observation-system|condUpdateObs&subject=urn:uuid:b7c10005-0000-0000-0000-000000000005"}
+							}
+						]
+					}
+					""",
+				"The placeholder sits in the conditional update URL rather than ifNoneExist; no observation matches → created in the new patient's compartment.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH, 0)
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Observation + Conditionally Create Patient | placeholder in the observation's ifNoneExist, patient entry second",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10006-0000-0000-0000-000000000006" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:b7c10006-0000-0000-0000-000000000006"}
+							}, {
+								"fullUrl" : "urn:uuid:b7c10006-0000-0000-0000-000000000006",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "condCreatePatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|condCreatePatient"}
+							}
+						]
+					}
+					""",
+				"Same as the ifNoneExist-placeholder scenario but with the referencer first: processing order is determined by the sorter, not entry order, and the response must preserve input order.",
+				List.of(
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 1),
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH)
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Patient + Conditionally Create Observation | percent-escaped placeholder in the observation's ifNoneExist",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10007-0000-0000-0000-000000000007",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "condCreatePatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|condCreatePatient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10007-0000-0000-0000-000000000007" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn%3Auuid%3Ab7c10007-0000-0000-0000-000000000007"}
+							}
+						]
+					}
+					""",
+				"The placeholder in ifNoneExist is percent-escaped (urn%3Auuid%3A...), a form performIdSubstitutionsInMatchUrl explicitly supports; must behave exactly like the raw form.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 0)
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Patient + Conditionally Update Observation | placeholder in the update URL, patient and observation match existing",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10008-0000-0000-0000-000000000008",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "existingPat1Ident1"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|existingPat1Ident1"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "obsExisting"} ],
+									"status" : "final",
+									"subject" : { "reference" : "urn:uuid:b7c10008-0000-0000-0000-000000000008" }
+								},
+								"request" : { "method" : "PUT", "url" : "Observation?identifier=observation-system|obsExisting&subject=urn:uuid:b7c10008-0000-0000-0000-000000000008"}
+							}
+						]
+					}
+					""",
+				"Placeholder in the conditional update URL resolves to Patient/pat1 and the URL matches the fixture Observation; the changed body updates it in place.",
+				List.of(
+					inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1"),
+					inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_UPDATE_WITH_CONDITIONAL_MATCH, "pat1")
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Create Patient + Conditionally Update Observation | placeholder inside the conditional update URL",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c10009-0000-0000-0000-000000000009",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "newPatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condUpdateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c10009-0000-0000-0000-000000000009" }
+								},
+								"request" : { "method" : "PUT", "url" : "Observation?identifier=observation-system|condUpdateObs&subject=urn:uuid:b7c10009-0000-0000-0000-000000000009"}
+							}
+						]
+					}
+					""",
+				"Unconditional patient create + placeholder inside the conditional update URL; no observation matches → created alongside the new patient.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH, 0)
+				),
+				allPartitionSearchOffModeRejectIdlessPatient()
+			),
+			Arguments.of(
+				"Conditionally Create Patient (bare spec-form ifNoneExist) + Observation | placeholder reference, patient matches existing",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c1000a-0000-0000-0000-00000000000a",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "existingPat1Ident1"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "identifier=old-sys|existingPat1Ident1"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "obsWithUrnRef"} ],
+									"subject" : { "reference" : "urn:uuid:b7c1000a-0000-0000-0000-00000000000a" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation"}
+							}
+						]
+					}
+					""",
+				"FHIR allows If-None-Exist to omit the type prefix; such bare URLs are never pre-fetched, so the machinery must not treat 'not pre-fetched' as 'no match' — the conditional create must still NOP to pat1 and the referencer must follow it.",
+				List.of(
+					inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1"),
+					inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, "pat1")
+				),
+				allPartitionSearchOffModeRejectNoCompartment("Observation")
+			),
+			Arguments.of(
+				"Conditionally Create Patient (leading-? ifNoneExist) + Observation | placeholder reference, patient matches existing",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c1000c-0000-0000-0000-00000000000c",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "existingPat1Ident1"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "?identifier=old-sys|existingPat1Ident1"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "obsWithUrnRef"} ],
+									"subject" : { "reference" : "urn:uuid:b7c1000c-0000-0000-0000-00000000000c" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation"}
+							}
+						]
+					}
+					""",
+				"The leading-? form is a type-less variant the storage layer also accepts; like the bare form it must resolve to the existing patient rather than being treated as unmatched.",
+				List.of(
+					inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_WITH_CONDITIONAL_MATCH, "pat1"),
+					inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, "pat1")
+				),
+				allPartitionSearchOffModeRejectNoCompartment("Observation")
+			),
+			Arguments.of(
+				"Conditionally Create Patient ×2 (duplicate conditional URLs, distinct placeholders) + Observation ×2 | consolidated to one create, all co-located",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c1000b-0000-0000-0000-000000000b01",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "dupUrnPatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|dupUrnPatient"}
+							}, {
+								"fullUrl" : "urn:uuid:b7c1000b-0000-0000-0000-000000000b02",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "dupUrnPatient"} ]
+								},
+								"request" : { "method" : "POST", "url" : "Patient", "ifNoneExist" : "Patient?identifier=old-sys|dupUrnPatient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "obsViaDup1"} ],
+									"subject" : { "reference" : "urn:uuid:b7c1000b-0000-0000-0000-000000000b01" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "obsViaDup2"} ],
+									"subject" : { "reference" : "urn:uuid:b7c1000b-0000-0000-0000-000000000b02" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation"}
+							}
+						]
+					}
+					""",
+				"Two conditional creates sharing one match URL but carrying distinct placeholder fullUrls consolidate to a single create; references to either placeholder resolve to the one created patient.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, 0),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE, 0)
+				),
+				allPartitionSearchOffModeRejectNoCompartment("Observation")
+			),
+
 			// --- Patient + referencer, inline match URL references ---
 			Arguments.of(
 				"Conditionally Create Patient + Conditionally Update Observation | inline match URL binds to in-bundle entry, patient matches existing",

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionReferenceScenarios.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionReferenceScenarios.java
@@ -1491,6 +1491,67 @@ class PatientIdPartitionReferenceScenarios implements ArgumentsProvider {
 				allPartitionSearchOffModeRejectNoCompartment("Observation")
 			),
 			Arguments.of(
+				"Conditionally Update Patient + Conditionally Create Observation | placeholder in the observation's ifNoneExist, patient is new",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c1000d-0000-0000-0000-00000000000d",
+								"resource" : {
+									"resourceType" : "Patient",
+									"identifier" : [ { "system" : "old-sys", "value" : "condUpdatePatient"} ]
+								},
+								"request" : { "method" : "PUT", "url" : "Patient?identifier=old-sys|condUpdatePatient"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c1000d-0000-0000-0000-00000000000d" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:b7c1000d-0000-0000-0000-00000000000d"}
+							}
+						]
+					}
+					""",
+				"The referenced patient is a conditional update, which processes after the observation's conditional create — so the placeholder in the ifNoneExist cannot rely on write-order substitution and must be resolved up front.",
+				List.of(
+					inCompartmentOfSelf("Patient", StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH),
+					inSamePartitionAsEntry("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, 0)
+				),
+				allPartitionSearchOffModeRejectNoCompartment("Observation")
+			),
+			Arguments.of(
+				"Update-as-create Patient + Conditionally Create Observation | placeholder in the observation's ifNoneExist",
+				"""
+					{ "resourceType" : "Bundle", "type" : "transaction",
+						"entry" : [
+							{
+								"fullUrl" : "urn:uuid:b7c1000e-0000-0000-0000-00000000000e",
+								"resource" : {
+									"resourceType" : "Patient",
+									"id" : "patUacCondUrl",
+									"identifier" : [ { "system" : "old-sys", "value" : "newPatient"} ]
+								},
+								"request" : { "method" : "PUT", "url" : "Patient/patUacCondUrl"}
+							}, {
+								"resource" : {
+									"resourceType" : "Observation",
+									"identifier" : [ { "system" : "observation-system", "value" : "condCreateObs"} ],
+									"subject" : { "reference" : "urn:uuid:b7c1000e-0000-0000-0000-00000000000e" }
+								},
+								"request" : { "method" : "POST", "url" : "Observation", "ifNoneExist" : "Observation?identifier=observation-system|condCreateObs&subject=urn:uuid:b7c1000e-0000-0000-0000-00000000000e"}
+							}
+						]
+					}
+					""",
+				"The referenced patient is an explicit-id update-as-create, which also processes after the observation's conditional create; the placeholder in the ifNoneExist must resolve to the client-assigned id up front.",
+				List.of(
+					inCompartmentOf("Patient", StorageResponseCodeEnum.SUCCESSFUL_UPDATE_AS_CREATE, "patUacCondUrl"),
+					inCompartmentOf("Observation", StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH, "patUacCondUrl")
+				),
+				allPartitionSearchOffModeRejectNoCompartment("Observation")
+			),
+			Arguments.of(
 				"Conditionally Create Patient ×2 (duplicate conditional URLs, distinct placeholders) + Observation ×2 | consolidated to one create, all co-located",
 				"""
 					{ "resourceType" : "Bundle", "type" : "transaction",

--- a/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/UpliftedRefchainsAndChainedSortingR5Test.java
+++ b/hapi-fhir-jpaserver-test-r5/src/test/java/ca/uhn/fhir/jpa/dao/r5/UpliftedRefchainsAndChainedSortingR5Test.java
@@ -401,7 +401,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		// Verify SQL
 
 		// 1- Resolve resource forced IDs, and 2- Resolve Practitioner/PR1 reference
-		assertEquals(3, myCaptureQueriesListener.countSelectQueriesForCurrentThread());
+		assertEquals(2, myCaptureQueriesListener.countSelectQueriesForCurrentThread());
 
 		// Verify correct indexes are written
 		logAllStringIndexes();
@@ -445,7 +445,7 @@ public class UpliftedRefchainsAndChainedSortingR5Test extends BaseJpaR5Test {
 		// Verify SQL
 
 		myCaptureQueriesListener.logSelectQueriesForCurrentThread();
-		assertEquals(9, myCaptureQueriesListener.countSelectQueriesForCurrentThread());
+		assertEquals(7, myCaptureQueriesListener.countSelectQueriesForCurrentThread());
 
 		// Verify correct indexes are written
 		logAllStringIndexes();

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlService.java
@@ -252,6 +252,7 @@ public class MatchResourceUrlService<T extends IResourcePersistentId<?>> {
 	 * agree with the ones this service stores.
 	 */
 	public static String massageForStorage(String theResourceType, String theMatchUrl) {
+		Validate.notBlank(theResourceType, "theResourceType must not be null or blank");
 		Validate.notBlank(theMatchUrl, "theMatchUrl must not be null or blank");
 		int questionMarkIdx = theMatchUrl.indexOf("?");
 		if (questionMarkIdx > 0) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlService.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/dao/MatchResourceUrlService.java
@@ -243,7 +243,15 @@ public class MatchResourceUrlService<T extends IResourcePersistentId<?>> {
 		return dao;
 	}
 
-	private String massageForStorage(String theResourceType, String theMatchUrl) {
+	/**
+	 * Canonicalizes a conditional/match URL to the type-qualified form used as the storage and lookup key:
+	 * {@code Type?params} is returned unchanged, while the type-less spellings a conditional request may
+	 * legally use — {@code ?params} and bare {@code params} (the form the FHIR specification shows for
+	 * If-None-Exist) — are prefixed with the given resource type. Callers that record or look up match URLs
+	 * outside this service (e.g. transaction pre-fetch) must apply the same canonicalization so their keys
+	 * agree with the ones this service stores.
+	 */
+	public static String massageForStorage(String theResourceType, String theMatchUrl) {
 		Validate.notBlank(theMatchUrl, "theMatchUrl must not be null or blank");
 		int questionMarkIdx = theMatchUrl.indexOf("?");
 		if (questionMarkIdx > 0) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -121,6 +121,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  */
 @Interceptor
 public class PatientIdPartitionInterceptor {
+	private static final Logger ourLog = LoggerFactory.getLogger(PatientIdPartitionInterceptor.class);
+
 	public static final String PATIENT_COMPARTMENT_NONE = "NONE";
 
 	/**
@@ -131,7 +133,16 @@ public class PatientIdPartitionInterceptor {
 	// Created by Claude Fable 5
 	public static final int STORAGE_TRANSACTION_PROCESSING_ORDER_NORMALIZE = 1000;
 
-	private static final Logger ourLog = LoggerFactory.getLogger(PatientIdPartitionInterceptor.class);
+	/**
+	 * The live response codes a rewritten entry produces when its match URL indeed had no match at write time —
+	 * the only situation the recorded rewrite intent describes, and therefore the only outcomes
+	 * {@link #restoreRewrittenPatientOutcomes} may replace.
+	 */
+	// Created by Claude Fable 5
+	private static final Set<String> RESTORABLE_LIVE_CODES = Set.of(
+		StorageResponseCodeEnum.SUCCESSFUL_UPDATE_AS_CREATE.name(),
+		StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH.name());
+
 	private static final String PATIENT_STR = "Patient";
 
 	/**
@@ -1011,6 +1022,17 @@ public class PatientIdPartitionInterceptor {
 						theVersionAdapter.setRequestUrl(entry, substituted);
 					}
 				}
+			} else {
+				String url = theVersionAdapter.getEntryRequestUrl(entry);
+				if (url != null
+						&& url.contains("?")
+						&& !Strings.CS.equals(
+								url, BaseTransactionProcessor.performIdSubstitutionsInMatchUrl(idSubstitutions, url))) {
+					ourLog.debug(
+							"Leaving placeholder reference in the conditional URL of a {} entry for the write loop's native substitution: {}",
+							verb,
+							url);
+				}
 			}
 		}
 	}
@@ -1063,16 +1085,6 @@ public class PatientIdPartitionInterceptor {
 			}
 		}
 	}
-
-	/**
-	 * The live response codes a rewritten entry produces when its match URL indeed had no match at write time —
-	 * the only situation the recorded rewrite intent describes, and therefore the only outcomes
-	 * {@link #restoreRewrittenPatientOutcomes} may replace.
-	 */
-	// Created by Claude Fable 5
-	private static final Set<String> RESTORABLE_LIVE_CODES = Set.of(
-			StorageResponseCodeEnum.SUCCESSFUL_UPDATE_AS_CREATE.name(),
-			StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH.name());
 
 	/** The StorageResponseCode carried by the outcome's primary issue, or null if it carries none. */
 	// Created by Claude Fable 5

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -932,16 +932,10 @@ public class PatientIdPartitionInterceptor {
 						theMatchUrlToMintedReference.computeIfAbsent(conditionalUrl, k -> mintPatientReference());
 				theIdSubstitutions.put(theFullUrl, newReference);
 				if ("POST".equals(method) && resolution.prefetched()) {
-					// The entry stays a conditional POST with the minted id stamped as server-assigned: the
-					// write loop then consolidates in-bundle duplicates, writes the HFJ_RES_SEARCH_URL row
-					// that makes a concurrent transaction creating the same conditional URL collide instead
-					// of duplicating the patient, and reports the no-match create outcome — all natively.
+					// The entry stays a conditional POST with the minted id stamped as server-assigned.
 					stampServerAssignedId(resource, newReference);
 				} else {
-					// Rewritten to a conditional PUT with the minted body id. Reached by a conditional update,
-					// and by a match URL the pre-fetch never attempted — treating "never looked" as "no match"
-					// is only safe on this path because a write-time match then collides with the minted body
-					// id instead of quietly diverging from the references substituted above.
+					// Rewritten to a conditional PUT with the minted body id.
 					rewriteAsPut(versionAdapter, theEntry, resource, newReference, conditionalUrl);
 					RewriteIntent intent = "POST".equals(method)
 							? RewriteIntent.CONDITIONAL_CREATE_NO_MATCH
@@ -990,13 +984,7 @@ public class PatientIdPartitionInterceptor {
 
 	/**
 	 * Replaces placeholder (urn) references inside each entry's conditional URL — POST ifNoneExist and conditional
-	 * PUT request URLs — with the concrete ids resolved above. The write loop performs the same substitution
-	 * natively, but only from substitutions registered as earlier entries complete; an entry whose placeholder
-	 * points at a Patient processed in the PUT phase (a conditional update or an explicit-id update-as-create)
-	 * always runs after the conditional creates referencing it, so its placeholder must be resolved up front.
-	 * DELETE and PATCH URLs are deliberately left to the write loop: DELETEs process before anything a placeholder
-	 * could resolve to exists (native processing sees the unsubstituted URL and matches nothing), and PATCHes
-	 * process last, when the write loop's substitution map is already complete.
+	 * PUT request URLs — with the concrete ids resolved above.
 	 */
 	// Created by Claude Fable 5
 	private void substituteConditionalUrlPlaceholders(
@@ -1283,8 +1271,7 @@ public class PatientIdPartitionInterceptor {
 	/**
 	 * Consults what the pre-fetch resolved for the given match URL, via
 	 * {@link TransactionDetails#getResolvedMatchUrls()} and the reverse-id map. The lookup key is canonicalized
-	 * the same way the pre-fetch records it, so the type-less If-None-Exist spellings resolve too. No search is
-	 * performed — we act only on what the pre-fetch put in the transaction details.
+	 * the same way the pre-fetch records it, so the type-less If-None-Exist spellings resolve too.
 	 */
 	// Created by Claude Fable 5
 	private PreFetchResolution getPreFetchResolution(String theMatchUrl, TransactionDetails theTransactionDetails) {

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -140,8 +140,8 @@ public class PatientIdPartitionInterceptor {
 	 */
 	// Created by Claude Fable 5
 	private static final Set<String> RESTORABLE_LIVE_CODES = Set.of(
-		StorageResponseCodeEnum.SUCCESSFUL_UPDATE_AS_CREATE.name(),
-		StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH.name());
+			StorageResponseCodeEnum.SUCCESSFUL_UPDATE_AS_CREATE.name(),
+			StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH.name());
 
 	private static final String PATIENT_STR = "Patient";
 

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -805,11 +805,8 @@ public class PatientIdPartitionInterceptor {
 	/**
 	 * Once {@code preFetch} has resolved every conditional URL and reference target, resolve each Patient entry to a
 	 * concrete ID and substitute all in-bundle references to it. This makes compartment placement independent of the
-	 * order entries are processed in: a matched conditional Patient reuses the existing resource's ID, while a new
-	 * Patient has a minted UUID stamped as its server-assigned id
-	 * ({@link JpaConstants#RESOURCE_ID_SERVER_ASSIGNED_VALUE}) without changing the entry's verb — so the write
-	 * loop's native entry ordering, duplicate consolidation, conditional-URL id substitution and operation outcomes
-	 * all apply unchanged.
+	 * order entries are processed in: a matched conditional Patient reuses the existing resource's ID; a new Patient
+	 * gets a minted UUID stamped as its server-assigned id ({@link JpaConstants#RESOURCE_ID_SERVER_ASSIGNED_VALUE}).
 	 */
 	// Created by Claude Opus 4.7
 	@Hook(Pointcut.STORAGE_TRANSACTION_WRITE_AFTER_PREFETCH)

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -40,8 +40,10 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.BaseStorageDao;
 import ca.uhn.fhir.jpa.dao.ITransactionProcessorVersionAdapter;
+import ca.uhn.fhir.jpa.dao.MatchResourceUrlService;
 import ca.uhn.fhir.jpa.dao.PreFetchSkippableMethodNotAllowedException;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
+import ca.uhn.fhir.jpa.model.util.JpaConstants;
 import ca.uhn.fhir.jpa.partition.BaseRequestPartitionHelperSvc;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.jpa.searchparam.extractor.ISearchParamExtractor;
@@ -144,14 +146,12 @@ public class PatientIdPartitionInterceptor {
 	 */
 	// Created by Claude Opus 4.7
 	private enum RewriteIntent {
-		UNCONDITIONAL_CREATE,
 		CONDITIONAL_CREATE_NO_MATCH,
 		CONDITIONAL_UPDATE_NO_MATCH
 	}
 
 	/**
-	 * @param conditionalUrl the original conditional match URL, needed to render the outcome message; null for
-	 *                       {@link RewriteIntent#UNCONDITIONAL_CREATE}.
+	 * @param conditionalUrl the original conditional match URL, needed to render the outcome message.
 	 */
 	// Created by Claude Opus 4.7
 	private record RewrittenOutcome(RewriteIntent intent, String conditionalUrl) {}
@@ -803,10 +803,11 @@ public class PatientIdPartitionInterceptor {
 	/**
 	 * Once {@code preFetch} has resolved every conditional URL and reference target, resolve each Patient entry to a
 	 * concrete ID and substitute all in-bundle references to it. This makes compartment placement independent of the
-	 * order entries are processed in: a matched conditional Patient reuses the existing resource's ID; an
-	 * unconditional Patient is assigned a UUID and its create is rewritten as a direct update so the ID sticks; an
-	 * unmatched conditional Patient is assigned a UUID on the body but stays a conditional update, so in-bundle
-	 * duplicates of the same match URL consolidate.
+	 * order entries are processed in: a matched conditional Patient reuses the existing resource's ID, while a new
+	 * Patient has a minted UUID stamped as its server-assigned id
+	 * ({@link JpaConstants#RESOURCE_ID_SERVER_ASSIGNED_VALUE}) without changing the entry's verb — so the write
+	 * loop's native entry ordering, duplicate consolidation, conditional-URL id substitution and operation outcomes
+	 * all apply unchanged.
 	 */
 	// Created by Claude Opus 4.7
 	@Hook(Pointcut.STORAGE_TRANSACTION_WRITE_AFTER_PREFETCH)
@@ -855,9 +856,11 @@ public class PatientIdPartitionInterceptor {
 
 	/**
 	 * Resolves one Patient entry carrying a placeholder (urn:uuid) fullUrl: a matched conditional reuses the
-	 * existing resource's ID; when the server assigns UUIDs, an unconditional create is assigned a minted ID and
-	 * rewritten as a direct update, and an unmatched conditional is assigned a minted ID but stays conditional.
-	 * Substitutions and minted references accumulate in the supplied maps.
+	 * existing resource's ID; when the server assigns UUIDs, a new Patient has a minted ID stamped as its
+	 * server-assigned id, leaving the verb untouched so the write loop processes the entry natively. The entry
+	 * is rewritten to a conditional update only where native processing cannot express the intent: an unmatched
+	 * conditional update needs the minted id on its body, and a match URL the pre-fetch never attempted has an
+	 * unknowable match state here. Substitutions and minted references accumulate in the supplied maps.
 	 */
 	// Created by Claude Fable 5
 	private void resolvePlaceholderPatientEntry(
@@ -893,9 +896,9 @@ public class PatientIdPartitionInterceptor {
 		if (isBlank(matchUrl)) {
 			if ("POST".equals(method)) {
 				if (serverAssignsUuids) {
-					String newReference = assignNewIdAndRewriteToPut(
-							versionAdapter, theTransactionDetails, theEntry, resource, theFullUrl, theIdSubstitutions);
-					rewrittenOutcomes.put(newReference, new RewrittenOutcome(RewriteIntent.UNCONDITIONAL_CREATE, null));
+					String newReference = mintPatientReference();
+					theIdSubstitutions.put(theFullUrl, newReference);
+					stampServerAssignedId(resource, newReference);
 				}
 			} else if ("PUT".equals(method) && isNotBlank(url) && !Strings.CS.equals(theFullUrl, url)) {
 				theIdSubstitutions.put(theFullUrl, url);
@@ -917,22 +920,43 @@ public class PatientIdPartitionInterceptor {
 					resource.setId(matchedReference);
 				}
 			} else if (serverAssignsUuids) {
-				// Keep the entry conditional (PUT Patient?<matchUrl>) rather than rewriting it to a direct
-				// update: the framework then consolidates in-bundle duplicates of the same match URL, and the
-				// create path writes the HFJ_RES_SEARCH_URL row that makes a concurrent transaction creating
-				// the same conditional URL collide instead of duplicating the patient. Duplicates share one
-				// minted id so references to any of them resolve to the single created patient.
-				String conditionalUrl = matchUrl.contains("?") ? matchUrl : PATIENT_STR + "?" + matchUrl;
+				// Duplicates of the same match URL share one minted id: same-verb duplicates then consolidate
+				// onto a single write, and references to any of them resolve to the single created patient. A
+				// create and an update sharing a match URL both write the shared id, which the write loop's
+				// post-write duplicate validation rejects exactly as outside partition mode.
+				String conditionalUrl = MatchResourceUrlService.massageForStorage(PATIENT_STR, matchUrl);
 				String newReference =
 						theMatchUrlToMintedReference.computeIfAbsent(conditionalUrl, k -> mintPatientReference());
 				theIdSubstitutions.put(theFullUrl, newReference);
-				rewriteAsPut(versionAdapter, theEntry, resource, newReference, conditionalUrl);
-				RewriteIntent intent = "POST".equals(method)
-						? RewriteIntent.CONDITIONAL_CREATE_NO_MATCH
-						: RewriteIntent.CONDITIONAL_UPDATE_NO_MATCH;
-				rewrittenOutcomes.putIfAbsent(newReference, new RewrittenOutcome(intent, matchUrl));
+				if ("POST".equals(method) && resolution.prefetched()) {
+					// The entry stays a conditional POST with the minted id stamped as server-assigned: the
+					// write loop then consolidates in-bundle duplicates, writes the HFJ_RES_SEARCH_URL row
+					// that makes a concurrent transaction creating the same conditional URL collide instead
+					// of duplicating the patient, and reports the no-match create outcome — all natively.
+					stampServerAssignedId(resource, newReference);
+				} else {
+					// Rewritten to a conditional PUT with the minted body id. Reached by a conditional update,
+					// and by a match URL the pre-fetch never attempted — treating "never looked" as "no match"
+					// is only safe on this path because a write-time match then collides with the minted body
+					// id instead of quietly diverging from the references substituted above.
+					rewriteAsPut(versionAdapter, theEntry, resource, newReference, conditionalUrl);
+					RewriteIntent intent = "POST".equals(method)
+							? RewriteIntent.CONDITIONAL_CREATE_NO_MATCH
+							: RewriteIntent.CONDITIONAL_UPDATE_NO_MATCH;
+					rewrittenOutcomes.putIfAbsent(newReference, new RewrittenOutcome(intent, matchUrl));
+				}
 			}
 		}
+	}
+
+	/**
+	 * Marks the minted reference's id part as the resource's server-assigned id
+	 * ({@link JpaConstants#RESOURCE_ID_SERVER_ASSIGNED_VALUE}): the create path adopts it as if the server had
+	 * generated it, so the entry's verb — and everything the write loop keys on it — stays untouched.
+	 */
+	// Created by Claude Fable 5
+	private static void stampServerAssignedId(IBaseResource theResource, String theNewReference) {
+		theResource.setUserData(JpaConstants.RESOURCE_ID_SERVER_ASSIGNED_VALUE, new IdDt(theNewReference).getIdPart());
 	}
 
 	/** Replaces every in-bundle reference that matches a substitution key with its concrete reference. */
@@ -964,7 +988,10 @@ public class PatientIdPartitionInterceptor {
 	/**
 	 * Once the transaction has been processed, restore the operation outcome each rewritten Patient entry would have
 	 * had if {@link #resolvePatientReferencesAfterPreFetch} hadn't rewritten its verb to make compartment placement
-	 * order-independent.
+	 * order-independent. The restoration only applies to an entry whose live outcome shows the write loop indeed
+	 * found no match ({@link #RESTORABLE_LIVE_CODES}) — any other live code means the recorded no-match intent went
+	 * stale (e.g. the match URL resolved to a patient another entry created moments earlier), and the native outcome
+	 * is the truth.
 	 */
 	// Created by Claude Opus 4.7
 	@Hook(Pointcut.STORAGE_TRANSACTION_RESPONSE_ASSEMBLED)
@@ -999,9 +1026,33 @@ public class PatientIdPartitionInterceptor {
 			// reported for the original verb, and a DAO that reports nothing would have reported nothing.
 			IBaseOperationOutcome liveOutcome = versionAdapter.getResponseOutcome(entry);
 			if (liveOutcome != null) {
-				restorePrimaryIssue(liveOutcome, code, message);
+				String liveCode = primaryResponseCode(liveOutcome);
+				if (liveCode != null && RESTORABLE_LIVE_CODES.contains(liveCode)) {
+					restorePrimaryIssue(liveOutcome, code, message);
+				}
 			}
 		}
+	}
+
+	/**
+	 * The live response codes a rewritten entry produces when its match URL indeed had no match at write time —
+	 * the only situation the recorded rewrite intent describes, and therefore the only outcomes
+	 * {@link #restoreRewrittenPatientOutcomes} may replace.
+	 */
+	// Created by Claude Fable 5
+	private static final Set<String> RESTORABLE_LIVE_CODES = Set.of(
+			StorageResponseCodeEnum.SUCCESSFUL_UPDATE_AS_CREATE.name(),
+			StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH.name());
+
+	/** The StorageResponseCode carried by the outcome's primary issue, or null if it carries none. */
+	// Created by Claude Fable 5
+	@Nullable
+	private String primaryResponseCode(IBaseOperationOutcome theOutcome) {
+		List<IBase> codes = myFhirContext.newTerser().getValues(theOutcome, "issue.details.coding.code");
+		if (codes.isEmpty()) {
+			return null;
+		}
+		return ((IPrimitiveType<?>) codes.get(0)).getValueAsString();
 	}
 
 	/**
@@ -1033,7 +1084,6 @@ public class PatientIdPartitionInterceptor {
 	// Created by Claude Opus 4.7
 	private StorageResponseCodeEnum restoredOutcomeCode(RewrittenOutcome theRewrite) {
 		return switch (theRewrite.intent()) {
-			case UNCONDITIONAL_CREATE -> StorageResponseCodeEnum.SUCCESSFUL_CREATE;
 			case CONDITIONAL_CREATE_NO_MATCH -> StorageResponseCodeEnum.SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH;
 			case CONDITIONAL_UPDATE_NO_MATCH -> StorageResponseCodeEnum.SUCCESSFUL_UPDATE_NO_CONDITIONAL_MATCH;
 		};
@@ -1043,7 +1093,6 @@ public class PatientIdPartitionInterceptor {
 	private String restoredOutcomeMessage(StorageResponseCodeEnum theCode, String theId, String theConditionalUrl) {
 		HapiLocalizer localizer = myFhirContext.getLocalizer();
 		return switch (theCode) {
-			case SUCCESSFUL_CREATE -> localizer.getMessageSanitized(BaseStorageDao.class, "successfulCreate", theId);
 			case SUCCESSFUL_CREATE_NO_CONDITIONAL_MATCH -> localizer.getMessageSanitized(
 					BaseStorageDao.class,
 					"successfulCreateConditionalNoMatch",
@@ -1057,23 +1106,6 @@ public class PatientIdPartitionInterceptor {
 					UrlUtil.sanitizeUrlPart(theConditionalUrl));
 			default -> theCode.getDisplay();
 		};
-	}
-
-	// Created by Claude Opus 4.7
-	private String assignNewIdAndRewriteToPut(
-			ITransactionProcessorVersionAdapter<IBaseBundle, IBase> theVersionAdapter,
-			TransactionDetails theTransactionDetails,
-			IBase theEntry,
-			IBaseResource theResource,
-			String theFullUrl,
-			Map<String, String> theIdSubstitutions) {
-		String newReference = mintPatientReference();
-		// A freshly minted id cannot exist yet. Record that the same way preFetch records unresolvable
-		// ids, so the update path skips its existence lookup.
-		theTransactionDetails.addResolvedResourceId(new IdDt(newReference), null);
-		theIdSubstitutions.put(theFullUrl, newReference);
-		rewriteAsPut(theVersionAdapter, theEntry, theResource, newReference, newReference);
-		return newReference;
 	}
 
 	/**
@@ -1193,27 +1225,34 @@ public class PatientIdPartitionInterceptor {
 	}
 
 	/**
-	 * What the pre-fetch resolved for a match URL: {@code matched} is true when the pre-fetch found an existing
-	 * resource. {@code matchedId} carries its FHIR id, or null when the match has no reverse-mapped id (non-token
-	 * match URL) — such an entry is matched yet its id is unknowable this early, so callers that mint ids for
-	 * unmatched URLs must not treat it as unmatched.
+	 * What the pre-fetch resolved for a match URL. {@code prefetched} is false when the pre-fetch never
+	 * attempted the URL at all (nothing recorded, not even NOT_FOUND) — such a URL may still match at write
+	 * time, so callers must not treat it like a confirmed miss. {@code matched} is true when the pre-fetch
+	 * found an existing resource. {@code matchedId} carries its FHIR id, or null when the match has no
+	 * reverse-mapped id (non-token match URL) — such an entry is matched yet its id is unknowable this early,
+	 * so callers that mint ids for unmatched URLs must not treat it as unmatched.
 	 */
 	// Created by Claude Fable 5
-	private record PreFetchResolution(boolean matched, @Nullable IIdType matchedId) {}
+	private record PreFetchResolution(boolean prefetched, boolean matched, @Nullable IIdType matchedId) {}
 
 	/**
 	 * Consults what the pre-fetch resolved for the given match URL, via
-	 * {@link TransactionDetails#getResolvedMatchUrls()} and the reverse-id map. No search is performed — we act
-	 * only on what the pre-fetch put in the transaction details.
+	 * {@link TransactionDetails#getResolvedMatchUrls()} and the reverse-id map. The lookup key is canonicalized
+	 * the same way the pre-fetch records it, so the type-less If-None-Exist spellings resolve too. No search is
+	 * performed — we act only on what the pre-fetch put in the transaction details.
 	 */
 	// Created by Claude Fable 5
 	private PreFetchResolution getPreFetchResolution(String theMatchUrl, TransactionDetails theTransactionDetails) {
+		String canonicalUrl = MatchResourceUrlService.massageForStorage(PATIENT_STR, theMatchUrl);
 		IResourcePersistentId<?> resolved =
-				theTransactionDetails.getResolvedMatchUrls().get(theMatchUrl);
-		if (resolved == null || resolved == TransactionDetails.NOT_FOUND) {
-			return new PreFetchResolution(false, null);
+				theTransactionDetails.getResolvedMatchUrls().get(canonicalUrl);
+		if (resolved == null) {
+			return new PreFetchResolution(false, false, null);
 		}
-		return new PreFetchResolution(true, theTransactionDetails.getReverseResolvedId(resolved));
+		if (resolved == TransactionDetails.NOT_FOUND) {
+			return new PreFetchResolution(true, false, null);
+		}
+		return new PreFetchResolution(true, true, theTransactionDetails.getReverseResolvedId(resolved));
 	}
 
 	@SuppressWarnings("SameParameterValue")

--- a/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
+++ b/hapi-fhir-storage/src/main/java/ca/uhn/fhir/jpa/interceptor/PatientIdPartitionInterceptor.java
@@ -39,7 +39,9 @@ import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.dao.BaseStorageDao;
+import ca.uhn.fhir.jpa.dao.BaseTransactionProcessor;
 import ca.uhn.fhir.jpa.dao.ITransactionProcessorVersionAdapter;
+import ca.uhn.fhir.jpa.dao.IdSubstitutionMap;
 import ca.uhn.fhir.jpa.dao.MatchResourceUrlService;
 import ca.uhn.fhir.jpa.dao.PreFetchSkippableMethodNotAllowedException;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
@@ -822,6 +824,7 @@ public class PatientIdPartitionInterceptor {
 		Map<String, String> idSubstitutions =
 				rewriteResolvedOrAssignPatientEntryIds(thePrefetchDetails, theTransactionDetails);
 		substituteReferences(thePrefetchDetails.getVersionAdapter(), entries, idSubstitutions);
+		substituteConditionalUrlPlaceholders(thePrefetchDetails.getVersionAdapter(), entries, idSubstitutions);
 	}
 
 	/**
@@ -980,6 +983,48 @@ public class PatientIdPartitionInterceptor {
 				String substitution = theIdSubstitutions.get(referenceString);
 				if (substitution != null) {
 					reference.getResourceReference().setReference(substitution);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Replaces placeholder (urn) references inside each entry's conditional URL — POST ifNoneExist and conditional
+	 * PUT request URLs — with the concrete ids resolved above. The write loop performs the same substitution
+	 * natively, but only from substitutions registered as earlier entries complete; an entry whose placeholder
+	 * points at a Patient processed in the PUT phase (a conditional update or an explicit-id update-as-create)
+	 * always runs after the conditional creates referencing it, so its placeholder must be resolved up front.
+	 * DELETE and PATCH URLs are deliberately left to the write loop: DELETEs process before anything a placeholder
+	 * could resolve to exists (native processing sees the unsubstituted URL and matches nothing), and PATCHes
+	 * process last, when the write loop's substitution map is already complete.
+	 */
+	// Created by Claude Fable 5
+	private void substituteConditionalUrlPlaceholders(
+			ITransactionProcessorVersionAdapter<IBaseBundle, IBase> theVersionAdapter,
+			List<IBase> theEntries,
+			Map<String, String> theIdSubstitutions) {
+		if (theIdSubstitutions.isEmpty()) {
+			return;
+		}
+		IdSubstitutionMap idSubstitutions = new IdSubstitutionMap();
+		theIdSubstitutions.forEach((source, target) -> idSubstitutions.put(new IdDt(source), new IdDt(target)));
+		for (IBase entry : theEntries) {
+			String verb = theVersionAdapter.getEntryRequestVerb(myFhirContext, entry);
+			if ("POST".equals(verb)) {
+				String ifNoneExist = theVersionAdapter.getEntryRequestIfNoneExist(entry);
+				String substituted =
+						BaseTransactionProcessor.performIdSubstitutionsInMatchUrl(idSubstitutions, ifNoneExist);
+				if (!Strings.CS.equals(ifNoneExist, substituted)) {
+					theVersionAdapter.setRequestIfNoneExist(entry, substituted);
+				}
+			} else if ("PUT".equals(verb)) {
+				String url = theVersionAdapter.getEntryRequestUrl(entry);
+				if (url != null && url.contains("?")) {
+					String substituted =
+							BaseTransactionProcessor.performIdSubstitutionsInMatchUrl(idSubstitutions, url);
+					if (!Strings.CS.equals(url, substituted)) {
+						theVersionAdapter.setRequestUrl(entry, substituted);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #8270                                                                                                                                                                 

#### Problem Description                                                                                                                                                                              
In Patient ID partition mode, a transaction entry whose conditional URL (an                                                                                                 
If-None-Exist value or a conditional update URL) referenced another entry's                                                                                                 
placeholder fullUrl was rejected with HAPI-0539. The same bundle succeeds                                                                                                   
outside partition mode. 

#### What was done
- The partition interceptor's after-prefetch hook now stamps minted Patient ids                                                                                             
  as server-assigned ids (`RESOURCE_ID_SERVER_ASSIGNED_VALUE`) instead of                                                                                                   
  rewriting POST entries to PUTs, so the transaction write loop's native entry                                                                                              
  ordering, conditional-URL id substitution, duplicate consolidation, and                                                                                                   
  operation outcomes all apply unchanged.                                                                                                                                   
- The hook also resolves placeholders inside conditional URLs up front, covering                                                                                            
  referenced Patients that process in the PUT phase (conditional update /                                                                                                   
  update-as-create), which no write ordering can fix.                                                                                                                       
- Transaction pre-fetch now canonicalizes type-less If-None-Exist values (the                                                                                               
  bare form shown by the FHIR spec, and the leading-`?` form) via a shared                                                                                                  
  `massageForStorage`, giving them the same behaviour and query cost as the                                                                                                 
  type-qualified form (previously ~10x the SELECTs and, in partition mode,                                                                                                  
  HAPI-2279/HAPI-2006 failures).                                                                                                                                            
- Pre-fetch records match-URL-cache hits into the TransactionDetails, so                                                                                                    
  repeated conditional creates no longer fail in partition mode when                                                                                                        
  `matchUrlCacheEnabled` is on.                                                                                                                                             
- Added corresponding tests.