### PR TITLE
Fix mass ingestion mode with Patient ID Partitioning

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8356-patient-compartment-enforcing-interceptor-mass-ingestion-npe.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8356-patient-compartment-enforcing-interceptor-mass-ingestion-npe.yaml
@@ -1,0 +1,7 @@
+---
+type: fix
+issue: 8356
+jira: SMILE-12792
+title: "When a `PatientCompartmentEnforcingInterceptor` was registered with mass ingestion mode enabled, resource 
+updates could fail with a NullPointerException (`HAPI-2223: theResource must not be null`). This affected registered 
+subclasses of the interceptor and the history rewrite path. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/patient-compartment-enforcing-interceptor-mass-ingestion-npe.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/patient-compartment-enforcing-interceptor-mass-ingestion-npe.yaml
@@ -1,3 +1,0 @@
----
-type: fix
-title: "When a `PatientCompartmentEnforcingInterceptor` was registered with mass ingestion mode enabled, resource updates could fail with a NullPointerException (`HAPI-2223: theResource must not be null`). This affected registered subclasses of the interceptor and the history rewrite path. This has been fixed."

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/patient-compartment-enforcing-interceptor-mass-ingestion-npe.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/patient-compartment-enforcing-interceptor-mass-ingestion-npe.yaml
@@ -1,0 +1,3 @@
+---
+type: fix
+title: "When a `PatientCompartmentEnforcingInterceptor` was registered with mass ingestion mode enabled, resource updates could fail with a NullPointerException (`HAPI-2223: theResource must not be null`). This affected registered subclasses of the interceptor and the history rewrite path. This has been fixed."

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
+import ca.uhn.fhir.interceptor.api.IInterceptorService;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
@@ -52,6 +53,7 @@ import ca.uhn.fhir.jpa.delete.DeleteConflictService;
 import ca.uhn.fhir.jpa.esr.ExternallyStoredResourceAddress;
 import ca.uhn.fhir.jpa.esr.ExternallyStoredResourceAddressMetadataKey;
 import ca.uhn.fhir.jpa.esr.ExternallyStoredResourceServiceRegistry;
+import ca.uhn.fhir.jpa.interceptor.PatientCompartmentEnforcingInterceptor;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.cross.IBasePersistedResource;
 import ca.uhn.fhir.jpa.model.cross.IResourceLookup;
@@ -286,6 +288,16 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 	@Override
 	protected IInterceptorBroadcaster getInterceptorBroadcaster() {
 		return myInterceptorBroadcaster;
+	}
+
+	/**
+	 * Returns <code>true</code> if a {@link PatientCompartmentEnforcingInterceptor} (or subclass) is
+	 * registered.
+	 */
+	protected boolean isPatientCompartmentEnforcingInterceptorRegistered() {
+		return myInterceptorBroadcaster instanceof IInterceptorService is
+				&& is.getAllRegisteredInterceptors().stream()
+						.anyMatch(PatientCompartmentEnforcingInterceptor.class::isInstance);
 	}
 
 	protected ApplicationContext getApplicationContext() {
@@ -1337,7 +1349,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> extends BaseStora
 			ResourceTable entity = (ResourceTable) theEntity;
 
 			IBaseResource oldResource;
-			if (getStorageSettings().isMassIngestionMode()) {
+			if (getStorageSettings().isMassIngestionMode() && !isPatientCompartmentEnforcingInterceptorRegistered()) {
 				oldResource = null;
 			} else {
 				oldResource = myJpaStorageResourceParser.toResource(entity, false);

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -29,7 +29,6 @@ import ca.uhn.fhir.i18n.Msg;
 import ca.uhn.fhir.interceptor.api.HookParams;
 import ca.uhn.fhir.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.interceptor.api.Pointcut;
-import ca.uhn.fhir.interceptor.executor.InterceptorService;
 import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistrationService;
@@ -48,7 +47,6 @@ import ca.uhn.fhir.jpa.api.svc.ResolveIdentityMode;
 import ca.uhn.fhir.jpa.dao.data.IResourceHistoryProvenanceDao;
 import ca.uhn.fhir.jpa.dao.tx.HapiTransactionService;
 import ca.uhn.fhir.jpa.delete.DeleteConflictUtil;
-import ca.uhn.fhir.jpa.interceptor.PatientCompartmentEnforcingInterceptor;
 import ca.uhn.fhir.jpa.model.cross.IBasePersistedResource;
 import ca.uhn.fhir.jpa.model.dao.JpaPid;
 import ca.uhn.fhir.jpa.model.dao.JpaPidFk;
@@ -3053,10 +3051,8 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 					null);
 		}
 
-		boolean shouldForcePopulateOldResourceForProcessing = myInterceptorBroadcaster instanceof InterceptorService
-				&& ((InterceptorService) myInterceptorBroadcaster)
-						.hasRegisteredInterceptor(PatientCompartmentEnforcingInterceptor.class);
-		theUpdateParameters.setShouldForcePopulateOldResourceForProcessing(shouldForcePopulateOldResourceForProcessing);
+		theUpdateParameters.setShouldForcePopulateOldResourceForProcessing(
+				isPatientCompartmentEnforcingInterceptorRegistered());
 		return super.doUpdateForUpdateOrPatch(theUpdateParameters);
 	}
 

--- a/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
+++ b/hapi-fhir-jpaserver-test-r4/src/test/java/ca/uhn/fhir/jpa/interceptor/PatientCompartmentEnforcingInterceptorTest.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.interceptor;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.api.model.DaoMethodOutcome;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.partition.IRequestPartitionHelperSvc;
@@ -68,6 +69,7 @@ public class PatientCompartmentEnforcingInterceptorTest extends BaseResourceProv
 		myPartitionSettings.setAllowReferencesAcrossPartitions(defaultPartitionSettings.getAllowReferencesAcrossPartitions());
 
 		myStorageSettings.setMassIngestionMode(false);
+		myStorageSettings.setUpdateWithHistoryRewriteEnabled(false);
 	}
 
 	@ParameterizedTest
@@ -252,6 +254,62 @@ public class PatientCompartmentEnforcingInterceptorTest extends BaseResourceProv
 		}
 
 
+	@Test
+	public void testUpdateResource_withInterceptorSubclassInMassIngestionMode_nonCrossing_succeeds() {
+		registerInterceptor(new SubclassedPatientCompartmentEnforcingInterceptor(getFhirContext(), myRequestPartitionHelperSvc));
+		myStorageSettings.setMassIngestionMode(true);
+
+		createPatientA();
+		createObservationWithSubject("O", "Patient/A");
+
+		Observation sameCompartment = new Observation();
+		sameCompartment.setId("O");
+		sameCompartment.getSubject().setReference("Patient/A");
+		sameCompartment.getNote().add(new Annotation().setText("some text"));
+
+		DaoMethodOutcome outcome = myObservationDao.update(sameCompartment, new SystemRequestDetails());
+		assertEquals("Patient/A", ((Observation) outcome.getResource()).getSubject().getReference());
+	}
+
+	@Test
+	public void testUpdateResource_withInterceptorSubclassInMassIngestionMode_crossing_throws() {
+		registerInterceptor(new SubclassedPatientCompartmentEnforcingInterceptor(getFhirContext(), myRequestPartitionHelperSvc));
+		myStorageSettings.setMassIngestionMode(true);
+
+		createPatientA();
+		createObservationWithSubject("O", "Patient/A");
+
+		String otherId = createPatientInSamePartitionAsA();
+		Observation updatedObs = new Observation();
+		updatedObs.setId("O");
+		updatedObs.getSubject().setReference("Patient/" + otherId);
+
+		assertThatThrownBy(() -> myObservationDao.update(updatedObs, new SystemRequestDetails()))
+			.isInstanceOf(PreconditionFailedException.class)
+			.hasMessageContaining("HAPI-2476: Resource compartment for Observation/O changed. Was a referenced Patient changed?");
+	}
+
+	@Test
+	public void testHistoryRewriteCurrentVersion_withInterceptorInMassIngestionMode_succeeds() {
+		registerInterceptor(mySvc);
+		myStorageSettings.setMassIngestionMode(true);
+		myStorageSettings.setUpdateWithHistoryRewriteEnabled(true);
+
+		createPatientA();
+		createObservationWithSubject("O", "Patient/A");
+
+		Observation rewritten = new Observation();
+		rewritten.setId("Observation/O/_history/1");
+		rewritten.getSubject().setReference("Patient/A");
+		rewritten.getNote().add(new Annotation().setText("rewritten"));
+
+		SystemRequestDetails rewriteRequest = new SystemRequestDetails();
+		rewriteRequest.setRewriteHistory(true);
+		DaoMethodOutcome outcome = myObservationDao.update(rewritten, rewriteRequest);
+
+		assertEquals("Patient/A", ((Observation) outcome.getResource()).getSubject().getReference());
+	}
+
 	private void registerInterceptor(boolean theUseNewInterceptor) {
 		if (theUseNewInterceptor) {
 			registerInterceptor(mySvc);
@@ -266,6 +324,34 @@ public class PatientCompartmentEnforcingInterceptorTest extends BaseResourceProv
 		patient.setId("Patient/A");
 		patient.setActive(true);
 		myPatientDao.update(patient, new SystemRequestDetails());
+	}
+
+	private void createObservationWithSubject(String theObservationId, String theSubjectReference){
+		Observation obs = new Observation();
+		obs.setId(theObservationId);
+		obs.getSubject().setReference(theSubjectReference);
+		myObservationDao.update(obs, new SystemRequestDetails());
+	}
+
+	private String createPatientInSamePartitionAsA() {
+		int patientAPartition = PatientIdPartitionInterceptor.defaultPartitionAlgorithm("A");
+		int count = 0;
+		String otherId;
+		do {
+			otherId = "A" + ++count;
+		} while (patientAPartition != PatientIdPartitionInterceptor.defaultPartitionAlgorithm(otherId));
+
+		Patient patient = new Patient();
+		patient.setId("Patient/" + otherId);
+		patient.setActive(true);
+		myPatientDao.update(patient, new SystemRequestDetails());
+		return otherId;
+	}
+
+	private static class SubclassedPatientCompartmentEnforcingInterceptor extends PatientCompartmentEnforcingInterceptor {
+		SubclassedPatientCompartmentEnforcingInterceptor(FhirContext theFhirContext, IRequestPartitionHelperSvc theRequestPartitionHelperSvc) {
+			super(theFhirContext, theRequestPartitionHelperSvc);
+		}
 	}
 
 }


### PR DESCRIPTION
When a `PatientCompartmentEnforcingInterceptor` was registered with mass ingestion mode enabled, resource 
updates could fail with a NullPointerException (`HAPI-2223: theResource must not be null`). This affected registered 
subclasses of the interceptor and the history rewrite path. This has been fixed.