### PR TITLE
#8331 store the relative URL for an export request, not the full URL so that we don't leak internal deployment details

### DIFF
--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProvider.java
@@ -76,6 +76,7 @@ import java.util.stream.Collectors;
 import static ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters.ExportStyle;
 import static ca.uhn.fhir.util.DatatypeUtil.toBooleanValue;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.stripEnd;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class BulkDataExportProvider {
@@ -552,7 +553,7 @@ public class BulkDataExportProvider {
 
 		BulkExportJobResults results = JsonUtil.deserialize(theJob.getReport(), BulkExportJobResults.class);
 		response.setMsg(results.getReportMsg());
-		response.setRequest(results.getOriginalRequestUrl());
+		response.setRequest(buildRequestUrl(theServerBase, results.getOriginalRequestUrl()));
 
 		// an output is required, even if empty, according to HL7 FHIR IG
 		response.getOutput();
@@ -569,6 +570,14 @@ public class BulkDataExportProvider {
 			}
 		}
 		return response;
+	}
+
+	private static String buildRequestUrl(String theServerBase, String theOriginalRequestUrl) {
+		if (isEmpty(theServerBase) || isEmpty(theOriginalRequestUrl)) {
+			return theOriginalRequestUrl;
+		}
+
+		return stripEnd(theServerBase, "/") + theOriginalRequestUrl;
 	}
 
 	private void handleDeleteRequest(

--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobService.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobService.java
@@ -37,6 +37,7 @@ import ca.uhn.fhir.rest.server.provider.ProviderConstants;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import ca.uhn.fhir.rest.server.util.CompositeInterceptorBroadcaster;
 import ca.uhn.fhir.util.Batch2JobDefinitionConstants;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 
 import java.util.ArrayList;
@@ -99,8 +100,9 @@ public class BulkExportJobService {
 			@Nonnull ServletRequestDetails theRequestDetails,
 			@Nonnull BulkExportJobParameters theBulkExportJobParameters) {
 		// Set the original request URL as part of the job information, as this is used in the poll-status-endpoint, and
-		// is needed for the report.
-		theBulkExportJobParameters.setOriginalRequestUrl(theRequestDetails.getCompleteUrl());
+		// is needed for the report. Stored relative to the server base so the completion document can prepend the
+		// externally-facing server base.
+		theBulkExportJobParameters.setOriginalRequestUrl(getRequestUrlRelativeToServerBase(theRequestDetails));
 
 		// If no _type parameter is provided, default to all resource types except Binary
 		if (theBulkExportJobParameters.getResourceTypes().isEmpty()) {
@@ -115,6 +117,17 @@ public class BulkExportJobService {
 						theRequestDetails, ProviderConstants.OPERATION_EXPORT);
 		myRequestPartitionHelperService.validateHasPartitionPermissions(theRequestDetails, "Binary", partitionId);
 		theBulkExportJobParameters.setPartitionIdForSecurity(partitionId);
+	}
+
+	@VisibleForTesting
+	static String getRequestUrlRelativeToServerBase(ServletRequestDetails theRequestDetails) {
+		// getRequestPath is the operation path after the server base (no leading slash), independent of any
+		// configured server address override, so it is safe to prepend the externally-facing base at completion time.
+		String requestPath = theRequestDetails.getRequestPath();
+		String completeUrl = theRequestDetails.getCompleteUrl();
+		int queryStringStart = completeUrl != null ? completeUrl.indexOf('?') : -1;
+		String queryString = queryStringStart >= 0 ? completeUrl.substring(queryStringStart) : "";
+		return "/" + requestPath + queryString;
 	}
 
 	/**

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProviderTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/export/BulkDataExportProviderTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -32,6 +33,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -86,7 +88,7 @@ class BulkDataExportProviderTest {
 		String reportMessage = "Report Message";
 		BulkExportJobResults jobResults = new BulkExportJobResults();
 		jobResults.setReportMsg(reportMessage);
-		jobResults.setOriginalRequestUrl("http://example.com/fhir-endpoint/Group/123/$export");
+		jobResults.setOriginalRequestUrl("/Group/123/$export");
 		jobResults.setResourceTypeToBinaryIds(Map.of("Patient", List.of("Binary/1123", "Binary/1124")));
 
 		job.setReport(JsonUtil.serialize(jobResults));
@@ -99,10 +101,77 @@ class BulkDataExportProviderTest {
 	    assertEquals(start, response.getTransactionTime(), "transactionTime should be useful as the _since param in the next $export request");
 	    assertEquals(reportMessage, response.getMsg());
 		assertEquals(true, response.getRequiresAccessToken());
-		assertEquals(jobResults.getOriginalRequestUrl(), response.getRequest());
+		assertEquals("http://example.com/fhir-endpoint/Group/123/$export", response.getRequest());
 		assertEquals(2, response.getOutput().size());
 		assertEquals(new BulkExportResponseJson.Output().setType("Patient").setUrl("http://example.com/fhir-endpoint/Binary/1123"), response.getOutput().get(0));
 
+	}
+
+	@ParameterizedTest
+	@CsvSource(
+		value = {
+			"https://external.example.com/fhir|/$export?_type=Patient,Observation|https://external.example.com/fhir/$export?_type=Patient,Observation",
+			"http://hapi.fhir.org/baseR4|/%24export|http://hapi.fhir.org/baseR4/%24export",
+			"https://external.example.com/fhir/|/$export|https://external.example.com/fhir/$export",
+			"https://external.example.com/fhir|/Patient/%24export?_type=Patient|https://external.example.com/fhir/Patient/%24export?_type=Patient",
+			"https://external.example.com:8443/fhir|/Patient/$export?_since=2026-08-24T11:41:35.845Z|https://external.example.com:8443/fhir/Patient/$export?_since=2026-08-24T11:41:35.845Z",
+			"http://external.example.com:8081/fhir|/Patient/123/$export?_type=Observation|http://external.example.com:8081/fhir/Patient/123/$export?_type=Observation",
+			"http://external.example.com/fhir|/Group/abc/$export?_type=Patient&_elements=id|http://external.example.com/fhir/Group/abc/$export?_type=Patient&_elements=id",
+			"http://external.example.com/fhir|/Group/abc/%24export?_type=Patient&_elements=id|http://external.example.com/fhir/Group/abc/%24export?_type=Patient&_elements=id",
+			"https://external.example.com/fhir|/$export|https://external.example.com/fhir/$export",
+			"https://external.example.com/fhir//|/$export|https://external.example.com/fhir/$export",
+			"https://external.example.com/hapi/fhir|/$export|https://external.example.com/hapi/fhir/$export",
+			"http://external.example.com/fhir|/Patient/123/%24export|http://external.example.com/fhir/Patient/123/%24export",
+			"https://external.example.com/fhir|/Patient/$export?_typeFilter=Patient%3Factive%3Dtrue|https://external.example.com/fhir/Patient/$export?_typeFilter=Patient%3Factive%3Dtrue"
+		},
+		delimiter = '|')
+	void buildCompleteResponseDocumentRewritesOriginalRequestUrlToServerBase(
+			String theServerBase, String theOriginalRequestUrl, String theExpectedRequestUrl) {
+		// given
+		JobInstance job = new JobInstance();
+		job.setStartTime(new Date());
+
+		BulkExportJobResults jobResults = new BulkExportJobResults();
+		jobResults.setOriginalRequestUrl(theOriginalRequestUrl);
+		job.setReport(JsonUtil.serialize(jobResults));
+
+		// when
+		BulkExportResponseJson response = BulkDataExportProvider.buildCompleteResponseDocument(theServerBase, job);
+
+		// then
+		assertEquals(theExpectedRequestUrl, response.getRequest());
+	}
+
+	@Test
+	void buildCompleteResponseDocumentWhenServerBaseEmptyReturnsStoredRequestUnchanged() {
+		// given
+		JobInstance job = new JobInstance();
+		job.setStartTime(new Date());
+		BulkExportJobResults jobResults = new BulkExportJobResults();
+		jobResults.setOriginalRequestUrl("/$export?_type=Patient");
+		job.setReport(JsonUtil.serialize(jobResults));
+
+		// when
+		BulkExportResponseJson response = BulkDataExportProvider.buildCompleteResponseDocument("", job);
+
+		// then
+		assertEquals("/$export?_type=Patient", response.getRequest());
+	}
+
+	@Test
+	void buildCompleteResponseDocumentWhenOriginalRequestUrlNullReturnsNullRequest() {
+		// given
+		JobInstance job = new JobInstance();
+		job.setStartTime(new Date());
+		BulkExportJobResults jobResults = new BulkExportJobResults();
+		job.setReport(JsonUtil.serialize(jobResults));
+
+		// when
+		BulkExportResponseJson response =
+				BulkDataExportProvider.buildCompleteResponseDocument("http://hapi.fhir.org/baseR4", job);
+
+		// then
+		assertNull(response.getRequest());
 	}
 
 	@Test

--- a/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobServiceTest.java
+++ b/hapi-fhir-storage-batch2-jobs/src/test/java/ca/uhn/fhir/batch2/jobs/export/BulkExportJobServiceTest.java
@@ -1,0 +1,75 @@
+package ca.uhn.fhir.batch2.jobs.export;
+
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BulkExportJobServiceTest {
+
+	@ParameterizedTest
+	@CsvSource(
+		value = {
+			// requestPath | completeUrl | expectedRelativeUrl
+			"$export|http://localhost:8080/fhir/$export|/$export",
+			"$export|http://localhost:8080/fhir/$export?_type=Patient|/$export?_type=Patient",
+			"$export|http://localhost:8080/fhir/$export?_type=Patient,Observation&_since=2026-08-24T11:41:35.845Z|/$export?_type=Patient,Observation&_since=2026-08-24T11:41:35.845Z",
+			"%24export|http://localhost:8080/fhir/%24export|/%24export",
+			"%24export|http://localhost:8080/fhir/%24export?_type=Patient|/%24export?_type=Patient",
+			"Patient/$export|http://localhost:8080/fhir/Patient/$export|/Patient/$export",
+			"Patient/$export|http://localhost:8080/fhir/Patient/$export?_type=Observation|/Patient/$export?_type=Observation",
+			"Patient/123/$export|http://localhost:8080/fhir/Patient/123/$export|/Patient/123/$export",
+			"Patient/123/%24export|http://localhost:8080/fhir/Patient/123/%24export?_type=Observation|/Patient/123/%24export?_type=Observation",
+			"Group/abc/$export|http://localhost:8080/fhir/Group/abc/$export?_type=Patient&_elements=id|/Group/abc/$export?_type=Patient&_elements=id",
+			"Group/abc/%24export|http://localhost:8080/fhir/Group/abc/%24export|/Group/abc/%24export",
+			// Server address override: completeUrl host differs from the externally-facing base, but requestPath is base-independent
+			"$export|https://internal.example.com:9443/fhir/$export?_type=Patient|/$export?_type=Patient",
+			// Tenant / extra base path segments are excluded because requestPath already excludes the server base
+			"$export|http://localhost:8080/fhir/DEFAULT/$export?_type=Patient|/$export?_type=Patient",
+			// Encoded characters in the query string are preserved verbatim
+			"Patient/$export|http://localhost:8080/fhir/Patient/$export?_typeFilter=Patient%3Factive%3Dtrue|/Patient/$export?_typeFilter=Patient%3Factive%3Dtrue"
+		},
+		delimiter = '|')
+	void getRequestUrlRelativeToServerBaseReturnsOperationPathWithQuery(
+			String theRequestPath, String theCompleteUrl, String theExpectedRelativeUrl) {
+		// given
+		ServletRequestDetails requestDetails = new ServletRequestDetails();
+		requestDetails.setRequestPath(theRequestPath);
+		requestDetails.setCompleteUrl(theCompleteUrl);
+
+		// when
+		String actual = BulkExportJobService.getRequestUrlRelativeToServerBase(requestDetails);
+
+		// then
+		assertThat(actual).isEqualTo(theExpectedRelativeUrl);
+	}
+
+	@Test
+	void getRequestUrlRelativeToServerBaseWhenCompleteUrlNullReturnsPathWithoutQuery() {
+		// given
+		ServletRequestDetails requestDetails = new ServletRequestDetails();
+		requestDetails.setRequestPath("$export");
+
+		// when
+		String actual = BulkExportJobService.getRequestUrlRelativeToServerBase(requestDetails);
+
+		// then
+		assertThat(actual).isEqualTo("/$export");
+	}
+
+	@Test
+	void getRequestUrlRelativeToServerBaseWhenCompleteUrlHasNoQueryReturnsPathOnly() {
+		// given
+		ServletRequestDetails requestDetails = new ServletRequestDetails();
+		requestDetails.setRequestPath("Group/abc/$export");
+		requestDetails.setCompleteUrl("http://localhost:8080/fhir/Group/abc/$export");
+
+		// when
+		String actual = BulkExportJobService.getRequestUrlRelativeToServerBase(requestDetails);
+
+		// then
+		assertThat(actual).isEqualTo("/Group/abc/$export");
+	}
+}


### PR DESCRIPTION
Addresses #8331 

Store the relative URL for an export request, not the full URL. Then presenting the response, rebuild the URL using the externally facing server base.

This ensures that the export response does not leak internal deployment details when the request is processed by a network protected FHIR repository.