### PR TITLE
Fix typo to exclude junit:junit from org.ogce:xpp3 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2472,7 +2472,7 @@
 				<exclusions>
 					<exclusion>
 						<groupId>junit</groupId>
-						<artifactId>junt</artifactId>
+						<artifactId>junit</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
The junit dependency is wrongly a runtime dependency. it was tried to be excluded but there was a typo missing the exclude. Currently, this old unmaintained org.ogce:xpp3 is pulling junit:junit@4.7.0 which is not compatible with latest maven-surefire-plugin 3.6.0 which requires junit 4.11

it is causing this kind of error for project which has updated to maven-surefire-plugin 3.6.0 and depending on hapi-fhir:
```
Caused by: org.apache.maven.plugin.MojoExecutionException: Surefire is not compatible with JUnit 4.11 or older. Project version is 4.7
    at org.apache.maven.plugin.surefire.AbstractSurefireMojo$JUnitPlatformProviderInfo.getProviderClasspath (AbstractSurefireMojo.java:3224)
```