### PR TITLE
8357 fallback to server default encoding rather than XML

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -750,9 +750,13 @@ public class RestfulServerUtils {
 			FhirContext theContext, FhirVersionEnum theForVersion, RequestDetails theRequestDetails) {
 		FhirContext context = getContextForVersion(theContext, theForVersion);
 
-		// Determine response encoding
-		EncodingEnum responseEncoding = RestfulServerUtils.determineResponseEncodingWithDefault(theRequestDetails)
-				.getEncoding();
+		// Determine response encoding. A negotiated encoding such as NDJSON cannot be produced by a parser, so fall
+		// back to the server's configured default encoding rather than silently defaulting to XML (see #8357).
+		EncodingEnum responseEncoding = determineParserEncoding(
+				RestfulServerUtils.determineResponseEncodingWithDefault(theRequestDetails)
+						.getEncoding(),
+				theRequestDetails.getServer().getDefaultResponseEncoding());
+
 		IParser parser;
 		switch (responseEncoding) {
 			case JSON:
@@ -770,6 +774,22 @@ public class RestfulServerUtils {
 		configureResponseParser(theRequestDetails, parser);
 
 		return parser;
+	}
+
+	/**
+	 * Returns the encoding to use when building a response parser. A negotiated encoding that cannot be produced by a
+	 * parser (e.g. NDJSON) falls back to the server's configured default encoding rather than XML. See #8357.
+	 */
+	static EncodingEnum determineParserEncoding(
+			EncodingEnum theNegotiatedEncoding, EncodingEnum theServerDefaultEncoding) {
+		switch (theNegotiatedEncoding) {
+			case JSON:
+			case RDF:
+			case XML:
+				return theNegotiatedEncoding;
+			default:
+				return theServerDefaultEncoding;
+		}
 	}
 
 	public static Set<String> parseAcceptHeaderAndReturnHighestRankedOptions(HttpServletRequest theRequest) {

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerUtilsTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/RestfulServerUtilsTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.rest.server;
 
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.DeleteCascadeModeEnum;
+import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.PreferHandlingEnum;
 import ca.uhn.fhir.rest.api.PreferHeader;
 import ca.uhn.fhir.rest.api.PreferReturnEnum;
@@ -54,6 +55,29 @@ public class RestfulServerUtilsTest {
 		PreferHeader header = RestfulServerUtils.parsePreferHeader(null, "return=representation");
 		assertEquals(PreferReturnEnum.REPRESENTATION, header.getReturn());
 		assertFalse(header.getRespondAsync());
+	}
+
+	/**
+	 * When the negotiated response encoding cannot be produced by a parser (e.g. NDJSON requested via the Accept
+	 * header), the response parser must fall back to the server's configured default encoding rather than silently
+	 * defaulting to XML. See #8357.
+	 */
+	@ParameterizedTest
+	@CsvSource({
+		// negotiatedEncoding | serverDefaultEncoding | expectedParserEncoding
+		"JSON   , XML    , JSON",
+		"XML    , JSON   , XML",
+		"RDF    , JSON   , RDF",
+		"NDJSON , JSON   , JSON",
+		"NDJSON , XML    , XML",
+		"NDJSON , RDF    , RDF",
+		"NDJSON , NDJSON , NDJSON",
+	})
+	void determineParserEncoding_fallsBackToServerDefaultForNonParseableEncoding(
+			String theNegotiatedEncoding, String theServerDefaultEncoding, String theExpectedEncoding) {
+		EncodingEnum actual = RestfulServerUtils.determineParserEncoding(
+				EncodingEnum.valueOf(theNegotiatedEncoding), EncodingEnum.valueOf(theServerDefaultEncoding));
+		assertThat(actual).isEqualTo(EncodingEnum.valueOf(theExpectedEncoding));
 	}
 
 	@Test


### PR DESCRIPTION
If a content encoding is provided that the parser can't process, fallback to server default, not XML.

Addresses #8357 