### PR TITLE
Preserve extensions on a valueless repeating primitive (#8370)

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -1405,6 +1405,23 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 								parseAlternates(nextValue, theState, alternateName, alternateName);
 								theState.endingElement();
 							}
+						} else if (nextValue.isArray()) {
+							/*
+							 * The same thing, but for a repeating primitive: e.g. an "_line" array
+							 * with no corresponding "line" array at all. Each entry of the alternate
+							 * array is one repetition of the primitive, so an element is entered for
+							 * every index in order to keep the extensions aligned with the
+							 * repetitions they belong to.
+							 */
+							BaseJsonLikeArray array = nextValue.getAsArray();
+							for (int i = 0; i < array.size(); i++) {
+								BaseJsonLikeValue nextEntry = array.get(i);
+								theState.enteringNewElement(null, nextName);
+								if (nextEntry != null && !nextEntry.isNull()) {
+									parseAlternates(nextEntry, theState, alternateName, alternateName);
+								}
+								theState.endingElement();
+							}
 						} else {
 							getErrorHandler()
 									.incorrectJsonType(

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/RDFParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/RDFParser.java
@@ -304,6 +304,24 @@ public class RDFParser extends BaseParser {
 	}
 
 	/**
+	 * Utility method to create a blank node for a primitive that carries no value but does carry
+	 * extensions. Such an element is legal in FHIR - the value is simply absent - so it still needs
+	 * a node for the extensions to hang off, just without a fhir:value predicate.
+	 * @param rdfModel Model to create node within
+	 * @param cardinalityIndex if a collection, this value is written as a fhir:index predicate
+	 * @return Blank node resource containing possibly fhir:index, but no fhir:value
+	 */
+	private Resource createFhirValuelessBlankNode(Model rdfModel, Integer cardinalityIndex) {
+		Resource blankNodeResource = rdfModel.createResource();
+		if (cardinalityIndex != null && cardinalityIndex > -1) {
+			blankNodeResource.addProperty(
+					rdfModel.createProperty(FHIR_NS + FHIR_INDEX),
+					rdfModel.createTypedLiteral(cardinalityIndex, XSDDatatype.XSDinteger));
+		}
+		return blankNodeResource;
+	}
+
+	/**
 	 * Builds the predicate name based on field definition
 	 * @param resource Resource being interrogated
 	 * @param definition field definition
@@ -400,41 +418,42 @@ public class RDFParser extends BaseParser {
 					assert pd != null;
 					String value = pd.getValueAsString();
 					if (value != null || !hasNoExtensions(pd)) {
+						String propertyName =
+								constructPredicateName(resource, childDefinition, childName, parentElement);
+						Resource valueResource;
 						if (value != null) {
-							String propertyName =
-									constructPredicateName(resource, childDefinition, childName, parentElement);
 							XSDDatatype dataType = getXSDDataTypeForFhirType(pd.fhirType(), value);
-							Resource valueResource =
-									this.createFhirValueBlankNode(rdfModel, value, dataType, cardinalityIndex);
-							if (!hasNoExtensions(pd)) {
-								IBaseHasExtensions hasExtension = (IBaseHasExtensions) pd;
-								if (hasExtension.getExtension() != null
-										&& hasExtension.getExtension().size() > 0) {
-									int i = 0;
-									for (IBaseExtension extension : hasExtension.getExtension()) {
-										RuntimeResourceDefinition resDef =
-												getContext().getResourceDefinition(resource);
-										Resource extensionResource = rdfModel.createResource();
-										extensionResource.addProperty(
-												rdfModel.createProperty(FHIR_NS + FHIR_INDEX),
-												rdfModel.createTypedLiteral(i, XSDDatatype.XSDinteger));
-										valueResource.addProperty(
-												rdfModel.createProperty(FHIR_NS + ELEMENT_EXTENSION),
-												extensionResource);
-										encodeCompositeElementToStreamWriter(
-												resource,
-												extension,
-												rdfModel,
-												extensionResource,
-												false,
-												new CompositeChildElement(resDef, theEncodeContext),
-												theEncodeContext);
-									}
+							valueResource = this.createFhirValueBlankNode(rdfModel, value, dataType, cardinalityIndex);
+						} else {
+							valueResource = this.createFhirValuelessBlankNode(rdfModel, cardinalityIndex);
+						}
+						if (!hasNoExtensions(pd)) {
+							IBaseHasExtensions hasExtension = (IBaseHasExtensions) pd;
+							if (hasExtension.getExtension() != null
+									&& hasExtension.getExtension().size() > 0) {
+								int i = 0;
+								for (IBaseExtension extension : hasExtension.getExtension()) {
+									RuntimeResourceDefinition resDef =
+											getContext().getResourceDefinition(resource);
+									Resource extensionResource = rdfModel.createResource();
+									extensionResource.addProperty(
+											rdfModel.createProperty(FHIR_NS + FHIR_INDEX),
+											rdfModel.createTypedLiteral(i, XSDDatatype.XSDinteger));
+									valueResource.addProperty(
+											rdfModel.createProperty(FHIR_NS + ELEMENT_EXTENSION), extensionResource);
+									encodeCompositeElementToStreamWriter(
+											resource,
+											extension,
+											rdfModel,
+											extensionResource,
+											false,
+											new CompositeChildElement(resDef, theEncodeContext),
+											theEncodeContext);
 								}
 							}
-
-							rdfResource.addProperty(rdfModel.createProperty(propertyName), valueResource);
 						}
+
+						rdfResource.addProperty(rdfModel.createProperty(propertyName), valueResource);
 					}
 					break;
 				}

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8370-dropped-extension-on-valueless-repeating-primitive.yaml
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/changelog/8_14_0/8370-dropped-extension-on-valueless-repeating-primitive.yaml
@@ -1,0 +1,4 @@
+---
+type: fix
+issue: 8370
+title: "Extensions on a repeating primitive that carries no value (for example an `_line` array with no corresponding `line` array) were silently dropped when parsing JSON, because an orphan alternate that is an array was reported as an incorrect JSON type and discarded by the lenient error handler. Such elements were also dropped when encoding RDF, since the primitive encoder only produced output when a value was present. Both have been fixed, and the elements are now re-encoded in the spec-conformant null-padded form."

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/JsonParserR4Test.java
@@ -2091,9 +2091,139 @@ public class JsonParserR4Test extends BaseTest {
 		TestUtil.randomizeLocaleAndTimezone();
 	}
 
+
+	/**
+	 * An extension on a <b>repeating</b> primitive that carries no value at all is emitted by some
+	 * tooling as an "_element" array with no corresponding value array, e.g.
+	 * <code>"_line": [ { "extension": [ ... ] } ]</code>. The non-repeating equivalent
+	 * (<code>"_family": { "extension": [ ... ] }</code>) has always parsed, but the array form was
+	 * reported to the error handler as an incorrect JSON type, so the default lenient handler
+	 * silently dropped the extensions. See #8238.
+	 */
+	@Test
+	public void testParseOrphanExtensionOnRepeatingPrimitive_ArrayFormIsPreserved() {
+		@Language("JSON")
+		String input = """
+			{
+			  "resourceType": "Patient",
+			  "name": [ {
+			    "_given": [ {
+			      "extension": [ {
+			        "url": "http://example.org/given",
+			        "valueString": "given-value"
+			      } ]
+			    } ]
+			  } ],
+			  "address": [ {
+			    "_line": [ {
+			      "extension": [ {
+			        "url": "http://example.org/line",
+			        "valueString": "line-value"
+			      } ]
+			    } ]
+			  } ]
+			}""";
+
+		Patient patient = ourCtx.newJsonParser().parseResource(Patient.class, input);
+
+		List<StringType> given = patient.getNameFirstRep().getGiven();
+		assertThat(given).hasSize(1);
+		assertThat(given.get(0).getValue()).isNull();
+		assertThat(given.get(0).getExtension()).hasSize(1);
+		assertEquals("http://example.org/given", given.get(0).getExtension().get(0).getUrl());
+		assertEquals("given-value", given.get(0).getExtension().get(0).getValue().primitiveValue());
+
+		List<StringType> line = patient.getAddressFirstRep().getLine();
+		assertThat(line).hasSize(1);
+		assertThat(line.get(0).getValue()).isNull();
+		assertThat(line.get(0).getExtension()).hasSize(1);
+		assertEquals("http://example.org/line", line.get(0).getExtension().get(0).getUrl());
+		assertEquals("line-value", line.get(0).getExtension().get(0).getValue().primitiveValue());
+	}
+
+	/**
+	 * As above, but the alternate array carries more than one entry, each of which is a separate
+	 * repetition of the primitive. See #8238.
+	 */
+	@Test
+	public void testParseOrphanExtensionOnRepeatingPrimitive_MultipleEntriesArePreserved() {
+		@Language("JSON")
+		String input = """
+			{
+			  "resourceType": "Patient",
+			  "address": [ {
+			    "_line": [ {
+			      "extension": [ { "url": "http://example.org/line", "valueString": "line-0" } ]
+			    }, {
+			      "extension": [ { "url": "http://example.org/line", "valueString": "line-1" } ]
+			    } ]
+			  } ]
+			}""";
+
+		Patient patient = ourCtx.newJsonParser().parseResource(Patient.class, input);
+
+		List<StringType> line = patient.getAddressFirstRep().getLine();
+		assertThat(line).hasSize(2);
+		assertEquals("line-0", line.get(0).getExtension().get(0).getValue().primitiveValue());
+		assertEquals("line-1", line.get(1).getExtension().get(0).getValue().primitiveValue());
+	}
+
+	/**
+	 * The extensions must survive a full parse/encode/parse cycle, which is what a server storing
+	 * and then serving the resource does. See #8238.
+	 */
+	@Test
+	public void testParseOrphanExtensionOnRepeatingPrimitive_RoundTrips() {
+		@Language("JSON")
+		String input = """
+			{
+			  "resourceType": "Patient",
+			  "address": [ {
+			    "_line": [ {
+			      "extension": [ { "url": "http://example.org/line", "valueString": "line-value" } ]
+			    } ]
+			  } ]
+			}""";
+
+		IParser parser = ourCtx.newJsonParser();
+		String encoded = parser.encodeResourceToString(parser.parseResource(Patient.class, input));
+		assertThat(encoded).contains("_line");
+
+		Patient reparsed = parser.parseResource(Patient.class, encoded);
+		List<StringType> line = reparsed.getAddressFirstRep().getLine();
+		assertThat(line).hasSize(1);
+		assertThat(line.get(0).getExtension()).hasSize(1);
+		assertEquals("line-value", line.get(0).getExtension().get(0).getValue().primitiveValue());
+	}
+
+	/**
+	 * Regression guard: the non-repeating (object) form of an orphan alternate must keep working.
+	 */
+	@Test
+	public void testParseOrphanExtensionOnNonRepeatingPrimitive_StillPreserved() {
+		@Language("JSON")
+		String input = """
+			{
+			  "resourceType": "Patient",
+			  "name": [ {
+			    "_family": {
+			      "extension": [ { "url": "http://example.org/family", "valueString": "family-value" } ]
+			    }
+			  } ]
+			}""";
+
+		Patient patient = ourCtx.newJsonParser().parseResource(Patient.class, input);
+
+		StringType family = patient.getNameFirstRep().getFamilyElement();
+		assertThat(family.getValue()).isNull();
+		assertThat(family.getExtension()).hasSize(1);
+		assertEquals("family-value", family.getExtension().get(0).getValue().primitiveValue());
+	}
+
 	@DatatypeDef(
 		 name = "UnknownPrimitiveType"
 	)
+
 	private static class MyUnknownPrimitiveType extends PrimitiveType<Object> {
 		@Override
 		public Object getValue() {


### PR DESCRIPTION
Fixes #8370.

## What

An extension on a **repeating** primitive that carries no value is emitted by some tooling as an `_element` array with no corresponding value array:

```json
"address": [ { "_line": [ { "extension": [ { "url": "...", "valueString": "..." } ] } ] } ]
```

`JsonParser` handled the **non-repeating** (object) form of such an orphan alternate — `"_family": { "extension": [...] }` — but sent the array form to `ErrorHandler.incorrectJsonType(...)`, so the default `LenientErrorHandler` logged it and discarded the extensions. Each entry of the array is now treated as one repetition of the primitive. An element is entered for every index, including `null` entries, so extensions stay aligned with the repetitions they belong to.

The parsed resource re-encodes to the spec-conformant null-padded form, so HAPI normalises the input rather than dropping it:

```json
"address": [ { "line": [ null ], "_line": [ { "extension": [ ... ] } ] } ]
```

## Why RDFParser is also touched

`RDFParser`'s `PRIMITIVE_DATATYPE` case is guarded by `value != null || !hasNoExtensions(pd)`, but every statement inside was nested in a further `if (value != null)`, so a valueless primitive carrying extensions produced no RDF output at all.

That was not observable before this PR, because such elements never survived JSON parsing. With the parser fix alone, **9 `RDFParserTest.testRDFRoundTrip` cases fail** — for example `activitydefinition-administer-zika-virus-exposure-assessment.json`, which contains `"_event": [ { "extension": [ { "url": ".../cqf-expression", ... } ] } ]`. The encoder now emits a blank node without a `fhir:value` predicate to carry the extensions. The bundled ShEx schemas accept this, and all 2696 `RDFParserTest` cases pass.

I kept it in the same PR because the parser fix cannot be merged green without it. Happy to split if you would rather review them separately.

## Relationship to #8260 (precondition)

These are independent bugs in the same area, but **#8260 is a precondition** for the real-world scenario: without it, encoding a resource with a contained Bundle carrying an extension on a root-level primitive throws `HAPI-2223` before the extension loss can be reached. This PR is based on `master` and does not include #8260.

With both applied, the SDC template-extract Questionnaires that motivated this round-trip losslessly:

| resource | `templateExtractValue` in | out |
|---|---|---|
| `ChEkmQuestionnaireGonorrhoea` | 51 | 51 |
| `ChEkmQuestionnaireMpox` | 107 | 107 |

On a build with #8260 only, the first is 51 in / 47 out — the four lost are all on `Address.line` and `HumanName.given`.

## Tests

Four tests added to `JsonParserR4Test`:

- `testParseOrphanExtensionOnRepeatingPrimitive_ArrayFormIsPreserved`
- `testParseOrphanExtensionOnRepeatingPrimitive_MultipleEntriesArePreserved`
- `testParseOrphanExtensionOnRepeatingPrimitive_RoundTrips`
- `testParseOrphanExtensionOnNonRepeatingPrimitive_StillPreserved` (regression guard for the object form)

The first three fail on `master` and pass with this change; the fourth passes on both.

Verified locally: `ca.uhn.fhir.parser.*Test` in `hapi-fhir-structures-r4` — 2833 run, 0 failures (5 pre-existing skips), including the full 2696-case `RDFParserTest` round-trip suite.

## Note, not addressed here

While restructuring the RDF primitive encoder I noticed the extension loop writes `fhir:index` from a counter `int i = 0` that is never incremented, so every extension on a primitive gets index 0. That is pre-existing and orthogonal, so I have left it alone — say the word if you would like it fixed here or in a separate issue.
