### PR TITLE
Deduplicate hapi-tinder-plugin declaration in jpaserver-base

### DIFF
--- a/hapi-fhir-jpaserver-base/pom.xml
+++ b/hapi-fhir-jpaserver-base/pom.xml
@@ -493,8 +493,36 @@
 							<baseResourceNames></baseResourceNames>
 						</configuration>
 					</execution>
+					<!-- Generate the DDL schema files -->
+					<execution>
+						<id>generate-ddl-legacy</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>generate-ddl</goal>
+						</goals>
+						<configuration>
+							<databasePartitionMode>false</databasePartitionMode>
+							<outputDirectory>${project.build.directory}/classes/ca/uhn/hapi/fhir/jpa/docs/database/nonpartitioned</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>generate-ddl-partitioned</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>generate-ddl</goal>
+						</goals>
+						<configuration>
+							<databasePartitionMode>true</databasePartitionMode>
+							<outputDirectory>${project.build.directory}/classes/ca/uhn/hapi/fhir/jpa/docs/database/partitioned</outputDirectory>
+						</configuration>
+					</execution>
 				</executions>
 				<dependencies>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-jpaserver-model</artifactId>
+						<version>${project.version}</version>
+					</dependency>
 					<dependency>
 						<groupId>ca.uhn.hapi.fhir</groupId>
 						<artifactId>hapi-fhir-structures-dstu2</artifactId>
@@ -516,37 +544,6 @@
 						<version>${project.version}</version>
 					</dependency>
 				</dependencies>
-			</plugin>
-
-			<!-- Generate the DDL schema files -->
-			<plugin>
-				<groupId>ca.uhn.hapi.fhir</groupId>
-				<artifactId>hapi-tinder-plugin</artifactId>
-				<version>${project.version}</version>
-				<executions>
-					<execution>
-						<id>generate-ddl-legacy</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>generate-ddl</goal>
-						</goals>
-						<configuration>
-							<databasePartitionMode>false</databasePartitionMode>
-							<outputDirectory>${project.build.directory}/classes/ca/uhn/hapi/fhir/jpa/docs/database/nonpartitioned</outputDirectory>
-						</configuration>
-					</execution>
-				<execution>
-					<id>generate-ddl-partitioned</id>
-					<phase>process-classes</phase>
-				<goals>
-					<goal>generate-ddl</goal>
-				</goals>
-					<configuration>
-						<databasePartitionMode>true</databasePartitionMode>
-						<outputDirectory>${project.build.directory}/classes/ca/uhn/hapi/fhir/jpa/docs/database/partitioned</outputDirectory>
-					</configuration>
-				</execution>
-				</executions>
 				<configuration>
 					<packageNames>
 						<packageName>ca.uhn.fhir.jpa.entity</packageName>
@@ -588,13 +585,6 @@
 						</dialect>
 					</dialects>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>ca.uhn.hapi.fhir</groupId>
-						<artifactId>hapi-fhir-jpaserver-model</artifactId>
-						<version>${project.version}</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
hapi-fhir-jpaserver-base declared ca.uhn.hapi.fhir:hapi-tinder-plugin twice in <build><plugins>: once for the generate-jparest-server executions and again for the generate-ddl executions. Maven keys plugins by groupId:artifactId, so the second declaration was a duplicate key and the model builder emitted:

```text
  [INFO] Scanning for projects...
  [WARNING] 
  [WARNING] Some problems were encountered while building the effective model for ca.uhn.hapi.fhir:hapi-fhir-jpaserver-base:jar:8.13.5-SNAPSHOT
  [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin ca.uhn.hapi.fhir:hapi-tinder-plugin @ line 522, column 12
  [WARNING] 
  [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
  [WARNING] 
  [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
  [WARNING] 
```

Fold the two into a single declaration: the generate-ddl executions join the existing <executions>, the hapi-fhir-jpaserver-model plugin dependency joins the existing <dependencies>, and the shared packageNames/dialects settings become the plugin-level <configuration>. This mirrors exactly what Maven was already producing when it merged the duplicate.

**Reviewer note** 
Verified: `mvn help:effective-pom -pl hapi-fhir-jpaserver-base` is byte-identical before and after, and `mvn clean process-classes` produces identical DDL for all 8 dialects in both the partitioned and nonpartitioned output directories.
