### PR TITLE
Allow a HAPI PR to point the CDR build at a specific CDR branch

### DIFF
--- a/.github/workflows/cdr_check/trigger_and_poll_gitlab.py
+++ b/.github/workflows/cdr_check/trigger_and_poll_gitlab.py
@@ -1,11 +1,17 @@
 import datetime
 import os
+import re
 import sys
 import json
 from time import sleep
 import requests
 
 ROBOGARY_URL = "https://slack-bots.azure.smilecdr.com/robogary/"
+GITHUB_API_URL = "https://api.github.com"
+HAPI_REPO = "hapifhir/hapi-fhir"
+# Marker that can be placed in a pull request description or comment to build
+# against a specific CDR branch, e.g. !cdr-branch=my-cdr-branch
+CDR_BRANCH_MARKER = re.compile(r"!cdr-branch=([\w.\-/]+)")
 
 complete_statuses = ["failed", "success", "canceled"]
 current_hapi_branch = os.getenv("HAPI_BRANCH")
@@ -29,9 +35,57 @@ def poll_for_pipeline_status(pipe_id):
     pipeline_status_json = resp.json()
     return pipeline_status_json
 
+def fetch_pull_request_text():
+    """
+    Fetch the pull request description followed by the bodies of its comments.
+    Returns an empty list if this is not a pull request build or if GitHub cannot be reached.
+    """
+    if not github_pr.isdigit() or not github_token:
+        return []
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github+json",
+    }
+    texts = []
+    for url in [
+        f"{GITHUB_API_URL}/repos/{HAPI_REPO}/pulls/{github_pr}",
+        f"{GITHUB_API_URL}/repos/{HAPI_REPO}/issues/{github_pr}/comments",
+    ]:
+        try:
+            resp = requests.get(url, headers=headers)
+            if resp.status_code > 399:
+                print(f"Warning: could not read {url} [status={resp.status_code}]")
+                continue
+            payload = resp.json()
+        except (requests.RequestException, ValueError) as e:
+            print(f"Warning: could not read {url} [error={e}]")
+            continue
+        if isinstance(payload, list):
+            texts.extend(comment.get("body") or "" for comment in payload)
+        else:
+            texts.append(payload.get("body") or "")
+    return texts
+
+
+def find_cdr_branch_in_pull_request():
+    """
+    Look for a !cdr-branch=<branch> marker in the pull request description, then in its comments.
+    Returns the branch name, or None if no marker is present.
+    """
+    for text in fetch_pull_request_text():
+        match = CDR_BRANCH_MARKER.search(text)
+        if match:
+            return match.group(1)
+    return None
+
+
 def resolve_cdr_branch(hapi_branch, explicit_cdr_branch):
     if explicit_cdr_branch:
         return explicit_cdr_branch
+    marker_cdr_branch = find_cdr_branch_in_pull_request()
+    if marker_cdr_branch:
+        print(f"Using CDR branch from pull request marker. [cdr_branch={marker_cdr_branch}]")
+        return marker_cdr_branch
     if hapi_branch and hapi_branch.startswith("rel_"):
         mapping_path = os.path.join(
             os.path.dirname(__file__), "hapi_cdr_branch_map.json"
@@ -54,7 +108,7 @@ target_cdr_branch = resolve_cdr_branch(current_hapi_branch, target_cdr_branch)
 # Prepare data for Robogary request
 request_data = {
     "github_pr": github_pr,
-    "github_repo": "hapifhir/hapi-fhir",
+    "github_repo": HAPI_REPO,
     "github_requester": github_requester,
     "hapi_branch": current_hapi_branch,
     "cdr_branch": target_cdr_branch

--- a/.github/workflows/compile_against_cdr.yml
+++ b/.github/workflows/compile_against_cdr.yml
@@ -1,3 +1,9 @@
+# Compiles Smile CDR against this pull request's HAPI branch.
+#
+# By default the CDR branch is master, or the release branch mapped to this HAPI rel_* branch in
+# cdr_check/hapi_cdr_branch_map.json. To compile against a different CDR branch, add a marker like
+# !cdr-branch=my-cdr-branch to the pull request description or to a comment on it, then re-run this
+# job (a comment added after the run is only picked up on the next run).
 name: Compile against CDR
 on:
   pull_request:


### PR DESCRIPTION
Adds a !cdr-branch=<branch> marker, read from the pull request description and its comments, mirroring the !hapi-branch= marker on the CDR side. It takes effect after the workflow_dispatch input and before the rel_* branch map, so existing behaviour is unchanged when no marker is present.

**Reviewer Notes**

1. Compile against CDR step picked indicated branch. See `Compile against CDR` step fragment:

```text
Getting source from Git repository
Gitaly correlation ID: a39101adeb472a4a-CDG
Fetching changes with git depth set to 10...
Reinitialized existing Git repository in /builds/simpatico.ai/cdr/.git/
Created fresh repository.
Checking out 39382318 as detached HEAD (ref is 9155-smile-12697-mdm-support-multiple-eids-for-a-single-resource-type)...
Skipping Git submodules setup
```

2. Build failed as expected because indicated CDR branch has code incompatible with hapi branch, for validations purposes. Will remove pointer and perform successful build after approval.
(removed now to make build run against master to pass)
